### PR TITLE
Quick add of base files to new ID67 RGB Matrix variant to allow base compile

### DIFF
--- a/keyboards/id67/id67.c
+++ b/keyboards/id67/id67.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Tybera
+ * Copyright 2021 thewerther
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "id67.h"

--- a/keyboards/id67/id67.h
+++ b/keyboards/id67/id67.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Tybera
+ * Copyright 2021 thewerther
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if defined(KEYBOARD_id67_default_rgb)
+    #include "default_rgb.h"
+#elif defined(KEYBOARD_id67_rgb)
+    #include "rgb.h"
+#endif
+
+#include "quantum.h"

--- a/keyboards/id67/readme.md
+++ b/keyboards/id67/readme.md
@@ -4,21 +4,25 @@ A 65% hotswap keyboard from IDOBAO.
 
 ## ANSI support:
 
-* Keyboard Maintainer: Tybera
+* Keyboard Maintainer: Tybera (default_rgb), thewerther (rgb)
 * Hardware Supported: IDOBAO ID67
 * Hardware Availability: [IDOBAO](https://www.idobao.net/products/idobao-id67-65-hot-swappable-mechanical-keyboard-kit-1)
 
 ## Variants
 
-Currently there are two variants for the id67:
-1. `rgb_default` which uses the `RGB Lightning` feature for the on-board LEDs.
-2. `rgb` which uses the more advanced `RGB Matrix` feature for the per-key and underglow (bottom of PCB) LEDs.
+Currently there are two variants of the firmware for the ID67:
+1. `default_rgb` which uses the *`RGB Lightning`* feature for the on-board LEDs.
+2. `rgb` which uses the more advanced *`RGB Matrix`* feature for the per-key and underglow (bottom of PCB) LEDs.
 
 Make examples for this keyboard (after setting up your build environment):
 
     make id67/default_rgb:default
 
     make id67/rgb:default
+    
+You may also use the orignial (which now compiles the `rgb`/*`RGB Matrix`* variant):
+
+    make id67:default
 
 Flashing examples for this keyboard:
 
@@ -27,3 +31,11 @@ Flashing examples for this keyboard:
     make id67/rgb:default:flash
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Physical reset button**: Briefly press the button on the back of the PCB
+* **Keycode in layout**: Press the key mapped to `RESET` if it is available

--- a/keyboards/id67/rules.mk
+++ b/keyboards/id67/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER=id67/rgb


### PR DESCRIPTION
## Description

PR #15558 added a RGB Matrix variant to the ID67 code base, buy retaining and moving to sub-folders.

This PR add 3 files:   `id67.h` , `id67.c`, and `rules.mk` that allow the original `make id67` compile command to still work, without the need for specificity of the sub-folder.

*(I have tested all three make commands to success.)*

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

none :( 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
