### PR TITLE
added missing audio_off_user() callback

### DIFF
--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -160,6 +160,8 @@ void audio_toggle(void) {
     eeconfig_update_audio(audio_config.raw);
     if (audio_config.enable) {
         audio_on_user();
+    } else {
+        audio_off_user();
     }
 }
 
@@ -172,6 +174,7 @@ void audio_on(void) {
 
 void audio_off(void) {
     PLAY_SONG(audio_off_song);
+    audio_off_user();
     wait_ms(100);
     audio_stop_all();
     audio_config.enable = 0;

--- a/quantum/process_keycode/process_audio.c
+++ b/quantum/process_keycode/process_audio.c
@@ -57,3 +57,4 @@ void process_audio_noteoff(uint8_t note) { stop_note(compute_freq_for_midi_note(
 void process_audio_all_notes_off(void) { stop_all_notes(); }
 
 __attribute__((weak)) void audio_on_user() {}
+__attribute__((weak)) void audio_off_user() {}

--- a/quantum/process_keycode/process_audio.h
+++ b/quantum/process_keycode/process_audio.h
@@ -8,3 +8,4 @@ void process_audio_noteoff(uint8_t note);
 void process_audio_all_notes_off(void);
 
 void audio_on_user(void);
+void audio_off_user(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This PR adds missing `audio_off_user()` callback. 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
In order to react on audio being enabled/disabled the callbacks `audio_on_user()` and `audio_off_user()` are desirable. 
The latter mentioned callback is missing. 


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization 
  - very minor enhancement
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
  - did not find a place to document

## Issues Fixed or Closed by This PR

* no issues found by the following filter: [is:open audio_off_user](https://github.com/qmk/qmk_firmware/issues?q=is%3Aissue+is%3Aopen+audio_off_user)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
    - [x] manual test on split keyboard (master reacts on audio on/off changes, then sends audio on/off requests to slave)
