### PR TITLE
[Core] Remove matrix_is_modified() and debounce_is_active()

### DIFF
--- a/keyboards/40percentclub/ut47/matrix.c
+++ b/keyboards/40percentclub/ut47/matrix.c
@@ -104,12 +104,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/ai03/orbit/matrix.c
+++ b/keyboards/ai03/orbit/matrix.c
@@ -83,11 +83,6 @@ inline uint8_t matrix_rows(void) { return MATRIX_ROWS; }
 
 inline uint8_t matrix_cols(void) { return MATRIX_COLS; }
 
-bool matrix_is_modified(void) {
-  if (debounce_active()) return false;
-  return true;
-}
-
 inline bool matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & ((matrix_row_t)1 << col)); }
 
 inline matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }

--- a/keyboards/amj96/matrix.c
+++ b/keyboards/amj96/matrix.c
@@ -108,12 +108,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/angel64/alpha/matrix.c
+++ b/keyboards/angel64/alpha/matrix.c
@@ -90,13 +90,6 @@ uint8_t matrix_cols(void) {
     return MATRIX_COLS;
 }
 
-//Deprecated.
-bool matrix_is_modified(void)
-{
-    if (debounce_active()) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/angel64/rev1/matrix.c
+++ b/keyboards/angel64/rev1/matrix.c
@@ -90,13 +90,6 @@ uint8_t matrix_cols(void) {
     return MATRIX_COLS;
 }
 
-//Deprecated.
-bool matrix_is_modified(void)
-{
-    if (debounce_active()) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/bpiphany/kitten_paw/matrix.c
+++ b/keyboards/bpiphany/kitten_paw/matrix.c
@@ -117,13 +117,6 @@ uint8_t matrix_scan(void) {
   return 1;
 }
 
-bool matrix_is_modified(void) {
-  if (debouncing)
-    return false;
-  else
-    return true;
-}
-
 inline bool matrix_is_on(uint8_t row, uint8_t col) {
   return (matrix[row] & ((matrix_row_t)1<<col));
 }

--- a/keyboards/bpiphany/pegasushoof/2013/matrix.c
+++ b/keyboards/bpiphany/pegasushoof/2013/matrix.c
@@ -110,13 +110,6 @@ uint8_t matrix_scan(void)
 	return 1;
 }
 
-bool matrix_is_modified(void)
-{
-	if (debouncing)
-		return false;
-	return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/converter/palm_usb/matrix.c
+++ b/keyboards/converter/palm_usb/matrix.c
@@ -58,8 +58,6 @@ static uint16_t disconnect_counter = 0;
 #define COL(code)    ((code & COL_MASK) )
 #define KEYUP(code) ((code & KEY_MASK) >>7 )
 
-static bool is_modified = false;
-
 __attribute__ ((weak))
 void matrix_init_kb(void) {
     matrix_init_user();
@@ -352,11 +350,6 @@ uint8_t matrix_scan(void)
 
     matrix_scan_quantum();
     return code;
-}
-
-bool matrix_is_modified(void)
-{
-    return is_modified;
 }
 
 inline

--- a/keyboards/converter/sun_usb/matrix.c
+++ b/keyboards/converter/sun_usb/matrix.c
@@ -38,8 +38,6 @@ static uint8_t matrix[MATRIX_ROWS];
 #define ROW(code)      ((code>>3)&0xF)
 #define COL(code)      (code&0x07)
 
-static bool is_modified = false;
-
 __attribute__ ((weak))
 void matrix_init_kb(void) {
     matrix_init_user();
@@ -152,11 +150,6 @@ uint8_t matrix_scan(void)
 
     matrix_scan_quantum();
     return code;
-}
-
-bool matrix_is_modified(void)
-{
-    return is_modified;
 }
 
 inline

--- a/keyboards/converter/usb_usb/custom_matrix.cpp
+++ b/keyboards/converter/usb_usb/custom_matrix.cpp
@@ -192,10 +192,6 @@ extern "C"
         return 1;
     }
 
-    bool matrix_is_modified(void) {
-        return matrix_is_mod;
-    }
-
     bool matrix_is_on(uint8_t row, uint8_t col) {
         uint8_t code = CODE(row, col);
 

--- a/keyboards/dc01/arrow/matrix.c
+++ b/keyboards/dc01/arrow/matrix.c
@@ -205,14 +205,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/dc01/left/matrix.c
+++ b/keyboards/dc01/left/matrix.c
@@ -230,14 +230,6 @@ if (i2c_transaction(SLAVE_I2C_ADDRESS_NUMPAD, 0x1FFFF, 11)) {
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/dc01/numpad/matrix.c
+++ b/keyboards/dc01/numpad/matrix.c
@@ -205,14 +205,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/dc01/right/matrix.c
+++ b/keyboards/dc01/right/matrix.c
@@ -206,14 +206,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/dm9records/ergoinu/matrix.c
+++ b/keyboards/dm9records/ergoinu/matrix.c
@@ -223,12 +223,6 @@ void matrix_slave_scan(void) {
   }
 }
 
-bool matrix_is_modified(void)
-{
-  if (debouncing) return false;
-  return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/duck/jetfire/matrix.c
+++ b/keyboards/duck/jetfire/matrix.c
@@ -116,12 +116,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/ergodox_stm32/matrix.c
+++ b/keyboards/ergodox_stm32/matrix.c
@@ -119,10 +119,6 @@ uint8_t matrix_scan(void) {
   return 0;
 }
 
-bool matrix_is_modified(void) {
-  return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col) {
   return (matrix[row] & (1 << col));

--- a/keyboards/ergotaco/matrix.c
+++ b/keyboards/ergotaco/matrix.c
@@ -199,11 +199,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void) // deprecated and evidently not called.
-{
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/gboards/gergoplex/matrix.c
+++ b/keyboards/gboards/gergoplex/matrix.c
@@ -152,11 +152,6 @@ uint8_t matrix_scan(void) {
     return 1;
 }
 
-bool matrix_is_modified(void)  // deprecated and evidently not called.
-{
-    return true;
-}
-
 inline bool         matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & ((matrix_row_t)1 << col)); }
 inline matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }
 

--- a/keyboards/georgi/matrix.c
+++ b/keyboards/georgi/matrix.c
@@ -220,11 +220,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void) // deprecated and evidently not called.
-{
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/gergo/matrix.c
+++ b/keyboards/gergo/matrix.c
@@ -273,11 +273,6 @@ uint8_t matrix_scan(void) {
     return 1;
 }
 
-bool matrix_is_modified(void) // deprecated and evidently not called.
-{
-    return true;
-}
-
 inline bool matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & ((matrix_row_t)1 << col)); }
 
 inline matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }

