### PR TITLE
[Keymap] Fix Corne Cherry default RGBLIGHT setting.

### DIFF
--- a/keyboards/crkbd/keymaps/default/config.h
+++ b/keyboards/crkbd/keymaps/default/config.h
@@ -35,8 +35,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef RGBLIGHT_ENABLE
     #undef RGBLED_NUM
+    #undef RGBLED_SPLIT
     #define RGBLIGHT_ANIMATIONS
-    #define RGBLED_NUM 27
+    #define RGBLED_NUM 54
+    #define RGBLED_SPLIT { 27, 27 }
     #define RGBLIGHT_LIMIT_VAL 120
     #define RGBLIGHT_HUE_STEP 10
     #define RGBLIGHT_SAT_STEP 17


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
crkbd initially loads the following setting. This setting is just for underglow LEDs.
https://github.com/qmk/qmk_firmware/blob/94624d64bab74b11d93b86d8796dd83b4677e024/keyboards/crkbd/rev1/config.h#L27-L32

Then, default keymap override `RGBLED_NUM` to `27` which is just the total LEDs of a half hand (`6`: underglow, `21`: backlight).
https://github.com/qmk/qmk_firmware/blob/94624d64bab74b11d93b86d8796dd83b4677e024/keyboards/crkbd/keymaps/default/config.h#L36-L39

I guess it should be both hands total; `54`. Also `RGBLED_SPLIT` should be override as below.
```c
#define RGBLED_SPLIT { 27, 27 }
```

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
