### PR TITLE
Return false in handwired/onekey:oled's oled_task_user function

### DIFF
--- a/keyboards/handwired/onekey/keymaps/oled/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/oled/keymap.c
@@ -390,7 +390,7 @@ bool oled_task_user(void) {
         // This mode is also forced when the screen update speed test is performed.
         if (!need_update) {
             if (test_mode != TEST_SLOW_UPDATE) {
-                return;
+                return false;
             }
         }
         need_update = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Returns false in `oled_task_user` to fix the following compiler error:
```
❯ qmk compile -kb handwired/onekey -km oled
Ψ Compiling keymap with make --jobs=1 handwired/onekey/promicro:oled


QMK Firmware 0.15.12
Making handwired/onekey/promicro with keymap oled

avr-gcc (GCC) 5.4.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text	   data	    bss	    dec	    hex	filename
      0	  25678	      0	  25678	   644e	.build/handwired_onekey_promicro_oled.hex

Compiling: keyboards/handwired/onekey/keymaps/oled/keymap.c                                        keyboards/handwired/onekey/keymaps/oled/keymap.c: In function ‘oled_task_user’:
keyboards/handwired/onekey/keymaps/oled/keymap.c:393:17: error: ‘return’ with no value, in function returning non-void [-Werror]
                 return;
                 ^
cc1: all warnings being treated as errors
 [ERRORS]
 | 
 | 
 | 
make[1]: *** [tmk_core/rules.mk:457: .build/obj_handwired_onekey_promicro_oled/keyboards/handwired/onekey/keymaps/oled/keymap.o] Error 1
Make finished with errors
make: *** [Makefile:478: handwired/onekey/promicro:oled] Error 1
```
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
