### PR TITLE
Pass in the keyrecord_t of the dual-role/tapping key when calling per-key tap hold functions

### DIFF
--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -124,7 +124,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
             || (
 #        ifdef RETRO_TAPPING_PER_KEY
-                get_retro_tapping(tapping_keycode, keyp) &&
+                get_retro_tapping(tapping_keycode, &tapping_key) &&
 #        endif
                 (RETRO_SHIFT + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_SHIFT + 0)
             )
@@ -158,7 +158,7 @@ bool process_tapping(keyrecord_t *keyp) {
                         (
                             (
 #        ifdef TAPPING_TERM_PER_KEY
-                                get_tapping_term(tapping_keycode, keyp)
+                                get_tapping_term(tapping_keycode, &tapping_key)
 #        else
                                 g_tapping_term
 #        endif
@@ -166,7 +166,7 @@ bool process_tapping(keyrecord_t *keyp) {
                             )
 
 #        ifdef PERMISSIVE_HOLD_PER_KEY
-                            || get_permissive_hold(tapping_keycode, keyp)
+                            || get_permissive_hold(tapping_keycode, &tapping_key)
 #        elif defined(PERMISSIVE_HOLD)
                             || true
 #        endif
@@ -177,7 +177,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     || (
 #            ifdef RETRO_TAPPING_PER_KEY
-                        get_retro_tapping(tapping_keycode, keyp) &&
+                        get_retro_tapping(tapping_keycode, &tapping_key) &&
 #            endif
                         (
                             // Rolled over the two keys.
@@ -188,7 +188,7 @@ bool process_tapping(keyrecord_t *keyp) {
                                     || (
                                         IS_LT(tapping_keycode)
 #                ifdef HOLD_ON_OTHER_KEY_PRESS_PER_KEY
-                                        && get_hold_on_other_key_press(tapping_keycode, keyp)
+                                        && get_hold_on_other_key_press(tapping_keycode, &tapping_key)
 #                endif
                                     )
 #            endif
@@ -196,7 +196,7 @@ bool process_tapping(keyrecord_t *keyp) {
                                     || (
                                         IS_MT(tapping_keycode)
 #                ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
-                                        && !get_ignore_mod_tap_interrupt(tapping_keycode, keyp)
+                                        && !get_ignore_mod_tap_interrupt(tapping_keycode, &tapping_key)
 #                endif
                                     )
 #            endif
@@ -252,7 +252,7 @@ bool process_tapping(keyrecord_t *keyp) {
                         tapping_key.tap.interrupted = true;
 #    if defined(HOLD_ON_OTHER_KEY_PRESS) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
 #        if defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
-                        if (get_hold_on_other_key_press(tapping_keycode, keyp))
+                        if (get_hold_on_other_key_press(tapping_keycode, &tapping_key))
 #        endif
                         {
                             debug("Tapping: End. No tap. Interfered by pressed key\n");
@@ -360,7 +360,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
             || (
 #        ifdef RETRO_TAPPING_PER_KEY
-                get_retro_tapping(tapping_keycode, keyp) &&
+                get_retro_tapping(tapping_keycode, &tapping_key) &&
 #        endif
                 (RETRO_SHIFT + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_SHIFT + 0)
             )
@@ -373,7 +373,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #    if !defined(TAPPING_FORCE_HOLD) || defined(TAPPING_FORCE_HOLD_PER_KEY)
                     if (
 #        ifdef TAPPING_FORCE_HOLD_PER_KEY
-                        !get_tapping_force_hold(tapping_keycode, keyp) &&
+                        !get_tapping_force_hold(tapping_keycode, &tapping_key) &&
 #        endif
                         !tapping_key.tap.interrupted && tapping_key.tap.count > 0) {
                         // sequential tap.

--- a/quantum/pointing_device_drivers.c
+++ b/quantum/pointing_device_drivers.c
@@ -101,7 +101,7 @@ const pointing_device_driver_t pointing_device_driver = {
 #        ifdef TAPPING_TERM_PER_KEY
 #            include "action.h"
 #            include "action_tapping.h"
-#            define CIRQUE_PINNACLE_TAPPING_TERM get_tapping_term(KC_BTN1, NULL)
+#            define CIRQUE_PINNACLE_TAPPING_TERM get_tapping_term(KC_BTN1, &(keyrecord_t){})
 #        else
 #            ifdef TAPPING_TERM
 #                define CIRQUE_PINNACLE_TAPPING_TERM TAPPING_TERM

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -173,7 +173,7 @@ void tap_dance_task() {
             tap_user_defined = action->custom_tapping_term;
         } else {
 #ifdef TAPPING_TERM_PER_KEY
-            tap_user_defined = get_tapping_term(action->state.keycode, NULL);
+            tap_user_defined = get_tapping_term(action->state.keycode, &(keyrecord_t){});
 #else
             tap_user_defined = TAPPING_TERM;
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

[BUG FIX]

The second `keyrecord_t*` argument given to tap hold per key functions should refer to the same key as that given in the first `uint16_t keycode`  argument. All the per-key functions called in `bool process_tapping(keyrecord_t *keyp)` use the same pattern : `get_option(tapping_keycode, keyp)` but from what I've gathered, `keyp` is not necessarily the `tapping_key` so it should instead be `get_option(tapping_keycode, &tapping_key)`.

To illustrate my point:

Let the key on row=1, col=3 be MT(MOD_LSFT, KC_S) (hexadecimal keycode=0x6216 ) and the key on row=2, col=7 be KC_H.
Consider the following body for the `get_tapping_term` function.
```c
uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
    uprintf("0x%04X,%u,%u,%u,%u\n",
         keycode,
         record->event.key.row,
         record->event.key.col,
         get_highest_layer(layer_state),
         record->event.pressed
         );
    return TAPPING_TERM;
}  
```

If we try to capitalise H by holding down the S shift modtap, we can see the following appear in the printed output:
```
0x6216,1,3,0,1
0x6216,2,7,0,1
0x6216,1,3,0,1
```
 
The second printed line shows the keycode of the mod-tap but the `keyrecord_t` information of `KC_H`
Isn't `keycode` and `record` supposed to refer to the same underlying key event?

You can't even really exploit it that much, it seems. I thought that perhaps this might be useful to tweak the tapping term of a specific modtap if it is combined with another key but the following doesn't increase the tapping term for `LSFT_T(KC_S)` when its tap is interrupted by `KC_H` (row=2, col=7)

```c
uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
    uprintf("0x%04X,%u,%u,%u,%u\n",
         keycode,
         record->event.key.row,
         record->event.key.col,
         get_highest_layer(layer_state),
         record->event.pressed
         );
    switch (keycode) {
        case LSFT_T(KC_S):
            if (record->event.key.row == 2 && record->event.key.col == 7) {
                return 8000;
            } else {
                return TAPPING_TERM-10;
            }
        default:
            return TAPPING_TERM;
    }
};
```

As in, I most definitely do not need to be holding down `LSFT_T(KC_S)` for 8s before pressing `KC_H` in order to capitalise it.

When discussing this issue on the Discord server, sigprof also pointed out instances where the `get_tapping_term` function is called with a NULL second argument in core QMK code which presents the high risk of nullptr dereference at runtime if a user, for example, dereferences the `record` argument to fetch the keypos information in their per-key tap hold function(s). To avoid this problem, I replaced the NULLs by an empty keyrecord structure (`&(keyrecord_t){}`). Let me know if there's a better substitute that I can use.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
