### PR TITLE
[massdrop/thekey] macos requires LGUI modifier instead of LCTL

### DIFF
--- a/keyboards/massdrop/thekey/keymaps/url-copy-paste-macos/keymap.c
+++ b/keyboards/massdrop/thekey/keymaps/url-copy-paste-macos/keymap.c
@@ -21,7 +21,7 @@ enum custom_keycodes {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(TK_URL, C(KC_C), C(KC_V)),
+    [0] = LAYOUT(TK_URL, G(KC_C), G(KC_V)),
 };
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {


### PR DESCRIPTION
## Description

The `url-copy-paste-macos` keymap is broken because it uses `LCTL` instead of the OSX-compatible `LGUI`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
