### PR TITLE
[Keyboard] Fix Pegasus Hoof (2013) layout, matrix and pin assignment

### DIFF
--- a/keyboards/bpiphany/pegasushoof/2013/2013.h
+++ b/keyboards/bpiphany/pegasushoof/2013/2013.h
@@ -21,21 +21,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "quantum.h"
 
 #define LAYOUT( \
-    KG6,      KH4, KI4, KI2, KI6, KP5, KL6, KM2, KM4, KO4, KO5, KO6, KO0,   KN5, KN7, KP7, \
-    KG4, KG5, KH5, KI5, KJ5, KJ4, KK4, KK5, KL5, KM5, KF5, KF4, KL4, KO2,   KR4, KC4, KE4, \
-    KG2, KG7, KH7, KI7, KJ7, KJ2, KK2, KK7, KL7, KM7, KF7, KF2, KL2, KO3,   KQ4, KC5, KE5, \
-    KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6,      KO1,                  \
-    KB2, KH6, KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0,      KB3,        KC6,      \
-    KP4, KD2, KN6,                KQ6,                KN0, KA3, KM0, KP1,   KC0, KQ0, KR0    \
-    ) { /*         00-A    01-B    02-C    03-D    04-E    05-F    06-G    07-H    08-I    09-J    10-K    11-L    12-M    13-N    14-O    15-P    16-Q    17-R */  \
-        /* 0 */  { KC_NO , KC_NO , KC0   , KC_NO , KC_NO , KF0   , KC_NO , KC_NO , KC_NO , KJ0   , KK0   , KC_NO , KM0   , KN0   , KO0   , KC_NO , KQ0   , KR0   }, \
-        /* 1 */  { KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KG1   , KH1   , KI1   , KJ1   , KK1   , KL1   , KM1   , KC_NO , KO1   , KP1   , KC_NO , KC_NO }, \
-        /* 2 */  { KC_NO , KB2   , KC_NO , KD2   , KC_NO , KF2   , KG2   , KH2   , KI2   , KJ2   , KK2   , KL2   , KM2   , KC_NO , KO2   , KC_NO , KC_NO , KC_NO }, \
-        /* 3 */  { KA3   , KB3   , KC_NO , KC_NO , KC_NO , KF3   , KG3   , KH3   , KI3   , KJ3   , KK3   , KL3   , KM3   , KC_NO , KO3   , KC_NO , KC_NO , KC_NO }, \
-        /* 4 */  { KC_NO , KC_NO , KC4   , KC_NO , KE4   , KF4   , KG4   , KH4   , KI4   , KJ4   , KK4   , KL4   , KM4   , KC_NO , KO4   , KP4   , KQ4   , KR4   }, \
-        /* 5 */  { KC_NO , KC_NO , KC5   , KC_NO , KE5   , KF5   , KG5   , KH5   , KI5   , KJ5   , KK5   , KL5   , KM5   , KN5   , KO5   , KP5   , KC_NO , KC_NO }, \
-        /* 6 */  { KC_NO , KC_NO , KC6   , KC_NO , KC_NO , KF6   , KG6   , KH6   , KI6   , KJ6   , KK6   , KL6   , KC_NO , KN6   , KO6   , KC_NO , KQ6   , KC_NO }, \
-        /* 7 */  { KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KF7   , KG7   , KH7   , KI7   , KJ7   , KK7   , KL7   , KM7   , KN7   , KC_NO , KP7   , KC_NO , KC_NO }  \
+    KJ6,      KI4, KH4, KH2, KH6, KA7, KE6, KD2, KD4, KB4, KB7, KB6, KB0,   KC7, KC5, KA5, \
+    KJ4, KJ7, KI7, KH7, KG7, KG4, KF4, KF7, KE7, KD7, KR7, KR4, KE4, KB2,   KL4, KO4, KQ4, \
+    KJ2, KJ5, KI5, KH5, KG5, KG2, KF2, KF5, KE5, KD5, KR5, KR2, KE2, KB3,   KK4, KO7, KQ7, \
+    KI2, KJ3, KI3, KH3, KG3, KG6, KF6, KF3, KE3, KD3, KR3, KR6,      KB1,                  \
+    KN2, KI6, KJ1, KI1, KH1, KG1, KG0, KF0, KF1, KE1, KD1, KR0,      KN3,        KO6,      \
+    KA4, KP2, KC6,                KK6,                KC0, KM3, KD0, KA1,   KO0, KK0, KL0  \
+    ) { /*         00-A   01-B   02-C   03-D   04-E   05-F   06-G   07-H   08-I   09-J   10-K   11-L   12-M   13-N   14-O   15-P   16-Q   17-R */  \
+        /* 0 */  { KC_NO, KB0,   KC0,   KD0,   KC_NO, KF0,   KG0,   KC_NO, KC_NO, KC_NO, KK0,   KL0,   KC_NO, KC_NO, KO0,   KC_NO, KC_NO, KR0   }, \
+        /* 1 */  { KA1,   KB1,   KC_NO, KD1,   KE1,   KF1,   KG1,   KH1,   KI1,   KJ1,   KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+        /* 2 */  { KC_NO, KB2,   KC_NO, KD2,   KE2,   KF2,   KG2,   KH2,   KI2,   KJ2,   KC_NO, KC_NO, KC_NO, KN2,   KC_NO, KP2,   KC_NO, KR2   }, \
+        /* 3 */  { KC_NO, KB3,   KC_NO, KD3,   KE3,   KF3,   KG3,   KH3,   KI3,   KJ3,   KC_NO, KC_NO, KM3,   KN3,   KC_NO, KC_NO, KC_NO, KR3   }, \
+        /* 4 */  { KA4,   KB4,   KC_NO, KD4,   KE4,   KF4,   KG4,   KH4,   KI4,   KJ4,   KK4,   KL4,   KC_NO, KC_NO, KO4,   KC_NO, KQ4,   KR4   }, \
+        /* 5 */  { KA5,   KC_NO, KC5,   KD5,   KE5,   KF5,   KG5,   KH5,   KI5,   KJ5,   KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KR5   }, \
+        /* 6 */  { KC_NO, KB6,   KC6,   KC_NO, KE6,   KF6,   KG6,   KH6,   KI6,   KJ6,   KK6,   KC_NO, KC_NO, KC_NO, KO6,   KC_NO, KC_NO, KR6   }, \
+        /* 7 */  { KA7,   KB7,   KC7,   KD7,   KE7,   KF7,   KG7,   KH7,   KI7,   KJ7,   KC_NO, KC_NO, KC_NO, KC_NO, KO7,   KC_NO, KQ7,   KR7   }  \
     }
 
 #define LAYOUT_tkl_ansi( \
@@ -45,15 +45,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6,      KO1,                  \
     KB2,      KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0,      KB3,        KC6,      \
     KP4, KD2, KN6,                KQ6,                KN0, KA3, KM0, KP1,   KC0, KQ0, KR0  \
-    ) { /*         00-A    01-B    02-C    03-D    04-E    05-F    06-G    07-H    08-I    09-J    10-K    11-L    12-M    13-N    14-O    15-P    16-Q    17-R */  \
-        /* 0 */  { KC_NO , KC_NO , KC0   , KC_NO , KC_NO , KF0   , KC_NO , KC_NO , KC_NO , KJ0   , KK0   , KC_NO , KM0   , KN0   , KO0   , KC_NO , KQ0   , KR0   }, \
-        /* 1 */  { KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KG1   , KH1   , KI1   , KJ1   , KK1   , KL1   , KM1   , KC_NO , KO1   , KP1   , KC_NO , KC_NO }, \
-        /* 2 */  { KC_NO , KB2   , KC_NO , KD2   , KC_NO , KF2   , KG2   , KH2   , KI2   , KJ2   , KK2   , KL2   , KM2   , KC_NO , KO2   , KC_NO , KC_NO , KC_NO }, \
-        /* 3 */  { KA3   , KB3   , KC_NO , KC_NO , KC_NO , KF3   , KG3   , KH3   , KI3   , KJ3   , KK3   , KL3   , KM3   , KC_NO , KO3   , KC_NO , KC_NO , KC_NO }, \
-        /* 4 */  { KC_NO , KC_NO , KC4   , KC_NO , KE4   , KF4   , KG4   , KH4   , KI4   , KJ4   , KK4   , KL4   , KM4   , KC_NO , KO4   , KP4   , KQ4   , KR4   }, \
-        /* 5 */  { KC_NO , KC_NO , KC5   , KC_NO , KE5   , KF5   , KG5   , KH5   , KI5   , KJ5   , KK5   , KL5   , KM5   , KN5   , KO5   , KP5   , KC_NO , KC_NO }, \
-        /* 6 */  { KC_NO , KC_NO , KC6   , KC_NO , KC_NO , KF6   , KG6   , KC_NO , KI6   , KJ6   , KK6   , KL6   , KC_NO , KN6   , KO6   , KC_NO , KQ6   , KC_NO }, \
-        /* 7 */  { KC_NO , KC_NO , KC_NO , KC_NO , KC_NO , KF7   , KG7   , KH7   , KI7   , KJ7   , KK7   , KL7   , KM7   , KN7   , KC_NO , KP7   , KC_NO , KC_NO }  \
+    ) { /*         00-A   01-B   02-C   03-D   04-E  05-F    06-G   07-H   08-I   09-J   10-K   11-L   12-M   13-N   14-O   15-P   16-Q   17-R */  \
+        /* 0 */  { KC_NO, KC_NO, KC0,   KC_NO, KC_NO, KF0,   KC_NO, KC_NO, KC_NO, KJ0,   KK0,   KC_NO, KM0,   KN0,   KO0,   KC_NO, KQ0,   KR0   }, \
+        /* 1 */  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KG1,   KH1,   KI1,   KJ1,   KK1,   KL1,   KM1,   KC_NO, KO1,   KP1,   KC_NO, KC_NO }, \
+        /* 2 */  { KC_NO, KB2,   KC_NO, KD2,   KC_NO, KF2,   KG2,   KH2,   KI2,   KJ2,   KK2,   KL2,   KM2,   KC_NO, KO2,   KC_NO, KC_NO, KC_NO }, \
+        /* 3 */  { KA3,   KB3,   KC_NO, KC_NO, KC_NO, KF3,   KG3,   KH3,   KI3,   KJ3,   KK3,   KL3,   KM3,   KC_NO, KO3,   KC_NO, KC_NO, KC_NO }, \
+        /* 4 */  { KC_NO, KC_NO, KC4,   KC_NO, KE4,   KF4,   KG4,   KH4,   KI4,   KJ4,   KK4,   KL4,   KM4,   KC_NO, KO4,   KP4,   KQ4,   KR4   }, \
+        /* 5 */  { KC_NO, KC_NO, KC5,   KC_NO, KE5,   KF5,   KG5,   KH5,   KI5,   KJ5,   KK5,   KL5,   KM5,   KN5,   KO5,   KP5,   KC_NO, KC_NO }, \
+        /* 6 */  { KC_NO, KC_NO, KC6,   KC_NO, KC_NO, KF6,   KG6,   KC_NO, KI6,   KJ6,   KK6,   KL6,   KC_NO, KN6,   KO6,   KC_NO, KQ6,   KC_NO }, \
+        /* 7 */  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KF7,   KG7,   KH7,   KI7,   KJ7,   KK7,   KL7,   KM7,   KN7,   KC_NO, KP7,   KC_NO, KC_NO }  \
     }
 
 #define LAYOUT_tkl_jis( \
