### PR TITLE
[Keyboard] Add via config for the id67 rgb variant

### DIFF
--- a/keyboards/id67/rgb/config.h
+++ b/keyboards/id67/rgb/config.h
@@ -70,6 +70,8 @@
 
 // RGB Matrix config
 #if defined(RGB_MATRIX_ENABLE)
+    #define VIA_QMK_RGBLIGHT_ENABLE
+
     #define DRIVER_LED_TOTAL 77
     #define DRIVER_LED_UNDERGLOW 10
 
@@ -77,6 +79,8 @@
     #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 150 // limits maximum brightness of LEDs to 200 out of 255. If not defined maximum brightness is set to 255
 
     #define RGB_MATRIX_KEYPRESSES
+    #define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+
     #define ENABLE_RGB_MATRIX_ALPHAS_MODS          // Static dual hue, speed is hue for secondary hue
     #define ENABLE_RGB_MATRIX_GRADIENT_UP_DOWN     // Static gradient top to bottom, speed controls how much gradient changes
     #define ENABLE_RGB_MATRIX_GRADIENT_LEFT_RIGHT  // Static gradient left to right, speed controls how much gradient changes
@@ -103,6 +107,10 @@
     #define ENABLE_RGB_MATRIX_HUE_BREATHING        // Hue shifts up a slight ammount at the same time, then shifts back
     #define ENABLE_RGB_MATRIX_HUE_PENDULUM         // Hue shifts up a slight ammount in a wave to the right, then back to the left
     #define ENABLE_RGB_MATRIX_HUE_WAVE             // Hue shifts up a slight ammount and then back down in a wave to the right
+#if defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS)
+    #define ENABLE_RGB_MATRIX_TYPING_HEATMAP       // How hot is your WPM!
+    #define ENABLE_RGB_MATRIX_DIGITAL_RAIN         // That famous computer simulation
+#endif
 #if defined(RGB_MATRIX_KEYPRESSES) || defined(RGB_MATRIX_KEYRELEASES)
     #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE// Pulses keys hit to hue & value then fades value out
     #define ENABLE_RGB_MATRIX_SOLID_REACTIVE       // Static single hue, pulses keys hit to shifted hue then fades to current hue

--- a/keyboards/id67/rgb/keymaps/thewerther/config.h
+++ b/keyboards/id67/rgb/keymaps/thewerther/config.h
@@ -18,6 +18,7 @@
 
 #define DRIVER_LED_UNDERGLOW 10
 #define TAPPING_TERM 500
+#define TAPPING_TERM_PER_KEY
 
 #if defined(RGB_MATRIX_ENABLE)
     #define RGB_DISABLE_WHEN_USB_SUSPENDED true // turn off effects when suspended
@@ -31,6 +32,7 @@
     #define RGBLIGHT_HUE_STEP 5
 
     #define RGB_MATRIX_KEYPRESSES
+    #define RGB_MATRIX_FRAMEBUFFER_EFFECTS
 
     // disable effects from keyboard level config.h
     #undef ENABLE_RGB_MATRIX_ALPHAS_MODS
@@ -83,7 +85,15 @@
     #define ENABLE_RGB_MATRIX_RAINBOW_BEACON
     #define ENABLE_RGB_MATRIX_JELLYBEAN_RAINDROPS
     #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_MULTINEXUS
+    #define ENABLE_RGB_MATRIX_TYPING_HEATMAP
+    #define ENABLE_RGB_MATRIX_DIGITAL_RAIN
     #define ENABLE_RGB_MATRIX_CYCLE_UP_DOWN
+
+#if defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS)
+    #define ENABLE_RGB_MATRIX_TYPING_HEATMAP      // How hot is your WPM!
+    #define ENABLE_RGB_MATRIX_DIGITAL_RAIN        // That famous computer simulation
+#endif
+
 
 #if defined(RGB_MATRIX_KEYPRESSES) || defined(RGB_MATRIX_KEYRELEASES)
     #define ENABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE// Pulses keys hit to hue & value then fades value out

