### PR TITLE
[Bug] Fix hack for chibiOS reset name

### DIFF
--- a/quantum/keymap.h
+++ b/quantum/keymap.h
@@ -35,9 +35,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keycode_config.h"
 
 // ChibiOS uses RESET in its FlagStatus enumeration
-// Therefore define it as QK_RESET here, to avoid name collision
+// Therefore define it as QK_BOOTLOADER here, to avoid name collision
 #if defined(PROTOCOL_CHIBIOS)
-#    define RESET QK_RESET
+#    define RESET QK_BOOTLOADER
 #endif
 // Gross hack, remove me and change RESET keycode to QK_BOOT
 #if defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1287__)


### PR DESCRIPTION
## Description

Fix hacky workaround being broken, by re-applying hack. Followup to #15968 

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature

## Issues Fixed or Closed by This PR

* Compilation issue

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
