### PR TITLE
Fixup paths for `ramonimbao/wete/v2`.

### DIFF
--- a/keyboards/ramonimbao/wete/readme.md
+++ b/keyboards/ramonimbao/wete/readme.md
@@ -7,8 +7,8 @@ Southpaw numpad 75% boards.
 
 Make example for these keyboards (after setting up your build environment):
 
-    make ramonimbao/wete/rev1:default
+    make ramonimbao/wete/v1:default
     
-    make ramonimbao/wete/rev2:default
+    make ramonimbao/wete/v2:default
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/ramonimbao/wete/rules.mk
+++ b/keyboards/ramonimbao/wete/rules.mk
@@ -1,1 +1,1 @@
-DEFAULT_FOLDER = ramonimbao/wete/rev2
+DEFAULT_FOLDER = ramonimbao/wete/v2

--- a/keyboards/ramonimbao/wete/v2/readme.md
+++ b/keyboards/ramonimbao/wete/v2/readme.md
@@ -9,11 +9,11 @@ Round two of the Wete keyboard. Now uses the ATmega32u4, adds an encoder, and sw
 
 Make example for this keyboard (after setting up your build environment):
 
-    make ramonimbao/wete/rev2:default
+    make ramonimbao/wete/v2:default
 
 Flashing example for this keyboard:
 
-    make ramonimbao/wete/rev2:default:flash
+    make ramonimbao/wete/v2:default:flash
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 


### PR DESCRIPTION
## Description

As it says on the tin. Causes issues with `qmk multibuild` due to wrong path.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