--- a/keyboards/id67/rgb/keymaps/thewerther/keymap.c
+++ b/keyboards/id67/rgb/keymaps/thewerther/keymap.c
@@ -27,29 +27,146 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
     [1] = LAYOUT_65_ansi_blocker(
         _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,          _______,
-        _______,     _______, _______,  _______, _______, _______, _______, KC_PGUP, _______, _______, _______, _______, _______, _______,     _______,
-        _______,        _______, _______, KC_PGDN, _______, _______, KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT,  _______, _______, _______,            _______,
+        _______,     _______, _______,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,     _______,
+        _______,        _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT,  _______, _______, _______,            _______,
         _______,           _______,  _______,  _______, _______, _______, _______, _______, _______, _______,  _______,  _______,  _______,    _______,
         _______,   _______,   _______,                      _______,                              _______,   _______,   _______,   _______,    _______
     ),
     [2] = LAYOUT_65_ansi_blocker(
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,      _______,     _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,
         _______,     RGB_TOG, _______,  RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_MPLY, KC_MPRV, KC_MNXT, _______,     _______,
         _______,        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,            KC_HOME,
         _______,           RESET,  RGB_SPI,  RGB_SPD, _______, KC_VOLD, KC_MUTE, KC_VOLU, _______, _______,  _______,  _______,  _______,      KC_END,
         _______,   _______,   _______,                      _______,                              _______,   _______,   _______,   _______,    _______
-    )
-
+    ),
 };
