### PR TITLE
[Core] Deprecate Split Transaction status field

### DIFF
--- a/drivers/serial.h
+++ b/drivers/serial.h
@@ -26,21 +26,4 @@ void soft_serial_initiator_init(void);
 // target is interrupt accept side
 void soft_serial_target_init(void);
 
-// initiator result
-#define TRANSACTION_END 0
-#define TRANSACTION_NO_RESPONSE 0x1
-#define TRANSACTION_DATA_ERROR 0x2
-#define TRANSACTION_TYPE_ERROR 0x4
-int soft_serial_transaction(int sstd_index);
-
-// target status
-// *SSTD_t.status has
-//   initiator:
-//       TRANSACTION_END
-//    or TRANSACTION_NO_RESPONSE
-//    or TRANSACTION_DATA_ERROR
-//   target:
-//       TRANSACTION_DATA_ERROR
-//    or TRANSACTION_ACCEPTED
-#define TRANSACTION_ACCEPTED 0x8
-int soft_serial_get_and_clean_status(int sstd_index);
+bool soft_serial_transaction(int sstd_index);

--- a/platforms/chibios/drivers/serial_usart.c
+++ b/platforms/chibios/drivers/serial_usart.c
@@ -36,7 +36,7 @@ static SerialDriver* serial_driver = &SERIAL_USART_DRIVER;
 static inline bool react_to_transactions(void);
 static inline bool __attribute__((nonnull)) receive(uint8_t* destination, const size_t size);
 static inline bool __attribute__((nonnull)) send(const uint8_t* source, const size_t size);
-static inline int  initiate_transaction(uint8_t sstd_index);
+static inline bool initiate_transaction(uint8_t sstd_index);
 static inline void usart_clear(void);
 
 /**
@@ -206,14 +206,12 @@ static inline bool react_to_transactions(void) {
      to signal that the slave is ready to receive possible transaction buffers  */
     sstd_index ^= HANDSHAKE_MAGIC;
     if (!send(&sstd_index, sizeof(sstd_index))) {
-        *trans->status = TRANSACTION_DATA_ERROR;
         return false;
     }
 
     /* Receive transaction buffer from the master. If this transaction requires it.*/
     if (trans->initiator2target_buffer_size) {
         if (!receive(split_trans_initiator2target_buffer(trans), trans->initiator2target_buffer_size)) {
-            *trans->status = TRANSACTION_DATA_ERROR;
             return false;
         }
     }
@@ -226,12 +224,10 @@ static inline bool react_to_transactions(void) {
     /* Send transaction buffer to the master. If this transaction requires it. */
     if (trans->target2initiator_buffer_size) {
         if (!send(split_trans_target2initiator_buffer(trans), trans->target2initiator_buffer_size)) {
-            *trans->status = TRANSACTION_DATA_ERROR;
             return false;
         }
     }
 
-    *trans->status = TRANSACTION_ACCEPTED;
     return true;
 }
 
