### PR TITLE
zigotica userspace rows tweak: TAB in default layer, ESC in sym/fn layers

### DIFF
--- a/users/zigotica/rows.h
+++ b/users/zigotica/rows.h
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *   |       |       |       |       | TD ]} |         |  TD ; |       |       |       |  TD : |
  *   `-------+-------+-------+-------+-------|         |-------+-------+-------+-------+-------.
  *                           |       |       |         |       |       |
- *                           |  ESC  |  SPC  |         |   E   | INTRO |
+ *                           |  TAB  |  SPC  |         |   E   | INTRO |
  *                           |  num  |  nav  |         |  sym  |   fn  |
  *                           `---------------'         `---------------'
  *
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define _STENAI_L1      KC_GRV,           KC_W,            KC_D,          KC_P,             KC_F
 #define _STENAI_L2      LALT_T(KC_H),     LCTL_T(KC_R),    LSFT_T(KC_S),  LGUI_T(KC_T),     KC_G
 #define _STENAI_L3      KC_B,             KC_X,            KC_C,          KC_V,             ZK_BRC
-#define _STENAI_LT      LT(_NUM, KC_ESC), LT(_NAV, KC_SPC)
+#define _STENAI_LT      LT(_NUM, KC_TAB), LT(_NAV, KC_SPC)
 
 #define _STENAI_R1      KC_K,             KC_Y,            KC_U,          KC_Q,             KC_QUOT
 #define _STENAI_R2      KC_M,             RGUI_T(KC_N),    RSFT_T(KC_A),  RCTL_T(KC_I),     RALT_T(KC_O)
@@ -147,14 +147,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *   |       |       |       |       |       |         |       |       |       |       |       |
 *   `-------+-------+-------+-------+-------|         |-------+-------+-------+-------+-------.
 *                           |       |       |         |:::::::|       |
-*                           |       |  TAB  |         |:::::::|       |
+*                           |       |  ESC  |         |:::::::|       |
 *                           |       |       |         |:::::::|       |
 *                           `---------------'         `---------------'
 */
 #define ____SYM_L1      KC_PERC, KC_AMPR, KC_QUES, KC_PIPE, KC_EXLM
 #define ____SYM_L2      KC_HASH, KC_AT,   KC_COLN, KC_SCLN, KC_DLR
 #define ____SYM_L3      ZK_PRN,  KC_TILD, KC_SLSH, KC_BSLS, KC_CIRC
-#define ____SYM_LT      _______, KC_TAB
+#define ____SYM_LT      _______, KC_ESC
 
 #define ____SYM_R1      _BLANK_ROW
 #define ____SYM_R2      _BLANK_ROW
@@ -178,14 +178,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *   |       |       |       |       |       |         |       |       |       |       |       |
 *   `-------+-------+-------+-------+-------|         |-------+-------+-------+-------+-------.
 *                           |       |       |         |       |:::::::|
-*                           |       |  TAB  |         |       |:::::::|
+*                           |       |  ESC  |         |       |:::::::|
 *                           |       |       |         |       |:::::::|
 *                           `---------------'         `---------------'
 */
 #define ____FN_L1       _BLANK_ROW
 #define ____FN_L2       _BLANK_ROW
 #define ____FN_L3       _BLANK_ROW
-#define ____FN_LT       _______, KC_TAB
+#define ____FN_LT       _______, KC_ESC
 
 #define ____FN_R1       _______,  KC_F7,  KC_F8,  KC_F9,  KC_F10
 #define ____FN_R2       _______,  KC_F1,  KC_F2,  KC_F3,  KC_F11


### PR DESCRIPTION
## Description

TAB in default layer, ESC in sym/fn layers

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* none

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
