### PR TITLE
[Keyboard] Fix erroneous SRC for Clueboard 66 hotswap

### DIFF
--- a/keyboards/clueboard/66_hotswap/gen1/rules.mk
+++ b/keyboards/clueboard/66_hotswap/gen1/rules.mk
@@ -1,2 +1,0 @@
-# project specific files
-SRC =	led.c


### PR DESCRIPTION


## Description

No such led.c exists for this board (but it does for the clueboard 60)

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
