### PR TITLE
Enable a default task throttle for split pointing.

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -203,7 +203,7 @@ void           pointing_device_driver_set_cpi(uint16_t cpi) {}
 |`POINTING_DEVICE_MOTION_PIN`      | (Optional) If supported, will only read from sensor if pin is active. | _not defined_     |
 |`POINTING_DEVICE_TASK_THROTTLE_MS`      | (Optional) Limits the frequency that the sensor is polled for motion. | _not defined_     |
 
-!> When using `SPLIT_POINTING_ENABLE` the `POINTING_DEVICE_MOTION_PIN` functionality is not supported and would recommend `POINTING_DEVICE_TASK_THROTTLE_MS` be set to `1`. Increasing this value will increase transport performance at the cost of possible mouse responsiveness.
+!> When using `SPLIT_POINTING_ENABLE` the `POINTING_DEVICE_MOTION_PIN` functionality is not supported and `POINTING_DEVICE_TASK_THROTTLE_MS` will default to `1`. Increasing this value will increase transport performance at the cost of possible mouse responsiveness.
 
 
 ## Split Keyboard Configuration

--- a/quantum/pointing_device.c
+++ b/quantum/pointing_device.c
@@ -217,16 +217,12 @@ __attribute__((weak)) void pointing_device_task(void) {
     };
 #endif
 
-#if defined(POINTING_DEVICE_TASK_THROTTLE_MS)
+#if (POINTING_DEVICE_TASK_THROTTLE_MS > 0)
     static uint32_t last_exec = 0;
     if (timer_elapsed32(last_exec) < POINTING_DEVICE_TASK_THROTTLE_MS) {
         return;
     }
     last_exec = timer_read32();
-#else
-#    if defined(SPLIT_POINTING_ENABLE)
-#        pragma message("It's recommended you enable a throttle when sharing pointing devices.")
-#    endif
 #endif
 
     // Gather report info

--- a/quantum/pointing_device.h
+++ b/quantum/pointing_device.h
@@ -94,6 +94,9 @@ report_mouse_t pointing_device_adjust_by_defines(report_mouse_t mouse_report);
 #if defined(SPLIT_POINTING_ENABLE)
 void     pointing_device_set_shared_report(report_mouse_t report);
 uint16_t pointing_device_get_shared_cpi(void);
+#    if !defined(POINTING_DEVICE_TASK_THROTTLE_MS)
+#        define POINTING_DEVICE_TASK_THROTTLE_MS 1
+#    endif
 #    if defined(POINTING_DEVICE_COMBINED)
 void           pointing_device_set_cpi_on_side(bool left, uint16_t cpi);
 report_mouse_t pointing_device_combine_reports(report_mouse_t left_report, report_mouse_t right_report);

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -624,7 +624,7 @@ static void pointing_handlers_slave(matrix_row_t master_matrix[], matrix_row_t s
 #    endif
     report_mouse_t temp_report;
     uint16_t       temp_cpi;
-#    ifdef POINTING_DEVICE_TASK_THROTTLE_MS
+#    if (POINTING_DEVICE_TASK_THROTTLE_MS > 0)
     static uint32_t last_exec = 0;
     if (timer_elapsed32(last_exec) < POINTING_DEVICE_TASK_THROTTLE_MS) {
         return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This doesn't appear to have any downsides and only improves split performance with the default of 1. AVR in particular struggles with this not being limited.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
