### PR TITLE
adafruit_ble: support chibios

### DIFF
--- a/tmk_core/protocol/chibios/chibios.c
+++ b/tmk_core/protocol/chibios/chibios.c
@@ -66,6 +66,15 @@ void    send_digitizer(report_digitizer_t *report);
 /* host struct */
 host_driver_t chibios_driver = {keyboard_leds, send_keyboard, send_mouse, send_system, send_consumer, send_programmable_button};
 
+#ifdef BLUETOOTH_ENABLE
+#    include "outputselect.h"
+#    ifdef BLUETOOTH_BLUEFRUIT_LE
+#        include "bluefruit_le.h"
+#    elif BLUETOOTH_RN42
+#        include "rn42.h"
+#    endif
+#endif
+
 #ifdef VIRTSER_ENABLE
 void virtser_task(void);
 #endif
@@ -208,6 +217,9 @@ void protocol_pre_task(void) {
 void protocol_post_task(void) {
 #ifdef CONSOLE_ENABLE
     console_task();
+#endif
+#ifdef BLUETOOTH_BLUEFRUIT_LE
+    bluefruit_le_task();
 #endif
 #ifdef MIDI_ENABLE
     midi_ep_task();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
Enable ADAFRUIT_BLE  on ChibiOS.

## Description

<!--- Describe your changes in detail here. -->

Tested on a Bluefruit LE SPI with an STM32F405, it seems to mostly work.
It seems to work fine I pair my phone over Bluetooth, if I power cycle the board, then I can reconnect as normal but no keystrokes get sent even after `OUT_BT` is pressed.
If I unpair and then pair again it works until the next power cycle.
Disconnecting from my phone without turning off the board works fine.

EDIT: Apparently the latest Bluefruit firmware is just buggy, a cursory test of 0.6.7 as suggested from https://github.com/adafruit/Adafruit_BluefruitLE_Firmware/issues/27 seems to work fine, although it causes one of the QMK init commands to fail with `  > result: ERROR`.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
