### PR TITLE
[Docs] Include ASCII diagram to explain tap-hold modes

### DIFF
--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -126,6 +126,61 @@ The code which decides between the tap and hold actions of dual-role keys suppor
 
 Note that until the tap-or-hold decision completes (which happens when either the dual-role key is released, or the tapping term has expired, or the extra condition for the selected decision mode is satisfied), key events are delayed and not transmitted to the host immediately.  The default mode gives the most delay (if the dual-role key is held down, this mode always waits for the whole tapping term), and the other modes may give less delay when other keys are pressed, because the hold action may be selected earlier.
 
+### Default Mode
+Example sequence 1 (the `L` key is also mapped to `KC_RGHT` on layer 2):
+
+```
+             TAPPING_TERM
+  +---------------|--------------------+
+  | +-------------|-------+            |
+  | | LT(2, KC_A) |       |            |
+  | +-------------|-------+            |
+  |               | +--------------+   |
+  |               | | KC_L         |   |
+  |               | +--------------+   |
+  +---------------|--------------------+
+```
+The above sequence would send a `KC_RGHT`, since `LT(2, KC_A)` is held longer than the `TAPPING_TERM`.
+
+---
+
+Example sequence 2 (the `L` key is also mapped to `KC_RGHT` on layer 2):
+
+```
+                           TAPPING_TERM
+  +-----------------------------|------+
+  | +---------------+           |      |
+  | | LT(2, KC_A)   |           |      |
+  | +---------------+           |      |
+  |            +--------------+ |      |
+  |            | KC_L         | |      |
+  |            +--------------+ |      |
+  +-----------------------------|------+
+```
+The above sequence will not send a `KC_RGHT` but a `KC_L`, since `LT(2, KC_A)` is not held longer than the `TAPPING_TERM`.
+
+---
+
+Example sequence 3 (Mod Tap):
+
+```
+                         TAPPING_TERM
+  +---------------------------|--------+
+  | +-------------+           |        |
+  | | SFT_T(KC_A) |           |        |
+  | +-------------+           |        |
+  |       +--------------+    |        |
+  |       | KC_X         |    |        |
+  |       +--------------+    |        |
+  +---------------------------|--------+
+```
+Based on the examples above, you might have expected the output of the above sequence to be `ax`
+since `SFT_T(KC_A)` is NOT held longer than the `TAPPING_TERM`.
+However, the actual output would be capital `X` (`SHIFT` + `x`) due to reasons
+explained under [Ignore Mod Tap Interrupt](#ignore-mod-tap-interrupt).
+
+
+
 ### Permissive Hold
 
 The “permissive hold” mode can be enabled for all dual-role keys by adding the corresponding option to `config.h`:

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -157,7 +157,7 @@ Example sequence 2 (the `L` key is also mapped to `KC_RGHT` on layer 2):
   |            +--------------+ |      |
   +-----------------------------|------+
 ```
-The above sequence will not send a `KC_RGHT` but a `KC_L`, since `LT(2, KC_A)` is not held longer than the `TAPPING_TERM`.
+The above sequence will not send `KC_RGHT` but `KC_A` `KC_L` instead, since `LT(2, KC_A)` is not held longer than the `TAPPING_TERM`.
 
 ---
 
@@ -174,7 +174,7 @@ Example sequence 3 (Mod Tap):
   |       +--------------+    |        |
   +---------------------------|--------+
 ```
-Based on the examples above, you might have expected the output of the above sequence to be `ax`
+Based previous examples, you might have expected the output of the above sequence to be `KC_A` `KC_X`
 since `SFT_T(KC_A)` is NOT held longer than the `TAPPING_TERM`.
 However, the actual output would be capital `X` (`SHIFT` + `x`) due to reasons
 explained under [Ignore Mod Tap Interrupt](#ignore-mod-tap-interrupt).

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -145,6 +145,18 @@ An example of a sequence which is affected by the “permissive hold” mode:
 - `KC_L` Up
 - `LT(2, KC_A)` Up
 
+```
+                         TAPPING_TERM   
+  +---------------------------|--------+
+  | +----------------------+  |        |
+  | | LT(2, KC_A)          |  |        |
+  | +----------------------+  |        |
+  |    +--------------+       |        |
+  |    | KC_L         |       |        |
+  |    +--------------+       |        |
+  +---------------------------|--------+
+```
+
 Normally, if you do all this within the `TAPPING_TERM` (default: 200ms), this will be registered as `al` by the firmware and host system.  With the `PERMISSIVE_HOLD` option enabled, the Layer Tap key is considered as a layer switch if another key is tapped, and the above sequence would be registered as `KC_RGHT` (the mapping of `L` on layer 2). We could describe this sequence as a “nested press” (the modified key's key down and key up events are “nested” between the dual-role key's key down and key up events).
 
 However, this slightly different sequence will not be affected by the “permissive hold” mode:
@@ -153,6 +165,18 @@ However, this slightly different sequence will not be affected by the “permiss
 - `KC_L` Down (the `L` key is also mapped to `KC_RGHT` on layer 2)
 - `LT(2, KC_A)` Up
 - `KC_L` Up
+
+```
+                         TAPPING_TERM   
+  +---------------------------|--------+
+  | +-------------+           |        |
+  | | LT(2, KC_A) |           |        |
+  | +-------------+           |        |
+  |       +--------------+    |        |
+  |       | KC_L         |    |        |
+  |       +--------------+    |        |
+  +---------------------------|--------+
+```
 
 In the sequence above the dual-role key is released before the other key is released, and if that happens within the tapping term, the “permissive hold” mode will still choose the tap action for the dual-role key, and the sequence will be registered as `al` by the host. We could describe this as a “rolling press” (the two keys' key down and key up events behave as if you were rolling a ball across the two keys, first pressing each key down in sequence and then releasing them in the same order).
 
@@ -197,6 +221,18 @@ An example of a sequence which is affected by the “hold on other key press” 
 - `KC_L` Down (the `L` key is also mapped to `KC_RGHT` on layer 2)
 - `LT(2, KC_A)` Up
 - `KC_L` Up
+
+```
+                         TAPPING_TERM
+  +---------------------------|--------+
+  | +-------------+           |        |
+  | | LT(2, KC_A) |           |        |
+  | +-------------+           |        |
+  |       +--------------+    |        |
+  |       | KC_L         |    |        |
+  |       +--------------+    |        |
+  +---------------------------|--------+
+```
 
 Normally, if you do all this within the `TAPPING_TERM` (default: 200ms), this will be registered as `al` by the firmware and host system.  With the `HOLD_ON_OTHER_KEY_PRESS` option enabled, the Layer Tap key is considered as a layer switch if another key is pressed, and the above sequence would be registered as `KC_RGHT` (the mapping of `L` on layer 2).
 
@@ -244,6 +280,18 @@ An example of a sequence which will be affected by the `IGNORE_MOD_TAP_INTERRUPT
 - `KC_X` Down
 - `SFT_T(KC_A)` Up
 - `KC_X` Up
+
+```
+                         TAPPING_TERM
+  +---------------------------|--------+
+  | +-------------+           |        |
+  | | SFT_T(KC_A) |           |        |
+  | +-------------+           |        |
+  |       +--------------+    |        |
+  |       | KC_X         |    |        |
+  |       +--------------+    |        |
+  +---------------------------|--------+
+```
 
 Normally, this would send a capital `X` (`SHIFT`+`x`), even if the sequence is performed faster than the `TAPPING_TERM`.  However, if the `IGNORE_MOD_TAP_INTERRUPT` option is enabled, the `SFT_T(KC_A)` key must be held longer than the `TAPPING_TERM` to register the hold action.  A quick tap will output `ax` in this case, while a hold will still output a capital `X` (`SHIFT`+`x`).
 
@@ -326,6 +374,18 @@ To enable `retro tapping`, add the following to your `config.h`:
 Holding and releasing a dual function key without pressing another key will result in nothing happening. With retro tapping enabled, releasing the key without pressing another will send the original keycode even if it is outside the tapping term.
 
 For instance, holding and releasing `LT(2, KC_SPC)` without hitting another key will result in nothing happening. With this enabled, it will send `KC_SPC` instead.
+
+```
+               TAPPING_TERM
+  +-----------------|------------------+
+  | +---------------|-------+          |
+  | | LT(2, KC_SPC) |       |          |
+  | +---------------|-------+          |
+  |                 |                  |
+  |                 |                  |
+  |                 |                  |
+  +-----------------|------------------+
+```
 
 For more granular control of this feature, you can add the following to your `config.h`:
 


### PR DESCRIPTION
## Description

When reading the [Tap Hold Configuration Options](https://docs.qmk.fm/#/tap_hold?id=tap-hold-configuration-options), I find it hard to visualize the behaviour of each tap-hold modes.

To help future users better visualize, ASCII diagrams are included for each example sequences.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
