### PR TITLE
Remove manual enable of LTO within keyboards

### DIFF
--- a/keyboards/1upkeyboards/1up60hse/rules.mk
+++ b/keyboards/1upkeyboards/1up60hse/rules.mk
@@ -17,6 +17,6 @@ NKRO_ENABLE = yes            # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes
 
 LAYOUTS = 60_ansi

--- a/keyboards/alf/x11/rules.mk
+++ b/keyboards/alf/x11/rules.mk
@@ -17,4 +17,4 @@ NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes

--- a/keyboards/butterstick/rules.mk
+++ b/keyboards/butterstick/rules.mk
@@ -13,4 +13,4 @@ STENO_ENABLE		= yes 		# Needed for chording
 
 OPT_DEFS += -DONLYQWERTY -DDEBUG_MATRIX
 SRC += sten.c
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes

--- a/keyboards/clueboard/66_hotswap/prototype/rules.mk
+++ b/keyboards/clueboard/66_hotswap/prototype/rules.mk
@@ -3,4 +3,4 @@
 #
 BACKLIGHT_DRIVER = custom
 
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes

--- a/keyboards/converter/usb_usb/ble/rules.mk
+++ b/keyboards/converter/usb_usb/ble/rules.mk
@@ -15,4 +15,4 @@ AUDIO_ENABLE = no           # Audio output
 BLUETOOTH_ENABLE = yes
 BLUETOOTH_DRIVER = AdafruitBLE
 
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes

--- a/keyboards/georgi/rules.mk
+++ b/keyboards/georgi/rules.mk
@@ -12,5 +12,5 @@ CONSOLE_ENABLE      = yes
 COMMAND_ENABLE      = no
 NKRO_ENABLE			= yes
 
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes
 SRC += matrix.c i2c_master.c sten.c

--- a/keyboards/hineybush/h87a/rules.mk
+++ b/keyboards/hineybush/h87a/rules.mk
@@ -17,4 +17,4 @@ NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes       # Enable RGB underglow
 AUDIO_ENABLE = no           # Audio output
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes

--- a/keyboards/idobo/rules.mk
+++ b/keyboards/idobo/rules.mk
@@ -17,6 +17,6 @@ NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-EXTRAFLAGS += -flto        # Use link time optimization
+LTO_ENABLE = yes            # Use link time optimization
 
 LAYOUTS = ortho_5x15

--- a/keyboards/noxary/260/rules.mk
+++ b/keyboards/noxary/260/rules.mk
@@ -17,6 +17,6 @@ NKRO_ENABLE = no            # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes
 
 LAYOUTS = 60_ansi 60_iso 60_hhkb 60_tsangan_hhkb

--- a/keyboards/percent/booster/rules.mk
+++ b/keyboards/percent/booster/rules.mk
@@ -17,6 +17,6 @@ NKRO_ENABLE = no             # USB Nkey Rollover
 BACKLIGHT_ENABLE = yes       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no            # Audio output
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes
 
 LAYOUTS = numpad_5x4

--- a/keyboards/scarletbandana/rules.mk
+++ b/keyboards/scarletbandana/rules.mk
@@ -17,4 +17,4 @@ NKRO_ENABLE = no            # USB Nkey Rollover
 AUDIO_ENABLE = yes          # Audio output
 RGBLIGHT_ENABLE = yes       # Enable WS2812 RGB underlight.  Do not enable this with audio at the same time.
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality, also set ISSI_ENABLE below for Miera
-EXTRAFLAGS += -flto
+LTO_ENABLE = yes

--- a/keyboards/tetris/rules.mk
+++ b/keyboards/tetris/rules.mk
@@ -16,5 +16,5 @@ NKRO_ENABLE = yes		# USB Nkey Rollover - if this doesn't work, see here: https:/
 BACKLIGHT_ENABLE = no  # Enable keyboard backlight functionality
 AUDIO_ENABLE = yes
 RGBLIGHT_ENABLE = yes
-EXTRAFLAGS        = -flto 
+LTO_ENABLE = yes
 ENCODER_ENABLE = yes

--- a/keyboards/tkc/candybar/lefty/rules.mk
+++ b/keyboards/tkc/candybar/lefty/rules.mk
@@ -7,7 +7,7 @@ BOOTLOADER = stm32-dfu
 # Build Options
 #   comment out to disable the options.
 #
-# EXTRAFLAGS+=-flto
+# LTO_ENABLE = yes
 LTO_ENABLE = yes
 BACKLIGHT_ENABLE = no
 BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite

--- a/keyboards/tkc/candybar/righty/rules.mk
+++ b/keyboards/tkc/candybar/righty/rules.mk
@@ -7,7 +7,7 @@ BOOTLOADER = stm32-dfu
 # Build Options
 #   comment out to disable the options.
 #
-# EXTRAFLAGS+=-flto
+# LTO_ENABLE = yes
 LTO_ENABLE = yes
 BACKLIGHT_ENABLE = no
 BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Setting a bad example....

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