--- a/keyboards/handwired/dactyl/matrix.c
+++ b/keyboards/handwired/dactyl/matrix.c
@@ -281,14 +281,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void) // deprecated and evidently not called.
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/handwired/frenchdev/matrix.c
+++ b/keyboards/handwired/frenchdev/matrix.c
@@ -174,12 +174,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/handwired/not_so_minidox/matrix.c
+++ b/keyboards/handwired/not_so_minidox/matrix.c
@@ -239,12 +239,6 @@ void matrix_slave_scan(void) {
 #endif
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/handwired/promethium/matrix.c
+++ b/keyboards/handwired/promethium/matrix.c
@@ -148,14 +148,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 

--- a/keyboards/handwired/pterodactyl/matrix.c
+++ b/keyboards/handwired/pterodactyl/matrix.c
@@ -282,14 +282,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void) // deprecated and evidently not called.
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/helix/pico/matrix.c
+++ b/keyboards/helix/pico/matrix.c
@@ -273,12 +273,6 @@ void matrix_slave_scan(void) {
 #endif
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/helix/rev1/matrix.c
+++ b/keyboards/helix/rev1/matrix.c
@@ -239,12 +239,6 @@ void matrix_slave_scan(void) {
 #endif
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/helix/rev2/matrix.c
+++ b/keyboards/helix/rev2/matrix.c
@@ -287,12 +287,6 @@ void matrix_slave_scan(void) {
 #endif
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/hhkb/ansi/matrix.c
+++ b/keyboards/hhkb/ansi/matrix.c
@@ -163,15 +163,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        if (matrix[i] != matrix_prev[i])
-            return true;
-    }
-    return false;
-}
-
 inline
 bool matrix_has_ghost(void)
 {

--- a/keyboards/hhkb/jp/matrix.c
+++ b/keyboards/hhkb/jp/matrix.c
@@ -164,15 +164,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        if (matrix[i] != matrix_prev[i])
-            return true;
-    }
-    return false;
-}
-
 inline
 bool matrix_has_ghost(void)
 {

--- a/keyboards/hid_liber/matrix.c
+++ b/keyboards/hid_liber/matrix.c
@@ -218,12 +218,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    // NOTE: no longer used
-    return true;
-}
-
 inline
 bool matrix_has_ghost(void)
 {

--- a/keyboards/kinesis/alvicstep/matrix.c
+++ b/keyboards/kinesis/alvicstep/matrix.c
@@ -136,12 +136,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/meira/matrix.c
+++ b/keyboards/meira/matrix.c
@@ -161,12 +161,6 @@ uint8_t matrix_scan(void)
 	return ret;
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/nek_type_a/matrix.c
+++ b/keyboards/nek_type_a/matrix.c
@@ -205,14 +205,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/redscarf_iiplus/verb/matrix.c
+++ b/keyboards/redscarf_iiplus/verb/matrix.c
@@ -94,13 +94,6 @@ uint8_t matrix_cols(void) {
     return MATRIX_COLS;
 }
 
-//Deprecated.
-bool matrix_is_modified(void)
-{
-    if (debounce_active()) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/redscarf_iiplus/verc/matrix.c
+++ b/keyboards/redscarf_iiplus/verc/matrix.c
@@ -94,13 +94,6 @@ uint8_t matrix_cols(void) {
     return MATRIX_COLS;
 }
 
-//Deprecated.
-bool matrix_is_modified(void)
-{
-    if (debounce_active()) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/redscarf_iiplus/verd/matrix.c
+++ b/keyboards/redscarf_iiplus/verd/matrix.c
@@ -94,13 +94,6 @@ uint8_t matrix_cols(void) {
     return MATRIX_COLS;
 }
 
-//Deprecated.
-bool matrix_is_modified(void)
-{
-    if (debounce_active()) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/sirius/unigo66/custom_matrix.cpp
+++ b/keyboards/sirius/unigo66/custom_matrix.cpp
@@ -172,10 +172,6 @@ extern "C"
         return 1;
     }
 
-    bool matrix_is_modified(void) {
-        return matrix_is_mod;
-    }
-
     bool matrix_is_on(uint8_t row, uint8_t col) {
         uint8_t code = CODE(row, col);
 

--- a/keyboards/sixkeyboard/matrix.c
+++ b/keyboards/sixkeyboard/matrix.c
@@ -114,11 +114,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/sx60/matrix.c
+++ b/keyboards/sx60/matrix.c
@@ -172,14 +172,6 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
-{
-#if (DEBOUNCE > 0)
-    if (debouncing) return false;
-#endif
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/thedogkeyboard/matrix.c
+++ b/keyboards/thedogkeyboard/matrix.c
@@ -90,13 +90,6 @@ uint8_t matrix_cols(void) {
     return MATRIX_COLS;
 }
 
-//Deprecated.
-bool matrix_is_modified(void)
-{
-    if (debounce_active()) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/keyboards/yosino58/rev1/matrix.c
+++ b/keyboards/yosino58/rev1/matrix.c
@@ -289,12 +289,6 @@ void matrix_slave_scan(void) {
 #endif
 }
 
-bool matrix_is_modified(void)
-{
-    if (debouncing) return false;
-    return true;
-}
-
 inline
 bool matrix_is_on(uint8_t row, uint8_t col)
 {

--- a/quantum/debounce.h
+++ b/quantum/debounce.h
@@ -6,8 +6,6 @@
 // changed is true if raw has changed since the last call
 void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed);
 
-bool debounce_active(void);
-
 void debounce_init(uint8_t num_rows);
 
 void debounce_free(void);

--- a/quantum/debounce/asym_eager_defer_pk.c
+++ b/quantum/debounce/asym_eager_defer_pk.c
@@ -165,7 +165,6 @@ static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], ui
     }
 }
 
-bool debounce_active(void) { return true; }
 #else
 #    include "none.c"
 #endif

--- a/quantum/debounce/none.c
+++ b/quantum/debounce/none.c
@@ -26,6 +26,4 @@ void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool 
     }
 }
 
-bool debounce_active(void) { return false; }
-
 void debounce_free(void) {}

--- a/quantum/debounce/sym_defer_g.c
+++ b/quantum/debounce/sym_defer_g.c
@@ -44,8 +44,6 @@ void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool 
     }
 }
 
