### PR TITLE
Add a warning about USBtinyISP limitations to the ISP flashing guide

### DIFF
--- a/docs/isp_flashing_guide.md
+++ b/docs/isp_flashing_guide.md
@@ -57,13 +57,33 @@ To use a Teensy 2.0 as an ISP flashing tool, you will first need to load a [spec
 
 !> Note that the `B0` pin on the Teensy should be wired to the `RESET` pin on the keyboard's controller. ***DO NOT*** connect the `RESET` pin on the Teensy to the `RESET` on the keyboard.
 
-### SparkFun PocketAVR / USBtinyISP / USBasp
+### SparkFun PocketAVR / USBtinyISP
 
 [SparkFun PocketAVR](https://www.sparkfun.com/products/9825)  
 [Adafruit USBtinyISP](https://www.adafruit.com/product/46)  
+
+!> SparkFun PocketAVR and USBtinyISP **DO NOT support** AVR chips with more than 64 KiB of flash (e.g., the AT90USB128 series). This limitation is mentioned on the [shop page for SparkFun PocketAVR](https://www.sparkfun.com/products/9825) and in the [FAQ for USBtinyISP](https://learn.adafruit.com/usbtinyisp/f-a-q#faq-2270879). If you try to use one of these programmers with AT90USB128 chips, you will get verification errors from `avrdude`, and the bootloader won't be flashed properly (e.g., see the [issue #3286](https://github.com/qmk/qmk_firmware/issues/3286)).
+
+**AVRDUDE Programmer**: `usbtiny`  
+**AVRDUDE Port**: `usb`
+
+#### Wiring
+
+|ISP      |Keyboard|
+|---------|--------|
+|`VCC`    |`VCC`   |
+|`GND`    |`GND`   |
+|`RST`    |`RESET` |
+|`SCLK`   |`SCLK`  |
+|`MOSI`   |`MOSI`  |
+|`MISO`   |`MISO`  |
+
+
+### USBasp
+
 [Thomas Fischl's USBasp](https://www.fischl.de/usbasp/)
 
-**AVRDUDE Programmer**: `usbtiny` / `usbasp`  
+**AVRDUDE Programmer**: `usbasp`  
 **AVRDUDE Port**: `usb`
 
 #### Wiring


### PR DESCRIPTION
## Description

ISP programmers based on USBtinyISP (including SparkFun PocketAVR) do not support AVR chips with more than 64 KiB of flash (e.g., AT90USB1286/7).  Add a warning about that limitation to the ISP flashing guide (apparently the shop pages for those programmers do not emphasise this limitation enough).

The limitation is actually in the USB protocol between `avrdude` and the programmer firmware (the field for byte address in the flash has only 16 bits), so it cannot be fixed with “just” a minor firmware update (which would require a second ISP flasher anyway).

USBasp now has a separate section, because it does not have the 64 KiB flash size limit (in fact, the USBasp firmware seems to support even chips with more than 128 KiB of flash, which need an extra command to set high address bits).

I also looked at other ISP flashers, and apparently the code from https://github.com/arduino/arduino-examples/blob/main/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino (I suppose that's the source for the Pro Micro and Teensy 2.0 ISP firmware hex files) seems to support at least devices with 128 KiB of flash (it uses 16-bit *word address*, which is just enough for that, and the “Load Extended Address Byte” command, which would be needed for even larger devices, could probably be sent by the host through the “universal” command). Not sure about the Bus Pirate, but it seems to be a generic bitbang or SPI master device, so it should support large chips if `avrdude` sends the correct commands over SPI.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
