### PR TITLE
[Keyboard] Fix over sized compiliation for Bandiominedoni via keymap

### DIFF
--- a/keyboards/bandominedoni/keymaps/via/rules.mk
+++ b/keyboards/bandominedoni/keymaps/via/rules.mk
@@ -1,4 +1,3 @@
 RGB_MATRIX_ENABLE = yes      # Use RGB matrix (Don't enable this when RGBLIGHT_ENABLE is used.)
 RGB_MATRIX_CUSTOM_KB = yes   #
 VIA_ENABLE = yes
-MOUSEKEY_ENABLE = yes        # Mouse keys


### PR DESCRIPTION
## Description

AVR + rgb + midi + mousekeys + via == bad times.  Too large.

## Types of Changes

- [x] Keymap/layout/userspace (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
