### PR TITLE
[Bug] Fix compile error caused by variable exclusion

### DIFF
--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -124,7 +124,9 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
     bool LED_3 = false;
     bool LED_4 = false;
     bool LED_5 = false;
+#if !defined(CAPS_LOCK_STATUS)
     bool LED_6 = false;
+#endif
 
     uint8_t layer = get_highest_layer(state);
     switch (layer) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Correction to exclude declaration of LED_6 variable, that was added in #15644

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Bug reported by user on Discord

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
