### PR TITLE
[Keyboard] Fix frosty_flake LED pin assignment

### DIFF
--- a/keyboards/bpiphany/frosty_flake/20130602/20130602.c
+++ b/keyboards/bpiphany/frosty_flake/20130602/20130602.c
@@ -1,9 +1,9 @@
 #include "frosty_flake.h"
 
 void keyboard_pre_init_kb() {
-    setPinOutput(B7); // num lock
+    setPinOutput(B7); // caps lock
     writePinHigh(B7);
-    setPinOutput(C5); // caps lock
+    setPinOutput(C5); // num lock
     writePinHigh(C7);
     setPinOutput(C6); // scroll lock
     writePinHigh(C6);
@@ -16,8 +16,8 @@ bool led_update_kb(led_t usb_led) {
     if (!led_update_user(usb_led))
         return true;
 
-    writePin(C5, !usb_led.caps_lock);
-    writePin(B7, !usb_led.num_lock);
+    writePin(C5, !usb_led.num_lock);
+    writePin(B7, !usb_led.caps_lock);
     writePin(C6, !usb_led.scroll_lock);
 
     return true;

--- a/keyboards/bpiphany/frosty_flake/20140521/20140521.c
+++ b/keyboards/bpiphany/frosty_flake/20140521/20140521.c
@@ -16,8 +16,8 @@ bool led_update_kb(led_t usb_led) {
     if (!led_update_user(usb_led))
         return true;
 
-    writePin(B7, !usb_led.caps_lock);
-    writePin(C5, !usb_led.num_lock);
+    writePin(C5, !usb_led.caps_lock);
+    writePin(B7, !usb_led.num_lock);
     writePin(C6, !usb_led.scroll_lock);
 
     return true;


### PR DESCRIPTION
4c080be seemed to swap the LED pins for the 20130602 and 20140521
variants. 20140521 is fine now, 20130602 untested but per the
schematics at https://deskthority.net/wiki/Costar_replacement_controllers
it seems correct.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This addresses the mixup of LED assignment for the frosty flake controller (20140521 vs 20130602) that happened in 4c080be

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* regression introduced in https://github.com/qmk/qmk_firmware/pull/15365

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
