### PR TITLE
Adjust tap_code16 to account for TAP_HOLD_CAPS_DELAY

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -98,9 +98,12 @@ void unregister_code16(uint16_t code) {
 
 void tap_code16(uint16_t code) {
     register_code16(code);
-#if TAP_CODE_DELAY > 0
-    wait_ms(TAP_CODE_DELAY);
-#endif
+    if (code == KC_CAPS_LOCK) {
+        wait_ms(TAP_HOLD_CAPS_DELAY);
+    }
+    else if (TAP_CODE_DELAY > 0) {
+        wait_ms(TAP_CODE_DELAY); 
+    }
     unregister_code16(code);
 }
 


### PR DESCRIPTION
## Description

Unlike `tap_code`, `tap_code16` does not apply the caps lock delay (`TAP_HOLD_CAPS_DELAY`), when the key code is caps lock. As a result, in most operating systems, the caps lock key will not register since it's cycled too quickly. This change mirrors [the structure of `tap_code`](https://github.com/qmk/qmk_firmware/blob/c6ad3bf23d10d806c784c4cc3ceb7491a874de69/quantum/action.c#L970), but using the same function `wait_ms`, [as is currently in `tap_code16`](https://github.com/qmk/qmk_firmware/blob/c6ad3bf23d10d806c784c4cc3ceb7491a874de69/quantum/quantum.c#L102), to add this delay in, if the key code is caps lock.

This is consistent with existing documentation which says that the 16 version of the function behaves "similar" to the non 16 version.

> These functions work similar to their regular counterparts, but allow you to use modded keycodes (with Shift, Alt, Control, and/or GUI applied to them).
> \- https://docs.qmk.fm/#/feature_macros

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
