### PR TITLE
Fixed docs: host_layout to host_language

### DIFF
--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -46,7 +46,7 @@ If you type in a language other than English, or use a non-QWERTY layout like Co
 {
     "keyboard": "handwired/my_macropad",
     "keymap": "my_keymap",
-    "host_layout": "dvorak",
+    "host_language": "dvorak",
     "macros": [
         ["Hello, World!"]
     ],


### PR DESCRIPTION
The docs mentioned `host_language` but in the code example `host_layout` was used.

## Description

See above.

## Types of Changes


- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
