### PR TITLE
Add Auto Mod based on Auto Shift

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -621,6 +621,22 @@ ifeq ($(strip $(AUTO_SHIFT_ENABLE)), yes)
     endif
 endif
 
+ifeq ($(strip $(AUTO_MOD_ENABLE)), yes)
+    SRC += $(QUANTUM_DIR)/process_keycode/process_auto_mod.c
+    OPT_DEFS += -DAUTO_MOD_ENABLE
+    # get which mod key to use
+    ifeq ($strip $(AUTO_MOD), ctrl)
+        OPT_DEFS += -DAUTO_MOD_CTRL
+    else ifeq ($strip $(AUTO_MOD), alt)
+        OPT_DEFS += -DAUTO_MOD_ALT
+    else ifeq ($strip $(AUTO_MOD), gui)
+        OPT_DEFS += -DAUTO_MOD_GUI
+    endif
+    ifeq ($(strip $(AUTO_MOD_MODIFIERS)), yes)
+        OPT_DEFS += -DAUTO_MOD_MODIFIERS
+    endif
+endif
+
 ifeq ($(strip $(PS2_MOUSE_ENABLE)), yes)
     PS2_ENABLE := yes
     SRC += ps2_mouse.c

--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -78,7 +78,7 @@
     * [US ANSI Shifted Keys](keycodes_us_ansi_shifted.md)
 
   * Software Features
-    * [Auto Shift](feature_auto_shift.md)
+    * [Auto Mod](feature_auto_mod.md)
     * [Combos](feature_combo.md)
     * [Debounce API](feature_debounce_type.md)
     * [Key Lock](feature_key_lock.md)

