### PR TITLE
Fix some wrong keycode macros in locale mapping files

### DIFF
--- a/quantum/keymap_extras/keymap_lithuanian_azerty.h
+++ b/quantum/keymap_extras/keymap_lithuanian_azerty.h
@@ -138,7 +138,7 @@
 #define LT_CIRC ALGR(LT_COMM) // ^
 #define LT_AMPR ALGR(LT_DOT)  // &
 #define LT_ASTR ALGR(LT_EQL)  // *
-#define LT_LBRC ALGR(LT_LRPN) // [
+#define LT_LBRC ALGR(LT_LPRN) // [
 #define LT_RBRC ALGR(LT_RPRN) // ]
 #define LT_QUOT ALGR(LT_QUES) // '
 #define LT_PERC ALGR(LT_X)    // %

--- a/quantum/keymap_extras/keymap_slovak.h
+++ b/quantum/keymap_extras/keymap_slovak.h
@@ -102,10 +102,10 @@
 // Row 1
 #define SK_RNGA S(SK_SCLN) // ° (dead)
 #define SK_1    S(SK_PLUS) // 1
-#define SK_2    S(SK_LACU) // 2
+#define SK_2    S(SK_LCAR) // 2
 #define SK_3    S(SK_SCAR) // 3
 #define SK_4    S(SK_CCAR) // 4
-#define SK_5    S(SK_TACU) // 5
+#define SK_5    S(SK_TCAR) // 5
 #define SK_6    S(SK_ZCAR) // 6
 #define SK_7    S(SK_YACU) // 7
 #define SK_8    S(SK_AACU) // 8

--- a/quantum/keymap_extras/sendstring_lithuanian_azerty.h
+++ b/quantum/keymap_extras/sendstring_lithuanian_azerty.h
@@ -76,9 +76,9 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     //       !        "        #        $        %        &        '
     KC_SPC,  LT_EXLM, LT_EDOT, LT_SLSH, LT_SCLN, LT_X,    LT_DOT,  LT_QUES,
     // (     )        *        +        ,        -        .        /
-    LT_LRPN, LT_RPRN, LT_EQL,  LT_QUES, LT_COMM, LT_MINS, LT_DOT,  LT_SLSH,
+    LT_LPRN, LT_RPRN, LT_EQL,  LT_QUES, LT_COMM, LT_MINS, LT_DOT,  LT_SLSH,
     // 0     1        2        3        4        5        6        7
-    LT_RPRN, LT_EXLM, LT_MINS, LT_SLSH, LT_SLCN, LT_COLN, LT_COMM, LT_DOT,
+    LT_RPRN, LT_EXLM, LT_MINS, LT_SLSH, LT_SCLN, LT_COLN, LT_COMM, LT_DOT,
     // 8     9        :        ;        <        =        >        ?
     LT_EQL,  LT_LPRN, LT_COLN, LT_SCLN, LT_LABK, LT_EQL,  LT_LABK, LT_QUES,
     // @     A        B        C        D        E        F        G

--- a/quantum/keymap_extras/sendstring_slovak.h
+++ b/quantum/keymap_extras/sendstring_slovak.h
@@ -78,7 +78,7 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // (     )        *        +        ,        -        .        /
     SK_ADIA, SK_NCAR, SK_AMPR, SK_PLUS, SK_COMM, SK_MINS, SK_DOT,  SK_UACU,
     // 0     1        2        3        4        5        6        7
-    SK_EACU, SK_PLUS, SK_LACU, SK_SCAR, SK_CCAR, SK_TACU, SK_ZCAR, SK_YACU,
+    SK_EACU, SK_PLUS, SK_LCAR, SK_SCAR, SK_CCAR, SK_TCAR, SK_ZCAR, SK_YACU,
     // 8     9        :        ;        <        =        >        ?
     SK_AACU, SK_IACU, SK_DOT,  SK_SCLN, SK_AMPR, SK_EQL,  SK_Y,    SK_COMM,
     // @     A        B        C        D        E        F        G


### PR DESCRIPTION
Fix the issue that some undefined macros are used in `keymap_[locale].h` files and `sendstring_[locale].h` files. 

## Description

There are some undefined macros in `keymap_[locale].h` files and `sendstring_[locale].h` files. The compilation of the code set for each keyboard will be failed, if the code set includes these wrong header files.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
