### PR TITLE
Fix inverted gt and lt send_string mapping in canadian multilingual

### DIFF
--- a/quantum/keymap_extras/sendstring_canadian_multilingual.h
+++ b/quantum/keymap_extras/sendstring_canadian_multilingual.h
@@ -80,7 +80,7 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // 0     1        2        3        4        5        6        7
     CA_0,    CA_1,    CA_2,    CA_3,    CA_4,    CA_5,    CA_6,    CA_7,
     // 8     9        :        ;        <        =        >        ?
-    CA_8,    CA_9,    CA_SCLN, CA_SCLN, CA_DOT,  CA_EQL,  CA_COMM, CA_6,
+    CA_8,    CA_9,    CA_SCLN, CA_SCLN, CA_COMM, CA_EQL,  CA_DOT, CA_6,
     // @     A        B        C        D        E        F        G
     CA_2,    CA_A,    CA_B,    CA_C,    CA_D,    CA_E,    CA_F,    CA_G,
     // H     I        J        K        L        M        N        O

--- a/quantum/keymap_extras/sendstring_canadian_multilingual.h
+++ b/quantum/keymap_extras/sendstring_canadian_multilingual.h
@@ -80,7 +80,7 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // 0     1        2        3        4        5        6        7
     CA_0,    CA_1,    CA_2,    CA_3,    CA_4,    CA_5,    CA_6,    CA_7,
     // 8     9        :        ;        <        =        >        ?
-    CA_8,    CA_9,    CA_SCLN, CA_SCLN, CA_COMM, CA_EQL,  CA_DOT, CA_6,
+    CA_8,    CA_9,    CA_SCLN, CA_SCLN, CA_COMM, CA_EQL,  CA_DOT,  CA_6,
     // @     A        B        C        D        E        F        G
     CA_2,    CA_A,    CA_B,    CA_C,    CA_D,    CA_E,    CA_F,    CA_G,
     // H     I        J        K        L        M        N        O


### PR DESCRIPTION
It seems to me `<` and `>` were inversed in the canadian multilingual mapping.