### PR TITLE
Generate prettier keymap.c

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -247,7 +247,7 @@ Creates a keymap.c from a QMK Configurator export.
 **Usage**:
 
 ```
-qmk json2c [-o OUTPUT] filename
+qmk json2c [-km KEYMAP -kb KEYBOARD [-s]]|[-o OUTPUT] filename
 ```
 
 ## `qmk c2json`

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -5,14 +5,20 @@ import json
 from argcomplete.completers import FilesCompleter
 from milc import cli
 
+from qmk.decorators import automagic_keyboard, automagic_keymap
+from qmk.info import info_json
 import qmk.keymap
 import qmk.path
 
 
+@cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, help='Keyboard to convert keymap for')
+@cli.argument('-km', '--keymap', help='Keymap to save the output of json2c')
 @cli.argument('-o', '--output', arg_only=True, type=qmk.path.normpath, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('filename', type=qmk.path.FileType('r'), arg_only=True, completer=FilesCompleter('.json'), help='Configurator JSON file')
 @cli.subcommand('Creates a keymap.c from a QMK Configurator export.')
+@automagic_keyboard
+@automagic_keymap
 def json2c(cli):
     """Generate a keymap.c from a configurator export.
 
@@ -33,8 +39,13 @@ def json2c(cli):
         cli.args.output = None
 
     # Generate the keymap
-    keymap_c = qmk.keymap.generate_c(user_keymap)
+    kb_info_json = None
+    if cli.config.info.keyboard:
+        kb_info_json = info_json(cli.config.info.keyboard)
 
+    keymap_c = qmk.keymap.generate_c(user_keymap, kb_info_json)
+
+    # TODO(unassigned/pfn): automatically output to keymap.c specified by -km
     if cli.args.output:
         cli.args.output.parent.mkdir(parents=True, exist_ok=True)
         if cli.args.output.exists():

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -15,6 +15,7 @@ import qmk.path
 
 @cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, help='Keyboard to convert keymap for')
 @cli.argument('-km', '--keymap', help='Keymap to save the output of json2c')
+@cli.argument('-s', '--save', arg_only=True, action='store_true', help="Save the keymap file")
 @cli.argument('-o', '--output', arg_only=True, type=qmk.path.normpath, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('filename', type=qmk.path.FileType('r'), arg_only=True, completer=FilesCompleter('.json'), help='Configurator JSON file')
@@ -47,7 +48,7 @@ def json2c(cli):
 
     keymap_c = qmk.keymap.generate_c(user_keymap, kb_info_json)
 
-    if cli.config.info.keyboard and cli.config.info.keymap:
+    if cli.config.info.keyboard and cli.config.info.keymap and cli.args.save:
         keymap_path = locate_keymap(cli.config.info.keyboard, cli.config.info.keymap)
         if keymap_path and keymap_path.suffix == '.c':
             keymap_path.replace(keymap_path.parent / (keymap_path.name + '.bak'))

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -7,6 +7,7 @@ from milc import cli
 
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.info import info_json
+from qmk.keyboard import keyboard_completer, keyboard_folder
 import qmk.keymap
 import qmk.path
 

--- a/lib/python/qmk/cli/json2c.py
+++ b/lib/python/qmk/cli/json2c.py
@@ -8,6 +8,7 @@ from milc import cli
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.info import info_json
 from qmk.keyboard import keyboard_completer, keyboard_folder
+from qmk.keymap import locate_keymap
 import qmk.keymap
 import qmk.path
 
@@ -46,8 +47,13 @@ def json2c(cli):
 
     keymap_c = qmk.keymap.generate_c(user_keymap, kb_info_json)
 
-    # TODO(unassigned/pfn): automatically output to keymap.c specified by -km
-    if cli.args.output:
+    if cli.config.info.keyboard and cli.config.info.keymap:
+        keymap_path = locate_keymap(cli.config.info.keyboard, cli.config.info.keymap)
+        if keymap_path and keymap_path.suffix == '.c':
+            keymap_path.replace(keymap_path.parent / (keymap_path.name + '.bak'))
+            keymap_path.write_text(keymap_c)
+        cli.log.info("Wrote keymap to %s. ", keymap_path)
+    elif cli.args.output:
         cli.args.output.parent.mkdir(parents=True, exist_ok=True)
         if cli.args.output.exists():
             cli.args.output.replace(cli.args.output.parent / (cli.args.output.name + '.bak'))

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -206,6 +206,7 @@ def _extract_layout_desc(info_json):
         lt = layouts[k]
     return lt['layout'] if lt else None
 
+
 # TODO(unassigned/pfn): Write unit tests
 def _generate_c_layout_with_desc(layer, layout_desc):
     """Returns a single LAYOUT macro argument line.
@@ -233,6 +234,7 @@ def _generate_c_layout_with_desc(layer, layout_desc):
         return layer_keys[:-1]  # drop trailing ,
     else:
         return ', '.join(layer)
+
 
 def generate_c(keymap_json, info_json=None):
     """Returns a `keymap.c`.

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -215,19 +215,24 @@ def generate_c(keymap_json, info_json = None):
             layer_txt[-1] = layer_txt[-1] + ','
         layer = map(_strip_trans, map(_strip_any, layer))
         # TODO(unassigned/pfn): Write unit tests
-        if info_json is not None and info_json['layouts']['LAYOUT']['layout']:
-            layout_desc = info_json['layouts']['LAYOUT']['layout']
+        layouts = info_json.get('layouts')
+        lt = None
+        if layouts:
+            k = [*layouts.keys()][0]
+            lt = layouts[k]
+        if lt:
+            layout_desc = lt['layout']
             last_x = 0
             chars = 0
             layer_keys = "\n"
             for i, k in zip(range(len(layout_desc)), layer):
                 x = layout_desc[i]['x']
-                pos = x * 9
+                pos = x * 8
                 if last_x > x:
                     layer_keys += "\n"
                     chars = 0
-                indent = pos - chars - max(8, len(k)) - max(0, chars - pos)
-                width = 8 - max(0, chars - pos)
+                indent = pos - chars - max(7, len(k)) - max(0, chars - pos)
+                width = 7 - max(0, chars - pos)
                 fmt = "%s%" + str(width) + "s,"
                 layer_keys += fmt % (indent * " ", k)
                 last_x = x

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -67,6 +67,14 @@ def template_c(keyboard):
     return template
 
 
+def _strip_trans(keycode):
+    """Translate KC_TRNS to _______"""
+    if keycode == "KC_TRNS":
+        keycode = "_______"
+
+    return keycode
+
+
 def _strip_any(keycode):
     """Remove ANY() from a keycode.
     """
@@ -205,7 +213,7 @@ def generate_c(keymap_json, info_json = None):
     for layer_num, layer in enumerate(keymap_json['layers']):
         if layer_num != 0:
             layer_txt[-1] = layer_txt[-1] + ','
-        layer = map(_strip_any, layer)
+        layer = map(_strip_trans, map(_strip_any, layer))
         # TODO(unassigned/pfn): Write unit tests
         if info_json is not None and info_json['layouts']['LAYOUT']['layout']:
             layout_desc = info_json['layouts']['LAYOUT']['layout']

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -190,7 +190,7 @@ def generate_json(keymap, keyboard, layout, layers):
     return new_keymap
 
 
-def generate_c(keymap_json, info_json = None):
+def generate_c(keymap_json, info_json=None):
     """Returns a `keymap.c`.
 
     `keymap_json` is a dictionary with the following keys:
@@ -237,7 +237,7 @@ def generate_c(keymap_json, info_json = None):
                 layer_keys += fmt % (indent * " ", k)
                 last_x = x
                 chars = chars + max(width + 1, len(k) + 1) + max(0, indent)
-            layer_keys = layer_keys[:-1] # drop trailing ,
+            layer_keys = layer_keys[:-1]  # drop trailing ,
         else:
             layer_keys = ', '.join(layer)
 

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -215,8 +215,10 @@ def generate_c(keymap_json, info_json=None):
             layer_txt[-1] = layer_txt[-1] + ','
         layer = map(_strip_trans, map(_strip_any, layer))
         # TODO(unassigned/pfn): Write unit tests
-        layouts = info_json.get('layouts')
         lt = None
+        layouts = None
+        if info_json:
+            layouts = info_json.get('layouts')
         if layouts:
             k = [*layouts.keys()][0]
             lt = layouts[k]

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -139,13 +139,13 @@ def test_list_keymaps_no_keyboard_found():
 def test_json2c():
     result = check_subcommand('json2c', 'keyboards/handwired/pytest/has_template/keymaps/default_json/keymap.json')
     check_returncode(result)
-    assert result.stdout == '#include QMK_KEYBOARD_H\nconst uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {\t[0] = LAYOUT_ortho_1x1(KC_A)};\n\n'
+    assert "".join(result.stdout.split()) == "".join('#include QMK_KEYBOARD_H\nconst uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {\t[0] = LAYOUT_ortho_1x1(KC_A)};\n\n'.split())
 
 
 def test_json2c_macros():
     result = check_subcommand("json2c", 'keyboards/handwired/pytest/macro/keymaps/default/keymap.json')
     check_returncode(result)
-    assert 'LAYOUT_ortho_1x1(MACRO_0)' in result.stdout
+    assert 'LAYOUT_ortho_1x1(MACRO_0)' in "".join(result.stdout.split())
     assert 'case MACRO_0:' in result.stdout
     assert 'SEND_STRING("Hello, World!"SS_TAP(X_ENTER));' in result.stdout
 
@@ -153,7 +153,7 @@ def test_json2c_macros():
 def test_json2c_stdin():
     result = check_subcommand_stdin('keyboards/handwired/pytest/has_template/keymaps/default_json/keymap.json', 'json2c', '-')
     check_returncode(result)
-    assert result.stdout == '#include QMK_KEYBOARD_H\nconst uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {\t[0] = LAYOUT_ortho_1x1(KC_A)};\n\n'
+    assert "".join(result.stdout.split()) == "".join('#include QMK_KEYBOARD_H\nconst uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {\t[0] = LAYOUT_ortho_1x1(KC_A)};\n\n'.split())
 
 
 def test_info():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Start making json2c info.json aware by reading --keyboard and --keymap, `-s` to write`keymap.c` to the correct location
 
Generates output like this for my dactyl manuform 4x6:

```c
 $ qmk json2c no_mod_tap_a.json
Ψ Wrote keymap to keyboards/handwired/dactyl_manuform/4x6/keymaps/pfn/keymap.c.
#include QMK_KEYBOARD_H


/* THIS FILE WAS GENERATED!
 *
 * This file was generated by qmk json2c. You may or may not want to
 * edit it directly.
 */

const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
        [0] = LAYOUT(
  KC_ESC,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                                         KC_Y,    KC_U,    KC_I,    KC_O,    KC_P, KC_BSPC,
LCTL_T(KC_TAB),KC_A,  KC_S,    KC_D,LT(3,KC_F),LT(4,KC_G),                                     KC_H,    KC_J,    KC_K,    KC_L,RALT_T(KC_SCLN),RCTL_T(KC_QUOT),
 KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,LSFT_T(KC_B),                             RSFT_T(KC_N),    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT,
           KC_WBAK, KC_WFWD,                                                                                  KC_MPRV, KC_MNXT,
                               MO(1),  KC_ENT,                                               KC_SPC,   MO(2),
                                               KC_LALT, KC_LCTL,          KC_MPLY, KC_MUTE,
                                                KC_GRV, KC_LGUI,          KC_VOLU, KC_VOLD),
        [1] = LAYOUT(
 KC_TRNS, KC_PGUP, KC_HOME,   KC_UP,  KC_END, KC_LCBR,                                      KC_RCBR,    KC_7,    KC_8,    KC_9, KC_PERC, KC_PSLS,
 KC_TRNS, KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, KC_LBRC,                                      KC_RBRC,    KC_4,    KC_5,    KC_6, KC_PMNS, KC_PAST,
 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_LPRN,                                      KC_RPRN,    KC_1,    KC_2,    KC_3, KC_PLUS,  KC_EQL,
             RESET, KC_TRNS,                                                                                     KC_0, KC_PDOT,
                             KC_TRNS, KC_TRNS,                                              KC_TRNS,   TG(3),
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS),
        [2] = LAYOUT(
  KC_GRV,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                                        KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_DEL,
 KC_TILD, KC_EXLM,   KC_AT, KC_HASH,  KC_DLR, KC_PERC,                                      KC_CIRC, KC_AMPR, KC_ASTR, KC_MINS,  KC_EQL, KC_BSLS,
 KC_TRNS,  KC_F11,  KC_F12, KC_TRNS, KC_TRNS, KC_TRNS,                                      KC_TRNS, KC_TRNS, KC_TRNS, KC_UNDS, KC_PLUS, KC_PIPE,
             RESET, KC_TRNS,                                                                                  KC_TRNS, KC_TRNS,
                               TG(4), KC_TRNS,                                              KC_TRNS, KC_TRNS,
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS),
        [3] = LAYOUT(
   TG(3), KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                                      KC_PGUP, KC_HOME,  KC_END, KC_TRNS, KC_TRNS, KC_TRNS,
 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                                      KC_LEFT, KC_DOWN,   KC_UP, KC_RGHT, KC_TRNS, KC_TRNS,
 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                                      KC_PGDN, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
           KC_TRNS, KC_TRNS,                                                                                  KC_TRNS, KC_TRNS,
                             KC_TRNS, KC_TRNS,                                              KC_TRNS,   TG(3),
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS),
        [4] = LAYOUT(
   TG(4), KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                                      KC_WH_U, KC_BTN1, KC_MS_U, KC_BTN2, KC_TRNS, KC_TRNS,
 KC_TRNS, KC_TRNS, KC_TRNS, KC_BTN1, KC_BTN2, KC_TRNS,                                      KC_WH_D, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS, KC_TRNS,
 KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                                      KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
           KC_TRNS, KC_TRNS,                                                                                  KC_TRNS, KC_TRNS,
                               TG(4), KC_TRNS,                                              KC_TRNS, KC_TRNS,
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,
                                               KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS)
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
