### PR TITLE
[Core] Add TAPPING_RELEASE_HOLD_TERM option for Tapping Force Hold

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -165,6 +165,8 @@ If you define these options you will enable the associated feature, which may in
   * Breaks any Tap Toggle functionality (`TT` or the One Shot Tap Toggle)
 * `#define TAPPING_FORCE_HOLD_PER_KEY`
   * enables handling for per key `TAPPING_FORCE_HOLD` settings
+* `#define TAPPING_RELEASE_HOLD_TERM 100`
+  * tap and hold timing to interrupt `TAPPING_FORCE_HOLD`
 * `#define LEADER_TIMEOUT 300`
   * how long before the leader key times out
     * If you're having issues finishing the sequence before it times out, you may need to increase the timeout setting. Or you may want to enable the `LEADER_PER_KEY_TIMING` option, which resets the timeout after each key is tapped.

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -318,7 +318,7 @@ bool get_tapping_force_hold(uint16_t keycode, keyrecord_t *record) {
 For an option to interrupt force hold, add the following to `config.h`:
 
 ```c
-#define TAPPING_RELEASE_HOLD_TERM TAPPING_TERM - 100
+#define TAPPING_RELEASE_HOLD_TERM 100
 ```
 
 When a tap-hold key is held again after tapping within `TAPPING_RELEASE_HOLD_TERM` in milliseconds, force hold will be interrupted. This will provide user the ability to deliberately override force hold with quick tap and hold action to auto-repeat a key. `TAPPING_RELEASE_HOLD_TERM` must be less than `TAPPING_TERM` or tapping force hold will be disabled.

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -315,6 +315,16 @@ bool get_tapping_force_hold(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
+For an option to interrupt force hold, add the following to `config.h`:
+
+```c
+#define TAPPING_RELEASE_HOLD_TERM TAPPING_TERM - 100
+```
+
+When a tap-hold key is held again after tapping within `TAPPING_RELEASE_HOLD_TERM` in milliseconds, force hold will be interrupted. This will provide user the ability to deliberately override force hold with quick tap and hold action to auto-repeat a key. `TAPPING_RELEASE_HOLD_TERM` must be less than `TAPPING_TERM` or tapping force hold will be disabled.
+
+?> `TAPPING_RELEASE_HOLD_TERM` will only apply to `TAPPING_FORCE_HOLD_PER_KEY` when both are used together.
+
 ## Retro Tapping
 
 To enable `retro tapping`, add the following to your `config.h`:

--- a/tests/tap_hold_configurations/tapping_force_hold/config.h
+++ b/tests/tap_hold_configurations/tapping_force_hold/config.h
@@ -19,3 +19,4 @@
 #include "test_common.h"
 
 #define TAPPING_FORCE_HOLD
+#define TAPPING_RELEASE_HOLD_TERM 100

--- a/tests/tap_hold_configurations/tapping_force_hold/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/tapping_force_hold/test_tap_hold.cpp
@@ -211,3 +211,37 @@ TEST_F(TappingForceHold, tap_mod_tap_hold_key_twice_and_hold_on_second_time) {
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
+
+TEST_F(TappingForceHold, tap_mod_tap_hold_key_twice_and_hold_within_release_hold_term) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_T));
+
+    set_keymap({mod_tap_hold_key});
+
+    /* Press mod-tap-hold key. */
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
+    mod_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release mod-tap-hold key. */
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_T)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press mod-tap-hold key again within release hold term. */
+    EXPECT_CALL(driver, send_keyboard_mock(_)).Times(0);
+    mod_tap_hold_key.press();
+    idle_for(TAPPING_RELEASE_HOLD_TERM - 3);
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release mod-tap-hold key. */
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_T)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change adds `TAPPING_RELEASE_HOLD_TERM ` option to the [Tapping Force Hold](https://docs.qmk.fm/#/tap_hold?id=tapping-force-hold) function. It will allow force hold to be interrupted when user holds a tap-hold key (quickly) after tapping within `TAPPING_RELEASE_HOLD_TERM ` duration in milliseconds.

When used together with `TAPPING_FORCE_HOLD_PER_KEY`, it will only apply to tap-hold keycodes define by the `get_tapping_force_hold` function.  The value must be less than `TAPPING_TERM`, or Force Hold will be disabled completely.


### Test cases
* Without `TAPPING_FORCE_HOLD`:
  * Tap and hold action on all mod-tap keys should trigger auto-repeat normally.
* `TAPPING_FORCE_HOLD` only:
  * Tap and hold action on all mod-tap keys should never trigger auto-repeat.
* `TAPPING_FORCE_HOLD_PER_KEY`:
  * Tap and hold action on keycodes defined in `get_tapping_force_hold` should never trigger auto-repeat.
  * All other mod-tap keys should trigger auto-repeat normally.
* `TAPPING_RELEASE_HOLD_TERM 100`:
  * Tap and hold action on all mod-tap keys should trigger auto-repeat with _quick_ deliberate action.
  * Reducing `TAPPING_RELEASE_HOLD_TERM ` to `50` should make them even harder to trigger.
* `TAPPING_FORCE_HOLD_PER_KEY` and `TAPPING_RELEASE_HOLD_TERM 100`:
  * Tap and hold action on keycodes defined in `get_tapping_force_hold` should trigger auto-repeat with _quick_ deliberate action.
  * Reducing `TAPPING_RELEASE_HOLD_TERM ` to `50` should make those keycodes even harder to trigger.
  * All other mod-tap keys should trigger auto-repeat normally, unaffected by `TAPPING_RELEASE_HOLD_TERM ` values.
* Regression test: all other features and normal operations associated with mod-tap / tap-hold keys should remain unaffected.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
