### PR TITLE
Fix BACKLIGHT_CAPS_LOCK warning

### DIFF
--- a/quantum/led.c
+++ b/quantum/led.c
@@ -17,7 +17,7 @@
 #include "host.h"
 #include "debug.h"
 
-#if defined(BACKLIGHT_CAPS_LOCK)
+#ifdef BACKLIGHT_CAPS_LOCK
 #    ifdef BACKLIGHT_ENABLE
 #        include "backlight.h"
 extern backlight_config_t backlight_config;

--- a/quantum/led.c
+++ b/quantum/led.c
@@ -17,19 +17,21 @@
 #include "host.h"
 #include "debug.h"
 
-#ifdef BACKLIGHT_ENABLE
-#    include "backlight.h"
+#if defined(BACKLIGHT_CAPS_LOCK)
+#    ifdef BACKLIGHT_ENABLE
+#        include "backlight.h"
 extern backlight_config_t backlight_config;
-#else
-#    pragma message "Cannot use BACKLIGHT_CAPS_LOCK without backlight being enabled"
-#    undef BACKLIGHT_CAPS_LOCK
+#    else
+#        pragma message "Cannot use BACKLIGHT_CAPS_LOCK without backlight being enabled"
+#        undef BACKLIGHT_CAPS_LOCK
+#    endif
 #endif
 
 #ifndef LED_PIN_ON_STATE
 #    define LED_PIN_ON_STATE 1
 #endif
 
-#if defined(BACKLIGHT_CAPS_LOCK)
+#ifdef BACKLIGHT_CAPS_LOCK
 /** \brief Caps Lock indicator using backlight (for keyboards without dedicated LED)
  */
 static void handle_backlight_caps_lock(led_t led_state) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Non backlight keyboards are currently spitting out the following error:
```
Compiling: quantum/led.c                                                                           quantum/led.c:24:13: note: '#pragma message: Cannot use BACKLIGHT_CAPS_LOCK without backlight being enabled'
   24 | #    pragma message "Cannot use BACKLIGHT_CAPS_LOCK without backlight being enabled"
      |             ^~~~~~~
 [OK]
Compiling: 
```

Seems i let the some logic changes slip through when merging files.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
