### PR TITLE
checkerboards/quark_squared: fix broken layout macro reference in info.json

### DIFF
--- a/keyboards/checkerboards/quark_squared/info.json
+++ b/keyboards/checkerboards/quark_squared/info.json
@@ -3,7 +3,7 @@
     "url": "https://www.checkerboards.xyz/Quark2_p_35.html",
     "maintainer": "nasp",
     "layouts": {
-        "LAYOUT_ortho_4x12_2x225u": {
+        "LAYOUT_4_2x225u": {
             "layout": [{"label":"Tab", "x":0, "y":0}, {"label":"Q", "x":1, "y":0}, {"label":"W", "x":2, "y":0}, {"label":"E", "x":3, "y":0}, {"label":"R", "x":4, "y":0}, {"label":"T", "x":5, "y":0}, {"label":"Y", "x":6, "y":0}, {"label":"U", "x":7, "y":0}, {"label":"I", "x":8, "y":0}, {"label":"O", "x":9, "y":0}, {"label":"P", "x":10, "y":0}, {"label":"Back Space", "x":11, "y":0}, {"label":"Esc", "x":0, "y":1}, {"label":"A", "x":1, "y":1}, {"label":"S", "x":2, "y":1}, {"label":"D", "x":3, "y":1}, {"label":"F", "x":4, "y":1}, {"label":"G", "x":5, "y":1}, {"label":"H", "x":6, "y":1}, {"label":"J", "x":7, "y":1}, {"label":"K", "x":8, "y":1}, {"label":"L", "x":9, "y":1}, {"label":";", "x":10, "y":1}, {"label":"'", "x":11, "y":1}, {"label":"Shift", "x":0, "y":2}, {"label":"Z", "x":1, "y":2}, {"label":"X", "x":2, "y":2}, {"label":"C", "x":3, "y":2}, {"label":"V", "x":4, "y":2}, {"label":"B", "x":5, "y":2}, {"label":"N", "x":6, "y":2}, {"label":"M", "x":7, "y":2}, {"label":",", "x":8, "y":2}, {"label":".", "x":9, "y":2}, {"label":"/", "x":10, "y":2}, {"label":"Return", "x":11, "y":2}, {"label":"Ctrl", "x":0, "y":3, "w":1.25}, {"label":"Super", "x":1.25, "y":3, "w":1.25}, {"label":"Alt", "x":2.5, "y":3, "w":1.25}, {"x":3.75, "y":3, "w":2.25}, {"x":6, "y":3, "w":2.25}, {"label":"Alt", "x":8.25, "y":3, "w":1.25}, {"label":"Super", "x":9.5, "y":3, "w":1.25}, {"label":"Ctrl", "x":10.75, "y":3, "w":1.25}]
         },
         "LAYOUT_4_2u": {


### PR DESCRIPTION
## Description

[title]

Fixes:
![image](https://user-images.githubusercontent.com/18669334/148352044-426a8bc0-c637-4ab5-b6cd-fb19bff9ec98.png)


cc @npspears (keyboard maintainer)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
