### PR TITLE
Remove deprecated defines from my keymaps

### DIFF
--- a/keyboards/keebio/iris/keymaps/mnil/keymap.c
+++ b/keyboards/keebio/iris/keymaps/mnil/keymap.c
@@ -62,7 +62,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                   //├────────┼────────┼────────┼────────┼────────┼────────┤                           ├────────┼────────┼────────┼────────┼────────┼────────┤
                      KC_TRNS, SE_LCBR, SE_RCBR, SE_LPRN, SE_RPRN, KC_NO,                               SE_PLUS, S(KC_1), S(KC_2), S(KC_3), SE_AMPR, KC_TRNS,
                   //├────────┼────────┼────────┼────────┼────────┼────────┼────────┐         ┌────────┼────────┼────────┼────────┼────────┼────────┼────────┤
-                     KC_TRNS, M_TILD,  M_CIRC,  SE_LESS, SE_GRTR, KC_NO,   KC_TRNS,           KC_TRNS, SE_APOS, SE_SLSH, SE_BSLS, SE_ASTR, M_BTCK,  KC_TRNS,
+                     KC_TRNS, M_TILD,  M_CIRC,  SE_LABK, SE_RABK, KC_NO,   KC_TRNS,           KC_TRNS, SE_QUOT, SE_SLSH, SE_BSLS, SE_ASTR, M_BTCK,  KC_TRNS,
                   //└────────┴────────┴────────┴───┬────┴───┬────┴───┬────┴───┬────┘         └───┬────┴───┬────┴───┬────┴───┬────┴────────┴────────┴────────┘
                                                     KC_TRNS, KC_TRNS, KC_TRNS,                    KC_TRNS, KC_TRNS, KC_TRNS ),
                   //                               └────────┴────────┴────────┘                  └────────┴────────┴────────┘

--- a/keyboards/planck/keymaps/mnil/keymap.c
+++ b/keyboards/planck/keymaps/mnil/keymap.c
@@ -29,8 +29,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 ),
 
 [_QWERTY] = LAYOUT_planck_2x2u(
-    KC_TRNS, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    SE_AA,
-    KC_TRNS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    SE_OSLH, SE_AE,
+    KC_TRNS, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    SE_ARNG,
+    KC_TRNS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    SE_ODIA, SE_ADIA,
     KC_TRNS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,    KC_TRNS,          KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 ),
@@ -38,7 +38,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_SYMBOLS] = LAYOUT_planck_2x2u(
     KC_TRNS, KC_NO,   SE_PIPE, SE_LBRC, SE_RBRC, KC_NO,   S(KC_5), SE_QUES, SE_AT,   SE_EQL,  SE_DLR,  KC_BSPC,
     KC_TRNS, SE_LCBR, SE_RCBR, SE_LPRN, SE_RPRN, KC_NO,   SE_PLUS, S(KC_1), S(KC_2), S(KC_3), SE_AMPR, KC_QUOT,
-    KC_TRNS, M_TILD,  M_CIRC,  SE_LESS, SE_GRTR, KC_NO,   SE_APOS, SE_SLSH, SE_BSLS, SE_ASTR, M_BTCK,  KC_ENT,
+    KC_TRNS, M_TILD,  M_CIRC,  SE_LABK, SE_RABK, KC_NO,   SE_QUOT, SE_SLSH, SE_BSLS, SE_ASTR, M_BTCK,  KC_ENT,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,    KC_TRNS,          KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 ),
 

--- a/users/mnil/mnil.c
+++ b/users/mnil/mnil.c
@@ -86,7 +86,7 @@ void ae_finished(qk_tap_dance_state_t *state, void *user_data) {
             register_code(KC_A);
             break;
         case SINGLE_HOLD:
-            tap_code(SE_AE);
+            tap_code(SE_ADIA);
             break;
         case DOUBLE_SINGLE_TAP:
             tap_code(KC_A);
@@ -113,15 +113,15 @@ void aa_finished(qk_tap_dance_state_t *state, void *user_data) {
     aa_tap_state.state = cur_dance(state);
     switch (aa_tap_state.state) {
         case SINGLE_TAP:
-            register_code(SE_OSLH);
+            register_code(SE_ODIA);
             break;
         case SINGLE_HOLD:
-            register_code(SE_AA);
-            unregister_code(SE_AA);
+            register_code(SE_ARNG);
+            unregister_code(SE_ARNG);
             break;
         case DOUBLE_SINGLE_TAP:
-            tap_code(SE_OSLH);
-            register_code(SE_OSLH);
+            tap_code(SE_ODIA);
+            register_code(SE_ODIA);
             break;
     }
 }
@@ -129,10 +129,10 @@ void aa_finished(qk_tap_dance_state_t *state, void *user_data) {
 void aa_reset(qk_tap_dance_state_t *state, void *user_data) {
     switch (aa_tap_state.state) {
         case SINGLE_TAP:
-            unregister_code(SE_OSLH);
+            unregister_code(SE_ODIA);
             break;
         case DOUBLE_SINGLE_TAP:
-            unregister_code(SE_OSLH);
+            unregister_code(SE_ODIA);
             break;
     }
     aa_tap_state.state = 0;


### PR DESCRIPTION
Commit 50d4dfd deprecated and removed a couple of Swedish character
defines that was still used in my keymap. This commit remedies that and
updates to the supported character names.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
