### PR TITLE
Fix RESET not working for keyboards with Kiibohd bootloader

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -290,7 +290,7 @@ Compatible flashers:
 Flashing sequence:
 
 1. Enter the bootloader using any of the following methods:
-    * Tap the `RESET` keycode (this may only enter the MCU into a "secure" bootloader mode; see https://github.com/qmk/qmk_firmware/issues/6112)
+    * Tap the `RESET` keycode
     * Press the `RESET` button on the PCB
 2. Wait for the OS to detect the device
 3. Flash a .bin file

--- a/platforms/chibios/bootloader.c
+++ b/platforms/chibios/bootloader.c
@@ -123,7 +123,6 @@ void enter_bootloader_mode_if_requested(void) { /* Jumping to bootloader is not 
 #    if defined(BOOTLOADER_KIIBOHD)
 /* Kiibohd Bootloader (MCHCK and Infinity KB) */
 #        define SCB_AIRCR_VECTKEY_WRITEMAGIC 0x05FA0000
-
 const uint8_t              sys_reset_to_loader_magic[] = "\xff\x00\x7fRESET TO LOADER\x7f\x00\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 __attribute__((weak)) void bootloader_jump(void) {
     void *volatile vbat = (void *)VBAT;

--- a/platforms/chibios/bootloader.c
+++ b/platforms/chibios/bootloader.c
@@ -124,15 +124,10 @@ void enter_bootloader_mode_if_requested(void) { /* Jumping to bootloader is not 
 /* Kiibohd Bootloader (MCHCK and Infinity KB) */
 #        define SCB_AIRCR_VECTKEY_WRITEMAGIC 0x05FA0000
 
-// taken from Kiibohd/controller
-#        define VBAT_SECURE1            *(volatile uint32_t *)0x4003E018 // Kiibohd Secure 32 bit register 1 (24th byte)
-#        define VBAT_SECURE2            *(volatile uint32_t *)0x4003E01C // Kiibohd Secure 32 bit register 2 (28th byte)
-const uint8_t              sys_reset_to_loader_magic[] = "\xff\x00\x7fRESET TO LOADER\x7f\x00\xff";
+const uint8_t              sys_reset_to_loader_magic[] = "\xff\x00\x7fRESET TO LOADER\x7f\x00\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 __attribute__((weak)) void bootloader_jump(void) {
     void *volatile vbat = (void *)VBAT;
     __builtin_memcpy(vbat, (const void *)sys_reset_to_loader_magic, sizeof(sys_reset_to_loader_magic));
-    VBAT_SECURE1 = 0;
-    VBAT_SECURE2 = 0;
     // request reset
     SCB->AIRCR = SCB_AIRCR_VECTKEY_WRITEMAGIC | SCB_AIRCR_SYSRESETREQ_Msk;
 }

--- a/platforms/chibios/bootloader.c
+++ b/platforms/chibios/bootloader.c
@@ -123,10 +123,16 @@ void enter_bootloader_mode_if_requested(void) { /* Jumping to bootloader is not 
 #    if defined(BOOTLOADER_KIIBOHD)
 /* Kiibohd Bootloader (MCHCK and Infinity KB) */
 #        define SCB_AIRCR_VECTKEY_WRITEMAGIC 0x05FA0000
+
+// taken from Kiibohd/controller
+#        define VBAT_SECURE1            *(volatile uint32_t *)0x4003E018 // Kiibohd Secure 32 bit register 1 (24th byte)
+#        define VBAT_SECURE2            *(volatile uint32_t *)0x4003E01C // Kiibohd Secure 32 bit register 2 (28th byte)
 const uint8_t              sys_reset_to_loader_magic[] = "\xff\x00\x7fRESET TO LOADER\x7f\x00\xff";
 __attribute__((weak)) void bootloader_jump(void) {
     void *volatile vbat = (void *)VBAT;
     __builtin_memcpy(vbat, (const void *)sys_reset_to_loader_magic, sizeof(sys_reset_to_loader_magic));
+    VBAT_SECURE1 = 0;
+    VBAT_SECURE2 = 0;
     // request reset
     SCB->AIRCR = SCB_AIRCR_VECTKEY_WRITEMAGIC | SCB_AIRCR_SYSRESETREQ_Msk;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This is a fix for https://github.com/qmk/qmk_firmware/issues/6112. Keyboards with the Kiibohd bootloader would go into [secure DFU mode](https://github.com/kiibohd/controller/blob/master/Bootloader/Documentation/SecureDFU.md). In secure DFU mode the bootloader would do an extra key verification where it would look for a key in the first block of the new firmware. There is a way to disable this functionality, and after talking with @haata, I was able to implement this fix.

I have a K-type and this fixed the issue on my keyboard. If anyone that has a different keyboard, let me know if this fix also works on your board.


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* Fixes #6112

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
