### PR TITLE
Fix right side ws2812 leds having two indices

### DIFF
--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -305,8 +305,9 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
         } else {
             return;
         }
-    } else if (is_keyboard_left() && (i >= k_rgb_matrix_split[0]))
+    } else if (i >= k_rgb_matrix_split[0]) {
         return;
+    }
 #    endif
 
     rgb_matrix_ws2812_array[i].r = r;

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -299,8 +299,12 @@ static void flush(void) {
 static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
 #    if defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
     const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
-    if (!is_keyboard_left() && (i >= k_rgb_matrix_split[0])) {
-        i -= k_rgb_matrix_split[0];
+    if (!is_keyboard_left()) {
+        if (i >= k_rgb_matrix_split[0]) {
+            i -= k_rgb_matrix_split[0];
+        } else {
+            return;
+        }
     } else if (is_keyboard_left() && (i >= k_rgb_matrix_split[0]))
         return;
 #    endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I'm assuming this is a bug but I'm unsure if targeting master is the correct option as it may break users keymaps depending on which index they used to address the right side leds.

So the example below shows the issue, where index 12 and 30 currently refers to the same physical led on the right side.

```c
// config.h
RGB_MATRIX_SPLIT { 18, 18 }

// keymap.c
void rgb_matrix_indicators_user(void) {
    rgb_matrix_set_color(30, 0, 0, 255); // blue
    rgb_matrix_set_color(12, 255, 255, 255); // white
}
```
This currently results in the led being white but after applying this PR it's blue as you'd expect.



## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
