### PR TITLE
[Keyboard] Switch LAYOUT to split_3x5_2

### DIFF
--- a/keyboards/a_dux/a_dux.h
+++ b/keyboards/a_dux/a_dux.h
@@ -28,7 +28,7 @@
 // readability
 #define ___ KC_NO
 
-#define LAYOUT( \
+#define LAYOUT_split_3x5_2( \
         L01, L02, L03, L04, L05, R01, R02, R03, R04, R05, \
         L06, L07, L08, L09, L10, R06, R07, R08, R09, R10, \
         L11, L12, L13, L14, L15, R11, R12, R13, R14, R15, \
@@ -44,4 +44,6 @@
         { R11, R12, R13, R14, R15 }, \
         { R16, R17, ___, ___, ___ }  \
     }
+
+#define LAYOUT LAYOUT_split_3x5_2
 

--- a/keyboards/a_dux/info.json
+++ b/keyboards/a_dux/info.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/tapioki/cephalopoda",
     "maintainer": "@tapioki",
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_split_3x5_2": {
             "layout": [
                 {"x": 0, "y": 1.33},
                 {"x": 1, "y": 0.31},

--- a/keyboards/a_dux/keymaps/default/keymap.c
+++ b/keyboards/a_dux/keymaps/default/keymap.c
@@ -7,31 +7,31 @@
 // https://stevep99.github.io/seniply
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
+    [0] = LAYOUT_split_3x5_2(
     KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
     KC_A,    KC_S,    KC_D,    KC_F,    KC_G,        KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,
     KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
                           LT(3,KC_TAB), KC_LSFT,     KC_SPC,  LT(1,KC_ENT)
     ),
-    [1] = LAYOUT(
+    [1] = LAYOUT_split_3x5_2(
     KC_EXLM, KC_AT,   KC_SCLN, KC_COLN, KC_UNDS,     KC_EQL,  KC_7,    KC_8,    KC_9,    KC_PLUS,
     KC_BSLS, KC_PIPE, KC_LCBR, KC_LPRN, KC_LBRC,     KC_ASTR, KC_4,    KC_5,    KC_6,    KC_MINS,
     KC_NO,   KC_NO,   KC_RCBR, KC_RPRN, KC_RBRC,     KC_0,    KC_1,    KC_2,    KC_3,    KC_SLSH,
                                _______, MO(2),       _______, _______
     ),
-    [2] = LAYOUT(
+    [2] = LAYOUT_split_3x5_2(
     RALT(KC_1), RALT(KC_2), RALT(KC_3), RALT(KC_4), KC_BRIU,     KC_NO,   KC_AMPR, KC_GRV,  KC_TILD, KC_NO,
     KC_MUTE,    KC_VOLD,    KC_MPLY,    KC_VOLU,    KC_BRID,     KC_NO,   KC_DLR,  KC_PERC, KC_CIRC, KC_UNDS,
     KC_EJCT,    KC_MPRV,    KC_MSTP,    KC_MNXT,    KC_NO,       KC_NO,   KC_EXLM, KC_AT,   KC_HASH, KC_NO,
                                            _______, _______,     _______, _______
     ),
-    [3] = LAYOUT(
+    [3] = LAYOUT_split_3x5_2(
     KC_ESC,        LALT(KC_LEFT), LCTL(KC_F),    LALT(KC_RGHT), KC_INS,            KC_PGUP, KC_HOME, KC_UP,   KC_END,  KC_CAPS,
     OSM(MOD_LALT), OSM(MOD_LGUI), OSM(MOD_LSFT), OSM(MOD_LCTL), OSM(MOD_RALT),     KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, KC_DEL,
     LCTL(KC_Z),    LCTL(KC_X),    LCTL(KC_C),    KC_TAB,        LCTL(KC_V),        KC_ENT,  KC_BSPC, KC_RCTL, KC_LALT, KC_APP,
                                                        _______, _______,           _______, MO(4)
     ),
-    [4] = LAYOUT(
+    [4] = LAYOUT_split_3x5_2(
     KC_NO,         KC_NO,         RCS(KC_F),     KC_PSCR,       KC_NO,             KC_F12,  KC_F7,   KC_F8,   KC_F9,   KC_NO,
     OSM(MOD_LALT), OSM(MOD_LGUI), OSM(MOD_LSFT), OSM(MOD_LCTL), OSM(MOD_RALT),     KC_F11,  KC_F4,   KC_F5,   KC_F6,   KC_NO,
     RCS(KC_Z),     RCS(KC_X),     RCS(KC_C),     LSFT(KC_TAB),  RCS(KC_V),         KC_F10,  KC_F1,   KC_F2,   KC_F3,   KC_NO,

--- a/keyboards/cradio/cradio.h
+++ b/keyboards/cradio/cradio.h
@@ -31,7 +31,7 @@
 // readability
 #define ___ KC_NO
 
-#define LAYOUT( \
+#define LAYOUT_split_3x5_2( \
         L01, L02, L03, L04, L05, R01, R02, R03, R04, R05, \
         L06, L07, L08, L09, L10, R06, R07, R08, R09, R10, \
         L11, L12, L13, L14, L15, R11, R12, R13, R14, R15, \

--- a/keyboards/cradio/info.json
+++ b/keyboards/cradio/info.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/davidphilipbarr/Sweep",
     "maintainer": "@davidphilipbarr",
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_split_3x5_2": {
             "layout": [
                 {"x": 0, "y": 1.27},
                 {"x": 1, "y": 0.31},

--- a/keyboards/cradio/keymaps/default/keymap.c
+++ b/keyboards/cradio/keymaps/default/keymap.c
@@ -24,28 +24,29 @@
  */
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
+    [0] = LAYOUT_split_3x5_2(
     KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
     SFT_T(KC_A),ALT_T(KC_S),CTL_T(KC_D),GUI_T(KC_F), KC_G,    KC_H, GUI_T(KC_J),CTL_T(KC_K),ALT_T(KC_L),SFT_T(KC_SCLN),
     KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
                           LT(2,KC_TAB), KC_ENT,      KC_SPC,  LT(1,KC_BSPC)
     ),
-    [1] = LAYOUT(
+    [1] = LAYOUT_split_3x5_2(
     _______, KC_1,    KC_2,    KC_3,    KC_VOLU,     KC_HOME, KC_PGDN, KC_PGUP, KC_END,  KC_DQUO,
     _______, KC_4,    KC_5,    KC_6,    KC_VOLD,     KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_QUOT,
     KC_CAPS, KC_7,    KC_8,    KC_9,    KC_0,        _______, _______, _______, _______, _______,
                                MO(3),   KC_GESC,     _______, _______
     ),
-    [2] = LAYOUT(
+    [2] = LAYOUT_split_3x5_2(
     _______, KC_LBRC, KC_LCBR, KC_RCBR, _______,     KC_CIRC, KC_LPRN, KC_RPRN, KC_RBRC, KC_TILD,
     KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,     KC_AMPR, KC_MINS, KC_EQL,  KC_BSLS, KC_GRV,
     _______, _______, _______, _______, _______,     KC_ASTR, KC_UNDS, KC_PLUS, KC_PIPE, _______,
                                _______, _______,     KC_DEL,  MO(3)
     ),
-    [3] = LAYOUT(
+    [3] = LAYOUT_split_3x5_2(
     _______, KC_F1,   KC_F2,   KC_F3,   KC_F10,      _______, KC_WH_U, KC_WH_D, _______, RESET,
     _______, KC_F4,   KC_F5,   KC_F6,   KC_F11,      KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R, KC_INS,
     _______, KC_F7,   KC_F8,   KC_F9,   KC_F12,      _______, KC_BTN1, KC_BTN2, _______, _______,
                                _______, _______,     _______, _______
     )
 };
+

--- a/keyboards/ferris/0_1/0_1.h
+++ b/keyboards/ferris/0_1/0_1.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // clang-format off
 
 /*              left hand                           right hand      */
-#define LAYOUT(\
+#define LAYOUT_split_3x5_2(\
     K0_0, K0_1, K0_2, K0_3, K0_4,       K0_5, K0_6, K0_7, K0_8, K0_9,\
     K1_0, K1_1, K1_2, K1_3, K1_4,       K1_5, K1_6, K1_7, K1_8, K1_9,\
     K2_0, K2_1, K2_2, K2_3, K2_4,       K2_5, K2_6, K2_7, K2_8, K2_9,\
@@ -41,3 +41,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 }
 
 // clang-format on
+#define LAYOUT LAYOUT_split_3x5_2

--- a/keyboards/ferris/0_2/0_2.h
+++ b/keyboards/ferris/0_2/0_2.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // clang-format off
 
 /*              left hand                           right hand      */
-#define LAYOUT(\
+#define LAYOUT_split_3x5_2(\
     K0_0, K0_1, K0_2, K0_3, K0_4,       K0_5, K0_6, K0_7, K0_8, K0_9,\
     K1_0, K1_1, K1_2, K1_3, K1_4,       K1_5, K1_6, K1_7, K1_8, K1_9,\
     K2_0, K2_1, K2_2, K2_3, K2_4,       K2_5, K2_6, K2_7, K2_8, K2_9,\
@@ -41,3 +41,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 }
 
 // clang-format on
+#define LAYOUT LAYOUT_split_3x5_2

--- a/keyboards/ferris/info.json
+++ b/keyboards/ferris/info.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/pierrechevalier83/ferris/",
     "maintainer": "@pierrec83",
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_split_3x5_2": {
             "layout": [
                 {"x": 0, "y": 0.93},
                 {"x": 1, "y": 0.31},

--- a/keyboards/ferris/keymaps/default/keymap.json
+++ b/keyboards/ferris/keymaps/default/keymap.json
@@ -3,7 +3,7 @@
     "documentation": "\"This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK's source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`\"\n",
     "keyboard": "ferris/0_1",
     "keymap": "default",
-    "layout": "LAYOUT",
+    "layout": "LAYOUT_split_3x5_2",
     "layers": [
         ["KC_Q"        , "KC_W"        , "KC_E"           , "KC_R"          , "KC_T",
          "KC_Y"        , "KC_U"        , "KC_I"           , "KC_O"          , "KC_P",

--- a/keyboards/ferris/sweep/sweep.h
+++ b/keyboards/ferris/sweep/sweep.h
@@ -28,7 +28,7 @@
 // readability
 #define ___ KC_NO
 
-#define LAYOUT( \
+#define LAYOUT_split_3x5_2( \
         L01, L02, L03, L04, L05, R01, R02, R03, R04, R05, \
         L06, L07, L08, L09, L10, R06, R07, R08, R09, R10, \
         L11, L12, L13, L14, L15, R11, R12, R13, R14, R15, \
@@ -45,3 +45,4 @@
         { R16, R17, ___, ___, ___ }  \
     }
 
+#define LAYOUT LAYOUT_split_3x5_2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Update a_dux, cradio and ferris with the new split_3x5_2 community layout.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
