### PR TITLE
ChibiOS timer fixes

### DIFF
--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -3,6 +3,8 @@
 #include "timer.h"
 
 static uint32_t ticks_offset = 0;
+static uint32_t last_ticks   = 0;
+static uint32_t ms_offset    = 0;
 #if CH_CFG_ST_RESOLUTION < 32
 static uint32_t last_systime = 0;
 static uint32_t overflow     = 0;
@@ -30,11 +32,21 @@ static inline uint32_t get_system_time_ticks(void) {
     return systime;
 }
 
+// The highest multiple of CH_CFG_ST_FREQUENCY that fits into uint32_t.  This number of ticks will necessarily
+// correspond to some integer number of seconds.
+#define OVERFLOW_ADJUST_TICKS ((uint32_t)((UINT32_MAX / CH_CFG_ST_FREQUENCY) * CH_CFG_ST_FREQUENCY))
+
+// The time in milliseconds which corresponds to OVERFLOW_ADJUST_TICKS ticks (this is a precise conversion, because
+// OVERFLOW_ADJUST_TICKS corresponds to an integer number of seconds).
+#define OVERFLOW_ADJUST_MS (TIME_I2MS(OVERFLOW_ADJUST_TICKS))
+
 void timer_init(void) { timer_clear(); }
 
 void timer_clear(void) {
     chSysLock();
     ticks_offset = get_system_time_ticks();
+    last_ticks   = 0;
+    ms_offset    = 0;
     chSysUnlock();
 }
 
@@ -43,9 +55,22 @@ uint16_t timer_read(void) { return (uint16_t)timer_read32(); }
 uint32_t timer_read32(void) {
     chSysLock();
     uint32_t ticks = get_system_time_ticks() - ticks_offset;
+    if (ticks < last_ticks) {
+        // The 32-bit tick counter overflowed and wrapped around.  We cannot just extend the counter to 64 bits here,
+        // because TIME_I2MS() may encounter overflows when handling a 64-bit argument; therefore the solution here is
+        // to subtract a reasonably large number of ticks from the tick counter to bring its value below the 32-bit
+        // limit again, and then add the equivalent number of milliseconds to the converted value.  (Adjusting just the
+        // converted value to account for 2**32 ticks is not possible in general, because 2**32 ticks may not correspond
+        // to an integer number of milliseconds).
+        ticks -= OVERFLOW_ADJUST_TICKS;
+        ticks_offset += OVERFLOW_ADJUST_TICKS;
+        ms_offset += OVERFLOW_ADJUST_MS;
+    }
+    last_ticks              = ticks;
+    uint32_t ms_offset_copy = ms_offset;  // read while still holding the lock to ensure a consistent value
     chSysUnlock();
 
-    return (uint32_t)TIME_I2MS(ticks);
+    return (uint32_t)TIME_I2MS(ticks) + ms_offset_copy;
 }
 
 uint16_t timer_elapsed(uint16_t last) { return TIMER_DIFF_16(timer_read(), last); }

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -8,38 +8,44 @@ static uint32_t last_systime = 0;
 static uint32_t overflow     = 0;
 #endif
 
+// Get the current system time in ticks as a 32-bit number.
+// This function must be called from within a system lock zone (so that it can safely use and update the static data).
+static inline uint32_t get_system_time_ticks(void) {
+    uint32_t systime = (uint32_t)chVTGetSystemTimeX();
+
+#if CH_CFG_ST_RESOLUTION < 32
+    // If the real system timer resolution is less than 32 bits, provide the missing bits by checking for the counter
+    // overflow.  For this to work, this function must be called at least once for every overflow of the system timer.
+    // In the 16-bit case, the corresponding times are:
+    //    - CH_CFG_ST_FREQUENCY = 100000, overflow will occur every ~0.65 seconds
+    //    - CH_CFG_ST_FREQUENCY = 10000, overflow will occur every ~6.5 seconds
+    //    - CH_CFG_ST_FREQUENCY = 1000, overflow will occur every ~65 seconds
+    if (systime < last_systime) {
+        overflow += ((uint32_t)1) << CH_CFG_ST_RESOLUTION;
+    }
+    last_systime = systime;
+    systime += overflow;
+#endif
+
+    return systime;
+}
+
 void timer_init(void) { timer_clear(); }
 
 void timer_clear(void) {
-    reset_point = (uint32_t)chVTGetSystemTime();
-#if CH_CFG_ST_RESOLUTION < 32
-    last_systime = reset_point;
-    overflow     = 0;
-#endif
+    chSysLock();
+    reset_point = get_system_time_ticks();
+    chSysUnlock();
 }
 
 uint16_t timer_read(void) { return (uint16_t)timer_read32(); }
 
 uint32_t timer_read32(void) {
-    uint32_t systime = (uint32_t)chVTGetSystemTime();
+    chSysLock();
+    uint32_t systime = get_system_time_ticks() - reset_point;
+    chSysUnlock();
 
-#if CH_CFG_ST_RESOLUTION < 32
-    // If/when we need to support 64-bit chips, this may need to be modified to match the native bit-ness of the MCU.
-    // At this point, the only SysTick resolution allowed other than 32 is 16 bit.
-    // In the 16-bit case, at:
-    //    - CH_CFG_ST_FREQUENCY = 100000, overflow will occur every ~0.65 seconds
-    //    - CH_CFG_ST_FREQUENCY = 10000, overflow will occur every ~6.5 seconds
-    //    - CH_CFG_ST_FREQUENCY = 1000, overflow will occur every ~65 seconds
-    // With this implementation, as long as we ensure a timer read happens at least once during the overflow period, timing should be accurate.
-    if (systime < last_systime) {
-        overflow += ((uint32_t)1) << CH_CFG_ST_RESOLUTION;
-    }
-
-    last_systime = systime;
-    return (uint32_t)TIME_I2MS(systime - reset_point + overflow);
-#else
-    return (uint32_t)TIME_I2MS(systime - reset_point);
-#endif
+    return (uint32_t)TIME_I2MS(systime);
 }
 
 uint16_t timer_elapsed(uint16_t last) { return TIMER_DIFF_16(timer_read(), last); }

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -2,7 +2,7 @@
 
 #include "timer.h"
 
