### PR TITLE
Add note about qmk doctor in newbs_flashing.md

### DIFF
--- a/docs/newbs_flashing.md
+++ b/docs/newbs_flashing.md
@@ -108,6 +108,8 @@ However, this does rely on the bootloader being set by the keyboard. If this inf
 
 In this case, you'll have to fall back on specifying the bootloader. See the [Flashing Firmware](flashing.md) Guide for more details.
 
+If your bootloader is not detected by `qmk flash`, try running `qmk doctor` for suggestions on how to fix common problems.
+
 ## Test It Out!
 
 Congrats! Your custom firmware has been programmed to your keyboard and you're ready to test it out!

--- a/docs/newbs_flashing.md
+++ b/docs/newbs_flashing.md
@@ -108,7 +108,7 @@ However, this does rely on the bootloader being set by the keyboard. If this inf
 
 In this case, you'll have to fall back on specifying the bootloader. See the [Flashing Firmware](flashing.md) Guide for more details.
 
-If your bootloader is not detected by `qmk flash`, try running `qmk doctor` for suggestions on how to fix common problems.
+!> If your bootloader is not detected by `qmk flash`, try running `qmk doctor` for suggestions on how to fix common problems.
 
 ## Test It Out!
 


### PR DESCRIPTION
## Description

On Archlinux, the newbs flashing guide doesn't work as the required udev rules for non-root flashing are not applied. qmk doctor informs the user about this, so it should be mentioned for newbs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
