### PR TITLE
Flip encoder and fix weird volume behavior for Herringbone Pro

### DIFF
--- a/keyboards/ramonimbao/herringbone/pro/config.h
+++ b/keyboards/ramonimbao/herringbone/pro/config.h
@@ -51,6 +51,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define ENCODERS_PAD_A { C2 }
 #define ENCODERS_PAD_B { C3 }
 
+#define ENCODER_DIRECTION_FLIP
+
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 

--- a/keyboards/ramonimbao/herringbone/pro/config.h
+++ b/keyboards/ramonimbao/herringbone/pro/config.h
@@ -48,10 +48,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DIODE_DIRECTION COL2ROW
 
 /* Encoder pin assignment */
-#define ENCODERS_PAD_A { C2 }
-#define ENCODERS_PAD_B { C3 }
-
-#define ENCODER_DIRECTION_FLIP
+#define ENCODERS_PAD_A { C3 }
+#define ENCODERS_PAD_B { C2 }
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5

--- a/keyboards/ramonimbao/herringbone/pro/keymaps/via/keymap.c
+++ b/keyboards/ramonimbao/herringbone/pro/keymaps/via/keymap.c
@@ -64,14 +64,12 @@ keyevent_t encoder_cw = {
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_ccw)) {
-        wait_ms(20);
         encoder_ccw.pressed = false;
         encoder_ccw.time = (timer_read() | 1);
         action_exec(encoder_ccw);
     }
 
     if (IS_PRESSED(encoder_cw)) {
-        wait_ms(20);
         encoder_cw.pressed = false;
         encoder_cw.time = (timer_read() | 1);
         action_exec(encoder_cw);
@@ -90,12 +88,14 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
         encoder_cw.pressed = true;
         encoder_cw.time = (timer_read() | 1);
         action_exec(encoder_cw);
+        wait_ms(20);
         anim_sleep = timer_read32();
         oled_on();
     } else {
         encoder_ccw.pressed = true;
         encoder_ccw.time = (timer_read() | 1);
         action_exec(encoder_ccw);
+        wait_ms(20);
         anim_sleep = timer_read32();
         oled_on();
     }

--- a/keyboards/ramonimbao/herringbone/pro/keymaps/via/keymap.c
+++ b/keyboards/ramonimbao/herringbone/pro/keymaps/via/keymap.c
@@ -76,6 +76,27 @@ void matrix_scan_user(void) {
     }
 }
 
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case KC_VOLD:
+            if (record->event.pressed) {
+                tap_code_delay(KC_VOLD, 20);
+            } else {
+                unregister_code(KC_VOLD);
+            }
+            return false;
+        case KC_VOLU:
+            if (record->event.pressed) {
+                tap_code_delay(KC_VOLU, 20);
+            } else {
+                unregister_code(KC_VOLU);
+            }
+            return false;
+        default:
+            return true;
+    }
+}
+
 #ifdef OLED_ENABLE
 uint32_t anim_timer = 0;
 uint32_t anim_sleep = 0;

--- a/keyboards/ramonimbao/herringbone/pro/keymaps/via/keymap.c
+++ b/keyboards/ramonimbao/herringbone/pro/keymaps/via/keymap.c
@@ -64,36 +64,17 @@ keyevent_t encoder_cw = {
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_ccw)) {
+        wait_ms(20);
         encoder_ccw.pressed = false;
         encoder_ccw.time = (timer_read() | 1);
         action_exec(encoder_ccw);
     }
 
     if (IS_PRESSED(encoder_cw)) {
+        wait_ms(20);
         encoder_cw.pressed = false;
         encoder_cw.time = (timer_read() | 1);
         action_exec(encoder_cw);
-    }
-}
-
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
-        case KC_VOLD:
-            if (record->event.pressed) {
-                tap_code_delay(KC_VOLD, 20);
-            } else {
-                unregister_code(KC_VOLD);
-            }
-            return false;
-        case KC_VOLU:
-            if (record->event.pressed) {
-                tap_code_delay(KC_VOLU, 20);
-            } else {
-                unregister_code(KC_VOLU);
-            }
-            return false;
-        default:
-            return true;
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
1) Flips the encoder behavior so it behaves correctly.

2) Users were encountering a weird behavior where turning the encoder sometimes causes it to go to min or max volume, even if using high quality ALPS encoders.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

The weird volume issue only happens with VIA keymap so it must be because of the encoder mapping code thing. I added code to override the behavior of `KC_VOLU` and `KC_VOLD`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
