### PR TITLE
Fix "No C files in filelist: None"

### DIFF
--- a/lib/python/qmk/cli/format/c.py
+++ b/lib/python/qmk/cli/format/c.py
@@ -17,7 +17,7 @@ ignored = ('tmk_core/protocol/usb_hid', 'platforms/chibios/boards')
 def is_relative_to(file, other):
     """Provide similar behavior to PurePath.is_relative_to in Python > 3.9
     """
-    return str(normpath(file)).startswith(str(normpath(other)))
+    return str(normpath(file).resolve()).startswith(str(normpath(other).resolve()))
 
 
 def find_clang_format():

--- a/lib/python/qmk/cli/format/c.py
+++ b/lib/python/qmk/cli/format/c.py
@@ -1,6 +1,5 @@
 """Format C code according to QMK's style.
 """
-from os import path
 from shutil import which
 from subprocess import CalledProcessError, DEVNULL, Popen, PIPE
 
@@ -13,6 +12,12 @@ from qmk.c_parse import c_source_files
 c_file_suffixes = ('c', 'h', 'cpp')
 core_dirs = ('drivers', 'quantum', 'tests', 'tmk_core', 'platforms')
 ignored = ('tmk_core/protocol/usb_hid', 'platforms/chibios/boards')
+
+
+def is_relative_to(file, other):
+    """Provide similar behavior to PurePath.is_relative_to in Python > 3.9
+    """
+    return str(normpath(file)).startswith(str(normpath(other)))
 
 
 def find_clang_format():
@@ -68,18 +73,19 @@ def cformat_run(files):
 def filter_files(files, core_only=False):
     """Yield only files to be formatted and skip the rest
     """
+    files = list(map(normpath, filter(None, files)))
     if core_only:
         # Filter non-core files
         for index, file in enumerate(files):
             # The following statement checks each file to see if the file path is
             # - in the core directories
             # - not in the ignored directories
-            if not any(str(file).startswith(i) for i in core_dirs) or any(str(file).startswith(i) for i in ignored):
-                files[index] = None
+            if not any(is_relative_to(file, i) for i in core_dirs) or any(is_relative_to(file, i) for i in ignored):
+                del files[index]
                 cli.log.debug("Skipping non-core file %s, as '--core-only' is used.", file)
 
     for file in files:
-        if file and file.name.split('.')[-1] in c_file_suffixes:
+        if file.suffix[1:] in c_file_suffixes:
             yield file
         else:
             cli.log.debug('Skipping file %s', file)
@@ -118,12 +124,8 @@ def format_c(cli):
             print(git_diff.stderr)
             return git_diff.returncode
 
-        files = []
-
-        for file in git_diff.stdout.strip().split('\n'):
-            if not any([file.startswith(ignore) for ignore in ignored]):
-                if path.exists(file) and file.split('.')[-1] in c_file_suffixes:
-                    files.append(file)
+        changed_files = git_diff.stdout.strip().split('\n')
+        files = list(filter_files(changed_files, True))
 
     # Sanity check
     if not files:

--- a/lib/python/qmk/cli/format/python.py
+++ b/lib/python/qmk/cli/format/python.py
@@ -25,8 +25,9 @@ def yapf_run(files):
 def filter_files(files):
     """Yield only files to be formatted and skip the rest
     """
+    files = list(map(normpath, filter(None, files)))
     for file in files:
-        if file and normpath(file).name.split('.')[-1] in py_file_suffixes:
+        if file.suffix[1:] in py_file_suffixes:
             yield file
         else:
             cli.log.debug('Skipping file %s', file)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Noticed on 15555 that the formatters did not correctly kick in <https://github.com/qmk/qmk_firmware/runs/4608117091?check_suite_focus=true>.

Fixes the following issues:

1. core/ignore path comparison getting mixed up with absolute and relative paths
2. `cli.args.files` was being modified which caused the filtered filenames to later be printed as `None`

The behaviour can be tested locally with:
```console
qmk format-c --core-only quantum/quantum.c
```
A valid core file, yet formatting fails.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
