### PR TITLE
Workaround in Makefile for recursive rule matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,24 +119,21 @@ endef
 # a function that returns the value
 COMPARE_AND_REMOVE_FROM_RULE = $(eval $(call COMPARE_AND_REMOVE_FROM_RULE_HELPER,$1))$(RULE_FOUND)
 
-# Try to find the longest match for the start of the rule to be checked
+# Try to find a match for the start of the rule to be checked
 # $1 The list to be checked
 # If a match is found, then RULE_FOUND is set to true
 # and MATCHED_ITEM to the item that was matched
 define TRY_TO_MATCH_RULE_FROM_LIST_HELPER
-    # $$(info R $$(RULE))
+    # Split on ":", padding with empty strings to avoid indexing issues
     TOKEN1:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[0])" $$(RULE))
     TOKENr:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[1])" $$(RULE))
-    # $$(info TOKEN1 $$(TOKEN1) TOKENr $$(TOKENr))
+
     FOUNDx:=$$(shell echo $1 | tr " " "\n" | grep -Fx $$(TOKEN1))
-    # $$(info $$(FOUNDx))
     ifneq ($$(FOUNDx),)
-        BEST_MATCH := $$(FOUNDx)
         RULE := $$(TOKENr)
         RULE_FOUND := true
-        MATCHED_ITEM := $$(FOUNDx)
+        MATCHED_ITEM := $$(TOKEN1)
     else
-        BEST_MATCH :=
         RULE_FOUND := false
         MATCHED_ITEM :=
     endif

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ COMPARE_AND_REMOVE_FROM_RULE = $(eval $(call COMPARE_AND_REMOVE_FROM_RULE_HELPER
 # and MATCHED_ITEM to the item that was matched
 define TRY_TO_MATCH_RULE_FROM_LIST_HELPER
     # $$(info R $$(RULE))
-    TOKEN1:=$$(shell python -c "import sys; print((sys.argv[1].split(':',1)+[''])[0])" $$(RULE))
-    TOKENr:=$$(shell python -c "import sys; print((sys.argv[1].split(':',1)+[''])[1])" $$(RULE))
+    TOKEN1:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[0])" $$(RULE))
+    TOKENr:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[1])" $$(RULE))
     # $$(info TOKEN1 $$(TOKEN1) TOKENr $$(TOKENr))
     FOUNDx:=$$(shell echo $1 | tr " " "\n" | grep -Fx $$(TOKEN1))
     # $$(info $$(FOUNDx))

--- a/Makefile
+++ b/Makefile
@@ -119,54 +119,24 @@ endef
 # a function that returns the value
 COMPARE_AND_REMOVE_FROM_RULE = $(eval $(call COMPARE_AND_REMOVE_FROM_RULE_HELPER,$1))$(RULE_FOUND)
 
-
-# Recursively try to find a match for the start of the rule to be checked
-# $1 The list to be checked
-# If a match is found, then RULE_FOUND is set to true
-# and MATCHED_ITEM to the item that was matched
-define TRY_TO_MATCH_RULE_FROM_LIST_HELPER3
-    ifneq ($1,)
-        ifeq ($$(call COMPARE_AND_REMOVE_FROM_RULE,$$(firstword $1)),true)
-            MATCHED_ITEM := $$(firstword $1)
-        else
-            $$(eval $$(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER3,$$(wordlist 2,9999,$1)))
-        endif
-    endif
-endef
-
-# A recursive helper function for finding the longest match
-# $1 The list to be checked
-# It works by always removing the currently matched item from the list
-define TRY_TO_MATCH_RULE_FROM_LIST_HELPER2
-    # Stop the recursion when the list is empty
-    ifneq ($1,)
-        RULE_BEFORE := $$(RULE)
-        $$(eval $$(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER3,$1))
-        # If a match is found in the current list, otherwise just return what we had before
-        ifeq ($$(RULE_FOUND),true)
-            # Save the best match so far and call itself recursively
-            BEST_MATCH := $$(MATCHED_ITEM)
-            BEST_MATCH_RULE := $$(RULE)
-            RULE_FOUND := false
-            RULE := $$(RULE_BEFORE)
-            $$(eval $$(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER2,$$(filter-out $$(MATCHED_ITEM),$1)))
-        endif
-     endif
-endef
-
-
-# Recursively try to find the longest match for the start of the rule to be checked
+# Try to find the longest match for the start of the rule to be checked
 # $1 The list to be checked
 # If a match is found, then RULE_FOUND is set to true
 # and MATCHED_ITEM to the item that was matched
 define TRY_TO_MATCH_RULE_FROM_LIST_HELPER
-    BEST_MATCH :=
-    $$(eval $$(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER2,$1))
-    ifneq ($$(BEST_MATCH),)
+    # $$(info R $$(RULE))
+    TOKEN1:=$$(shell python -c "import sys; print((sys.argv[1].split(':',1)+[''])[0])" $$(RULE))
+    TOKENr:=$$(shell python -c "import sys; print((sys.argv[1].split(':',1)+[''])[1])" $$(RULE))
+    # $$(info TOKEN1 $$(TOKEN1) TOKENr $$(TOKENr))
+    FOUNDx:=$$(shell echo $1 | tr " " "\n" | grep -Fx $$(TOKEN1))
+    # $$(info $$(FOUNDx))
+    ifneq ($$(FOUNDx),)
+        BEST_MATCH := $$(FOUNDx)
+        RULE := $$(TOKENr)
         RULE_FOUND := true
-        RULE := $$(BEST_MATCH_RULE)
-        MATCHED_ITEM := $$(BEST_MATCH)
+        MATCHED_ITEM := $$(FOUNDx)
     else
+        BEST_MATCH :=
         RULE_FOUND := false
         MATCHED_ITEM :=
     endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
* Match with grep rather than recursive calls
* Use python to minimise any environment issues
* Try not to break things...

Some crude perf testing seems to suggest its roughly the same on msys, and maybe marginally faster under wsl.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #13416

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
