### PR TITLE
[Core] Add configuration of PMW3360 lift off distance

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -150,6 +150,7 @@ The PMW 3360 is an SPI driven optical sensor, that uses a built in IR LED for su
 |`PMW3360_SPI_LSBFIRST`       | (Optional) Sets the Least/Most Significant Byte First setting for SPI.                     | `false`       |
 |`PMW3360_SPI_MODE`           | (Optional) Sets the SPI Mode for the sensor.                                               | `3`           |
 |`PMW3360_SPI_DIVISOR`        | (Optional) Sets the SPI Divisor used for SPI communication.                                | _varies_      |
+|`PMW3360_LIFTOFF_DISTANCE`   | (Optional) Sets the lift off distance at run time                                          | `0x02`        |
 |`ROTATIONAL_TRANSFORM_ANGLE` | (Optional) Allows for the sensor data to be rotated +/- 30 degrees directly in the sensor. | `0`           |
 
 The CPI range is 100-12000, in increments of 100. Defaults to 1600 CPI.

--- a/drivers/sensors/pmw3360.c
+++ b/drivers/sensors/pmw3360.c
@@ -186,6 +186,10 @@ bool pmw3360_init(void) {
 
     spi_write_adv(REG_Angle_Tune, constrain(ROTATIONAL_TRANSFORM_ANGLE, -30, 30));
 
+#ifdef PMW3360_LIFTOFF_DISTANCE
+    spi_write_adv(REG_Lift_Config, PMW3360_LIFTOFF_DISTANCE);
+#endif
+
     bool init_success = pmw3360_check_signature();
 
     writePinLow(PMW3360_CS_PIN);

--- a/drivers/sensors/pmw3360.c
+++ b/drivers/sensors/pmw3360.c
@@ -186,9 +186,7 @@ bool pmw3360_init(void) {
 
     spi_write_adv(REG_Angle_Tune, constrain(ROTATIONAL_TRANSFORM_ANGLE, -30, 30));
 
-#ifdef PMW3360_LIFTOFF_DISTANCE
     spi_write_adv(REG_Lift_Config, PMW3360_LIFTOFF_DISTANCE);
-#endif
 
     bool init_success = pmw3360_check_signature();
 

--- a/drivers/sensors/pmw3360.h
+++ b/drivers/sensors/pmw3360.h
@@ -46,6 +46,10 @@
 #    endif
 #endif
 
+#ifndef PMW3360_LIFTOFF_DISTANCE
+#    define PMW3360_LIFTOFF_DISTANCE 0x02
+#endif
+
 #ifndef ROTATIONAL_TRANSFORM_ANGLE
 #    define ROTATIONAL_TRANSFORM_ANGLE 0x00
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds the ability to set the lift off distance between the sensor and the surface.
Currently the default is set to `0x02` (please refer to the datasheet). 
Using `#define PMW3360_LIFTOFF_DISTANCE xxx` will allow the user to set the wanted distance. 

e.g. `#define PMW3360_LIFTOFF_DISTANCE 0x27`

Tested and working

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Add lift off distance change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
