### PR TITLE
split_util.c: add SPLIT_USB_FORCE_LEFT and SPLIT_USB_FORCE_RIGHT

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -386,6 +386,15 @@ This sets how many LEDs are directly connected to each controller.  The first nu
 
 Enabling this option changes the startup behavior to listen for an active USB communication to delegate which part is master and which is slave. With this option enabled and theres's USB communication, then that half assumes it is the master, otherwise it assumes it is the slave.
 
+```c
+#define SPLIT_USB_FORCE_LEFT
+#define SPLIT_USB_FORCE_RIGHT
+```
+
+Forces the usb connection to be enabled on the corresponding half. If both are set, left wins over right.
+
+?> Only set these options if `SPLIT_USB_DETECT` does not work as intended.
+
 Without this option, the master is the half that can detect voltage on the physical USB connection (VBUS detection).
 
 Enabled by default on ChibiOS/ARM.

--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -386,18 +386,9 @@ This sets how many LEDs are directly connected to each controller.  The first nu
 
 Enabling this option changes the startup behavior to listen for an active USB communication to delegate which part is master and which is slave. With this option enabled and theres's USB communication, then that half assumes it is the master, otherwise it assumes it is the slave.
 
-```c
-#define SPLIT_USB_FORCE_LEFT
-#define SPLIT_USB_FORCE_RIGHT
-```
-
-Forces the usb connection to be enabled on the corresponding half. If both are set, left wins over right.
-
-?> Only set these options if `SPLIT_USB_DETECT` does not work as intended.
+Enabled by default on ChibiOS/ARM.
 
 Without this option, the master is the half that can detect voltage on the physical USB connection (VBUS detection).
-
-Enabled by default on ChibiOS/ARM.
 
 ?> This setting will stop the ability to demo using battery packs.
 
@@ -410,6 +401,15 @@ This sets the maximum timeout when detecting master/slave when using `SPLIT_USB_
 #define SPLIT_USB_TIMEOUT_POLL 10
 ```
 This sets the poll frequency when detecting master/slave when using `SPLIT_USB_DETECT`
+
+```c
+#define SPLIT_USB_FORCE_LEFT
+#define SPLIT_USB_FORCE_RIGHT
+```
+
+Forces the USB connection to be enabled on the corresponding half. If both are set, left wins over right.
+
+?> Only set these options if `SPLIT_USB_DETECT` does not work as intended.
 
 ## Hardware Considerations and Mods
 

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -56,7 +56,15 @@ static uint8_t connection_errors = 0;
 
 volatile bool isLeftHand = true;
 
-#if defined(SPLIT_USB_DETECT)
+#if defined(SPLIT_USB_FORCE_LEFT)
+static bool usbIsActive(void) {
+    return is_keyboard_left();
+}
+#elif defined(SPLIT_USB_FORCE_RIGHT)
+static bool usbIsActive(void) {
+    return !is_keyboard_left();
+}
+#elif defined(SPLIT_USB_DETECT)
 static bool usbIsActive(void) {
     for (uint8_t i = 0; i < (SPLIT_USB_TIMEOUT / SPLIT_USB_TIMEOUT_POLL); i++) {
         // This will return true if a USB connection has been established


### PR DESCRIPTION
## Description

This circumvents a corner case where a micro controller does not properly
detect a new usb connection when waking the computer from suspend.

We found this issue when doing a "build your own keyboard" workshop at Chaos inKL earlier this year. You can read more of our findings here: https://www.chaos-inkl.de/wiki/workshop:tastatur_bauen_standby_problem (in german).

The issue was brought up by multiple members of the workshop, this was the only fix we found so far.
Please tell me if there's something we missed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ x Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