@@ -63,15 +63,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6, KO3, KO1,                       \
     KB2,      KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0, KL0, KB3,             KC6,      \
     KP4, KD2, KN6, KG0,           KQ6,           KH0, KI0, KN0, KM0, KP1,        KC0, KQ0, KR0  \
-    ) { /*         00-A  01-B  02-C  03-D  04-E  05-F  06-G  07-H  08-I  09-J  10-K  11-L  12-M  13-N  14-O  15-P  16-Q  17-R */ \
-        /* 0 */  { KC_NO,  KC_NO,  KC0,    KC_NO,  KC_NO,  KF0,    KG0,    KH0,    KI0,    KJ0,    KK0,    KL0,    KM0,    KN0,    KO0,    KC_NO,  KQ0,    KR0   }, \
-        /* 1 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KG1,    KH1,    KI1,    KJ1,    KK1,    KL1,    KM1,    KC_NO,  KO1,    KP1,    KC_NO,  KC_NO }, \
-        /* 2 */  { KC_NO,  KB2,    KC_NO,  KD2,    KC_NO,  KF2,    KG2,    KH2,    KI2,    KJ2,    KK2,    KL2,    KM2,    KC_NO,  KO2,    KC_NO,  KC_NO,  KC_NO }, \
-        /* 3 */  { KC_NO,  KB3,    KC_NO,  KC_NO,  KC_NO,  KF3,    KG3,    KH3,    KI3,    KJ3,    KK3,    KL3,    KM3,    KC_NO,  KO3,    KC_NO,  KC_NO,  KC_NO }, \
-        /* 4 */  { KC_NO,  KC_NO,  KC4,    KC_NO,  KE4,    KF4,    KG4,    KH4,    KI4,    KJ4,    KK4,    KL4,    KM4,    KC_NO,  KO4,    KP4,    KQ4,    KR4   }, \
-        /* 5 */  { KC_NO,  KC_NO,  KC5,    KC_NO,  KE5,    KF5,    KG5,    KH5,    KI5,    KJ5,    KK5,    KL5,    KM5,    KN5,    KO5,    KP5,    KC_NO,  KC_NO }, \
-        /* 6 */  { KC_NO,  KC_NO,  KC6,    KC_NO,  KC_NO,  KF6,    KG6,    KC_NO,  KI6,    KJ6,    KK6,    KL6,    KC_NO,  KN6,    KO6,    KC_NO,  KQ6,    KC_NO }, \
-        /* 7 */  { KC_NO,  KC_NO,  KC_NO,  KC_NO,  KC_NO,  KF7,    KG7,    KH7,    KI7,    KJ7,    KK7,    KL7,    KK7,    KL7,    KO7,    KP7,    KC_NO,  KC_NO }  \
+    ) { /*         00-A   01-B   02-C   03-D   04-E   05-F   06-G   07-H   08-I   09-J   10-K   11-L   12-M   13-N   14-O   15-P   16-Q   17-R */ \
+        /* 0 */  { KC_NO, KC_NO, KC0,   KC_NO, KC_NO, KF0,   KG0,   KH0,   KI0,   KJ0,   KK0,   KL0,   KM0,   KN0,   KO0,   KC_NO, KQ0,   KR0   },\
+        /* 1 */  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KG1,   KH1,   KI1,   KJ1,   KK1,   KL1,   KM1,   KC_NO, KO1,   KP1,   KC_NO, KC_NO },\
+        /* 2 */  { KC_NO, KB2,   KC_NO, KD2,   KC_NO, KF2,   KG2,   KH2,   KI2,   KJ2,   KK2,   KL2,   KM2,   KC_NO, KO2,   KC_NO, KC_NO, KC_NO },\
+        /* 3 */  { KC_NO, KB3,   KC_NO, KC_NO, KC_NO, KF3,   KG3,   KH3,   KI3,   KJ3,   KK3,   KL3,   KM3,   KC_NO, KO3,   KC_NO, KC_NO, KC_NO },\
+        /* 4 */  { KC_NO, KC_NO, KC4,   KC_NO, KE4,   KF4,   KG4,   KH4,   KI4,   KJ4,   KK4,   KL4,   KM4,   KC_NO, KO4,   KP4,   KQ4,   KR4   },\
+        /* 5 */  { KC_NO, KC_NO, KC5,   KC_NO, KE5,   KF5,   KG5,   KH5,   KI5,   KJ5,   KK5,   KL5,   KM5,   KN5,   KO5,   KP5,   KC_NO, KC_NO },\
+        /* 6 */  { KC_NO, KC_NO, KC6,   KC_NO, KC_NO, KF6,   KG6,   KC_NO, KI6,   KJ6,   KK6,   KL6,   KC_NO, KN6,   KO6,   KC_NO, KQ6,   KC_NO },\
+        /* 7 */  { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KF7,   KG7,   KH7,   KI7,   KJ7,   KK7,   KL7,   KK7,   KL7,   KO7,   KP7,   KC_NO, KC_NO } \
 }
 
 inline void ph_caps_led_on(void)  { DDRC |=  (1<<6); PORTC &= ~(1<<6); }
