### PR TITLE
[Keyboard] Add missng define for 4x6 Tractyl Manuform

### DIFF
--- a/keyboards/handwired/tractyl_manuform/4x6_right/config.h
+++ b/keyboards/handwired/tractyl_manuform/4x6_right/config.h
@@ -89,3 +89,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* PMW3360 Settings */
 #define PMW3360_CS_PIN           B0
+
+#define POINTING_DEVICE_RIGHT


### PR DESCRIPTION
## Description

Made changes to the kb split sync code, but forgot to update the 4x6 variant. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