+
+void set_layer_rgb_color(uint8_t led_min, uint8_t led_max, uint8_t layer);
+static bool shift_space_pressed = false;
+
+void keyboard_post_init_user(void) {
+#   if defined(COMMAND_ENABLE) || defined(CONSOLE_ENABLE)
+    // Customise these values to desired behaviour
+    debug_enable=true;
+    debug_matrix=true;
+    //debug_keyboard=true;
+    //debug_mouse=true;
+#   endif
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    // If console is enabled, it will print the matrix position and status
+    // of each key pressed.
+#   if defined(CONSOLE_ENABLE)
+    uprintf("KL: kc: %u, col: %u, row: %u, pressed: %u\n",
+            keycode,
+            record->event.key.col,
+            record->event.key.row,
+            record->event.pressed);
+#   endif
+    switch (keycode) {
+        case LT(1, KC_SPC):
+            if (record->event.pressed) { // key pressed
+                // disable the hold action of LT(1, KC_SPC) when pressing LSFT
+                // TODO: There is probably a better way of doing this
+                if ((get_mods() & MOD_BIT(KC_LSFT)) == MOD_BIT(KC_LSFT)) {
+                    /* On LSHIFT down we set this to false again to avoid
+                     * getting space "stuck" and keep sending down events.
+                     */
+                    shift_space_pressed = true;
+                    register_code(KC_SPC);
+                    return false;
+                } else {
+                    return true;
+                }
+            } else { // key released
+                if ((get_mods() & MOD_BIT(KC_LSFT)) == MOD_BIT(KC_LSFT)) {
+                    if (shift_space_pressed) {
+                        unregister_code(KC_SPC);
+                        return true;
+                    }
+                } else {
+                    return true;
+                }
+            }
+            return true;
+
+        case KC_LSHIFT:
+            if (!record->event.pressed) {
+                if (shift_space_pressed) {
+                    unregister_code(KC_SPC);
+                    shift_space_pressed = false;
+                }
+            }
+            return true;
+        default:
+            return true;
+    }
+    return true;
+}
+
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case LT(1, KC_SPC):
+            // When pressing shift and space set tapping term to 0 in order to
+            // be able to press space faster consecutively
+            if ((get_mods() & MOD_BIT(KC_LSFT)) == MOD_BIT(KC_LSFT)) {
+                return 0;
+            } else {
+                return TAPPING_TERM;
+            }
+        default:
+            return TAPPING_TERM;
+    }
+}
 
 void matrix_scan_user(void) {
 #   if defined(RGB_MATRIX_ENABLE)
+    /* Set the bottom leds of the PCB to the current color for all reactive
+     * RGB Matrix effects.
+     */
     int current_effect = rgb_matrix_get_mode();
-    if (current_effect >= RGB_MATRIX_SOLID_REACTIVE_SIMPLE && current_effect <= RGB_MATRIX_SOLID_MULTISPLASH) {
+    if (current_effect >= RGB_MATRIX_SOLID_REACTIVE_SIMPLE &&
+        current_effect <= RGB_MATRIX_SOLID_MULTISPLASH) {
         // set all underglow leds to current color
         RGB current_color = hsv_to_rgb(rgb_matrix_get_hsv());
-        for (int i = DRIVER_LED_TOTAL - DRIVER_LED_UNDERGLOW; i < DRIVER_LED_TOTAL; i++) {
-            rgb_matrix_set_color(i, current_color.r, current_color.g, current_color.b);
+        for (int i = DRIVER_LED_TOTAL - DRIVER_LED_UNDERGLOW;
+            i < DRIVER_LED_TOTAL; i++) {
+            rgb_matrix_set_color(i,
+                    current_color.r,
+                    current_color.g,
+                    current_color.b);
+        }
+    }
+#   endif
+}
+
+void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+#   if defined(RGB_MATRIX_ENABLE)
+    if (get_highest_layer(layer_state) > 0) {
+        uint8_t layer = get_highest_layer(layer_state);
+        set_layer_rgb_color(led_min, led_max, layer);
+    }
+#   endif
+}
+
+void set_layer_rgb_color(uint8_t led_min, uint8_t led_max, uint8_t layer) {
+    // Set only the assigned keys of the current layer to a specific color.
+#   if defined(RGB_MATRIX_ENABLE)
+    RGB color = hsv_to_rgb((HSV){0, 0, rgb_matrix_config.hsv.v});
+    if (layer == 2) {
+        color = hsv_to_rgb(rgb_matrix_get_hsv());
+    }
+    for (uint8_t row = 0; row < MATRIX_ROWS; ++row) {
+        for (uint8_t col = 0; col < MATRIX_COLS; ++col) {
+            uint8_t index = g_led_config.matrix_co[row][col];
+
+            if (index >= led_min &&
+                index <= led_max &&
+                index != NO_LED &&
+                keymap_key_to_keycode(layer, (keypos_t){col,row}) > KC_TRNS) {
+                    rgb_matrix_set_color(index, color.r, color.g, color.b);
+            }
         }
     }
 #   endif

--- a/keyboards/id67/rgb/keymaps/thewerther/rules.mk
+++ b/keyboards/id67/rgb/keymaps/thewerther/rules.mk
@@ -1,2 +1,3 @@
+MOUSEKEY_ENABLE = no        # Mouse keys
 CONSOLE_ENABLE = no         # Console for debug
 COMMAND_ENABLE = no         # Commands for debug and configuration

--- a/keyboards/id67/rgb/keymaps/via/keymap.c
+++ b/keyboards/id67/rgb/keymaps/via/keymap.c
@@ -1,0 +1,48 @@
+/* Copyright 2021 Tybera
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT_65_ansi_blocker(
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          KC_TILD,
+        KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,      KC_DEL,
+        KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,              KC_PGUP,
+        KC_LSFT,            KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,          KC_PGDN,
+        KC_LCTL,   KC_LGUI,   KC_LALT,                       KC_SPC,                              MO(1),     KC_RCTL,   KC_LEFT,   KC_DOWN,    KC_RGHT
+    ),
+    [1] = LAYOUT_65_ansi_blocker(
+        _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,          _______,
+        _______,     RGB_TOG, KC_UP,   RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______, _______, _______,      _______,
+        _______,       KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, KC_INS,  KC_HOME, KC_PGUP, _______,             _______,
+        _______,           RESET,  RGB_SPI,  RGB_SPD, _______, KC_VOLD, KC_MUTE, KC_VOLU, _______, KC_DEL,  KC_END,  KC_PGDN, _______,         _______,
+        _______,   _______,   _______,                      _______,                              _______,   _______,   _______,   _______,    _______
+    ),
+	[2] = LAYOUT_65_ansi_blocker(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,
+        _______,     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,      _______,
+        _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
+        _______,            _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        _______,
+        _______,   _______,   _______,                      _______,                              _______,   _______,   _______,   _______,    _______
+    ),
+	[3] = LAYOUT_65_ansi_blocker(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,
+        _______,     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,      _______,
+        _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
+        _______,            _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        _______,
+        _______,   _______,   _______,                      _______,                              _______,   _______,   _______,   _______,    _______
+    ),
+};

--- a/keyboards/id67/rgb/keymaps/via/rules.mk
+++ b/keyboards/id67/rgb/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/id67/rgb/rules.mk
+++ b/keyboards/id67/rgb/rules.mk
@@ -16,6 +16,7 @@ NKRO_ENABLE = no            # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
+LTO_ENABLE = yes            # Enable Link Time Optimization
 
 RGB_MATRIX_ENABLE = yes     # Enable RGB Matrix feature
 RGB_MATRIX_DRIVER = WS2812 	# ID67 uses WS2812 driver


### PR DESCRIPTION
Add the necessary changes to the `via` keymap in the new id67 `rgb` variant folder.
Plus some changes to my personal keymap.

## Description

- Added RGB Matrix support to the id67. The via part will be added when this PR has been merged.
- Updated my personal keymap

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
