### PR TITLE
Overwrite RGB_TOG function in ikki68_aurora:via

### DIFF
--- a/keyboards/wuque/ikki68_aurora/keymaps/via/keymap.c
+++ b/keyboards/wuque/ikki68_aurora/keymaps/via/keymap.c
@@ -16,6 +16,15 @@
 
 #include QMK_KEYBOARD_H
 
+typedef union {
+    uint32_t raw;
+    struct {
+        uint8_t led_mode : 8;
+    };
+} user_config_t;
+
+user_config_t user_config;
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_all(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_BSPC,    KC_INS, KC_PGUP,
@@ -46,3 +55,55 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______,          _______,          _______,          _______,          _______, _______, _______,             _______, _______, _______
     ),
 };
+
+enum RGB_mode { LED_MODE_ALL = 0, LED_MODE_LOGO, LED_MODE_UNDERGLOW, LED_MODE_OFF };
+
+const uint8_t LED_MODE_TOTAL = 4;
+
+void update_led_mode(void) {
+    rgblight_setrgb(0, 0, 0);
+    switch (user_config.led_mode) {
+        case LED_MODE_ALL:
+            rgblight_set_effect_range(0, RGBLED_NUM);
+            rgblight_enable_noeeprom();
+            break;
+        case LED_MODE_LOGO:
+            rgblight_set_effect_range(16, 4);
+            rgblight_enable_noeeprom();
+            break;
+        case LED_MODE_UNDERGLOW:
+            rgblight_set_effect_range(0, 16);
+            rgblight_enable_noeeprom();
+            break;
+        case LED_MODE_OFF:
+            rgblight_disable_noeeprom();
+            break;
+    }
+}
+
+void keyboard_post_init_user(void) {
+    user_config.raw = eeconfig_read_user();
+    update_led_mode();
+}
+
+void eeconfig_init_user(void) {
+    user_config.raw = 0;
+    user_config.led_mode = LED_MODE_ALL;
+    eeconfig_update_user(user_config.raw);
+    rgblight_enable();
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case RGB_TOG:
+            if (record->event.pressed) {
+                user_config.led_mode = (user_config.led_mode + 1) % LED_MODE_TOTAL;
+                update_led_mode();
+                eeconfig_update_user(user_config.raw);
+            }
+            return false;
+        default:
+            return true;
+    }
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Want to change 'Toggle LED Modes Function' as default function without adding a new key value, which still be supported by VIA.
Change based on https://github.com/qmk/qmk_firmware/pull/14838

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
