### PR TITLE
Relocate matrix_scan_quantum tasks

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -52,6 +52,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef ENCODER_ENABLE
 #    include "encoder.h"
 #endif
+#ifdef AUTO_SHIFT_ENABLE
+#    include "process_auto_shift.h"
+#endif
 #ifdef STENO_ENABLE
 #    include "process_steno.h"
 #endif

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <stdint.h>
+#include "quantum.h"
 #include "keyboard.h"
 #include "matrix.h"
 #include "keymap.h"
@@ -51,9 +52,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #ifdef ENCODER_ENABLE
 #    include "encoder.h"
-#endif
-#ifdef AUTO_SHIFT_ENABLE
-#    include "process_auto_shift.h"
 #endif
 #ifdef STENO_ENABLE
 #    include "process_steno.h"

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -450,6 +450,73 @@ MATRIX_LOOP_END:
     return matrix_changed;
 }
 
+/** \brief Tasks previously located in matrix_scan_quantum
+ *
+ * TODO: rationalise against keyboard_task and current split role
+ */
+void quantum_task(void) {
+#ifdef SPLIT_KEYBOARD
+    // some tasks should only run on master
+    if (!is_keyboard_master()) return;
+#endif
+
+#if defined(AUDIO_ENABLE) && defined(AUDIO_INIT_DELAY)
+    // There are some tasks that need to be run a little bit
+    // after keyboard startup, or else they will not work correctly
+    // because of interaction with the USB device state, which
+    // may still be in flux...
+    //
+    // At the moment the only feature that needs this is the
+    // startup song.
+    static bool     delayed_tasks_run  = false;
+    static uint16_t delayed_task_timer = 0;
+    if (!delayed_tasks_run) {
+        if (!delayed_task_timer) {
+            delayed_task_timer = timer_read();
+        } else if (timer_elapsed(delayed_task_timer) > 300) {
+            audio_startup();
+            delayed_tasks_run = true;
+        }
+    }
+#endif
+
+#if defined(AUDIO_ENABLE) && !defined(NO_MUSIC_MODE)
+    music_task();
+#endif
+
+#ifdef KEY_OVERRIDE_ENABLE
+    key_override_task();
+#endif
+
+#ifdef SEQUENCER_ENABLE
+    sequencer_task();
+#endif
+
+#ifdef TAP_DANCE_ENABLE
+    tap_dance_task();
+#endif
+
+#ifdef COMBO_ENABLE
+    combo_task();
+#endif
+
+#ifdef WPM_ENABLE
+    decay_wpm();
+#endif
+
+#ifdef HAPTIC_ENABLE
+    haptic_task();
+#endif
+
+#ifdef DIP_SWITCH_ENABLE
+    dip_switch_read(false);
+#endif
+
+#ifdef AUTO_SHIFT_ENABLE
+    autoshift_matrix_scan();
+#endif
+}
+
 /** \brief Keyboard task: Do keyboard routine jobs
  *
  * Do routine keyboard jobs:
@@ -464,6 +531,8 @@ MATRIX_LOOP_END:
 void keyboard_task(void) {
     bool matrix_changed = matrix_scan_task();
     (void)matrix_changed;
+
+    quantum_task();
 
 #if defined(RGBLIGHT_ENABLE)
     rgblight_task();

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -47,10 +47,6 @@ float default_layer_songs[][16][2] = DEFAULT_LAYER_SONGS;
 #    endif
 #endif
 
-#ifdef AUTO_SHIFT_ENABLE
-#    include "process_auto_shift.h"
-#endif
-
 uint8_t extract_mod_bits(uint16_t code) {
     switch (code) {
         case QK_MODS ... QK_MODS_MAX:

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -400,73 +400,8 @@ void matrix_init_quantum() {
     matrix_init_kb();
 }
 
-void matrix_scan_quantum() {
-#if defined(AUDIO_ENABLE) && defined(AUDIO_INIT_DELAY)
-    // There are some tasks that need to be run a little bit
-    // after keyboard startup, or else they will not work correctly
-    // because of interaction with the USB device state, which
-    // may still be in flux...
-    //
-    // At the moment the only feature that needs this is the
-    // startup song.
-    static bool     delayed_tasks_run  = false;
-    static uint16_t delayed_task_timer = 0;
-    if (!delayed_tasks_run) {
-        if (!delayed_task_timer) {
-            delayed_task_timer = timer_read();
-        } else if (timer_elapsed(delayed_task_timer) > 300) {
-            audio_startup();
-            delayed_tasks_run = true;
-        }
-    }
-#endif
-
-#if defined(AUDIO_ENABLE) && !defined(NO_MUSIC_MODE)
-    music_task();
-#endif
-
-#ifdef KEY_OVERRIDE_ENABLE
-    key_override_task();
-#endif
-
-#ifdef SEQUENCER_ENABLE
-    sequencer_task();
-#endif
-
-#ifdef TAP_DANCE_ENABLE
-    tap_dance_task();
-#endif
-
-#ifdef COMBO_ENABLE
-    combo_task();
-#endif
-
-#ifdef LED_MATRIX_ENABLE
-    led_matrix_task();
-#endif
-
-#ifdef WPM_ENABLE
-    decay_wpm();
-#endif
-
-#ifdef HAPTIC_ENABLE
-    haptic_task();
-#endif
-
-#ifdef DIP_SWITCH_ENABLE
-    dip_switch_read(false);
-#endif
-
-#ifdef AUTO_SHIFT_ENABLE
-    autoshift_matrix_scan();
-#endif
-
-    matrix_scan_kb();
-}
-
-#ifdef HD44780_ENABLED
-#    include "hd44780.h"
-#endif
+// TODO: remove legacy api
+void matrix_scan_quantum() { matrix_scan_kb(); }
 
 //------------------------------------------------------------------------------
 // Override these functions in your keymap file to play different tunes on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Dependency for #15722.

Having 2 files which collect the various `_task`s adds unnecessary complexity. While overall behaviour should be *mostly* the same, with this PR the order will have slightly changed.

Before:
1. scan matrix
2. master only tasks
3. ` matrix_scan_kb`/`matrix_scan_user`
4. other tasks

After:
1. scan matrix
3. ` matrix_scan_kb`/`matrix_scan_user`
2. master only tasks
4. other tasks

Given how the scan callbacks have little way in interaction with the other tasks, it should be fairly safe to change the order.

Also,
* `led_matrix_task` would previously be called twice on splits
* mid file `hd44780.h` include removed

*Note:* Future iterations are planned to further sort out the fragmentation shown by the tmk_core+quantum merge.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
