### PR TITLE
[Keymap] Fix onekey oled keymap

### DIFF
--- a/keyboards/handwired/onekey/keymaps/oled/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/oled/keymap.c
@@ -390,7 +390,7 @@ bool oled_task_user(void) {
         // This mode is also forced when the screen update speed test is performed.
         if (!need_update) {
             if (test_mode != TEST_SLOW_UPDATE) {
-                return;
+                return false;
             }
         }
         need_update = false;


### PR DESCRIPTION
## Description

One of the returns doesn't return a value and causes a compilation error.  This fixes that. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
