### PR TITLE
[Keyboard] Fix bug in Moonlander functions

### DIFF
--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -400,6 +400,7 @@ const uint8_t music_map[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_moonlander(
 
 #ifdef ORYX_CONFIGURATOR
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+    if (!process_record_user(keycode, record)) { return false; }
     switch (keycode) {
 #ifdef WEBUSB_ENABLE
         case WEBUSB_PAIR:
@@ -450,7 +451,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
             return false;
 #endif
     }
-    return process_record_user(keycode, record);
+    return true;
 }
 
 #endif
@@ -470,6 +471,7 @@ void matrix_init_kb(void) {
         rgb_matrix_set_flags(LED_FLAG_NONE);
     }
 #endif
+    matrix_init_user();
 }
 
 void eeconfig_init_kb(void) {  // EEPROM is getting reset!


### PR DESCRIPTION
## Description

Somebody (me) forgot to add `matrix_init_user` to the kb level function, causing it to not be called. 

Also, better handle process_record_*. 

## Types of Changes

- [x] Bugfix
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