@@ -252,11 +248,9 @@ void soft_serial_initiator_init(void) {
  * @brief Start transaction from the master half to the slave half.
  *
  * @param index Transaction Table index of the transaction to start.
- * @return int TRANSACTION_NO_RESPONSE in case of Timeout.
- *             TRANSACTION_TYPE_ERROR in case of invalid transaction index.
- *             TRANSACTION_END in case of success.
+ * @return bool Indicates success of transaction.
  */
-int soft_serial_transaction(int index) {
+bool soft_serial_transaction(int index) {
     /* Clear the receive queue, to start with a clean slate.
      * Parts of failed transactions or spurious bytes could still be in it. */
     usart_clear();
@@ -266,25 +260,19 @@ int soft_serial_transaction(int index) {
 /**
  * @brief Initiate transaction to slave half.
  */
-static inline int initiate_transaction(uint8_t sstd_index) {
+static inline bool initiate_transaction(uint8_t sstd_index) {
     /* Sanity check that we are actually starting a valid transaction. */
     if (sstd_index >= NUM_TOTAL_TRANSACTIONS) {
         dprintln("USART: Illegal transaction Id.");
-        return TRANSACTION_TYPE_ERROR;
+        return false;
     }
 
     split_transaction_desc_t* trans = &split_transaction_table[sstd_index];
 
-    /* Transaction is not registered. Abort. */
-    if (!trans->status) {
-        dprintln("USART: Transaction not registered.");
-        return TRANSACTION_TYPE_ERROR;
-    }
-
     /* Send transaction table index to the slave, which doubles as basic handshake token. */
     if (!send(&sstd_index, sizeof(sstd_index))) {
         dprintln("USART: Send Handshake failed.");
-        return TRANSACTION_TYPE_ERROR;
+        return false;
     }
 
     uint8_t sstd_index_shake = 0xFF;
@@ -295,14 +283,14 @@ static inline int initiate_transaction(uint8_t sstd_index) {
      */
     if (!receive(&sstd_index_shake, sizeof(sstd_index_shake)) || (sstd_index_shake != (sstd_index ^ HANDSHAKE_MAGIC))) {
         dprintln("USART: Handshake failed.");
-        return TRANSACTION_NO_RESPONSE;
+        return false;
     }
 
     /* Send transaction buffer to the slave. If this transaction requires it. */
     if (trans->initiator2target_buffer_size) {
         if (!send(split_trans_initiator2target_buffer(trans), trans->initiator2target_buffer_size)) {
             dprintln("USART: Send failed.");
-            return TRANSACTION_NO_RESPONSE;
+            return false;
         }
     }
 
@@ -310,9 +298,9 @@ static inline int initiate_transaction(uint8_t sstd_index) {
     if (trans->target2initiator_buffer_size) {
         if (!receive(split_trans_target2initiator_buffer(trans), trans->target2initiator_buffer_size)) {
             dprintln("USART: Receive failed.");
-            return TRANSACTION_NO_RESPONSE;
+            return false;
         }
     }
 
-    return TRANSACTION_END;
+    return true;
 }

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -35,11 +35,11 @@
 #define sizeof_member(type, member) sizeof(((type *)NULL)->member)
 
 #define trans_initiator2target_initializer_cb(member, cb) \
-    { &dummy, sizeof_member(split_shared_memory_t, member), offsetof(split_shared_memory_t, member), 0, 0, cb }
+    { sizeof_member(split_shared_memory_t, member), offsetof(split_shared_memory_t, member), 0, 0, cb }
 #define trans_initiator2target_initializer(member) trans_initiator2target_initializer_cb(member, NULL)
 
 #define trans_target2initiator_initializer_cb(member, cb) \
-    { &dummy, 0, 0, sizeof_member(split_shared_memory_t, member), offsetof(split_shared_memory_t, member), cb }
+    { 0, 0, sizeof_member(split_shared_memory_t, member), offsetof(split_shared_memory_t, member), cb }
 #define trans_target2initiator_initializer(member) trans_target2initiator_initializer_cb(member, NULL)
 
 #define transport_write(id, data, length) transport_execute_transaction(id, data, length, NULL, 0)
@@ -658,10 +658,9 @@ static void pointing_handlers_slave(matrix_row_t master_matrix[], matrix_row_t s
 
 ////////////////////////////////////////////////////
 
-uint8_t                  dummy;
 split_transaction_desc_t split_transaction_table[NUM_TOTAL_TRANSACTIONS] = {
     // Set defaults
-    [0 ...(NUM_TOTAL_TRANSACTIONS - 1)] = {NULL, 0, 0, 0, 0, 0},
+    [0 ...(NUM_TOTAL_TRANSACTIONS - 1)] = {0, 0, 0, 0, 0},
 
 #ifdef USE_I2C
     [I2C_EXECUTE_CALLBACK] = trans_initiator2target_initializer(transaction_id),

--- a/quantum/split_common/transactions.h
+++ b/quantum/split_common/transactions.h
@@ -27,7 +27,6 @@ typedef void (*slave_callback_t)(uint8_t initiator2target_buffer_size, const voi
 
 // Split transaction Descriptor
 typedef struct _split_transaction_desc_t {
-    uint8_t *        status;
     uint8_t          initiator2target_buffer_size;
     uint16_t         initiator2target_offset;
     uint8_t          target2initiator_buffer_size;

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -99,7 +99,7 @@ bool transport_execute_transaction(int8_t id, const void *initiator2target_buf, 
         memcpy(split_trans_initiator2target_buffer(trans), initiator2target_buf, len);
     }
 
-    if (soft_serial_transaction(id) != TRANSACTION_END) {
+    if (!soft_serial_transaction(id)) {
         return false;
     }
 


### PR DESCRIPTION
## Description

It is a left over from previous serial implementations like the helix keyboard. The field is read and written to in split communications, but never evaluated as the current core implementation relies on the return value of `soft_serial_transaction` which is treated as a bool anyways. Therefore status is removed and `soft_serial_transaction` returns a bool now.

`soft_serial_get_and_clean_status` is removed as well as it is dead code.

### Size impact

**AVR: -202 Bytes**

```
./util/size_regression.sh -d maintenance/deprecate-transaction-status crkbd:default
Size:    27572, delta:   -202 -- 2582edb1da Deprecate split transactions status field
```

**ARM: +96 Bytes**

```
./util/size_regression.sh -d maintenance/deprecate-transaction-status zvecr/zv48/f411:default
Size:    34352, delta:    +96 -- 2582edb1da Deprecate split transactions status field
```
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Actually frees about 200 bytes on AVR splits where space is already tight 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