--- a/docs/feature_auto_mod.md
+++ b/docs/feature_auto_mod.md
@@ -1,0 +1,381 @@
+# Auto Mod: Why Do We Need a Mod Key?
+
+> Auto Mod is heavily based on [Auto Shift](feature_auto_shift.md), adding
+> the ability to specify which mod key you would like applied when a key is
+> held.
+
+Tap a key and you get its character. Tap a key, but hold it *slightly* longer
+and you get its modded state. Voilà! No mod key needed! You can set the mod key
+to be *shift*, *ctrl*, *alt*, or *gui*.
+
+## Why Auto Mod?
+
+Many people suffer from various forms of RSI. A common cause is stretching your
+fingers repetitively long distances. For us on the keyboard, the pinky does that
+all too often when reaching for modifier keys. Auto Mod looks to alleviate that
+problem.
+
+## How Does It Work?
+
+When you tap a key, it stays depressed for a short period of time before it is
+then released. This depressed time is a different length for everyone. Auto Mod
+defines a constant `AUTO_MOD_TIMEOUT` which is typically set to twice your
+normal pressed state time. When you press a key, a timer starts, and if you
+have not released the key after the `AUTO_MOD_TIMEOUT` period, then a modded
+version of the key is emitted. If the time is less than the `AUTO_MOD_TIMEOUT`
+time, or you press another key, then the normal state is emitted.
+
+If `AUTO_MOD_REPEAT` is defined, there is keyrepeat support. Holding the key
+down will repeat the modded key, though this can be disabled with
+`AUTO_MOD_NO_AUTO_REPEAT`. If you want to repeat the normal key, then tap it
+once then immediately (within `TAPPING_TERM`) hold it down again (this works
+with the modded value as well if auto-repeat is disabled).
+
+There are also the `get_auto_mod_repeat` and `get_auto_mod_no_auto_repeat`
+functions for more granular control. Neither will have an effect unless
+`AUTO_MOD_REPEAT_PER_KEY` or `AUTO_MOD_NO_AUTO_REPEAT_PER_KEY` respectively
+are defined.
+
+## Are There Limitations to Auto Mod?
+
+Yes, unfortunately.
+
+1. You will have characters that are modded when you did not intend on modding, and
+   other characters you wanted modded, but were not. This simply comes down to
+   practice. As we get in a hurry, we think we have hit the key long enough for a
+   modded version, but we did not. On the other hand, we may think we are tapping
+   the keys, but really we have held it for a little longer than anticipated.
+2. Additionally, with keyrepeat the desired mod state can get mixed up. It will
+   always 'belong' to the last key pressed. For example, keyrepeating a capital
+   and then tapping something lowercase if the mod is set to *shift* (whether or not
+   it's an Auto Mod key) will result in the capital's *key* still being held, but
+   not shift.
+3. Auto Mod does not apply to Tap Hold keys. For automatic modding of Tap Hold
+   keys see [Retro Mod](#retro-mod).
+
+## How Do I Enable Auto Mod?
+
+Add to your `rules.mk` in the keymap folder:
+
+    AUTO_MOD_ENABLE = yes
+
+And optionally, one of these:
+
+    AUTO_MOD = shift
+    AUTO_MOD = ctrl
+    AUTO_MOD = alt
+    AUTO_MOD = gui
+
+This specifies which modifier key is added on hold. The default is *shift* if one
+is not specified.
+
+If no `rules.mk` exists, you can create one.
+
+Then compile and install your new firmware with Auto Mod enabled! That's it!
+
+## Modifiers
+
+By default, Auto Mod is disabled for any key press that is accompanied by one or more
+modifiers. Thus, holding Ctrl+A for a long time is not the same
+as Ctrl+Modifier+A.
+
+You can re-enable Auto Mod for modifiers by adding a define to your `config.h`
+
+```c
+#define AUTO_MOD_MODIFIERS
+```
+
+In which case, Ctrl+A held past the `AUTO_MOD_TIMEOUT` will be sent as Ctrl+Modifier+A
+
+
+## Configuring Auto Mod
+
+If desired, there is some configuration that can be done to change the
+behavior of Auto Mod. This is done by setting various variables in the
+`config.h` file located in your keymap folder.
+
+If no `config.h` file exists, you can create one.
+
+A sample:
+
+```c
+#pragma once
+
+#define AUTO_MOD_TIMEOUT 150
+#define NO_AUTO_MOD_SPECIAL
+```
+
+### AUTO_MOD_TIMEOUT (value in ms)
+
+This controls how long you have to hold a key before you get the modded state.
+Obviously, this is different for everyone. For the average person, a setting of
+135 to 150 works great. However, one should start with a value of at least 175,
+which is the default value, then work down from there. The idea is to have the
+shortest time required to get the modded state without having false positives.
+
+Play with this value until things are perfect. Many find that all will work well
+at a given value, but one or two keys will still emit the modded state on
+occasion. This is simply due to habit and holding some keys a little longer
+than others. Once you find this value, work on tapping your problem keys a little
+quicker than normal and you will be set.
+
+?> Auto Mod has three special keys that can help you get this value right very quickly. See "Auto Mod Setup" for more details!
+
+For more granular control of this feature, you can add the following to your `config.h`:
+
+```c
+#define AUTO_MOD_TIMEOUT_PER_KEY
+```
+
+You can then add the following function to your keymap:
+
+```c
+uint16_t get_automod_timeout(uint16_t keycode, keyrecord_t *record) {
+    switch(keycode) {
+        case AUTO_MOD_NUMERIC:
+            return 2 * get_generic_automod_timeout();
+        case AUTO_MOD_SPECIAL:
+            return get_generic_automod_timeout() + 50;
+        case AUTO_MOD_ALPHA:
+        default:
+            return get_generic_automod_timeout();
+    }
+}
+```
+
+Note that you cannot override individual keys that are in one of those groups
+if you are using them; trying to add a case for `KC_A` in the above example will
+not compile as `AUTO_MOD_ALPHA` is there. A possible solution is a second switch
+above to handle individual keys with no default case and only referencing the
+groups in the below fallback switch.
+
+### NO_AUTO_MOD_SPECIAL (simple define)
+
+Do not Auto Mod special keys, which include -\_, =+, [{, ]}, ;:, '", ,<, .>,
+and /?
+
+### NO_AUTO_MOD_NUMERIC (simple define)
+
+Do not Auto Mod numeric keys, zero through nine.
+
+### NO_AUTO_MOD_ALPHA (simple define)
+
+Do not Auto Mod alpha characters, which include A through Z.
+
+### Auto Mod Per Key
+
+There are functions that allows you to determine which keys shold be automodded,
+much like the tap-hold keys.
+
+The first of these, used to simply add a key to Auto Mod, is `get_custom_auto_modded_key`:
+
+```c
+bool get_custom_auto_modded_key(uint16_t keycode, keyrecord_t *record) {
+    switch(keycode) {
+        case KC_DOT:
+            return true;
+        default:
+            return false;
+    }
+}
+```
+
+For more granular control, there is `get_auto_modded_key`. The default function looks like this:
+
+```c
+bool get_auto_modded_key(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+#    ifndef NO_AUTO_MOD_ALPHA
+        case KC_A ... KC_Z:
+#    endif
+#    ifndef NO_AUTO_MOD_NUMERIC
+        case KC_1 ... KC_0:
+#    endif
+#    ifndef NO_AUTO_MOD_SPECIAL
+        case KC_TAB:
+        case KC_MINUS ... KC_SLASH:
+        case KC_NONUS_BACKSLASH:
+#    endif
+            return true;
+    }
+    return get_custom_auto_modded_key(keycode, record);
+}
+```
+
+This functionality is enabled by default, and does not need a define.
+
+### AUTO_MOD_REPEAT (simple define)
+
+Enables keyrepeat.
+
+### AUTO_MOD_NO_AUTO_REPEAT (simple define)
+
+Disables automatically keyrepeating when `AUTO_MOD_TIMEOUT` is exceeded.
+
+## Custom Modded Values
+
+Especially on small keyboards, the default modded value for many keys is not
+optimal. To provide more customizability, there are two user-definable
+functions, `automod_press/release_user`. These register or unregister the
+correct value for the passed key. Below is an example adding period to Auto
+Mod and making its modded value exclamation point. Make sure to use weak
+mods - setting real would make any keys following it use their modded values
+as if you were holding the key. Clearing of modifiers is handled by Auto Mod,
+and the OS-sent mod value if keyrepeating multiple keys is always that of
+the last key pressed (whether or not it's an Auto Mod key).
+
+You can also have non-modded keys for the modded values (or even no modded
+value), just don't set a modifier!
+
+Auto Mod uses the left modifier key codes. To manually apply the selected
+modifier, use `AUTO_MOD_KEY_L` as the key.
+
+```c
+bool get_custom_auto_moddeded_key(uint16_t keycode, keyrecord_t *record) {
+    switch(keycode) {
+        case KC_DOT:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void automod_press_user(uint16_t keycode, bool modded, keyrecord_t *record) {
+    switch(keycode) {
+        case KC_DOT:
+            register_code16((!modded) ? KC_DOT : KC_EXLM);
+            break;
+        default:
+            if (modded) {
+                add_weak_mods(MOD_BIT(AUTO_MOD_KEY_L));
+            }
+            // & 0xFF gets the Tap key for Tap Holds, required when using Retro Mod
+            register_code16((IS_RETRO(keycode)) ? keycode & 0xFF : keycode);
+    }
+}
+
+void automod_release_user(uint16_t keycode, bool modded, keyrecord_t *record) {
+    switch(keycode) {
+        case KC_DOT:
+            unregister_code16((!modded) ? KC_DOT : KC_EXLM);
+            break;
+        default:
+            // & 0xFF gets the Tap key for Tap Holds, required when using Retro Mod
+            // The IS_RETRO check isn't really necessary here, always using
+            // keycode & 0xFF would be fine.
+            unregister_code16((IS_RETRO(keycode)) ? keycode & 0xFF : keycode);
+    }
+}
+```
+
+## Retro Mod
+
+Holding and releasing a Tap Hold key without pressing another key will ordinarily
+result in only the hold. With `retro mod` enabled this action will instead
+produce a modded version of the tap keycode on release.
+
+It does not require [Retro Tapping](tap_hold.md#retro-tapping) to be enabled, and
+if both are enabled the state of `retro tapping` will only apply if the tap keycode
+is not matched by Auto Mod. `RETRO_TAPPING_PER_KEY` and its corresponding
+function, however, are checked before `retro mod` is applied.
+
+To enable `retro mod`, add the following to your `config.h`:
+
+```c
+#define RETRO_MOD
+```
+
+If `RETRO_MOD` is defined to a value, hold times greater than that value will
+not produce a tap on release for Mod Taps, and instead triggers the hold action.
+This enables modifiers to be held for combining with mouse clicks without
+generating taps on release. For example:
+
+```c
+#define RETRO_MOD 500
+```
+
+This value (if set) must be greater than one's `TAPPING_TERM`, as the key press
+must be designated as a 'hold' by `process_tapping` before we send the modifier.
+There is no such limitation in regards to `AUTO_MOD_TIMEOUT` for normal keys.
+
+### Retro Mod and Tap Hold Configurations
+
+Tap Hold Configurations work a little differently when using Retro Mod.
+Referencing `TAPPING_TERM` makes little sense, as holding longer would result in
+modding one of the keys.
+
+`IGNORE_MOD_TAP_INTERRUPT` changes *only* rolling from a mod tap (releasing it
+first), sending both keys instead of the modifier on the second. Its effects on
+nested presses are ignored.
+
+As nested taps were changed to act as though `PERMISSIVE_HOLD` is set unless only
+`IGNORE_MOD_TAP_INTERRUPT` is (outside of Retro Mod), and Retro Mod ignores
+`IGNORE_MOD_TAP_INTERRUPT`, `PERMISSIVE_HOLD` has no effect on Mod Taps.
+
+Nested taps will *always* act as though the `TAPPING_TERM` was exceeded for both
+Mod and Layer Tap keys.
+
+## Using Auto Mod Setup
+
+This will enable you to define keys to increase, decrease and report your `AUTO_MOD_TIMEOUT`.
+
+### Setup
+
+Map at least `KC_AMDN`, `KC_AMUP`, and `KC_AMRP` in your keymap:
+
+| Key Name | Description                                      |
+|----------|--------------------------------------------------|
+| KC_AMDN  | Lower the Auto Mod timeout variable (down)       |
+| KC_AMUP  | Raise the Auto Mod timeout variable (up)         |
+| KC_AMRP  | Report your current Auto Mod timeout value       |
+| KC_AMON  | Turns on the Auto Mod feature                    |
+| KC_AMOFF | Turns off the Auto Mod feature                   |
+| KC_AMTG  | Toggles the state of the Auto Mod feature        |
+
+Compile and upload your new firmware.
+
+### Use
+
+Testing is most easily done with *shift* as the modifier.
+
+It is important to note that during these tests, you should be typing
+normally with no intent to trigger Auto Mod.
+
+1. Type multiple sentences of alphabetical letters.
+2. Observe any upper case letters.
+3. If there are none, press the key you have mapped to `KC_AMDN` to decrease
+   time Auto Mod timeout value and go back to step 1.
+4. If there are some upper case letters, decide if you need to work on tapping
+   those keys with less down time, or if you need to increase the timeout.
+5. If you decide to increase the timeout, press the key you have mapped to
+   `KC_AMUP` and go back to step 1.
+6. Once you are happy with your results, press the key you have mapped to
+   `KC_AMRP`. The keyboard will type by itself the value of your
+   `AUTO_MOD_TIMEOUT`.
+7. Update `AUTO_MOD_TIMEOUT` in your `config.h` with the value reported.
+8. Add `AUTO_MOD_NO_SETUP` to your `config.h`.
+9. (optional) Remove the test key bindings from your keymap.
+10. Compile and upload your new firmware.
+
+#### An Example Run
+
+    hello world. my name is john doe. i am a computer programmer playing with
+    keyboards right now.
+
+    [PRESS KC_AMDN quite a few times]
+
+    heLLo woRLd. mY nAMe is JOHn dOE. i AM A compUTeR proGRaMMER PlAYiNG witH
+    KEYboArDS RiGHT NOw.
+
+    [PRESS KC_AMUP a few times]
+
+    hello world. my name is john Doe. i am a computer programmer playing with
+    keyboarDs right now.
+
+    [PRESS KC_AMRP]
+
+    115
+
+The keyboard typed `115` which represents your current `AUTO_MOD_TIMEOUT`
+value. You are now set! Practice on the *D* key a little bit that showed up
+in the testing and you'll be golden.

--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -1,5 +1,8 @@
 # Auto Shift: Why Do We Need a Shift Key?
 
+> [Auto Mod](feature_auto_mod.md) is an updated version of Auto Shift that
+> supports other modifiers as well as shift, and is recommended going forward.
+
 Tap a key and you get its character. Tap a key, but hold it *slightly* longer
 and you get its shifted state. Voilà! No shift key needed!
 

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -346,9 +346,9 @@ bool get_retro_tapping(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-### Retro Shift
+### Retro Mod
 
-[Auto Shift,](feature_auto_shift.md) has its own version of `retro tapping` called `retro shift`. It is extremely similar to `retro tapping`, but holding the key past `AUTO_SHIFT_TIMEOUT` results in the value it sends being shifted. Other configurations also affect it differently; see [here](feature_auto_shift.md#retro-shift) for more information.
+[Auto Mod,](feature_auto_mod.md) has its own version of `retro tapping` called `retro mod`. It is extremely similar to `retro tapping`, but holding the key past `AUTO_MOD_TIMEOUT` results in the value it sends being modded. Other configurations also affect it differently; see [here](feature_auto_mod.md#retro-mod) for more information.
 
 ## Why do we include the key record for the per key functions?
 

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -45,12 +45,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 int tp_buttons;
 
-#if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || (defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD))
 int retro_tapping_counter = 0;
 #endif
 
 #if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT) && !defined(NO_ACTION_TAPPING)
 #    include "process_auto_shift.h"
+#elif defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD) && !defined(NO_ACTION_TAPPING)
+#    include "process_auto_mod.h"
 #endif
 
 #ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
@@ -73,7 +75,7 @@ void action_exec(keyevent_t event) {
         dprint("EVENT: ");
         debug_event(event);
         dprintln();
-#if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || (defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD))
         retro_tapping_counter++;
 #endif
     }
@@ -113,6 +115,10 @@ void action_exec(keyevent_t event) {
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
     if (event.pressed) {
         retroshift_poll_time(&event);
+    }
+#    elif defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD)
+    if (event.pressed) {
+        retromod_poll_time(&event);
     }
 #    endif
     if (IS_NOEVENT(record.event) || pre_process_record_quantum(&record)) {
@@ -739,7 +745,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #endif
 
 #ifndef NO_ACTION_TAPPING
-#    if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#    if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || (defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD))
     if (!is_tap_action(action)) {
         retro_tapping_counter = 0;
     } else {
@@ -758,6 +764,8 @@ void process_action(keyrecord_t *record, action_t action) {
                     retro_tapping_counter == 2) {
 #        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     process_auto_shift(action.layer_tap.code, record);
+#        elif defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD)
+                    process_auto_mod(action.layer_tap.code, record);
 #        else
                     tap_code(action.layer_tap.code);
 #        endif

--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -48,6 +48,8 @@ __attribute__((weak)) bool get_hold_on_other_key_press(uint16_t keycode, keyreco
 
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
 #        include "process_auto_shift.h"
+#    elif defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD)
+#        include "process_auto_mod.h"
 #    endif
 
 static keyrecord_t tapping_key                         = {};
@@ -113,7 +115,7 @@ void action_tapping_process(keyrecord_t record) {
 /* return true when key event is processed or consumed. */
 bool process_tapping(keyrecord_t *keyp) {
     keyevent_t event = keyp->event;
-#    if (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || defined(TAPPING_TERM_PER_KEY) || defined(PERMISSIVE_HOLD_PER_KEY) || defined(TAPPING_FORCE_HOLD_PER_KEY) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
+#    if (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || (defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD)) || defined(TAPPING_TERM_PER_KEY) || defined(PERMISSIVE_HOLD_PER_KEY) || defined(TAPPING_FORCE_HOLD_PER_KEY) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
     uint16_t tapping_keycode = get_record_keycode(&tapping_key, false);
 #    endif
 
@@ -128,6 +130,13 @@ bool process_tapping(keyrecord_t *keyp) {
 #        endif
                 (RETRO_SHIFT + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_SHIFT + 0)
             )
+#    elif defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD)
+            || (
+#        ifdef RETRO_TAPPING_PER_KEY
+                get_retro_tapping(tapping_keycode, keyp) &&
+#        endif
+                (RETRO_MOD + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_MOD + 0)
+            )
 #    endif
         ) {
             // clang-format on
@@ -135,6 +144,8 @@ bool process_tapping(keyrecord_t *keyp) {
                 if (IS_TAPPING_RECORD(keyp) && !event.pressed) {
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     retroshift_swap_times();
+#    elif defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD)
+                    retromod_swap_times();
 #    endif
                     // first tap!
                     debug("Tapping: First tap(0->1).\n");
@@ -152,7 +163,7 @@ bool process_tapping(keyrecord_t *keyp) {
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
                 // clang-format off
-#    if defined(TAPPING_TERM_PER_KEY) || (TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD) || defined(PERMISSIVE_HOLD_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#    if defined(TAPPING_TERM_PER_KEY) || (TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD) || defined(PERMISSIVE_HOLD_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || (defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD))
                 else if (
                     (
                         (
@@ -172,9 +183,9 @@ bool process_tapping(keyrecord_t *keyp) {
 #        endif
                         ) && IS_RELEASED(event) && waiting_buffer_typed(event)
                     )
-                    // Causes nested taps to not wait past TAPPING_TERM/RETRO_SHIFT
+                    // Causes nested taps to not wait past TAPPING_TERM/RETRO_SHIFT/RETRO_MOD
                     // unnecessarily and fixes them for Layer Taps.
-#        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
+#        if (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || (defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD))
                     || (
 #            ifdef RETRO_TAPPING_PER_KEY
                         get_retro_tapping(tapping_keycode, keyp) &&
@@ -202,9 +213,9 @@ bool process_tapping(keyrecord_t *keyp) {
 #            endif
                                 ) && tapping_key.tap.interrupted == true
                             )
-                            // Makes Retro Shift ignore [IGNORE_MOD_TAP_INTERRUPT's
+                            // Makes Retro Shift/Mod ignore [IGNORE_MOD_TAP_INTERRUPT's
                             // effects on nested taps for MTs and the default
-                            // behavior of LTs] below TAPPING_TERM or RETRO_SHIFT.
+                            // behavior of LTs] below TAPPING_TERM or RETRO_SHIFT/RETRO_MOD.
                             || (
                                 IS_RETRO(tapping_keycode)
                                 && (event.key.col != tapping_key.event.key.col || event.key.row != tapping_key.event.key.row)
@@ -363,6 +374,13 @@ bool process_tapping(keyrecord_t *keyp) {
                 get_retro_tapping(tapping_keycode, keyp) &&
 #        endif
                 (RETRO_SHIFT + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_SHIFT + 0)
+            )
+#    elif defined(AUTO_MOD_ENABLE) && defined(RETRO_MOD)
+            || (
+#        ifdef RETRO_TAPPING_PER_KEY
+                get_retro_tapping(tapping_keycode, keyp) &&
+#        endif
+                (RETRO_MOD + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_MOD + 0)
             )
 #    endif
         ) {

--- a/quantum/process_keycode/process_auto_mod.c
+++ b/quantum/process_keycode/process_auto_mod.c
@@ -1,0 +1,508 @@
+/* Copyright 2017 Jeremy Cowgar
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef AUTO_MOD_ENABLE
+
+#    include <stdbool.h>
+#    include <stdio.h>
+#    include "process_auto_mod.h"
+
+#    ifndef AUTO_MOD_DISABLED_AT_STARTUP
+#        define AUTO_MOD_STARTUP_STATE true /* enabled */
+#    else
+#        define AUTO_MOD_STARTUP_STATE false /* disabled */
+#    endif
+
+#ifdef AUTO_MOD_KEY_L
+    #undef AUTO_MOD_KEY_L
+#endif
+#ifdef AUTO_MOD_KEY_R
+    #undef AUTO_MOD_KEY_R
+#endif
+
+#if defined(AUTO_MOD_CTRL)
+    #define AUTO_MOD_KEY_L KC_LCTL
+    #define AUTO_MOD_KEY_R KC_RCTL
+#elif defined(AUTO_MOD_ALT)
+    #define AUTO_MOD_KEY_L KC_LALT
+    #define AUTO_MOD_KEY_R KC_RALT
+#elif defined(AUTO_MOD_GUI)
+    #define AUTO_MOD_KEY_L KC_LGUI
+    #define AUTO_MOD_KEY_R KC_RGUI
+#else
+    #define AUTO_MOD_KEY_L KC_LSFT
+    #define AUTO_MOD_KEY_R KC_RSFT
+#endif
+
+// Stores the last Auto Mod key's up or down time, for evaluation or keyrepeat.
+static uint16_t automod_time = 0;
+#    if defined(RETRO_MOD) && !defined(NO_ACTION_TAPPING)
+// Stores the last key's up or down time, to replace automod_time so that Tap Hold times are accurate.
+static uint16_t retromod_time = 0;
+// Stores a possibly Retro Mod key's up or down time, as retromod_time needs
+// to be set before the Retro Mod key is evaluated if it is interrupted by an
+// Auto Modded key.
+static uint16_t last_retromod_time;
+#    endif
+static uint16_t    automod_timeout = AUTO_MOD_TIMEOUT;
+static uint16_t    automod_lastkey = KC_NO;
+static keyrecord_t automod_lastrecord;
+// Keys take 8 bits if modifiers are excluded. This records the mod state
+// when pressed for each key, so that can be passed to the release function
+// and it knows which key needs to be released (if modded is different base).
+static uint16_t automod_mod_states[((1 << 8) + 15) / 16];
+static struct {
+    // Whether Auto Mod is enabled.
+    bool enabled : 1;
+    // Whether the last auto-modded key was released after the timeout.  This
+    // is used to replicate the last key for a tap-then-hold.
+    bool lastmodded : 1;
+    // Whether an auto-modable key has been pressed but not processed.
+    bool in_progress : 1;
+    // Whether the auto-modded keypress has been registered.
+    bool holding_mod : 1;
+    // Whether the user is holding a mod and we removed it.
+    bool cancelling_lmod : 1;
+    bool cancelling_rmod : 1;
+    // clang-format wants to remove the true for some reason.
+    // clang-format off
+} automod_flags = {AUTO_MOD_STARTUP_STATE, false, false, false, false, false};
+// clang-format on
+
+/** \brief Called on physical press, returns whether key should be added to Auto Mod */
+__attribute__((weak)) bool get_custom_auto_modded_key(uint16_t keycode, keyrecord_t *record) { return false; }
+
+/** \brief Called on physical press, returns whether is Auto Mod key */
+__attribute__((weak)) bool get_auto_modded_key(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+#    ifndef NO_AUTO_MOD_ALPHA
+        case AUTO_MOD_ALPHA:
+#    endif
+#    ifndef NO_AUTO_MOD_NUMERIC
+        case AUTO_MOD_NUMERIC:
+#    endif
+#    ifndef NO_AUTO_MOD_SPECIAL
+        case AUTO_MOD_SPECIAL:
+#    endif
+            return true;
+    }
+    return get_custom_auto_modded_key(keycode, record);
+}
+
+/** \brief Called to check whether defines should apply if PER_KEY is set for it */
+__attribute__((weak)) bool get_auto_mod_repeat(uint16_t keycode, keyrecord_t *record) { return true; }
+__attribute__((weak)) bool get_auto_mod_no_auto_repeat(uint16_t keycode, keyrecord_t *record) { return true; }
+
+/** \brief Called when an Auto Mod key needs to be pressed */
+__attribute__((weak)) void automod_press_user(uint16_t keycode, bool modded, keyrecord_t *record) {
+    if (modded) {
+        add_weak_mods(MOD_BIT(AUTO_MOD_KEY_L));
+    }
+    register_code16((IS_RETRO(keycode)) ? keycode & 0xFF : keycode);
+}
+
+/** \brief Called when an Auto Mod key needs to be released */
+__attribute__((weak)) void automod_release_user(uint16_t keycode, bool modded, keyrecord_t *record) { unregister_code16((IS_RETRO(keycode)) ? keycode & 0xFF : keycode); }
+
+/** \brief Sets the mod state to use when keyrepeating, required by custom mods */
+void set_automod_mod_state(uint16_t keycode, bool modded) {
+    keycode = keycode & 0xFF;
+    if (modded) {
+        automod_mod_states[keycode / 16] |= (uint16_t)1 << keycode % 16;
+    } else {
+        automod_mod_states[keycode / 16] &= ~((uint16_t)1 << keycode % 16);
+    }
+}
+
+/** \brief Gets the mod state to use when keyrepeating, required by custom mods */
+bool get_automod_mod_state(uint16_t keycode) {
+    keycode = keycode & 0xFF;
+    return (automod_mod_states[keycode / 16] & (uint16_t)1 << keycode % 16) != (uint16_t)0;
+}
+
+/** \brief Restores the mod key if it was cancelled by Auto Mod */
+static void automod_flush_mod(void) {
+    automod_flags.holding_mod = false;
+    del_weak_mods(MOD_BIT(AUTO_MOD_KEY_L));
+    if (automod_flags.cancelling_lmod) {
+        automod_flags.cancelling_lmod = false;
+        add_mods(MOD_BIT(AUTO_MOD_KEY_L));
+    }
+    if (automod_flags.cancelling_rmod) {
+        automod_flags.cancelling_rmod = false;
+        add_mods(MOD_BIT(AUTO_MOD_KEY_R));
+    }
+    send_keyboard_report();
+}
+
+/** \brief Record the press of an automodable key
+ *
+ *  \return Whether the record should be further processed.
+ */
+static bool automod_press(uint16_t keycode, uint16_t now, keyrecord_t *record) {
+    // clang-format off
+    if ((get_mods()
+#    if !defined(NO_ACTION_ONESHOT) && !defined(NO_ACTION_TAPPING)
+            | get_oneshot_mods()
+#    endif
+        ) & (~MOD_BIT(AUTO_MOD_KEY_L))
+    ) {
+        // clang-format on
+        // Prevents keyrepeating unmodded value of key after using it in a key combo.
+        automod_lastkey = KC_NO;
+#    ifndef AUTO_MOD_MODIFIERS
+        // We can't return true here anymore because custom unmodded values are
+        // possible and there's no good way to tell whether the press returned
+        // true upon release.
+        set_automod_mod_state(keycode, false);
+        automod_press_user(keycode, false, record);
+#        if !defined(NO_ACTION_ONESHOT) && !defined(NO_ACTION_TAPPING)
+        set_oneshot_mods(get_oneshot_mods() & (~MOD_BIT(AUTO_MOD_KEY_L)));
+        clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
+#        endif
+        return false;
+#    endif
+    }
+
+    // Store record to be sent to user functions if there's no release record then.
+    automod_lastrecord               = *record;
+    automod_lastrecord.event.pressed = false;
+    automod_lastrecord.event.time    = 0;
+    // clang-format off
+#    if defined(AUTO_MOD_REPEAT) || defined(AUTO_MOD_REPEAT_PER_KEY)
+    if (keycode == automod_lastkey &&
+#        ifdef AUTO_MOD_REPEAT_PER_KEY
+        get_auto_mod_repeat(automod_lastkey, record) &&
+#        endif
+#        if !defined(AUTO_MOD_NO_AUTO_REPEAT) || defined(AUTO_MOD_NO_AUTO_REPEAT_PER_KEY)
+        (
+            !automod_flags.lastmodded
+#            ifdef AUTO_MOD_NO_AUTO_REPEAT_PER_KEY
+            || get_auto_mod_no_auto_repeat(automod_lastkey, record)
+#            endif
+        ) &&
+#        endif
+        TIMER_DIFF_16(now, automod_time) <
+#        ifdef TAPPING_TERM_PER_KEY
+        get_tapping_term(automod_lastkey, record)
+#        else
+        TAPPING_TERM
+#        endif
+    ) {
+        // clang-format on
+        // Allow a tap-then-hold for keyrepeat.
+        if (get_mods() & MOD_BIT(AUTO_MOD_KEY_L)) {
+            automod_flags.cancelling_lmod = true;
+            del_mods(MOD_BIT(AUTO_MOD_KEY_L));
+        }
+        if (get_mods() & MOD_BIT(AUTO_MOD_KEY_R)) {
+            automod_flags.cancelling_rmod = true;
+            del_mods(MOD_BIT(AUTO_MOD_KEY_R));
+        }
+        // automod_mod_state doesn't need to be changed.
+        automod_press_user(automod_lastkey, automod_flags.lastmodded, record);
+        return false;
+    }
+#    endif
+
+    // Use physical mod state of press event to be more like normal typing.
+#    if !defined(NO_ACTION_ONESHOT) && !defined(NO_ACTION_TAPPING)
+    automod_flags.lastmodded = (get_mods() | get_oneshot_mods()) & MOD_BIT(AUTO_MOD_KEY_L);
+    set_oneshot_mods(get_oneshot_mods() & (~MOD_BIT(AUTO_MOD_KEY_L)));
+#    else
+    automod_flags.lastmodded = get_mods() & MOD_BIT(AUTO_MOD_KEY_L);
+#    endif
+    // Record the keycode so we can simulate it later.
+    automod_lastkey           = keycode;
+    automod_time              = now;
+    automod_flags.in_progress = true;
+
+#    if !defined(NO_ACTION_ONESHOT) && !defined(NO_ACTION_TAPPING)
+    clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
+#    endif
+    return false;
+}
+
+/** \brief Registers an automodable key under the right conditions
+ *
+ * If automod_timeout has elapsed, register a mod and the key.
+ *
+ * If the Auto Mod key is released before the delay has elapsed, register the
+ * key without a mod.
+ *
+ * Called on key down with keycode=KC_NO, auto-modded key up, and timeout.
+ */
+static void automod_end(uint16_t keycode, uint16_t now, bool matrix_trigger, keyrecord_t *record) {
+    if (automod_flags.in_progress && (keycode == automod_lastkey || keycode == KC_NO)) {
+        // Process the auto-modable key.
+        automod_flags.in_progress = false;
+        // clang-format off
+        automod_flags.lastmodded =
+            automod_flags.lastmodded
+            || TIMER_DIFF_16(now, automod_time) >=
+#    ifdef AUTO_MOD_TIMEOUT_PER_KEY
+                get_automod_timeout(automod_lastkey, record)
+#    else
+                automod_timeout
+#    endif
+        ;
+        // clang-format on
+        set_automod_mod_state(automod_lastkey, automod_flags.lastmodded);
+        if (get_mods() & MOD_BIT(AUTO_MOD_KEY_L)) {
+            automod_flags.cancelling_lmod = true;
+            del_mods(MOD_BIT(AUTO_MOD_KEY_L));
+        }
+        if (get_mods() & MOD_BIT(AUTO_MOD_KEY_R)) {
+            automod_flags.cancelling_rmod = true;
+            del_mods(MOD_BIT(AUTO_MOD_KEY_R));
+        }
+        automod_press_user(automod_lastkey, automod_flags.lastmodded, record);
+
+        // clang-format off
+#    if (defined(AUTO_MOD_REPEAT) || defined(AUTO_MOD_REPEAT_PER_KEY)) && (!defined(AUTO_MOD_NO_AUTO_REPEAT) || defined(AUTO_MOD_NO_AUTO_REPEAT_PER_KEY))
+        if (matrix_trigger
+#        ifdef AUTO_MOD_REPEAT_PER_KEY
+            && get_auto_mod_repeat(automod_lastkey, record)
+#        endif
+#        ifdef AUTO_MOD_NO_AUTO_REPEAT_PER_KEY
+            && !get_auto_mod_no_auto_repeat(automod_lastkey, record)
+#        endif
+        ) {
+            // Prevents release.
+            return;
+        }
+#    endif
+        // clang-format on
+#    if TAP_CODE_DELAY > 0
+        wait_ms(TAP_CODE_DELAY);
+#    endif
+
+        automod_release_user(automod_lastkey, automod_flags.lastmodded, record);
+        automod_flush_mod();
+    } else {
+        // Release after keyrepeat.
+        automod_release_user(keycode, get_automod_mod_state(keycode), record);
+        if (keycode == automod_lastkey) {
+            // This will only fire when the key was the last auto-modable
+            // pressed. That prevents 'aaaaBBBB' then releasing a from unmodding
+            // later 'B's (if 'B' wasn't auto-modable).
+            automod_flush_mod();
+        }
+    }
+    // Roll the automod_time forward for detecting tap-and-hold.
+    automod_time = now;
+}
+
+/** \brief Simulates auto-modded key releases when timeout is hit
+ *
+ *  Can be called from \c matrix_scan_user so that auto-modded keys are sent
+ *  immediately after the timeout has expired, rather than waiting for the key
+ *  to be released.
+ */
+void automod_matrix_scan(void) {
+    if (automod_flags.in_progress) {
+        const uint16_t now = timer_read();
+        if (TIMER_DIFF_16(now, automod_time) >=
+#    ifdef AUTO_MOD_TIMEOUT_PER_KEY
+            get_automod_timeout(automod_lastkey, &automod_lastrecord)
+#    else
+            automod_timeout
+#    endif
+        ) {
+            automod_end(automod_lastkey, now, true, &automod_lastrecord);
+        }
+    }
+}
+
+void automod_toggle(void) {
+    automod_flags.enabled = !automod_flags.enabled;
+    automod_flush_mod();
+}
+
+void automod_enable(void) { automod_flags.enabled = true; }
+
+void automod_disable(void) {
+    automod_flags.enabled = false;
+    automod_flush_mod();
+}
+
+#    ifndef AUTO_MOD_NO_SETUP
+void automod_timer_report(void) {
+    char display[8];
+
+    snprintf(display, 8, "\n%d\n", automod_timeout);
+
+    send_string((const char *)display);
+}
+#    endif
+
+bool get_automod_state(void) { return automod_flags.enabled; }
+
+uint16_t                       get_generic_automod_timeout() { return automod_timeout; }
+__attribute__((weak)) uint16_t get_automod_timeout(uint16_t keycode, keyrecord_t *record) { return automod_timeout; }
+
+void set_automod_timeout(uint16_t timeout) { automod_timeout = timeout; }
+
+bool process_auto_mod(uint16_t keycode, keyrecord_t *record) {
+    // Note that record->event.time isn't reliable, see:
+    // https://github.com/qmk/qmk_firmware/pull/9826#issuecomment-733559550
+    // clang-format off
+    const uint16_t now =
+#    if !defined(RETRO_MOD) || defined(NO_ACTION_TAPPING)
+        timer_read()
+#    else
+        (record->event.pressed) ? retromod_time : timer_read()
+#    endif
+    ;
+    // clang-format on
+
+    if (record->event.pressed) {
+        if (automod_flags.in_progress) {
+            // Evaluate previous key if there is one.
+            automod_end(KC_NO, now, false, &automod_lastrecord);
+        }
+
+        switch (keycode) {
+            case KC_AMTG:
+                automod_toggle();
+                break;
+            case KC_AMON:
+                automod_enable();
+                break;
+            case KC_AMOFF:
+                automod_disable();
+                break;
+
+#    ifndef AUTO_MOD_NO_SETUP
+            case KC_AMUP:
+                automod_timeout += 5;
+                break;
+            case KC_AMDN:
+                automod_timeout -= 5;
+                break;
+            case KC_AMRP:
+                automod_timer_report();
+                break;
+#    endif
+        }
+        // If Retro Mod is disabled, possible custom actions shouldn't happen.
+        // clang-format off
+        if (IS_RETRO(keycode)
+#    if defined(RETRO_MOD) && !defined(NO_ACTION_TAPPING)
+            // Not tapped or #defines mean that rolls should use hold action.
+            && (
+                record->tap.count == 0
+#        ifdef RETRO_TAPPING_PER_KEY
+                || !get_retro_tapping(keycode, record)
+#        endif
+                || (record->tap.interrupted && (IS_LT(keycode)
+#        if defined(HOLD_ON_OTHER_KEY_PRESS) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
+#            ifdef HOLD_ON_OTHER_KEY_PRESS_PER_KEY
+                    ? get_hold_on_other_key_press(keycode, record)
+#            else
+                    ? true
+#            endif
+#        else
+                    ? false
+#        endif
+#        if defined(IGNORE_MOD_TAP_INTERRUPT) || defined(IGNORE_MOD_TAP_INTERRUPT_PER_KEY)
+#            ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+                    : !get_ignore_mod_tap_interrupt(keycode, record)
+#            else
+                    : false
+#            endif
+#        else
+                    : true
+#        endif
+                ))
+            )
+#    endif
+        ) {
+            // clang-format on
+            automod_lastkey = KC_NO;
+            return true;
+        }
+    } else {
+        if (keycode == AUTO_MOD_KEY_L) {
+            automod_flags.cancelling_lmod = false;
+        } else if (keycode == AUTO_MOD_KEY_R) {
+            automod_flags.cancelling_rmod = false;
+        }
+        // Same as above (for pressed), additional checks are not needed because
+        // tap.count gets set to 0 in process_action
+        // clang-format off
+        else if (IS_RETRO(keycode)
+#    if defined(RETRO_MOD) && !defined(NO_ACTION_TAPPING)
+            && (
+                record->tap.count == 0
+#        ifdef RETRO_TAPPING_PER_KEY
+                || !get_retro_tapping(keycode, record)
+#        endif
+            )
+#    endif
+        ) {
+            // Fixes modifiers not being applied to rolls with AUTO_MOD_MODIFIERS set.
+#    if !defined(IGNORE_MOD_TAP_INTERRUPT) || defined(IGNORE_MOD_TAP_INTERRUPT_PER_KEY)
+            if (automod_flags.in_progress
+#        ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+                && !get_ignore_mod_tap_interrupt(keycode, record)
+#        endif
+            ) {
+                automod_end(KC_NO, now, false, &automod_lastrecord);
+            }
+#    endif
+            // clang-format on
+            return true;
+        }
+    }
+
+    if (!automod_flags.enabled) {
+        return true;
+    }
+    if (get_auto_modded_key(keycode, record)) {
+        if (record->event.pressed) {
+            return automod_press(keycode, now, record);
+        } else {
+            automod_end(keycode, now, false, record);
+            return false;
+        }
+    }
+
+    // Prevent keyrepeating of older keys upon non-AM key event.
+    // Not commented at above returns but they serve the same function.
+    if (record->event.pressed) {
+        automod_lastkey = KC_NO;
+    }
+    return true;
+}
+
+#    if defined(RETRO_MOD) && !defined(NO_ACTION_TAPPING)
+// Called to record time before possible delays by action_tapping_process.
+void retromod_poll_time(keyevent_t *event) {
+    last_retromod_time = retromod_time;
+    retromod_time      = timer_read();
+}
+// Used to swap the times of Retro Modded key and Auto Mod key that interrupted it.
+void retromod_swap_times() {
+    if (last_retromod_time != 0 && automod_flags.in_progress) {
+        uint16_t temp      = retromod_time;
+        retromod_time      = last_retromod_time;
+        last_retromod_time = temp;
+    }
+}
+#    endif
+
+#endif

--- a/quantum/process_keycode/process_auto_mod.h
+++ b/quantum/process_keycode/process_auto_mod.h
@@ -1,0 +1,57 @@
+/* Copyright 2017 Jeremy Cowgar
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "quantum.h"
+
+#ifndef AUTO_MOD_TIMEOUT
+#    define AUTO_MOD_TIMEOUT 175
+#endif
+
+#define AUTO_MOD_SHIFT 1
+#define AUTO_MOD_CTRL  2
+#define AUTO_MOD_ALT   3
+#define AUTO_MOD_GUI   4
+
+#define IS_LT(kc) ((kc) >= QK_LAYER_TAP && (kc) <= QK_LAYER_TAP_MAX)
+#define IS_MT(kc) ((kc) >= QK_MOD_TAP && (kc) <= QK_MOD_TAP_MAX)
+#define IS_RETRO(kc) (IS_MT(kc) || IS_LT(kc))
+#define DO_GET_AUTOMOD_TIMEOUT(keycode, record, ...) record
+// clang-format off
+#define AUTO_MOD_ALPHA KC_A ... KC_Z
+#define AUTO_MOD_NUMERIC KC_1 ... KC_0
+#define AUTO_MOD_SPECIAL          \
+             KC_TAB:                \
+        case KC_MINUS ... KC_SLASH: \
+        case KC_NONUS_BSLASH
+// clang-format on
+
+bool process_auto_mod(uint16_t keycode, keyrecord_t *record);
+void retromod_poll_time(keyevent_t *event);
+void retromod_swap_times(void);
+
+void     automod_enable(void);
+void     automod_disable(void);
+void     automod_toggle(void);
+bool     get_automod_state(void);
+uint16_t get_generic_automod_timeout(void);
+// clang-format off
+uint16_t (get_automod_timeout)(uint16_t keycode, keyrecord_t *record);
+void     set_automod_timeout(uint16_t timeout);
+void     automod_matrix_scan(void);
+bool     get_custom_auto_modded_key(uint16_t keycode, keyrecord_t *record);
+// clang-format on

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -47,8 +47,10 @@ float default_layer_songs[][16][2] = DEFAULT_LAYER_SONGS;
 #    endif
 #endif
 
-#ifdef AUTO_SHIFT_ENABLE
+#if defined(AUTO_SHIFT_ENABLE)
 #    include "process_auto_shift.h"
+#elif defined(AUTO_MOD_ENABLE)
+#    include "process_auto_mod.h"
 #endif
 
 uint8_t extract_mod_bits(uint16_t code) {
@@ -272,8 +274,10 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef PRINTING_ENABLE
             process_printer(keycode, record) &&
 #endif
-#ifdef AUTO_SHIFT_ENABLE
+#if defined(AUTO_SHIFT_ENABLE)
             process_auto_shift(keycode, record) &&
+#elif defined(AUTO_MOD_ENABLE)
+            process_auto_mod(keycode, record) &&
 #endif
 #ifdef DYNAMIC_TAPPING_TERM_ENABLE
             process_dynamic_tapping_term(keycode, record) &&
@@ -457,8 +461,10 @@ void matrix_scan_quantum() {
     dip_switch_read(false);
 #endif
 
-#ifdef AUTO_SHIFT_ENABLE
+#if defined(AUTO_SHIFT_ENABLE)
     autoshift_matrix_scan();
+#elif defined(AUTO_MOD_ENABLE)
+    automod_matrix_scan();
 #endif
 
     matrix_scan_kb();

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -121,8 +121,10 @@ extern layer_state_t layer_state;
 #    include "process_printer.h"
 #endif
 
-#ifdef AUTO_SHIFT_ENABLE
+#if defined(AUTO_SHIFT_ENABLE)
 #    include "process_auto_shift.h"
+#elif defined(AUTO_MOD_ENABLE)
+#    include "process_auto_mod.h"
 #endif
 
 #ifdef DYNAMIC_TAPPING_TERM_ENABLE

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -529,6 +529,14 @@ enum quantum_keycodes {
     DT_UP,
     DT_DOWN,
 
+    // Auto Mod
+    KC_AMUP,
+    KC_AMDN,
+    KC_AMRP,
+    KC_AMTG,
+    KC_AMON,
+    KC_AMOFF,
+
     // Programmable Button
     PROGRAMMABLE_BUTTON_1,
     PROGRAMMABLE_BUTTON_2,


### PR DESCRIPTION
Add Auto Mod based on Auto Shift. This lets you choose between _shift_, _ctrl_, _alt_, and _gui_ as the modifier to be applied when a key is held down.

The core processing is a modified version of Auto Shift, and anywhere it is referenced was updated with an extra `#elif defined(AUTO_MOD_ENABLE)` so that existing keyboards (regardless of whether they use Auto Shift) will continue working.

> I wanted an easier way to send ctrl+key whenever you hold down a key, so I expanded on Auto Shift so that you can easily specify the modifier you want. With the _shift_ modifier it's identical to current Auto Shift, but I left it in for now since obviously I didn't want to go breaking peoples' keymaps. However, longer term, Auto Shift could probably be removed.

## Description

`process_auto_mod.h` and `process_auto_mod.c` were added based off of the respective Auto Shift files, with just a small change so that the modifier key it uses is `#define`d instead of being hard-coded as shift. The other places where Auto Shift is referenced were then all updated with `#elif defined(AUTO_MOD_ENABLE)` so that if Auto Shift is enabled then that takes precedence over Auto Mod.

Documentation based off of the Auto Shift documentation was also created for Auto Mod.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
