### PR TITLE
[Keyboard] Fix bootloader type on mechmini v1 (bmc)

### DIFF
--- a/keyboards/mechmini/v1/rules.mk
+++ b/keyboards/mechmini/v1/rules.mk
@@ -2,7 +2,7 @@
 MCU = atmega32a
 
 # Bootloader selection
-BOOTLOADER = atmel-dfu
+BOOTLOADER = bootloadhid
 
 # Build Options
 #   change yes to no to disable


### PR DESCRIPTION
## Description

Recent changes to bootloader has revealed the compilation issue with the board.   The mechmini v1 is a bootmapper client board, so should be using the bootloadHID bootloader, not atmel-dfu. 

Targeting develop, since nobody has mentioned the issue. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
