### PR TITLE
Fix broken bootloader builds in develop.

### DIFF
--- a/keyboards/clueboard/60/info.json
+++ b/keyboards/clueboard/60/info.json
@@ -5,6 +5,7 @@
   "debounce": 6,
   "processor": "STM32F303",
   "board": "QMK_PROTON_C",
+  "bootloader": "stm32-dfu",
   "diode_direction": "COL2ROW",
   "features": {
     "audio": true,

--- a/keyboards/clueboard/66/rev4/info.json
+++ b/keyboards/clueboard/66/rev4/info.json
@@ -5,6 +5,7 @@
   "debounce": 5,
   "processor": "STM32F303",
   "board": "QMK_PROTON_C",
+  "bootloader": "stm32-dfu",
   "diode_direction": "COL2ROW",
   "features": {
     "audio": true,

--- a/keyboards/clueboard/66_hotswap/gen1/info.json
+++ b/keyboards/clueboard/66_hotswap/gen1/info.json
@@ -5,6 +5,7 @@
   "debounce": 5,
   "processor": "STM32F303",
   "board": "QMK_PROTON_C",
+  "bootloader": "stm32-dfu",
   "diode_direction": "COL2ROW",
   "features": {
     "audio": true,

--- a/keyboards/clueboard/california/info.json
+++ b/keyboards/clueboard/california/info.json
@@ -4,6 +4,7 @@
     "maintainer": "skullydazed",
     "processor": "STM32F303",
     "board": "QMK_PROTON_C",
+    "bootloader": "stm32-dfu",
     "matrix_pins": {
         "direct": [
             ["A10", "A9"],

--- a/keyboards/edi/hardlight/mk2/rules.mk
+++ b/keyboards/edi/hardlight/mk2/rules.mk
@@ -2,7 +2,7 @@
 MCU = STM32F072
 
 # Bootloader selection
-Bootloader = stm32-dfu
+BOOTLOADER = stm32-dfu
 
 # Wildcard to allow APM32 MCU
 DFU_SUFFIX_ARGS = -v FFFF -p FFFF

--- a/keyboards/ez_maker/directpins/proton_c/info.json
+++ b/keyboards/ez_maker/directpins/proton_c/info.json
@@ -5,6 +5,7 @@
     "debounce": 5,
     "processor": "STM32F303",
     "board": "QMK_PROTON_C",
+    "bootloader": "stm32-dfu",
     "features": {
         "bootmagic": true,
         "extrakey": true,

--- a/keyboards/forever65/info.json
+++ b/keyboards/forever65/info.json
@@ -3,6 +3,7 @@
     "manufacturer": "Nightingale Studios",
     "maintainer": "zvecr",
     "processor": "STM32F072",
+    "bootloader": "stm32-dfu",
     "diode_direction": "COL2ROW",
     "matrix_pins": {
         "cols": ["A3", "F1", "F0", "C15", "C14", "C13", "B11", "B10", "B2", "B1", "B0", "A7", "A5", "A6", "A4", "B5"],

--- a/keyboards/mechlovin/mechlovin9/rev1/rules.mk
+++ b/keyboards/mechlovin/mechlovin9/rev1/rules.mk
@@ -2,6 +2,9 @@
 MCU = STM32F303
 BOARD = QMK_PROTON_C
 
+# Bootloader selection
+BOOTLOADER = stm32-dfu
+
 # Build Options
 #   change yes to no to disable
 #

--- a/keyboards/rgbkb/mun/rules.mk
+++ b/keyboards/rgbkb/mun/rules.mk
@@ -1,6 +1,9 @@
 # MCU name
 MCU = STM32F303
 
+# Bootloader selection
+BOOTLOADER = stm32-dfu
+
 # Touch encoder needs
 SRC += ../common/touch_encoder.c
 SRC += ../common/common_oled.c

--- a/platforms/chibios/bootloaders/none.c
+++ b/platforms/chibios/bootloaders/none.c
@@ -16,4 +16,8 @@
 
 #include "bootloader.h"
 
+#pragma message "Unknown bootloader set, you may not be able to enter bootloader using software reset"
+
 __attribute__((weak)) void bootloader_jump(void) {}
+
+__attribute__((weak)) void enter_bootloader_mode_if_requested(void) {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Most are just missing a bootloader assignment as the change to info.py in #15638 seems to now require the bootloader to be set specifically in info.json.

This also adds a weak `enter_bootloader_mode_if_requested` so chibios builds with an unknown bootloader will compile successfully with an accompanying pragma message.

These keychron boards require the `BOOTLOADER` setting and `STM32_BOOTLOADER_ADDRESS` defining (which would go against the previous work if added to rules.mk). Maybe the MCU configuration should  be added to `builddefs/mcu_selection.mk` in a separate PR. (Compiles as a unknown bootloader with this PR)
```
  keychron/q2/rev_0110:default
  keychron/q2/rev_0110:via
  keychron/q2/rev_0111:default
  keychron/q2/rev_0111:via
  keychron/q2/rev_0112:default
  keychron/q2/rev_0112:via
  keychron/q2/rev_0113:default
  keychron/q2/rev_0113:via
```

These 2 matrix boards using custom booloaders now also compiles with the unknown bootloader pragma message.
```
  matrix/m20add:default
  matrix/noah:default
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
