### PR TITLE
[cli] `develop` changelog generator: use the PR title instead

### DIFF
--- a/lib/python/qmk/cli/generate/develop_pr_list.py
+++ b/lib/python/qmk/cli/generate/develop_pr_list.py
@@ -97,7 +97,7 @@ def generate_develop_pr_list(cli):
         match = git_expr.search(line)
         if match:
             pr_info = _get_pr_info(cache, gh, match.group("pr"))
-            commit_info = {'hash': match.group("hash"), 'title': match.group("title"), 'pr_num': int(match.group("pr")), 'pr_labels': [label.name for label in pr_info.labels.items]}
+            commit_info = {'hash': match.group("hash"), 'title': pr_info['title'], 'pr_num': int(match.group("pr")), 'pr_labels': [label.name for label in pr_info.labels.items]}
             _categorise_commit(commit_info)
 
     def _dump_commit_list(name, collection):


### PR DESCRIPTION
## Description

Swaps to using the PR title instead of parsing the git output and using it instead. PR titles seem to be more relevant.

Example for #15435, which makes sense as an isolated git commit when looking at the actual change (it adds support for mirroring the newer branches from the ChibiOS repo's):
```
* Add support for 21.11.x, remove 21.6.x as ChibiOS "canceled" it. ([#15435](https://github.com/qmk/qmk_firmware/pull/15435))
```
becomes:
```
* ChibiOS SVN mirror script update ([#15435](https://github.com/qmk/qmk_firmware/pull/15435))
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
