### PR TITLE
Add 'capslock backlight' feature to Iron180

### DIFF
--- a/keyboards/iron180/config.h
+++ b/keyboards/iron180/config.h
@@ -49,4 +49,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_RESYNC_ENABLE
 
 // Turn backlight on-off according to capslock (off by default)
-//#define CAPSLOCK_BACKLIGHT
+#define CAPSLOCK_BACKLIGHT

--- a/keyboards/iron180/config.h
+++ b/keyboards/iron180/config.h
@@ -47,3 +47,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
+
+// Turn backlight on-off according to capslock (off by default)
+//#define CAPSLOCK_BACKLIGHT

--- a/keyboards/iron180/iron180.c
+++ b/keyboards/iron180/iron180.c
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Álvaro "Gondolindrim" Volpato  <gondolindrim@acheronproject.com>
+Copyright 2021 Álvaro "Gondolindrim" Volpato  <gondolindrim@acheronproject.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -16,3 +16,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "iron180.h"
+
+#ifdef CAPSLOCK_BACKLIGHT
+bool led_update_kb(led_t led_state) {
+    bool res = led_update_user(led_state);
+    if (!led_state.caps_lock){
+        if (is_backlight_breathing()) breathing_disable();
+        backlight_disable();
+    }
+    else {
+	if (is_backlight_breathing()) breathing_enable();
+        backlight_enable();
+    }
+    return res;
+}
+#endif

--- a/keyboards/iron180/readme.md
+++ b/keyboards/iron180/readme.md
@@ -31,3 +31,16 @@ Then, after accessing the DFU state, use a tool like `dfu-util` or the QMK Toolb
     make iron180:default:flash
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## The 'caps lock backlight' feature
+
+The Iron180 firmware allows the user to adjust the backlight according to the caps lock key. This will toggle *all backlight LEDs* according to caps lock, enabling backlight when caps is on and disabling when it is off.
+
+This option is specially useful if you are only interested in the caps lock LED and want it to work as an indicator; however, it must be noted that this works keyboard-wide, so if that is your case you should only solder the caps lock key LED and none else.
+
+This option is disabled by default; in order to enable it, you must un-comment the last line in `config.h`:
+
+    // Turn backlight on-off according to capslock
+    #define CAPSLOCK_BACKLIGHT
+
+Then compile and flash the firmware.


### PR DESCRIPTION
## Description

Some Iron180 users have shown interest in only having the caps lock LED soldered and for it to work as a caps lock indicator.

This PR adds a `CAPSLOCK_BACKLIGHT`  define in `config.h` which in turn enables a led state function in `iron180.c`  that toggles backlight and breathing according to caps lock. The PR also contains README instructions.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
