### PR TITLE
EEPROM refactor: remove `eeprom_teensy.c` by default, use transient instead

### DIFF
--- a/platforms/chibios/eeprom_teensy.c
+++ b/platforms/chibios/eeprom_teensy.c
@@ -524,64 +524,7 @@ void eeprom_write_block(const void *buf, void *addr, uint32_t len) {
 }
 
 #else
-// No EEPROM supported, so emulate it
-
-#    ifndef EEPROM_SIZE
-#        include "eeconfig.h"
-#        define EEPROM_SIZE (((EECONFIG_SIZE + 3) / 4) * 4)  // based off eeconfig's current usage, aligned to 4-byte sizes, to deal with LTO
-#    endif
-__attribute__((aligned(4))) static uint8_t buffer[EEPROM_SIZE];
-
-uint8_t eeprom_read_byte(const uint8_t *addr) {
-    uint32_t offset = (uint32_t)addr;
-    return buffer[offset];
-}
-
-void eeprom_write_byte(uint8_t *addr, uint8_t value) {
-    uint32_t offset = (uint32_t)addr;
-    buffer[offset]  = value;
-}
-
-uint16_t eeprom_read_word(const uint16_t *addr) {
-    const uint8_t *p = (const uint8_t *)addr;
-    return eeprom_read_byte(p) | (eeprom_read_byte(p + 1) << 8);
-}
-
-uint32_t eeprom_read_dword(const uint32_t *addr) {
-    const uint8_t *p = (const uint8_t *)addr;
-    return eeprom_read_byte(p) | (eeprom_read_byte(p + 1) << 8) | (eeprom_read_byte(p + 2) << 16) | (eeprom_read_byte(p + 3) << 24);
-}
-
-void eeprom_read_block(void *buf, const void *addr, size_t len) {
-    const uint8_t *p    = (const uint8_t *)addr;
-    uint8_t *      dest = (uint8_t *)buf;
-    while (len--) {
-        *dest++ = eeprom_read_byte(p++);
-    }
-}
-
-void eeprom_write_word(uint16_t *addr, uint16_t value) {
-    uint8_t *p = (uint8_t *)addr;
-    eeprom_write_byte(p++, value);
-    eeprom_write_byte(p, value >> 8);
-}
-
-void eeprom_write_dword(uint32_t *addr, uint32_t value) {
-    uint8_t *p = (uint8_t *)addr;
-    eeprom_write_byte(p++, value);
-    eeprom_write_byte(p++, value >> 8);
-    eeprom_write_byte(p++, value >> 16);
-    eeprom_write_byte(p, value >> 24);
-}
-
-void eeprom_write_block(const void *buf, void *addr, size_t len) {
-    uint8_t *      p   = (uint8_t *)addr;
-    const uint8_t *src = (const uint8_t *)buf;
-    while (len--) {
-        eeprom_write_byte(p++, *src++);
-    }
-}
-
+#    error Unsupported Teensy EEPROM.
 #endif /* chip selection */
 // The update functions just calls write for now, but could probably be optimized
 


### PR DESCRIPTION
## Description

Default implementation of EEPROM when unspecified was to use a transient-like implementation, implemented in `eeprom_teensy.c`. This moves the normal implementation to be the _actual_ transient EEPROM implementation, decoupling the implementations further.

All keyboards build, apart from the same two boards currently failing on `develop`.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
