### PR TITLE
Fix compilation-database command under MSYS

### DIFF
--- a/lib/python/qmk/cli/generate/compilation_database.py
+++ b/lib/python/qmk/cli/generate/compilation_database.py
@@ -26,7 +26,7 @@ def system_libs(binary: str) -> List[Path]:
 
     # Actually query xxxxxx-gcc to find its include paths.
     if binary.endswith("gcc") or binary.endswith("g++"):
-        result = cli.run([binary, '-E', '-Wp,-v', '-'], capture_output=True, check=True, input='\n')
+        result = cli.run([binary, '-E', '-Wp,-v', '-'], capture_output=True, check=True, stdin=None, input='\n')
         paths = []
         for line in result.stderr.splitlines():
             if line.startswith(" "):

--- a/lib/python/qmk/cli/generate/compilation_database.py
+++ b/lib/python/qmk/cli/generate/compilation_database.py
@@ -26,6 +26,7 @@ def system_libs(binary: str) -> List[Path]:
 
     # Actually query xxxxxx-gcc to find its include paths.
     if binary.endswith("gcc") or binary.endswith("g++"):
+        # (TODO): Remove 'stdin' once 'input' no longer causes issues under MSYS
         result = cli.run([binary, '-E', '-Wp,-v', '-'], capture_output=True, check=True, stdin=None, input='\n')
         paths = []
         for line in result.stderr.splitlines():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently produces the following error,
```
$ qmk generate-compilation-database
Ψ Making clean with make clean
QMK Firmware 0.15.11
Deleting .build/ ... done.
Ψ Gathering build instructions from make -n --jobs=1 gmmk/pro/ansi:xxxxxx
<class 'ValueError'>
☒ stdin and input arguments may not both be used.
Traceback (most recent call last):
  File "G:/QMK_MSYS/mingw64/lib/python3.9/site-packages/milc/milc.py", line 526, in __call__
    return self.__call__()
  File "G:/QMK_MSYS/mingw64/lib/python3.9/site-packages/milc/milc.py", line 531, in __call__
    return self._subcommand(self)
  File "G:/qmk_firmware/lib/python/qmk/decorators.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "G:/qmk_firmware/lib/python/qmk/decorators.py", line 47, in wrapper
    return func(*args, **kwargs)
  File "G:/qmk_firmware/lib/python/qmk/cli/generate/compilation_database.py", line 121, in generate_compilation_database
    db = parse_make_n(result.stdout.splitlines())
  File "G:/qmk_firmware/lib/python/qmk/cli/generate/compilation_database.py", line 67, in parse_make_n
    for s in system_libs(args[0]):
  File "G:/qmk_firmware/lib/python/qmk/cli/generate/compilation_database.py", line 29, in system_libs
    result = cli.run([binary, '-E', '-Wp,-v', '-'], capture_output=True, check=True, input='\n')
  File "G:/QMK_MSYS/mingw64/lib/python3.9/site-packages/milc/milc.py", line 156, in run
    return subprocess.run(command, **kwargs)
  File "G:/QMK_MSYS/mingw64/lib/python3.9/subprocess.py", line 495, in run
    raise ValueError('stdin and input arguments may not both be used.')
ValueError: stdin and input arguments may not both be used.
```

This is due to the windows workarounds in milc <https://github.com/clueboard/milc/blob/master/milc/milc.py#L136-L137>.

Setting `stdin=None` partially undoes the previous workaround <https://github.com/clueboard/milc/blob/master/milc/milc.py#L147-L148>, resulting in the final args only containing 'input' and producing the expected output.

Longer term it might be worth fixing this within milc, so have added a TODO.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* <https://discord.com/channels/440868230475677696/568161140534935572/925568799258857552>

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