@@ -79,4 +79,3 @@ inline void ph_caps_led_off(void) { DDRC &= ~(1<<6); PORTC &= ~(1<<6); }
 
 inline void ph_sclk_led_on(void)  { DDRC |=  (1<<5); PORTC &= ~(1<<5); }
 inline void ph_sclk_led_off(void) { DDRC &= ~(1<<5); PORTC &= ~(1<<5); }
-

--- a/keyboards/bpiphany/pegasushoof/2013/matrix.c
+++ b/keyboards/bpiphany/pegasushoof/2013/matrix.c
@@ -35,12 +35,12 @@ static void select_row(uint8_t col);
 
 __attribute__ ((weak))
 void matrix_init_kb(void) {
-    matrix_init_user();
+	matrix_init_user();
 }
 
 __attribute__ ((weak))
 void matrix_scan_kb(void) {
-    matrix_scan_user();
+	matrix_scan_user();
 }
 
 __attribute__ ((weak))
@@ -66,10 +66,10 @@ void matrix_init(void)
 	/* Column output pins */
 	DDRD  |=  0b01111011;
 	/* Row input pins */
-	DDRC  &= ~0b10000000;
-	DDRB  &= ~0b01111111;
-	PORTC |=  0b10000000;
-	PORTB |=  0b01111111;
+	DDRC  &= (unsigned char) ~0b00000000;
+	DDRB  &= (unsigned char) ~0b11111111;
+	PORTC |= 0b00000000;
+	PORTB |= 0b11111111;
 
 	for (uint8_t i=0; i < MATRIX_ROWS; i++)  {
 		matrix[i] = 0;
@@ -151,72 +151,72 @@ uint8_t matrix_key_count(void)
 static matrix_row_t read_cols(void)
 {
 	return
-		(PINB & (1 << 5) ? 0 : 1 << 0) |
-		(PINC & (1 << 7) ? 0 : 1 << 1) |
-		(PINB & (1 << 4) ? 0 : 1 << 2) |
-		(PINB & (1 << 6) ? 0 : 1 << 3) |
-		(PINB & (1 << 1) ? 0 : 1 << 4) |
-		(PINB & (1 << 0) ? 0 : 1 << 5) |
-		(PINB & (1 << 3) ? 0 : 1 << 6) |
-		(PINB & (1 << 2) ? 0 : 1 << 7);
+		(PINB & (1 << 5) ? 0 : (matrix_row_t) 1 << 0) |
+		(PINB & (1 << 7) ? 0 : (matrix_row_t) 1 << 1) |
+		(PINB & (1 << 4) ? 0 : (matrix_row_t) 1 << 2) |
+		(PINB & (1 << 6) ? 0 : (matrix_row_t) 1 << 3) |
+		(PINB & (1 << 1) ? 0 : (matrix_row_t) 1 << 4) |
+		(PINB & (1 << 2) ? 0 : (matrix_row_t) 1 << 5) |
+		(PINB & (1 << 3) ? 0 : (matrix_row_t) 1 << 6) |
+		(PINB & (1 << 0) ? 0 : (matrix_row_t) 1 << 7);
 }
 
 static void select_row(uint8_t col)
 {
 	switch (col) {
 		case 0:
-			PORTD = (PORTD & ~0b01111011) | 0b00110011;
-			break;
-		case 1:
-			PORTD = (PORTD & ~0b01111011) | 0b01110000;
-			break;
-		case 2:
 			PORTD = (PORTD & ~0b01111011) | 0b00010011;
 			break;
-		case 3:
-			PORTD = (PORTD & ~0b01111011) | 0b01101000;
-			break;
-		case 4:
-			PORTD = (PORTD & ~0b01111011) | 0b00001011;
-			break;
-		case 5:
-			PORTD = (PORTD & ~0b01111011) | 0b00111011;
-			break;
-		case 6:
-			PORTD = (PORTD & ~0b01111011) | 0b01111000;
-			break;
-		case 7:
-			PORTD = (PORTD & ~0b01111011) | 0b01100001;
-			break;
-		case 8:
-			PORTD = (PORTD & ~0b01111011) | 0b01101001;
-			break;
-		case 9:
-			PORTD = (PORTD & ~0b01111011) | 0b01110001;
-			break;
-		case 10:
-			PORTD = (PORTD & ~0b01111011) | 0b01101010;
-			break;
-		case 11:
-			PORTD = (PORTD & ~0b01111011) | 0b01100010;
-			break;
-		case 12:
-			PORTD = (PORTD & ~0b01111011) | 0b01111001;
-			break;
-		case 13:
-			PORTD = (PORTD & ~0b01111011) | 0b01100000;
-			break;
-		case 14:
+		case 1:
 			PORTD = (PORTD & ~0b01111011) | 0b01000011;
 			break;
-		case 15:
+		case 2:
+			PORTD = (PORTD & ~0b01111011) | 0b01100000;
+			break;
+		case 3:
+			PORTD = (PORTD & ~0b01111011) | 0b01111001;
+			break;
+		case 4:
+			PORTD = (PORTD & ~0b01111011) | 0b01100010;
+			break;
+		case 5:
+			PORTD = (PORTD & ~0b01111011) | 0b01101010;
+			break;
+		case 6:
+			PORTD = (PORTD & ~0b01111011) | 0b01110001;
+			break;
+		case 7:
+			PORTD = (PORTD & ~0b01111011) | 0b01101001;
+			break;
+		case 8:
+			PORTD = (PORTD & ~0b01111011) | 0b01100001;
+			break;
+		case 9:
+			PORTD = (PORTD & ~0b01111011) | 0b01111000;
+			break;
+		case 10:
 			PORTD = (PORTD & ~0b01111011) | 0b00011011;
 			break;
-		case 16:
+		case 11:
 			PORTD = (PORTD & ~0b01111011) | 0b00100011;
 			break;
-		case 17:
+		case 12:
 			PORTD = (PORTD & ~0b01111011) | 0b00101011;
+			break;
+		case 13:
+			PORTD = (PORTD & ~0b01111011) | 0b01110000;
+			break;
+		case 14:
+			PORTD = (PORTD & ~0b01111011) | 0b00001011;
+			break;
+		case 15:
+			PORTD = (PORTD & ~0b01111011) | 0b01101000;
+			break;
+		case 16:
+			PORTD = (PORTD & ~0b01111011) | 0b00000011;
+			break;
+		case 17:
+			PORTD = (PORTD & ~0b01111011) | 0b00111011;
 			break;
 	}
 }


### PR DESCRIPTION
## Description
After a long long time I decided to update my Filco keyboard (w/ Pegasus Hoof 2013) and I found out many keys were not assigned properly or not working at all. I was surprised the "new" matrix, pin assignment and default layout was quite different from what it was supposed to be, compared to the [original bpiphany's files](https://github.com/BathroomEpiphanies/costar_keyboard/blob/master/models/common.h).

## Types of Changes
- [x] Bugfix

## Issues Fixed or Closed by This PR
* Default layout 
* Matrix
* Pin assignments

## Checklist
- [ ] I have tested the changes and verified that they work on my ISO keyboard, but both `LAYOUT_tkl_ansi` and `LAYOUT_tkl_jis` probably need to be tested and fixed as well.
