### PR TITLE
Fix bootloader_jump for certain CTRL boards

### DIFF
--- a/platforms/arm_atsam/bootloaders/md_boot.c
+++ b/platforms/arm_atsam/bootloaders/md_boot.c
@@ -38,22 +38,28 @@ void bootloader_jump(void) {
     if (!*ver_check) {                   // If check version pointer is NULL, all characters have matched
         *MAGIC_ADDR = BOOTLOADER_MAGIC;  // Set magic number into RAM
         NVIC_SystemReset();              // Perform system reset
-        while (1);  // Won't get here
+        while (1)
+            ;  // Won't get here
     }
 #endif
 
     // Set watchdog timer to reset. Directs the bootloader to stay in programming mode.
     WDT->CTRLA.bit.ENABLE = 0;
 
-    while (WDT->SYNCBUSY.bit.ENABLE);
-    while (WDT->CTRLA.bit.ENABLE);
+    while (WDT->SYNCBUSY.bit.ENABLE)
+        ;
+    while (WDT->CTRLA.bit.ENABLE)
+        ;
 
     WDT->CONFIG.bit.WINDOW   = 0;
     WDT->CONFIG.bit.PER      = 0;
     WDT->EWCTRL.bit.EWOFFSET = 0;
     WDT->CTRLA.bit.ENABLE    = 1;
 
-    while (WDT->SYNCBUSY.bit.ENABLE);
-    while (!WDT->CTRLA.bit.ENABLE);
-    while (1);  // Wait on timeout
+    while (WDT->SYNCBUSY.bit.ENABLE)
+        ;
+    while (!WDT->CTRLA.bit.ENABLE)
+        ;
+    while (1)
+        ;  // Wait on timeout
 }

--- a/platforms/arm_atsam/bootloaders/md_boot.c
+++ b/platforms/arm_atsam/bootloaders/md_boot.c
@@ -18,15 +18,14 @@
 
 #include "samd51j18a.h"
 
-#ifdef KEYBOARD_massdrop_ctrl
 // WARNING: These are only for CTRL bootloader release "v2.18Jun 22 2018 17:28:08" for bootloader_jump support
 extern uint32_t _eram;
-
-#    define BOOTLOADER_MAGIC 0x3B9ACA00
-#    define MAGIC_ADDR (uint32_t *)((intptr_t)(&_eram) - 4)
+#define BOOTLOADER_MAGIC 0x3B9ACA00
+#define MAGIC_ADDR (uint32_t *)((intptr_t)(&_eram) - 4)
 
 // CTRL keyboards released with bootloader version below must use RAM method. Otherwise use WDT method.
 void bootloader_jump(void) {
+#ifdef KEYBOARD_massdrop_ctrl
     uint8_t  ver_ram_method[] = "v2.18Jun 22 2018 17:28:08";  // The version to match (NULL terminated by compiler)
     uint8_t *ver_check        = ver_ram_method;               // Pointer to version match string for traversal
     uint8_t *ver_rom          = (uint8_t *)0x21A0;            // Pointer to address in ROM where this specific bootloader version would exist
@@ -39,34 +38,22 @@ void bootloader_jump(void) {
     if (!*ver_check) {                   // If check version pointer is NULL, all characters have matched
         *MAGIC_ADDR = BOOTLOADER_MAGIC;  // Set magic number into RAM
         NVIC_SystemReset();              // Perform system reset
-
-        while (1)
-            ;  // Won't get here
+        while (1);  // Won't get here
     }
-}
+#endif
 
-#else
-
-// Set watchdog timer to reset. Directs the bootloader to stay in programming mode.
-void bootloader_jump(void) {
+    // Set watchdog timer to reset. Directs the bootloader to stay in programming mode.
     WDT->CTRLA.bit.ENABLE = 0;
 
-    while (WDT->SYNCBUSY.bit.ENABLE)
-        ;
-    while (WDT->CTRLA.bit.ENABLE)
-        ;
+    while (WDT->SYNCBUSY.bit.ENABLE);
+    while (WDT->CTRLA.bit.ENABLE);
 
     WDT->CONFIG.bit.WINDOW   = 0;
     WDT->CONFIG.bit.PER      = 0;
     WDT->EWCTRL.bit.EWOFFSET = 0;
     WDT->CTRLA.bit.ENABLE    = 1;
 
-    while (WDT->SYNCBUSY.bit.ENABLE)
-        ;
-    while (!WDT->CTRLA.bit.ENABLE)
-        ;
-
-    while (1)
-        ;  // Wait on timeout
+    while (WDT->SYNCBUSY.bit.ENABLE);
+    while (!WDT->CTRLA.bit.ENABLE);
+    while (1);  // Wait on timeout
 }
-#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I misread the code here and for some reason reworked it so that *all* CTRL boards used this "RAM method" instead of tripping the watchdog... which is not correct.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
