### PR TITLE
Add a script that simplifies running commands under docker.

### DIFF
--- a/util/docker_cmd.sh
+++ b/util/docker_cmd.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# NOTE: This script uses tabs for indentation
+
+errcho() {
+	echo "$@" >&2
+}
+
+USAGE="Usage: $0 <command>"
+
+# Check preconditions
+for arg; do
+	if [ "$arg" = "--help" ]; then
+		echo "$USAGE"
+		exit 0
+	fi
+done
+
+# Allow $RUNTIME to be overriden by the user as an environment variable
+# Else check if either docker or podman exit and set them as runtime
+# if none are found error out
+if [ -z "$RUNTIME" ]; then
+	if command -v docker >/dev/null 2>&1; then
+		RUNTIME="docker"
+	elif command -v podman >/dev/null 2>&1; then
+		RUNTIME="podman"
+	else
+		errcho "Error: no compatible container runtime found."
+		errcho "Either podman or docker are required."
+		errcho "See https://podman.io/getting-started/installation"
+		errcho "or https://docs.docker.com/install/#supported-platforms"
+		errcho "for installation instructions."
+		exit 2
+	fi
+fi
+
+
+# IF we are using docker on non Linux and docker-machine isn't working print an error
+# ELSE set usb_args
+if [ ! "$(uname)" = "Linux" ] && [ "$RUNTIME" = "docker" ] && ! docker-machine active >/dev/null 2>&1; then
+    errcho "Error: target requires docker-machine to work on your platform"
+    errcho "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos"
+    exit 3
+else
+    usb_args="--privileged -v /dev:/dev"
+fi
+dir=$(pwd -W 2>/dev/null) || dir=$PWD  # Use Windows path if on Windows
+
+if [ "$RUNTIME" = "docker" ]; then
+	uid_arg="--user $(id -u):$(id -g)"
+fi
+
+# Run container and build firmware
+"$RUNTIME" run --rm -it \
+	$usb_args \
+	$uid_arg \
+	-w /qmk_firmware \
+	-v "$dir":/qmk_firmware \
+	qmkfm/qmk_cli \
+	"$@"


### PR DESCRIPTION
## Description

Newer versions of `clang-format` produce different output compared to what's in the container.
Given that CI runs in the container, needed a simpler method of executing against the "blessed" version.

This adds a new command, `util/docker_cmd.sh`, which effectively just executes whatever arguments you pass to the script as another command, but inside the container.

Basically a dupe of `util/docker_build.sh`.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
