### PR TITLE
[Core] Refactor `keyevent_t` for 1ms timing resolution 

### DIFF
--- a/docs/feature_stenography.md
+++ b/docs/feature_stenography.md
@@ -138,7 +138,7 @@ bool post_process_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t
 
 This function is called after a key has been processed, but before any decision about whether or not to send a chord. This is where to put hooks for things like, say, live displays of steno chords or keys.
 
-If `IS_PRESSED(record->event)` is false, and `n_pressed_keys` is 0 or 1, the chord will be sent shortly, but has not yet been sent. This relieves you of the need of keeping track of where a packet ends and another begins.
+If `record->event.pressed` is false, and `n_pressed_keys` is 0 or 1, the chord will be sent shortly, but has not yet been sent. This relieves you of the need of keeping track of where a packet ends and another begins.
 
 The `chord` argument contains the packet of the current chord as specified by the protocol in use. This is *NOT* simply a list of chorded steno keys of the form `[STN_E, STN_U, STN_BR, STN_GR]`. Refer to the appropriate protocol section of this document to learn more about the format of the packets in your steno protocol/mode of choice.
 

--- a/docs/ja/feature_stenography.md
+++ b/docs/ja/feature_stenography.md
@@ -80,7 +80,7 @@ bool process_steno_user(uint16_t keycode, keyrecord_t *record) { return true; }
 bool post_process_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[6], int8_t pressed);
 ```
 
-この関数はキーが処理された後、ただしコードを送信するかどうかを決める前に呼び出されます。`IS_PRESSED(record->event)` が false で、`pressed` が 0 または 1 の場合は、コードはまもなく送信されますが、まだ送信されてはいません。ここが速記コードあるいはキーのライブ表示などのフックを配置する場所です。
+この関数はキーが処理された後、ただしコードを送信するかどうかを決める前に呼び出されます。`record->event.pressed` が false で、`pressed` が 0 または 1 の場合は、コードはまもなく送信されますが、まだ送信されてはいません。ここが速記コードあるいはキーのライブ表示などのフックを配置する場所です。
 
 
 ## キーコードリファレンス :id=keycode-reference

--- a/keyboards/atlantis/encoder_actions.c
+++ b/keyboards/atlantis/encoder_actions.c
@@ -28,7 +28,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -40,7 +41,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/custommk/evo70/keymaps/via/keymap.c
+++ b/keyboards/custommk/evo70/keymaps/via/keymap.c
@@ -57,12 +57,14 @@ void set_custom_encoder_mode_user(bool custom_mode) {
 
 keyevent_t encoder_ccw = {
     .key = (keypos_t){.row = 4, .col = 7},
-    .pressed = false
+    .pressed = false,
+	.type = KEY_EVENT
 };
 
 keyevent_t encoder_cw = {
     .key = (keypos_t){.row = 4, .col = 10},
-    .pressed = false
+    .pressed = false,
+	.type = KEY_EVENT
 };
 
 
@@ -70,12 +72,12 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 	if (custom_encoder_mode) {
 	    if (clockwise) {
 	        encoder_cw.pressed = true;
-		    encoder_cw.time = (timer_read() | 1);
+		    encoder_cw.time = timer_read();
 		    action_exec(encoder_cw);
 	    }
 	    else {
 		    encoder_ccw.pressed = true;
-		    encoder_ccw.time = (timer_read() | 1);
+		    encoder_ccw.time = timer_read();
 		    action_exec(encoder_ccw);
 	    }
 		return false;
@@ -86,13 +88,13 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 void matrix_scan_user(void) {
 	if (IS_PRESSED(encoder_ccw)) {
 		encoder_ccw.pressed = false;
-		encoder_ccw.time = (timer_read() | 1);
+		encoder_ccw.time = timer_read();
 		action_exec(encoder_ccw);
 	}
 
 	if (IS_PRESSED(encoder_cw)) {
 		encoder_cw.pressed = false;
-		encoder_cw.time = (timer_read() | 1);
+		encoder_cw.time = timer_read();
 		action_exec(encoder_cw);
 	}
 }

--- a/keyboards/custommk/genesis/rev2/keymaps/via/keymap.c
+++ b/keyboards/custommk/genesis/rev2/keymaps/via/keymap.c
@@ -95,46 +95,50 @@ void keyboard_post_init_user(void) {
 
 keyevent_t encoder_left_ccw = {
     .key = (keypos_t){.row = 5, .col = 0},
-    .pressed = false
+    .pressed = false,
+	.type = KEY_EVENT
 };
 
 keyevent_t encoder_left_cw = {
     .key = (keypos_t){.row = 5, .col = 1},
     .pressed = false
+	.type = KEY_EVENT
 };
 
 keyevent_t encoder_right_ccw = {
     .key = (keypos_t){.row = 5, .col = 2},
     .pressed = false
+	.type = KEY_EVENT
 };
 
 keyevent_t encoder_right_cw = {
     .key = (keypos_t){.row = 5, .col = 3},
     .pressed = false
+	.type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_left_ccw)) {
         encoder_left_ccw.pressed = false;
-        encoder_left_ccw.time = (timer_read() | 1);
+        encoder_left_ccw.time = timer_read();
         action_exec(encoder_left_ccw);
     }
 
     if (IS_PRESSED(encoder_left_cw)) {
         encoder_left_cw.pressed = false;
-        encoder_left_cw.time = (timer_read() | 1);
+        encoder_left_cw.time = timer_read();
         action_exec(encoder_left_cw);
     }
 
     if (IS_PRESSED(encoder_right_ccw)) {
         encoder_right_ccw.pressed = false;
-        encoder_right_ccw.time = (timer_read() | 1);
+        encoder_right_ccw.time = timer_read();
         action_exec(encoder_right_ccw);
     }
 
     if (IS_PRESSED(encoder_right_cw)) {
         encoder_right_cw.pressed = false;
-        encoder_right_cw.time = (timer_read() | 1);
+        encoder_right_cw.time = timer_read();
         action_exec(encoder_right_cw);
     }
 	
@@ -145,21 +149,21 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 	if (index == 0) {
 		if (clockwise) {
 			encoder_left_cw.pressed = true;
-			encoder_left_cw.time = (timer_read() | 1);
+			encoder_left_cw.time = timer_read();
 			action_exec(encoder_left_cw);
 		} else {
 			encoder_left_ccw.pressed = true;
-			encoder_left_ccw.time = (timer_read() | 1);
+			encoder_left_ccw.time = timer_read();
 			action_exec(encoder_left_ccw);
 		}
 	} else {
 		if (clockwise) {
 			encoder_right_cw.pressed = true;
-			encoder_right_cw.time = (timer_read() | 1);
+			encoder_right_cw.time = timer_read();
 			action_exec(encoder_right_cw);
 		} else {
 			encoder_right_ccw.pressed = true;
-			encoder_right_ccw.time = (timer_read() | 1);
+			encoder_right_ccw.time = timer_read();
 			action_exec(encoder_right_ccw);
 		}
 	}

--- a/keyboards/dailycraft/owl8/keymaps/via/keymap.c
+++ b/keyboards/dailycraft/owl8/keymaps/via/keymap.c
@@ -52,46 +52,50 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder1_ccw = {
     .key = (keypos_t){.row = 0, .col = 12},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder1_cw = {
     .key = (keypos_t){.row = 0, .col = 13},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder2_ccw = {
     .key = (keypos_t){.row = 0, .col = 14},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder2_cw = {
     .key = (keypos_t){.row = 0, .col = 15},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder1_ccw)) {
         encoder1_ccw.pressed = false;
-        encoder1_ccw.time = (timer_read() | 1);
+        encoder1_ccw.time = timer_read();
         action_exec(encoder1_ccw);
     }
 
     if (IS_PRESSED(encoder1_cw)) {
         encoder1_cw.pressed = false;
-        encoder1_cw.time = (timer_read() | 1);
+        encoder1_cw.time = timer_read();
         action_exec(encoder1_cw);
     }
 
     if (IS_PRESSED(encoder2_ccw)) {
         encoder2_ccw.pressed = false;
-        encoder2_ccw.time = (timer_read() | 1);
+        encoder2_ccw.time = timer_read();
         action_exec(encoder2_ccw);
     }
 
     if (IS_PRESSED(encoder2_cw)) {
         encoder2_cw.pressed = false;
-        encoder2_cw.time = (timer_read() | 1);
+        encoder2_cw.time = timer_read();
         action_exec(encoder2_cw);
     }
 }
@@ -100,21 +104,21 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) { /* First encoder */
         if (clockwise) {
             encoder1_cw.pressed = true;
-            encoder1_cw.time = (timer_read() | 1);
+            encoder1_cw.time = timer_read();
             action_exec(encoder1_cw);
         } else {
             encoder1_ccw.pressed = true;
-            encoder1_ccw.time = (timer_read() | 1);
+            encoder1_ccw.time = timer_read();
             action_exec(encoder1_ccw);
         }
     } else if (index == 1) {
         if (clockwise) {
             encoder2_cw.pressed = true;
-            encoder2_cw.time = (timer_read() | 1);
+            encoder2_cw.time = timer_read();
             action_exec(encoder2_cw);
         } else {
             encoder2_ccw.pressed = true;
-            encoder2_ccw.time = (timer_read() | 1);
+            encoder2_ccw.time = timer_read();
             action_exec(encoder2_ccw);
         }
     }

--- a/keyboards/dailycraft/stickey4/keymaps/via/keymap.c
+++ b/keyboards/dailycraft/stickey4/keymaps/via/keymap.c
@@ -44,46 +44,50 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder1_ccw = {
     .key = (keypos_t){.row = 0, .col = 4},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder1_cw = {
     .key = (keypos_t){.row = 0, .col = 5},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder2_ccw = {
     .key = (keypos_t){.row = 0, .col = 6},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder2_cw = {
     .key = (keypos_t){.row = 0, .col = 7},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder1_ccw)) {
         encoder1_ccw.pressed = false;
-        encoder1_ccw.time = (timer_read() | 1);
+        encoder1_ccw.time = timer_read();
         action_exec(encoder1_ccw);
     }
 
     if (IS_PRESSED(encoder1_cw)) {
         encoder1_cw.pressed = false;
-        encoder1_cw.time = (timer_read() | 1);
+        encoder1_cw.time = timer_read();
         action_exec(encoder1_cw);
     }
 
     if (IS_PRESSED(encoder2_ccw)) {
         encoder2_ccw.pressed = false;
-        encoder2_ccw.time = (timer_read() | 1);
+        encoder2_ccw.time = timer_read();
         action_exec(encoder2_ccw);
     }
 
     if (IS_PRESSED(encoder2_cw)) {
         encoder2_cw.pressed = false;
-        encoder2_cw.time = (timer_read() | 1);
+        encoder2_cw.time = timer_read();
         action_exec(encoder2_cw);
     }
 }
@@ -92,21 +96,21 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) { /* First encoder */
         if (clockwise) {
             encoder1_cw.pressed = true;
-            encoder1_cw.time = (timer_read() | 1);
+            encoder1_cw.time = timer_read();
             action_exec(encoder1_cw);
         } else {
             encoder1_ccw.pressed = true;
-            encoder1_ccw.time = (timer_read() | 1);
+            encoder1_ccw.time = timer_read();
             action_exec(encoder1_ccw);
         }
     } else if (index == 1) {
         if (clockwise) {
             encoder2_cw.pressed = true;
-            encoder2_cw.time = (timer_read() | 1);
+            encoder2_cw.time = timer_read();
             action_exec(encoder2_cw);
         } else {
             encoder2_ccw.pressed = true;
-            encoder2_ccw.time = (timer_read() | 1);
+            encoder2_ccw.time = timer_read();
             action_exec(encoder2_ccw);
         }
     }

--- a/keyboards/dailycraft/wings42/rev2/keymaps/via/keymap.c
+++ b/keyboards/dailycraft/wings42/rev2/keymaps/via/keymap.c
@@ -82,91 +82,99 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder1_ccw = {
     .key = (keypos_t){.row = 4, .col = 0},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder1_cw = {
     .key = (keypos_t){.row = 4, .col = 1},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder2_ccw = {
     .key = (keypos_t){.row = 4, .col = 2},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder2_cw = {
     .key = (keypos_t){.row = 4, .col = 3},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder3_ccw = {
     .key = (keypos_t){.row = 9, .col = 1},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder3_cw = {
     .key = (keypos_t){.row = 9, .col = 0},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder4_ccw = {
     .key = (keypos_t){.row = 9, .col = 3},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder4_cw = {
     .key = (keypos_t){.row = 9, .col = 2},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder1_ccw)) {
         encoder1_ccw.pressed = false;
-        encoder1_ccw.time = (timer_read() | 1);
+        encoder1_ccw.time = timer_read();
         action_exec(encoder1_ccw);
     }
 
     if (IS_PRESSED(encoder1_cw)) {
         encoder1_cw.pressed = false;
-        encoder1_cw.time = (timer_read() | 1);
+        encoder1_cw.time = timer_read();
         action_exec(encoder1_cw);
     }
 
     if (IS_PRESSED(encoder2_ccw)) {
         encoder2_ccw.pressed = false;
-        encoder2_ccw.time = (timer_read() | 1);
+        encoder2_ccw.time = timer_read();
         action_exec(encoder2_ccw);
     }
 
     if (IS_PRESSED(encoder2_cw)) {
         encoder2_cw.pressed = false;
-        encoder2_cw.time = (timer_read() | 1);
+        encoder2_cw.time = timer_read();
         action_exec(encoder2_cw);
     }
 
     if (IS_PRESSED(encoder3_ccw)) {
         encoder3_ccw.pressed = false;
-        encoder3_ccw.time = (timer_read() | 1);
+        encoder3_ccw.time = timer_read();
         action_exec(encoder3_ccw);
     }
 
     if (IS_PRESSED(encoder3_cw)) {
         encoder3_cw.pressed = false;
-        encoder3_cw.time = (timer_read() | 1);
+        encoder3_cw.time = timer_read();
         action_exec(encoder3_cw);
     }
 
     if (IS_PRESSED(encoder4_ccw)) {
         encoder4_ccw.pressed = false;
-        encoder4_ccw.time = (timer_read() | 1);
+        encoder4_ccw.time = timer_read();
         action_exec(encoder4_ccw);
     }
 
     if (IS_PRESSED(encoder4_cw)) {
         encoder4_cw.pressed = false;
-        encoder4_cw.time = (timer_read() | 1);
+        encoder4_cw.time = timer_read();
         action_exec(encoder4_cw);
     }
 }
@@ -175,41 +183,41 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) {
         if (clockwise) {
             encoder1_cw.pressed = true;
-            encoder1_cw.time = (timer_read() | 1);
+            encoder1_cw.time = timer_read();
             action_exec(encoder1_cw);
         } else {
             encoder1_ccw.pressed = true;
-            encoder1_ccw.time = (timer_read() | 1);
+            encoder1_ccw.time = timer_read();
             action_exec(encoder1_ccw);
         }
     } else if (index == 1) {
         if (clockwise) {
             encoder2_cw.pressed = true;
-            encoder2_cw.time = (timer_read() | 1);
+            encoder2_cw.time = timer_read();
             action_exec(encoder2_cw);
         } else {
             encoder2_ccw.pressed = true;
-            encoder2_ccw.time = (timer_read() | 1);
+            encoder2_ccw.time = timer_read();
             action_exec(encoder2_ccw);
         }
     } else if (index == 2) {
         if (clockwise) {
             encoder3_cw.pressed = true;
-            encoder3_cw.time = (timer_read() | 1);
+            encoder3_cw.time = timer_read();
             action_exec(encoder3_cw);
         } else {
             encoder3_ccw.pressed = true;
-            encoder3_ccw.time = (timer_read() | 1);
+            encoder3_ccw.time = timer_read();
             action_exec(encoder3_ccw);
         }
     } else if (index == 3) {
         if (clockwise) {
             encoder4_cw.pressed = true;
-            encoder4_cw.time = (timer_read() | 1);
+            encoder4_cw.time = timer_read();
             action_exec(encoder4_cw);
         } else {
             encoder4_ccw.pressed = true;
-            encoder4_ccw.time = (timer_read() | 1);
+            encoder4_ccw.time = timer_read();
             action_exec(encoder4_ccw);
         }
     }

--- a/keyboards/gl516/n51gl/keymaps/salicylic/keymap.c
+++ b/keyboards/gl516/n51gl/keymaps/salicylic/keymap.c
@@ -111,7 +111,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
         key.row = 1;
         key.col = 0;
     }
-    action_exec((keyevent_t){.key = key, .pressed = true, .time = (timer_read() | 1)});
-    action_exec((keyevent_t){.key = key, .pressed = false, .time = (timer_read() | 1)});
+    action_exec(MAKE_KEYEVENT(key.row, key.col, true));
+    action_exec(MAKE_KEYEVENT(key.row, key.col, false));
     return true;
 }

--- a/keyboards/gl516/n51gl/keymaps/via/keymap.c
+++ b/keyboards/gl516/n51gl/keymaps/via/keymap.c
@@ -96,7 +96,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
         key.row = 1;
         key.col = 0;
     }
-    action_exec((keyevent_t){.key = key, .pressed = true, .time = (timer_read() | 1)});
-    action_exec((keyevent_t){.key = key, .pressed = false, .time = (timer_read() | 1)});
+    action_exec(MAKE_KEYEVENT(key.row, key.col, true));
+    action_exec(MAKE_KEYEVENT(key.row, key.col, false));
     return true;
 }

--- a/keyboards/jones/v1/keymaps/via/keymap.c
+++ b/keyboards/jones/v1/keymaps/via/keymap.c
@@ -178,7 +178,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -190,7 +191,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/kabedon/kabedon98e/kabedon98e.c
+++ b/keyboards/kabedon/kabedon98e/kabedon98e.c
@@ -25,7 +25,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -37,7 +38,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/keebio/encoder_actions.c
+++ b/keyboards/keebio/encoder_actions.c
@@ -28,7 +28,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -40,7 +41,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/meletrix/zoom65/zoom65.c
+++ b/keyboards/meletrix/zoom65/zoom65.c
@@ -30,7 +30,9 @@ void encoder_action_unregister(void)
             keyevent_t encoder_event = (keyevent_t){
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)};
+                .time = timer_read(),
+                .type = KEY_EVENT
+            };
             encoder_state[index] = 0;
             action_exec(encoder_event);
         }
@@ -41,7 +43,9 @@ void encoder_action_register(uint8_t index, bool clockwise)
     keyevent_t encoder_event = (keyevent_t){
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)};
+        .time = timer_read(),
+        .type = KEY_EVENT
+    };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);
 }

--- a/keyboards/meletrix/zoom65_lite/keymaps/via/keymap.c
+++ b/keyboards/meletrix/zoom65_lite/keymaps/via/keymap.c
@@ -29,7 +29,9 @@ void encoder_action_unregister(void)
             keyevent_t encoder_event = (keyevent_t){
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)};
+                .time = timer_read(),
+                .type = KEY_EVENT
+            };
             encoder_state[index] = 0;
             action_exec(encoder_event);
         }
@@ -40,7 +42,9 @@ void encoder_action_register(uint8_t index, bool clockwise)
     keyevent_t encoder_event = (keyevent_t){
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)};
+        .time = timer_read(),
+        .type = KEY_EVENT
+    };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);
 }

--- a/keyboards/ml/gas75/keymaps/via/keymap.c
+++ b/keyboards/ml/gas75/keymaps/via/keymap.c
@@ -169,7 +169,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -181,7 +182,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/monarch/keymaps/via/keymap.c
+++ b/keyboards/monarch/keymaps/via/keymap.c
@@ -54,24 +54,26 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder_ccw = {
     .key = (keypos_t){.row = 5, .col = 0},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder_cw = {
     .key = (keypos_t){.row = 5, .col = 1},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_ccw)) {
         encoder_ccw.pressed = false;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
 
     if (IS_PRESSED(encoder_cw)) {
         encoder_cw.pressed = false;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     }
 }
@@ -79,11 +81,11 @@ void matrix_scan_user(void) {
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (clockwise) {
         encoder_cw.pressed = true;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     } else {
         encoder_ccw.pressed = true;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
     return true;

--- a/keyboards/mwstudio/alicekk/keymaps/via/keymap.c
+++ b/keyboards/mwstudio/alicekk/keymaps/via/keymap.c
@@ -63,7 +63,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -75,7 +76,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/mwstudio/mw75r2/keymaps/via/keymap.c
+++ b/keyboards/mwstudio/mw75r2/keymaps/via/keymap.c
@@ -115,7 +115,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -127,7 +128,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/nightly_boards/adellein/encoder_action.c
+++ b/keyboards/nightly_boards/adellein/encoder_action.c
@@ -26,7 +26,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -38,7 +39,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/nightly_boards/n40_o/encoder_action.c
+++ b/keyboards/nightly_boards/n40_o/encoder_action.c
@@ -26,7 +26,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -38,7 +39,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/nightly_boards/n60_s/encoder_action.c
+++ b/keyboards/nightly_boards/n60_s/encoder_action.c
@@ -26,7 +26,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -38,7 +39,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/nightly_boards/octopad/encoder_action.c
+++ b/keyboards/nightly_boards/octopad/encoder_action.c
@@ -26,7 +26,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -38,7 +39,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/nullbitsco/tidbit/tidbit.c
+++ b/keyboards/nullbitsco/tidbit/tidbit.c
@@ -85,15 +85,11 @@ bool oled_task_kb(void) {
 #endif
 
 static void process_encoder_matrix(encodermap_t pos) {
-    action_exec((keyevent_t){
-        .key = (keypos_t){.row = pos.r, .col = pos.c}, .pressed = true, .time = (timer_read() | 1) /* time should not be 0 */
-    });
+    action_exec(MAKE_KEYEVENT(pos.r, pos.c, true));
 #if TAP_CODE_DELAY > 0
     wait_ms(TAP_CODE_DELAY);
 #endif
-    action_exec((keyevent_t){
-        .key = (keypos_t){.row = pos.r, .col = pos.c}, .pressed = false, .time = (timer_read() | 1) /* time should not be 0 */
-    });
+    action_exec(MAKE_KEYEVENT(pos.r, pos.c, false));
 }
 
 bool encoder_update_kb(uint8_t index, bool clockwise) {

--- a/keyboards/rate/pistachio_mp/keymaps/via/keymap.c
+++ b/keyboards/rate/pistachio_mp/keymaps/via/keymap.c
@@ -87,7 +87,8 @@ void encoder_action_unregister(void) {
         keyevent_t encoder_event = (keyevent_t) {
             .key = encoder_state >> 1 ? ENC_CW : ENC_CCW,
             .pressed = false,
-            .time = (timer_read() | 1)
+            .time = timer_read(),
+            .type = KEY_EVENT
         };
         encoder_state = 0;
         action_exec(encoder_event);
@@ -99,7 +100,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? ENC_CW : ENC_CCW,
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read()
+        .type = KEY_EVENT
     };
     encoder_state = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/rate/pistachio_pro/keymaps/via/keymap.c
+++ b/keyboards/rate/pistachio_pro/keymaps/via/keymap.c
@@ -135,7 +135,8 @@ void encoder_action_unregister(void) {
         keyevent_t encoder_event = (keyevent_t) {
             .key = encoder_state >> 1 ? ENC_CW : ENC_CCW,
             .pressed = false,
-            .time = (timer_read() | 1)
+            .time = timer_read(),
+            .type = KEY_EVENT
         };
         encoder_state = 0;
         action_exec(encoder_event);
@@ -146,7 +147,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? ENC_CW : ENC_CCW,
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/rgbkb/mun/rev1/rev1.c
+++ b/keyboards/rgbkb/mun/rev1/rev1.c
@@ -37,15 +37,11 @@ const encodermap_t touch_encoder_map[NUMBER_OF_TOUCH_ENCODERS][TOUCH_ENCODER_OPT
 };
 
 static void process_encoder_matrix(encodermap_t pos) {
-    action_exec((keyevent_t){
-        .key = (keypos_t){.row = pos.r, .col = pos.c}, .pressed = true, .time = (timer_read() | 1) /* time should not be 0 */
-    });
+    action_exec(MAKE_KEYEVENT(pos.r, pos.c, true));
 #if TAP_CODE_DELAY > 0
     wait_ms(TAP_CODE_DELAY);
 #endif
-    action_exec((keyevent_t){
-        .key = (keypos_t){.row = pos.r, .col = pos.c}, .pressed = false, .time = (timer_read() | 1) /* time should not be 0 */
-    });
+    action_exec(MAKE_KEYEVENT(pos.r, pos.c, false));
 }
 
 bool encoder_update_kb(uint8_t index, bool clockwise) {

--- a/keyboards/rgbkb/sol3/rev1/rev1.c
+++ b/keyboards/rgbkb/sol3/rev1/rev1.c
@@ -57,10 +57,7 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
         }
         case 1: {
             // Handle RGB Encoder switch press
-            action_exec((keyevent_t){
-                .key = (keypos_t){.row = isLeftHand ? 4 : 10, .col = 6},
-                .pressed = active, .time = (timer_read() | 1) /* time should not be 0 */
-            });
+            action_exec(MAKE_KEYEVENT(isLeftHand ? 4 : 10, 6, active));
             break;
         }
     }
@@ -68,15 +65,11 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
 }
 
 static void process_encoder_matrix(encodermap_t pos) {
-    action_exec((keyevent_t){
-        .key = (keypos_t){.row = pos.r, .col = pos.c}, .pressed = true, .time = (timer_read() | 1) /* time should not be 0 */
-    });
+    action_exec(MAKE_KEYEVENT(pos.r, pos.c, true));
 #if TAP_CODE_DELAY > 0
     wait_ms(TAP_CODE_DELAY);
 #endif
-    action_exec((keyevent_t){
-        .key = (keypos_t){.row = pos.r, .col = pos.c}, .pressed = false, .time = (timer_read() | 1) /* time should not be 0 */
-    });
+    action_exec(MAKE_KEYEVENT(pos.r, pos.c, false));
 }
 
 bool encoder_update_kb(uint8_t index, bool clockwise) {

--- a/keyboards/rmi_kb/chevron/keymaps/via/keymap.c
+++ b/keyboards/rmi_kb/chevron/keymaps/via/keymap.c
@@ -48,24 +48,26 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder_ccw = {
     .key = (keypos_t){.row = 4, .col = 0},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder_cw = {
     .key = (keypos_t){.row = 4, .col = 1},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_ccw)) {
         encoder_ccw.pressed = false;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
 
     if (IS_PRESSED(encoder_cw)) {
         encoder_cw.pressed = false;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     }
 }
@@ -73,12 +75,12 @@ void matrix_scan_user(void) {
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (clockwise) {
         encoder_cw.pressed = true;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
         wait_ms(20);
     } else {
         encoder_ccw.pressed = true;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
         wait_ms(20);
     }

--- a/keyboards/rmi_kb/herringbone/pro/keymaps/via/keymap.c
+++ b/keyboards/rmi_kb/herringbone/pro/keymaps/via/keymap.c
@@ -54,24 +54,26 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder_ccw = {
     .key = (keypos_t){.row = 6, .col = 0},
-    .pressed = false
-};
+    .pressed = false,
+    .type = KEY_EVENT
+ };
 
 keyevent_t encoder_cw = {
     .key = (keypos_t){.row = 6, .col = 1},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_ccw)) {
         encoder_ccw.pressed = false;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
 
     if (IS_PRESSED(encoder_cw)) {
         encoder_cw.pressed = false;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     }
 }
@@ -86,14 +88,14 @@ uint8_t current_frame = 0;
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (clockwise) {
         encoder_cw.pressed = true;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
         wait_ms(20);
         anim_sleep = timer_read32();
         oled_on();
     } else {
         encoder_ccw.pressed = true;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
         wait_ms(20);
         anim_sleep = timer_read32();

--- a/keyboards/rmi_kb/squishytkl/keymaps/via/keymap.c
+++ b/keyboards/rmi_kb/squishytkl/keymaps/via/keymap.c
@@ -29,24 +29,26 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder_ccw = {
     .key = (keypos_t){.row = 13, .col = 0},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder_cw = {
     .key = (keypos_t){.row = 13, .col = 1},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_ccw)) {
         encoder_ccw.pressed = false;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
 
     if (IS_PRESSED(encoder_cw)) {
         encoder_cw.pressed = false;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     }
 }
@@ -54,11 +56,11 @@ void matrix_scan_user(void) {
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (clockwise) {
         encoder_cw.pressed = true;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     } else {
         encoder_ccw.pressed = true;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
     return true;

--- a/keyboards/rmi_kb/wete/v2/keymaps/via/keymap.c
+++ b/keyboards/rmi_kb/wete/v2/keymaps/via/keymap.c
@@ -37,24 +37,26 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 keyevent_t encoder_ccw = {
     .key = (keypos_t){.row = 12, .col = 0},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 keyevent_t encoder_cw = {
     .key = (keypos_t){.row = 12, .col = 1},
-    .pressed = false
+    .pressed = false,
+    .type = KEY_EVENT
 };
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder_ccw)) {
         encoder_ccw.pressed = false;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
 
     if (IS_PRESSED(encoder_cw)) {
         encoder_cw.pressed = false;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     }
 }
@@ -62,11 +64,11 @@ void matrix_scan_user(void) {
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (clockwise) {
         encoder_cw.pressed = true;
-        encoder_cw.time = (timer_read() | 1);
+        encoder_cw.time = timer_read();
         action_exec(encoder_cw);
     } else {
         encoder_ccw.pressed = true;
-        encoder_ccw.time = (timer_read() | 1);
+        encoder_ccw.time = timer_read();
         action_exec(encoder_ccw);
     }
     return true;

--- a/keyboards/sawnsprojects/krush/krush65/hotswap/encoder_actions.c
+++ b/keyboards/sawnsprojects/krush/krush65/hotswap/encoder_actions.c
@@ -30,7 +30,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -42,7 +43,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/sofle/keymaps/keyhive_via/encoder.c
+++ b/keyboards/sofle/keymaps/keyhive_via/encoder.c
@@ -26,7 +26,7 @@
     void encoder_action_unregister(void) {
         for (int index = 0; index < 2; ++index) {
             if (encoder_state[index]) {
-                keyevent_t encoder_event = (keyevent_t){.key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index], .pressed = false, .time = (timer_read() | 1)};
+                keyevent_t encoder_event = (keyevent_t){.key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index], .pressed = false, .time = timer_read(), .type = KEY_EVENT};
                 encoder_state[index] = 0;
                 action_exec(encoder_event);
             }
@@ -34,7 +34,7 @@
     }
 
     void encoder_action_register(uint8_t index, bool clockwise) {
-        keyevent_t encoder_event = (keyevent_t){.key = clockwise ? encoder_cw[index] : encoder_ccw[index], .pressed = true, .time = (timer_read() | 1)};
+        keyevent_t encoder_event = (keyevent_t){.key = clockwise ? encoder_cw[index] : encoder_ccw[index], .pressed = true, .time = timer_read(), .type = KEY_EVENT};
         encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
         action_exec(encoder_event);
     }
@@ -46,4 +46,3 @@
         return false;
     };
 #endif
-

--- a/keyboards/stello65/beta/encoder_actions.c
+++ b/keyboards/stello65/beta/encoder_actions.c
@@ -29,7 +29,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -41,7 +42,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/synthlabs/solo/keymaps/via/keymap.c
+++ b/keyboards/synthlabs/solo/keymaps/via/keymap.c
@@ -37,7 +37,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -49,7 +50,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/takashicompany/spreadwriter/keymaps/via/keymap.c
+++ b/keyboards/takashicompany/spreadwriter/keymaps/via/keymap.c
@@ -98,7 +98,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -110,7 +111,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/wekey/we27/encoder_actions.c
+++ b/keyboards/wekey/we27/encoder_actions.c
@@ -29,7 +29,8 @@ void encoder_action_unregister(void) {
             keyevent_t encoder_event = (keyevent_t) {
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)
+                .time = timer_read(),
+                .type = KEY_EVENT
             };
             encoder_state[index] = 0;
             action_exec(encoder_event);
@@ -41,7 +42,8 @@ void encoder_action_register(uint8_t index, bool clockwise) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);

--- a/keyboards/winry/winry315/keymaps/via/encoder_actions.c
+++ b/keyboards/winry/winry315/keymaps/via/encoder_actions.c
@@ -37,7 +37,8 @@ static void exec_encoder_action(uint8_t index, bool clockwise, bool pressed) {
     keyevent_t encoder_event = (keyevent_t) {
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = pressed,
-        .time = (timer_read() | 1)
+        .time = timer_read(),
+        .type = KEY_EVENT
     };
     // clang-format on
     action_exec(encoder_event);

--- a/keyboards/wuque/mammoth20x/mammoth20x.c
+++ b/keyboards/wuque/mammoth20x/mammoth20x.c
@@ -30,7 +30,9 @@ void encoder_action_unregister(void)
             keyevent_t encoder_event = (keyevent_t){
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)};
+                .time = timer_read(),
+                .type = KEY_EVENT
+            };
             encoder_state[index] = 0;
             action_exec(encoder_event);
         }
@@ -41,7 +43,9 @@ void encoder_action_register(uint8_t index, bool clockwise)
     keyevent_t encoder_event = (keyevent_t){
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)};
+        .time = timer_read(),
+        .type = KEY_EVENT
+    };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);
 }

--- a/keyboards/wuque/mammoth75x/mammoth75x.c
+++ b/keyboards/wuque/mammoth75x/mammoth75x.c
@@ -30,7 +30,9 @@ void encoder_action_unregister(void)
             keyevent_t encoder_event = (keyevent_t){
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)};
+                .time = timer_read(),
+                .type = KEY_EVENT
+            };
             encoder_state[index] = 0;
             action_exec(encoder_event);
         }
@@ -41,7 +43,9 @@ void encoder_action_register(uint8_t index, bool clockwise)
     keyevent_t encoder_event = (keyevent_t){
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)};
+        .time = timer_read(),
+        .type = KEY_EVENT
+    };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);
 }
@@ -64,4 +68,3 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
     return true;
 }
 #endif
-

--- a/keyboards/wuque/serneity65/serneity65.c
+++ b/keyboards/wuque/serneity65/serneity65.c
@@ -30,7 +30,9 @@ void encoder_action_unregister(void)
             keyevent_t encoder_event = (keyevent_t){
                 .key = encoder_state[index] >> 1 ? encoder_cw[index] : encoder_ccw[index],
                 .pressed = false,
-                .time = (timer_read() | 1)};
+                .time = timer_read(),
+                .type = KEY_EVENT
+            };
             encoder_state[index] = 0;
             action_exec(encoder_event);
         }
@@ -41,7 +43,9 @@ void encoder_action_register(uint8_t index, bool clockwise)
     keyevent_t encoder_event = (keyevent_t){
         .key = clockwise ? encoder_cw[index] : encoder_ccw[index],
         .pressed = true,
-        .time = (timer_read() | 1)};
+        .time = timer_read(),
+        .type = KEY_EVENT
+    };
     encoder_state[index] = (clockwise ^ 1) | (clockwise << 1);
     action_exec(encoder_event);
 }

--- a/keyboards/yandrstudio/nz67v2/keymaps/via/keymap.c
+++ b/keyboards/yandrstudio/nz67v2/keymaps/via/keymap.c
@@ -43,20 +43,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_TRNS, KC_TRNS, KC_TRNS,                   KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS)
 };
 #ifdef ENCODER_ENABLE
-keyevent_t encoder1_ccw = {.key = (keypos_t){.row = 4, .col = 4}, .pressed = false};
+keyevent_t encoder1_ccw = {.key = (keypos_t){.row = 4, .col = 4}, .pressed = false, .type = KEY_EVENT};
 
-keyevent_t encoder1_cw = {.key = (keypos_t){.row = 4, .col = 6}, .pressed = false};
+keyevent_t encoder1_cw = {.key = (keypos_t){.row = 4, .col = 6}, .pressed = false, .type = KEY_EVENT};
 
 void matrix_scan_user(void) {
     if (IS_PRESSED(encoder1_ccw)) {
         encoder1_ccw.pressed = false;
-        encoder1_ccw.time    = (timer_read() | 1);
+        encoder1_ccw.time    = timer_read();
         action_exec(encoder1_ccw);
     }
 
     if (IS_PRESSED(encoder1_cw)) {
         encoder1_cw.pressed = false;
-        encoder1_cw.time    = (timer_read() | 1);
+        encoder1_cw.time    = timer_read();
         action_exec(encoder1_cw);
     }
 }
@@ -64,11 +64,11 @@ void matrix_scan_user(void) {
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (clockwise) {
         encoder1_cw.pressed = true;
-        encoder1_cw.time    = (timer_read() | 1);
+        encoder1_cw.time    = timer_read();
         action_exec(encoder1_cw);
     } else {
         encoder1_ccw.pressed = true;
-        encoder1_ccw.time    = (timer_read() | 1);
+        encoder1_ccw.time    = timer_read();
         action_exec(encoder1_ccw);
     }
     return true;

--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -17,14 +17,10 @@
 #        endif
 #    endif
 
-#    define IS_TAPPING() IS_EVENT(tapping_key.event)
-#    define IS_TAPPING_PRESSED() (IS_TAPPING() && tapping_key.event.pressed)
-#    define IS_TAPPING_RELEASED() (IS_TAPPING() && !tapping_key.event.pressed)
-#    define IS_TAPPING_KEY(k) (IS_TAPPING() && KEYEQ(tapping_key.event.key, (k)))
 #    ifndef COMBO_ENABLE
-#        define IS_TAPPING_RECORD(r) (IS_EVENT(r->event) && IS_TAPPING() && KEYEQ(tapping_key.event.key, (r->event.key)))
+#        define IS_TAPPING_RECORD(r) (KEYEQ(tapping_key.event.key, (r->event.key)))
 #    else
-#        define IS_TAPPING_RECORD(r) (IS_EVENT(r->event) && IS_TAPPING() && KEYEQ(tapping_key.event.key, (r->event.key)) && tapping_key.keycode == r->keycode)
+#        define IS_TAPPING_RECORD(r) (KEYEQ(tapping_key.event.key, (r->event.key)) && tapping_key.keycode == r->keycode)
 #    endif
 #    define WITHIN_TAPPING_TERM(e) (TIMER_DIFF_16(e.time, tapping_key.event.time) < GET_TAPPING_TERM(get_record_keycode(&tapping_key, false), &tapping_key))
 #    define WITHIN_QUICK_TAP_TERM(e) (TIMER_DIFF_16(e.time, tapping_key.event.time) < GET_QUICK_TAP_TERM(get_record_keycode(&tapping_key, false), &tapping_key))
@@ -96,7 +92,7 @@ void action_tapping_process(keyrecord_t record) {
             ac_dprintf("OVERFLOW: CLEAR ALL STATES\n");
             clear_keyboard();
             waiting_buffer_clear();
-            tapping_key = (keyrecord_t){};
+            tapping_key = (keyrecord_t){0};
         }
     }
 
@@ -123,7 +119,7 @@ void action_tapping_process(keyrecord_t record) {
  * conditional uses of it are hidden inside macros named TAP_...
  */
 #    if (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || defined(PERMISSIVE_HOLD_PER_KEY) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
-#        define TAP_DEFINE_KEYCODE uint16_t tapping_keycode = get_record_keycode(&tapping_key, false)
+#        define TAP_DEFINE_KEYCODE const uint16_t tapping_keycode = get_record_keycode(&tapping_key, false)
 #    else
 #        define TAP_DEFINE_KEYCODE
 #    endif
@@ -175,12 +171,37 @@ void action_tapping_process(keyrecord_t record) {
  */
 /* return true when key event is processed or consumed. */
 bool process_tapping(keyrecord_t *keyp) {
-    keyevent_t event = keyp->event;
+    const keyevent_t event = keyp->event;
+
+    // state machine is in the "reset" state, no tapping key is to be
+    // processed
+    if (IS_NOEVENT(tapping_key.event) && IS_EVENT(event)) {
+        if (event.pressed && is_tap_record(keyp)) {
+            // the currently pressed key is a tapping key, therefore transition
+            // into the "pressed" tapping key state
+            ac_dprintf("Tapping: Start(Press tap key).\n");
+            tapping_key = *keyp;
+            process_record_tap_hint(&tapping_key);
+            waiting_buffer_scan_tap();
+            debug_tapping_key();
+            return true;
+        } else {
+            // the current key is just a regular key, pass it on for regular
+            // processing
+            process_record(keyp);
+            return true;
+        }
+    }
+
     TAP_DEFINE_KEYCODE;
 
-    // if tapping
-    if (IS_TAPPING_PRESSED()) {
+    // process "pressed" tapping key state
+    if (tapping_key.event.pressed) {
         if (WITHIN_TAPPING_TERM(event) || MAYBE_RETRO_SHIFTING(event)) {
+            if (IS_NOEVENT(event)) {
+                // early return for tick events
+                return true;
+            }
             if (tapping_key.tap.count == 0) {
                 if (IS_TAPPING_RECORD(keyp) && !event.pressed) {
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
@@ -204,7 +225,7 @@ bool process_tapping(keyrecord_t *keyp) {
                 // clang-format off
                 else if (
                     (
-                        IS_RELEASED(event) && waiting_buffer_typed(event) &&
+                        !event.pressed && waiting_buffer_typed(event) &&
                         TAP_GET_PERMISSIVE_HOLD
                     )
                     // Causes nested taps to not wait past TAPPING_TERM/RETRO_SHIFT
@@ -223,7 +244,7 @@ bool process_tapping(keyrecord_t *keyp) {
                             || (
                                 TAP_IS_RETRO
                                 && (event.key.col != tapping_key.event.key.col || event.key.row != tapping_key.event.key.row)
-                                && IS_RELEASED(event) && waiting_buffer_typed(event)
+                                && !event.pressed && waiting_buffer_typed(event)
                             )
                         )
                     )
@@ -231,7 +252,7 @@ bool process_tapping(keyrecord_t *keyp) {
                     // clang-format on
                     ac_dprintf("Tapping: End. No tap. Interfered by typing key\n");
                     process_record(&tapping_key);
-                    tapping_key = (keyrecord_t){};
+                    tapping_key = (keyrecord_t){0};
                     debug_tapping_key();
                     // enqueue
                     return false;
@@ -240,7 +261,7 @@ bool process_tapping(keyrecord_t *keyp) {
                  * Without this unexpected repeating will occur with having fast repeating setting
                  * https://github.com/tmk/tmk_keyboard/issues/60
                  */
-                else if (IS_RELEASED(event) && !waiting_buffer_typed(event)) {
+                else if (!event.pressed && !waiting_buffer_typed(event)) {
                     // Modifier/Layer should be retained till end of this tapping.
                     action_t action = layer_switch_get_action(event.key);
                     switch (action.kind.id) {
@@ -276,7 +297,7 @@ bool process_tapping(keyrecord_t *keyp) {
                         if (TAP_GET_HOLD_ON_OTHER_KEY_PRESS) {
                             ac_dprintf("Tapping: End. No tap. Interfered by pressed key\n");
                             process_record(&tapping_key);
-                            tapping_key = (keyrecord_t){};
+                            tapping_key = (keyrecord_t){0};
                             debug_tapping_key();
                             // enqueue
                             return false;
@@ -317,9 +338,7 @@ bool process_tapping(keyrecord_t *keyp) {
                     debug_tapping_key();
                     return true;
                 } else {
-                    if (IS_EVENT(event)) {
-                        ac_dprintf("Tapping: key event while last tap(>0).\n");
-                    }
+                    ac_dprintf("Tapping: key event while last tap(>0).\n");
                     process_record(keyp);
                     return true;
                 }
@@ -332,15 +351,18 @@ bool process_tapping(keyrecord_t *keyp) {
                 debug_event(event);
                 ac_dprintf("\n");
                 process_record(&tapping_key);
-                tapping_key = (keyrecord_t){};
+                tapping_key = (keyrecord_t){0};
                 debug_tapping_key();
                 return false;
             } else {
+                if (IS_NOEVENT(event)) {
+                    return true;
+                }
                 if (IS_TAPPING_RECORD(keyp) && !event.pressed) {
                     ac_dprintf("Tapping: End. last timeout tap release(>0).");
                     keyp->tap = tapping_key.tap;
                     process_record(keyp);
-                    tapping_key = (keyrecord_t){};
+                    tapping_key = (keyrecord_t){0};
                     return true;
                 } else if (is_tap_record(keyp) && event.pressed) {
                     if (tapping_key.tap.count > 1) {
@@ -364,16 +386,20 @@ bool process_tapping(keyrecord_t *keyp) {
                     debug_tapping_key();
                     return true;
                 } else {
-                    if (IS_EVENT(event)) {
-                        ac_dprintf("Tapping: key event while last timeout tap(>0).\n");
-                    }
+                    ac_dprintf("Tapping: key event while last timeout tap(>0).\n");
                     process_record(keyp);
                     return true;
                 }
             }
         }
-    } else if (IS_TAPPING_RELEASED()) {
+    }
+    // process "released" tapping key state
+    else {
         if (WITHIN_TAPPING_TERM(event) || MAYBE_RETRO_SHIFTING(event)) {
+            if (IS_NOEVENT(event)) {
+                // early return for tick events
+                return true;
+            }
             if (event.pressed) {
                 if (IS_TAPPING_RECORD(keyp)) {
                     if (WITHIN_QUICK_TAP_TERM(event) && !tapping_key.tap.interrupted && tapping_key.tap.count > 0) {
@@ -404,33 +430,18 @@ bool process_tapping(keyrecord_t *keyp) {
                     return true;
                 }
             } else {
-                if (IS_EVENT(event)) ac_dprintf("Tapping: other key just after tap.\n");
+                ac_dprintf("Tapping: other key just after tap.\n");
                 process_record(keyp);
                 return true;
             }
         } else {
-            // FIX: process_action here?
-            // timeout. no sequential tap.
+            // Timeout - reset state machine.
             ac_dprintf("Tapping: End(Timeout after releasing last tap): ");
             debug_event(event);
             ac_dprintf("\n");
-            tapping_key = (keyrecord_t){};
+            tapping_key = (keyrecord_t){0};
             debug_tapping_key();
             return false;
-        }
-    }
-    // not tapping state
-    else {
-        if (event.pressed && is_tap_record(keyp)) {
-            ac_dprintf("Tapping: Start(Press tap key).\n");
-            tapping_key = *keyp;
-            process_record_tap_hint(&tapping_key);
-            waiting_buffer_scan_tap();
-            debug_tapping_key();
-            return true;
-        } else {
-            process_record(keyp);
-            return true;
         }
     }
 }
@@ -495,14 +506,16 @@ __attribute__((unused)) bool waiting_buffer_has_anykey_pressed(void) {
  * FIXME: Needs docs
  */
 void waiting_buffer_scan_tap(void) {
-    // tapping already is settled
-    if (tapping_key.tap.count > 0) return;
-    // invalid state: tapping_key released && tap.count == 0
-    if (!tapping_key.event.pressed) return;
+    // early return if:
+    // - tapping already is settled
+    // - invalid state: tapping_key released && tap.count == 0
+    if ((tapping_key.tap.count > 0) || !tapping_key.event.pressed) {
+        return;
+    }
 
     for (uint8_t i = waiting_buffer_tail; i != waiting_buffer_head; i = (i + 1) % WAITING_BUFFER_SIZE) {
         keyrecord_t *candidate = &waiting_buffer[i];
-        if (IS_EVENT(candidate->event) && IS_TAPPING_KEY(candidate->event.key) && !candidate->event.pressed && WITHIN_TAPPING_TERM(candidate->event)) {
+        if (IS_EVENT(candidate->event) && KEYEQ(candidate->event.key, tapping_key.event.key) && !candidate->event.pressed && WITHIN_TAPPING_TERM(candidate->event)) {
             tapping_key.tap.count = 1;
             candidate->tap.count  = 1;
             process_record(&tapping_key);

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -147,12 +147,12 @@ void encoder_init(void) {
 #ifdef ENCODER_MAP_ENABLE
 static void encoder_exec_mapping(uint8_t index, bool clockwise) {
     // The delays below cater for Windows and its wonderful requirements.
-    action_exec(clockwise ? ENCODER_CW_EVENT(index, true) : ENCODER_CCW_EVENT(index, true));
+    action_exec(clockwise ? MAKE_ENCODER_CW_EVENT(index, true) : MAKE_ENCODER_CCW_EVENT(index, true));
 #    if ENCODER_MAP_KEY_DELAY > 0
     wait_ms(ENCODER_MAP_KEY_DELAY);
 #    endif // ENCODER_MAP_KEY_DELAY > 0
 
-    action_exec(clockwise ? ENCODER_CW_EVENT(index, false) : ENCODER_CCW_EVENT(index, false));
+    action_exec(clockwise ? MAKE_ENCODER_CW_EVENT(index, false) : MAKE_ENCODER_CCW_EVENT(index, false));
 #    if ENCODER_MAP_KEY_DELAY > 0
     wait_ms(ENCODER_MAP_KEY_DELAY);
 #    endif // ENCODER_MAP_KEY_DELAY > 0

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -444,7 +444,7 @@ static inline void generate_tick_event(void) {
     static uint16_t last_tick = 0;
     const uint16_t  now       = timer_read();
     if (TIMER_DIFF_16(now, last_tick) != 0) {
-        action_exec(TICK_EVENT);
+        action_exec(MAKE_TICK_EVENT);
         last_tick = now;
     }
 }

--- a/quantum/keyboard.h
+++ b/quantum/keyboard.h
@@ -30,65 +30,70 @@ typedef struct {
     uint8_t row;
 } keypos_t;
 
+typedef enum keyevent_type_t { TICK_EVENT = 0, KEY_EVENT = 1, ENCODER_CW_EVENT = 2, ENCODER_CCW_EVENT = 3, COMBO_EVENT = 4 } keyevent_type_t;
+
 /* key event */
 typedef struct {
-    keypos_t key;
-    bool     pressed;
-    uint16_t time;
+    keypos_t        key;
+    uint16_t        time;
+    keyevent_type_t type;
+    bool            pressed;
 } keyevent_t;
 
 /* equivalent test of keypos_t */
 #define KEYEQ(keya, keyb) ((keya).row == (keyb).row && (keya).col == (keyb).col)
 
 /* special keypos_t entries */
-#define KEYLOC_TICK 255
-#define KEYLOC_COMBO 254
 #define KEYLOC_ENCODER_CW 253
 #define KEYLOC_ENCODER_CCW 252
 
-/* Rules for No Event:
- * 1) (time == 0) to handle (keyevent_t){} as empty event
- * 2) Matrix(255, 255) to make TICK event available
- */
-static inline bool IS_NOEVENT(keyevent_t event) {
-    return event.time == 0 || (event.key.row == KEYLOC_TICK && event.key.col == KEYLOC_TICK);
+static inline bool IS_NOEVENT(const keyevent_t event) {
+    return event.type == TICK_EVENT;
 }
-static inline bool IS_EVENT(keyevent_t event) {
-    return !IS_NOEVENT(event);
+static inline bool IS_EVENT(const keyevent_t event) {
+    return event.type != TICK_EVENT;
 }
-static inline bool IS_KEYEVENT(keyevent_t event) {
-    return event.key.row < MATRIX_ROWS && event.key.col < MATRIX_COLS;
+static inline bool IS_KEYEVENT(const keyevent_t event) {
+    return event.type == KEY_EVENT;
 }
-static inline bool IS_COMBOEVENT(keyevent_t event) {
-    return event.key.row == KEYLOC_COMBO;
+static inline bool IS_COMBOEVENT(const keyevent_t event) {
+    return event.type == COMBO_EVENT;
 }
-static inline bool IS_ENCODEREVENT(keyevent_t event) {
-    return event.key.row == KEYLOC_ENCODER_CW || event.key.row == KEYLOC_ENCODER_CCW;
+static inline bool IS_ENCODEREVENT(const keyevent_t event) {
+    return event.type == ENCODER_CW_EVENT || event.type == ENCODER_CCW_EVENT;
 }
-static inline bool IS_PRESSED(keyevent_t event) {
+static inline bool IS_PRESSED(const keyevent_t event) {
     return IS_EVENT(event) && event.pressed;
 }
-static inline bool IS_RELEASED(keyevent_t event) {
+static inline bool IS_RELEASED(const keyevent_t event) {
     return IS_EVENT(event) && !event.pressed;
 }
 
-/* Common keyevent object factory */
+/* Common keypos_t object factory */
 #define MAKE_KEYPOS(row_num, col_num) ((keypos_t){.row = (row_num), .col = (col_num)})
+
+/* Common keyevent_t object factory */
+#define MAKE_EVENT(row_num, col_num, press, event_type) ((keyevent_t){.key = MAKE_KEYPOS((row_num), (col_num)), .pressed = (press), .time = timer_read(), .type = (event_type)})
 
 /**
  * @brief Constructs a key event for a pressed or released key.
  */
-#define MAKE_KEYEVENT(row_num, col_num, press) ((keyevent_t){.key = MAKE_KEYPOS((row_num), (col_num)), .pressed = (press), .time = (timer_read() | 1)})
+#define MAKE_KEYEVENT(row_num, col_num, press) MAKE_EVENT((row_num), (col_num), (press), KEY_EVENT)
+
+/**
+ * @brief Constructs a combo event.
+ */
+#define MAKE_COMBOEVENT(press) MAKE_EVENT(0, 0, (press), COMBO_EVENT)
 
 /**
  * @brief Constructs a internal tick event that is used to drive the internal QMK state machine.
  */
-#define TICK_EVENT MAKE_KEYEVENT(KEYLOC_TICK, KEYLOC_TICK, false)
+#define MAKE_TICK_EVENT MAKE_EVENT(0, 0, false, TICK_EVENT)
 
 #ifdef ENCODER_MAP_ENABLE
 /* Encoder events */
-#    define ENCODER_CW_EVENT(enc_id, press) MAKE_KEYEVENT(KEYLOC_ENCODER_CW, (enc_id), (press))
-#    define ENCODER_CCW_EVENT(enc_id, press) MAKE_KEYEVENT(KEYLOC_ENCODER_CCW, (enc_id), (press))
+#    define MAKE_ENCODER_CW_EVENT(enc_id, press) MAKE_EVENT(KEYLOC_ENCODER_CW, (enc_id), (press), ENCODER_CW_EVENT)
+#    define MAKE_ENCODER_CCW_EVENT(enc_id, press) MAKE_EVENT(KEYLOC_ENCODER_CCW, (enc_id), (press), ENCODER_CCW_EVENT)
 #endif // ENCODER_MAP_ENABLE
 
 /* it runs once at early stage of startup before keyboard_init. */

--- a/quantum/keyboard.h
+++ b/quantum/keyboard.h
@@ -62,12 +62,6 @@ static inline bool IS_COMBOEVENT(const keyevent_t event) {
 static inline bool IS_ENCODEREVENT(const keyevent_t event) {
     return event.type == ENCODER_CW_EVENT || event.type == ENCODER_CCW_EVENT;
 }
-static inline bool IS_PRESSED(const keyevent_t event) {
-    return IS_EVENT(event) && event.pressed;
-}
-static inline bool IS_RELEASED(const keyevent_t event) {
-    return IS_EVENT(event) && !event.pressed;
-}
 
 /* Common keypos_t object factory */
 #define MAKE_KEYPOS(row_num, col_num) ((keypos_t){.row = (row_num), .col = (col_num)})

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -144,7 +144,7 @@ static queued_combo_t combo_buffer[COMBO_BUFFER_LENGTH];
 static inline void release_combo(uint16_t combo_index, combo_t *combo) {
     if (combo->keycode) {
         keyrecord_t record = {
-            .event   = MAKE_KEYEVENT(KEYLOC_COMBO, KEYLOC_COMBO, false),
+            .event   = MAKE_COMBOEVENT(false),
             .keycode = combo->keycode,
         };
 #ifndef NO_ACTION_TAPPING
@@ -232,7 +232,7 @@ static inline void dump_key_buffer(void) {
             process_record(record);
 #endif
         }
-        record->event.time = 0;
+        record->event.type = TICK_EVENT;
 
 #if defined(CAPS_WORD_ENABLE) && defined(AUTO_SHIFT_ENABLE)
         // Edge case: preserve the weak Left Shift mod if both Caps Word and
@@ -332,8 +332,8 @@ void apply_combo(uint16_t combo_index, combo_t *combo) {
         KEY_STATE_DOWN(state, key_index);
         if (ALL_COMBO_KEYS_ARE_DOWN(state, key_count)) {
             // this in the end executes the combo when the key_buffer is dumped.
-            record->keycode   = combo->keycode;
-            record->event.key = MAKE_KEYPOS(KEYLOC_COMBO, KEYLOC_COMBO);
+            record->keycode    = combo->keycode;
+            record->event.type = COMBO_EVENT;
 
             qrecord->combo_index = combo_index;
             ACTIVATE_COMBO(combo);
@@ -342,7 +342,7 @@ void apply_combo(uint16_t combo_index, combo_t *combo) {
         } else {
             // key was part of the combo but not the last one, "disable" it
             // by making it a TICK event.
-            record->event.time = 0;
+            record->event.type = TICK_EVENT;
         }
     }
     drop_combo_from_buffer(combo_index);

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -173,13 +173,13 @@ bool process_steno(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
 #ifdef STENO_ENABLE_ALL
         case QK_STENO_BOLT:
-            if (IS_PRESSED(record->event)) {
+            if (record->event.pressed) {
                 steno_set_mode(STENO_MODE_BOLT);
             }
             return false;
 
         case QK_STENO_GEMINI:
-            if (IS_PRESSED(record->event)) {
+            if (record->event.pressed) {
                 steno_set_mode(STENO_MODE_GEMINI);
             }
             return false;
@@ -193,7 +193,7 @@ bool process_steno(uint16_t keycode, keyrecord_t *record) {
         }
 #endif // STENO_COMBINEDMAP
         case STN__MIN ... STN__MAX:
-            if (IS_PRESSED(record->event)) {
+            if (record->event.pressed) {
                 n_pressed_keys++;
                 switch (mode) {
 #ifdef STENO_ENABLE_BOLT


### PR DESCRIPTION
## Description

The current `keyevent_t` time resolution is limited to a 2ms interval, this is due to the fact that "tick" events that should only drive the internal state machine have been generated by setting the time field to `0` and/or the row, col position to 255 before. So real key events that should generate a reaction have been generated by using the `.time = (timer_read() | 1)` pattern before. This PR introduces a proper `type` tag for the `keyevent_t` that is evaluated instead.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