-static uint32_t reset_point = 0;
+static uint32_t ticks_offset = 0;
 #if CH_CFG_ST_RESOLUTION < 32
 static uint32_t last_systime = 0;
 static uint32_t overflow     = 0;
@@ -34,7 +34,7 @@ void timer_init(void) { timer_clear(); }
 
 void timer_clear(void) {
     chSysLock();
-    reset_point = get_system_time_ticks();
+    ticks_offset = get_system_time_ticks();
     chSysUnlock();
 }
 
@@ -42,10 +42,10 @@ uint16_t timer_read(void) { return (uint16_t)timer_read32(); }
 
 uint32_t timer_read32(void) {
     chSysLock();
-    uint32_t systime = get_system_time_ticks() - reset_point;
+    uint32_t ticks = get_system_time_ticks() - ticks_offset;
     chSysUnlock();
 
-    return (uint32_t)TIME_I2MS(systime);
+    return (uint32_t)TIME_I2MS(ticks);
 }
 
 uint16_t timer_elapsed(uint16_t last) { return TIMER_DIFF_16(timer_read(), last); }


### PR DESCRIPTION
## Description

Fix several problems in the QMK timer API implementation for ChibiOS:

1.  The code uses a 32-bit tick counter internally, and that counter is overflowing and wrapping around faster than the 32-bit millisecond counter used by QMK:

    * With `CH_CFG_ST_FREQUENCY` set to 10000 (typically used with the periodic tick mode, or with 16-bit hardware timers), the tick counter overflow happens after slightly less than 5 days of continuous runtime.
    * With `CH_CFG_ST_FREQUENCY` set to 100000 (default for most chips with 32-bit hardware timers), the tick counter overflow happens after slightly less than 5 hours.

    However, the existing timer code did not handle the tick counter overflow correctly — instead of continuing the millisecond counting further, the QMK timer value was reset back to 0; this broke all code that used timers in various ways (in particular, the recently added deferred executors stopped working completely, because the expected timer values were never reached).

    Fixing the problem required adding some code to detect overflows of the 32-bit tick counter and handle them by adjusting two separate offsets — one for the tick counter, another for the converted millisecond value.  Using just a single offset was not really possible — passing 64-bit tick values to the time conversion routines could cause overflows during conversion, and adjusting the millisecond value for 2<sup>32</sup> ticks would result in timing errors, because 2<sup>32</sup> ticks in many cases do not correspond to an integer number of milliseconds.

    I tested the fix with some ridiculous values (`#define CH_CFG_ST_FREQUENCY 96000000` on F411, which results in a 32-bit tick counter overflow every ≈45 seconds), and it seems to work.

2.  For the 16-bit hardware timer case the timer code relied on `timer_read32()` calls being performed at least as frequently as the hardware timer overflows (otherwise some overflow periods would be skipped without advancing the timer value appropriately).  However, if the QMK code is blocked waiting for something without doing any timer checks (maybe there is just some large ChibiOS-based timeout for the operation), and at the same time the timer frequency is relatively high (e.g., on some SN32 chips the minimum possible timer frequency is 187500 Hz, because the prescaler is only 8-bit), some hardware timer overflows may still be missed.

    To make the timekeeping with a 16-bit hardware timer more reliable, I added a ChibiOS virtual timer to the code; that virtual timer fires every half of the hardware timer overflow period, and updates the tick counter state to account for possible hardware timer overflow and wraparound.  These periodic calls are usually not very frequent (every ≈3.28 seconds for 10000 Hz, or every ≈328 ms for 100000 Hz; certainly much less frequent than periodic timer interrupts) and should not result in much system load.

    In addition to making the timekeeping more reliable, these periodic calls also work around the recently discovered bug in ChibiOS for the 16-bit hardware timer case: when all active virtual timers have delays longer than the hardware timer overflow period, the handling of virtual timers stops completely.  In QMK this bug can result in a `wait_ms()` call with a delay larger than the hardware timer overflow period just hanging indefinitely.  However, when the timer update code adds a virtual timer with a shorter delay, all other virtual timers are also handled properly, even when their delay is longer.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
