### PR TITLE
Allow overriding the rule for `$(KEYMAP_OUTPUT)/src/keymap.c`

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -139,13 +139,6 @@ ifneq ("$(wildcard $(KEYMAP_JSON))", "")
     KEYMAP_C := $(KEYMAP_OUTPUT)/src/keymap.c
     KEYMAP_H := $(KEYMAP_OUTPUT)/src/config.h
 
-    # Load the keymap-level rules.mk if exists
-    -include $(KEYMAP_PATH)/rules.mk
-
-    # Load any rules.mk content from keymap.json
-    INFO_RULES_MK = $(shell $(QMK_BIN) generate-rules-mk --quiet --escape --keyboard $(KEYBOARD) --keymap $(KEYMAP) --output $(KEYMAP_OUTPUT)/src/rules.mk)
-    include $(INFO_RULES_MK)
-
 # Add rules to generate the keymap files - indentation here is important
 $(KEYMAP_OUTPUT)/src/keymap.c: $(KEYMAP_JSON)
 	$(QMK_BIN) json2c --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)
@@ -155,6 +148,12 @@ $(KEYMAP_OUTPUT)/src/config.h: $(KEYMAP_JSON)
 
 generated-files: $(KEYMAP_OUTPUT)/src/config.h $(KEYMAP_OUTPUT)/src/keymap.c
 
+    # Load the keymap-level rules.mk if exists
+    -include $(KEYMAP_PATH)/rules.mk
+
+    # Load any rules.mk content from keymap.json
+    INFO_RULES_MK = $(shell $(QMK_BIN) generate-rules-mk --quiet --escape --keyboard $(KEYBOARD) --keymap $(KEYMAP) --output $(KEYMAP_OUTPUT)/src/rules.mk)
+    include $(INFO_RULES_MK)
 endif
 
 ifeq ($(strip $(CTPC)), yes)


### PR DESCRIPTION
## Description

Reorder the keymap.json branch in build_keyboard.mk such that
keymap rules.mk definitions can define their own rule for the
generated keymap.c and config.h files

This is also a step towards #6873; provides a similar solution to what #13197 did, but this time by allowing a keymap to create their own keymap.c generation override.

For example, with the changes included on this branch, I am able to do this:

```
$(KEYMAP_C): $(KEYMAP_JSON)
	$(QMK_BIN) json2c --quiet --output $(KEYMAP_C) $(KEYMAP_JSON)
	sed -i -e '2 i #include "pfn_keymap.h"' $(KEYMAP_C)
```

The downside of this approach is that there is an overridden recipe warning, but perhaps that is a good thing.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #6873

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