-bool debounce_active(void) { return debouncing; }
-
 void debounce_free(void) {}
 #else  // no debouncing.
 #    include "none.c"

--- a/quantum/debounce/sym_defer_pk.c
+++ b/quantum/debounce/sym_defer_pk.c
@@ -134,7 +134,6 @@ static void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], u
     }
 }
 
-bool debounce_active(void) { return true; }
 #else
 #    include "none.c"
 #endif

--- a/quantum/debounce/sym_eager_pk.c
+++ b/quantum/debounce/sym_eager_pk.c
@@ -140,7 +140,6 @@ static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], ui
     }
 }
 
-bool debounce_active(void) { return true; }
 #else
 #    include "none.c"
 #endif

--- a/quantum/debounce/sym_eager_pr.c
+++ b/quantum/debounce/sym_eager_pr.c
@@ -132,7 +132,6 @@ static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], ui
     }
 }
 
-bool debounce_active(void) { return true; }
 #else
 #    include "none.c"
 #endif

--- a/quantum/matrix.h
+++ b/quantum/matrix.h
@@ -46,8 +46,6 @@ void matrix_setup(void);
 void matrix_init(void);
 /* scan all key states on matrix */
 uint8_t matrix_scan(void);
-/* whether modified from previous scan. used after matrix_scan. */
-bool matrix_is_modified(void) __attribute__((deprecated));
 /* whether a switch is on */
 bool matrix_is_on(uint8_t row, uint8_t col);
 /* matrix state on row */

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -45,12 +45,6 @@ inline matrix_row_t matrix_get_row(uint8_t row) {
 #endif
 }
 
-// Deprecated.
-bool matrix_is_modified(void) {
-    if (debounce_active()) return false;
-    return true;
-}
-
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header() print("\nr/c 01234567\n")
 #    define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))


### PR DESCRIPTION
## Description

**Remove `matrix_is_modified()`**
    
This method was deprecated by commit b78c654693014c60ced089648c29f46939d23437 on 12th of march 2013 which should be enough time by now. It also served no real purpose and was not used by any code in QMK.

**Remove `debounce_active()`**
    
this method was used in `matrix_is_modified()` to determine if a matrix had changes, but was never correctly implemented for all algorithms yet used in practice. With the removal of `matrix_is_modified()` there is no reason to keep it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
