### PR TITLE
[Core] ChibiOS: shorten USB disconnect state on boot to 50ms

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -734,7 +734,7 @@ void init_usb_driver(USBDriver *usbp) {
      * after a reset.
      */
     usbDisconnectBus(usbp);
-    wait_ms(1500);
+    wait_ms(50);
     usbStart(usbp, &usbcfg);
     usbConnectBus(usbp);
 


### PR DESCRIPTION
## Description

(Disclaimer: This is the rationale a came up after reading the USB spec, please feel free the chime in if this is wrong)

A SE0 state for longer then 2.5us signals a device disconnect from the USB bus - according to the USB specs. So the 1500ms are much longer than actually needed and had been copied from the ChibiOS demo code. That code does not state any reason for the long wait.

The new 50ms wait was chosen arbitrarily to be barely noticeable, but to be plenty of time for hosts/hubs that do not adhere to the specs. For split keyboards which rely on a fast enumeration for primary / secondary negotiation this shortens the boot up noticeably.

Also a soft reset for the USB connection should only be necessary for:

* MCUs with fixed pull-ups on the data lines that always signal readiness
to establish a USB connection to the host
* In situations where a system is reset without a real cable disconnect

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Noticeable timeout for ChibiOS based keyboards on boot

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
