### PR TITLE
[Bug] Fix compilation issues for led indicators

### DIFF
--- a/quantum/led.c
+++ b/quantum/led.c
@@ -16,6 +16,7 @@
 #include "led.h"
 #include "host.h"
 #include "debug.h"
+#include "gpio.h"
 
 #ifdef BACKLIGHT_CAPS_LOCK
 #    ifdef BACKLIGHT_ENABLE


### PR DESCRIPTION
## Description

It's erroring out on chibiOS on the gpio controls. 

Includes gpio.h, which should fix the issue.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* compilation error

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
