### PR TITLE
Save a single byte of memory for joystick buttons

### DIFF
--- a/quantum/joystick.h
+++ b/quantum/joystick.h
@@ -50,7 +50,7 @@ extern joystick_config_t joystick_axes[JOYSTICK_AXES_COUNT];
 enum joystick_status { JS_INITIALIZED = 1, JS_UPDATED = 2 };
 
 typedef struct {
-  uint8_t buttons[(JOYSTICK_BUTTON_COUNT - 1) / 8 + 1];
+    uint8_t buttons[(JOYSTICK_BUTTON_COUNT - 1) / 8 + 1];
 
     int16_t axes[JOYSTICK_AXES_COUNT];
     uint8_t status : 2;

--- a/quantum/joystick.h
+++ b/quantum/joystick.h
@@ -50,7 +50,7 @@ extern joystick_config_t joystick_axes[JOYSTICK_AXES_COUNT];
 enum joystick_status { JS_INITIALIZED = 1, JS_UPDATED = 2 };
 
 typedef struct {
-    uint8_t buttons[JOYSTICK_BUTTON_COUNT / 8 + 1];
+  uint8_t buttons[(JOYSTICK_BUTTON_COUNT - 1) / 8 + 1];
 
     int16_t axes[JOYSTICK_AXES_COUNT];
     uint8_t status : 2;


### PR DESCRIPTION
While tracking down a bug in the joystick QMK implementation I noticed that the struct containing buttons allocates a byte more than needed.

Of course no big issue, but since I found it I better share it.

## Description
Allocate precisely enough memory (in bytes) to contain the number of buttons, instead of one byte too much.

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
