### PR TITLE
[Bug] Remove config.h include in dynamic_keymap.c

### DIFF
--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -14,7 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "keymap.h"  // to get keymaps[][][]
 #include "eeprom.h"
 #include "progmem.h"  // to read default from flash


### PR DESCRIPTION
## Description

Exposed by `karlb/kbic65:via`, if there is no config.h, because all the config is in the info.json, via and dynamic keymap will fail to compile.   

config.h should not need to be included, as it's included by the build/make system, automatically. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
