### PR TITLE
[Keyboard] fix compiler issue with Tractyl Manuform 4x6

### DIFF
--- a/keyboards/handwired/tractyl_manuform/4x6_right/rules.mk
+++ b/keyboards/handwired/tractyl_manuform/4x6_right/rules.mk
@@ -21,9 +21,7 @@ RGB_MATRIX_DRIVER = WS2812
 
 
 POINTING_DEVICE_ENABLE = yes
-MOUSE_SHARED_EP = no
+POINTING_DEVICE_DRIVER = pmw3360
+MOUSE_SHARED_EP = yes
 
 SPLIT_KEYBOARD = yes
-
-SRC += drivers/sensors/pmw3360.c
-QUANTUM_LIB_SRC += spi_master.c tm_sync.c


### PR DESCRIPTION
## Description

Removed tm_sync.c, but forgot to update the 4x6 version...


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
