### PR TITLE
Fix inverted ploopy trackball

### DIFF
--- a/keyboards/ploopyco/trackball/config.h
+++ b/keyboards/ploopyco/trackball/config.h
@@ -60,3 +60,4 @@
 
 /* PMW3360 Settings */
 #define PMW3360_CS_PIN             B0
+#define POINTING_DEVICE_INVERT_Y


### PR DESCRIPTION
After the ploopy firmware was rewritten to use the new QMK pointing
device feature it got the unfortunate behaviour of inverting the
trackball in the Y-axis.

This commit inverts the Y-axis so that the ploopy firmware
behave like it used to do before the pointing device changes.
