### PR TITLE
[Docs] Fix Header formatting in compatible mcu doc

### DIFF
--- a/docs/compatible_microcontrollers.md
+++ b/docs/compatible_microcontrollers.md
@@ -38,7 +38,7 @@ You can also use any ARM chip with USB that [ChibiOS](https://www.chibios.org) s
  * [STM32L433](https://www.st.com/en/microcontrollers-microprocessors/stm32l4x3.html)
  * [STM32L443](https://www.st.com/en/microcontrollers-microprocessors/stm32l4x3.html)
  
- ### WestBerryTech (WB32)
+### WestBerryTech (WB32)
 
  * [WB32F3G71xx](http://www.westberrytech.com)
 

--- a/docs/compatible_microcontrollers.md
+++ b/docs/compatible_microcontrollers.md
@@ -37,7 +37,7 @@ You can also use any ARM chip with USB that [ChibiOS](https://www.chibios.org) s
  * [STM32L422](https://www.st.com/en/microcontrollers-microprocessors/stm32l4x2.html)
  * [STM32L433](https://www.st.com/en/microcontrollers-microprocessors/stm32l4x3.html)
  * [STM32L443](https://www.st.com/en/microcontrollers-microprocessors/stm32l4x3.html)
- 
+
 ### WestBerryTech (WB32)
 
  * [WB32F3G71xx](http://www.westberrytech.com)


### PR DESCRIPTION
## Description

There is an errant space before `### WestberryTech` and it's messing up the formatting.

![](https://media.discordapp.net/attachments/473506116718952450/918344148275310612/unknown.png)

## Types of Changes

- [x] Documentation

## Issues Fixed or Closed by This PR

* https://discord.com/channels/440868230475677696/473506116718952450/918344148891861012

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
