### PR TITLE
Remove `keyboard_folder` instances from `info.json` files

### DIFF
--- a/keyboards/caffeinated/serpent65/info.json
+++ b/keyboards/caffeinated/serpent65/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "Serpent65",
-    "keyboard_folder": "caffeinated/serpent65",
     "url": "https",
     "maintainer": "jrfhoutx",
     "layouts": {

--- a/keyboards/dumbpad/v0x/info.json
+++ b/keyboards/dumbpad/v0x/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "dumbpad/v0x",
-    "keyboard_folder": "dumbpad/v0x",
     "url": "https://www.github.com/imchipwood/dumbpad",
     "maintainer": "imchipwood",
     "layouts": {

--- a/keyboards/dumbpad/v0x_dualencoder/info.json
+++ b/keyboards/dumbpad/v0x_dualencoder/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "dumbpad/v0x_dualencoder",
-    "keyboard_folder": "dumbpad/v0x_dualencoder",
     "url": "https://www.github.com/imchipwood/dumbpad",
     "maintainer": "imchipwood",
     "layouts": {

--- a/keyboards/dumbpad/v0x_right/info.json
+++ b/keyboards/dumbpad/v0x_right/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "dumbpad/v0x_right",
-    "keyboard_folder": "dumbpad/v0x_right",
     "url": "https://www.github.com/imchipwood/dumbpad",
     "maintainer": "imchipwood",
     "layouts": {

--- a/keyboards/dumbpad/v1x/info.json
+++ b/keyboards/dumbpad/v1x/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "dumbpad/v1x",
-    "keyboard_folder": "dumbpad/v1x",
     "url": "https://www.github.com/imchipwood/dumbpad",
     "maintainer": "imchipwood",
     "layouts": {

--- a/keyboards/dumbpad/v1x_dualencoder/info.json
+++ b/keyboards/dumbpad/v1x_dualencoder/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "dumbpad/v1x_dualencoder",
-    "keyboard_folder": "dumbpad/v1x_dualencoder",
     "url": "https://www.github.com/imchipwood/dumbpad",
     "maintainer": "imchipwood",
     "layouts": {

--- a/keyboards/dumbpad/v1x_right/info.json
+++ b/keyboards/dumbpad/v1x_right/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "dumbpad/v1x_right",
-    "keyboard_folder": "dumbpad/v1x_right",
     "url": "https://www.github.com/imchipwood/dumbpad",
     "maintainer": "imchipwood",
     "layouts": {

--- a/keyboards/mlego/m48/info.json
+++ b/keyboards/mlego/m48/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "mlego/m48",
-    "keyboard_folder": "mlego/m48",
     "url": "https://gitlab.com/m-lego/m48",
     "maintainer": "alin elena",
     "layouts": {

--- a/keyboards/mlego/m60/info.json
+++ b/keyboards/mlego/m60/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "mlego/m60",
-    "keyboard_folder": "mlego/m60",
     "url": "https://gitlab.com/m-lego/m60",
     "maintainer": "alin elena",
     "layouts": {

--- a/keyboards/mlego/m65/info.json
+++ b/keyboards/mlego/m65/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "M65",
-    "keyboard_folder": "mlego/m65",
     "url": "https://gitlab.com/m-lego/m65",
     "maintainer": "alin elena",
     "layouts": {

--- a/keyboards/neopad/rev1/info.json
+++ b/keyboards/neopad/rev1/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "neopad",
-    "keyboard_folder": "neopad/rev1",
     "url": "https://github.com/rookiebwoy/neopad)",
     "maintainer": "rookiebwoy",
     "layouts": {

--- a/keyboards/spaceman/pancake/rev2/info.json
+++ b/keyboards/spaceman/pancake/rev2/info.json
@@ -1,6 +1,5 @@
 {
   "keyboard_name": "Pancake 2",
-  "keyboard_folder": "pancake/rev2",
   "url": "",
   "maintainer": "Spaceman",
   "layouts": {


### PR DESCRIPTION
## Description

Recently learned that an incorrect `keyboard_folder` value can prevent QMK Configurator from compiling a keyboard. Most of these were correct, but clearing them out since they're not at all needed.

### Maintainers Affected

* @jrfhoutx (`caffeinated/serpent65`)
* @imchipwood (`dumbpad`)
* @alinelena (`mlego/` directory)
* @rookiebwoy (`neopad/rev1`)
* @Spaceman (`spaceman/pancake/rev2`)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
