### PR TITLE
Add new keymap for GMMK with some additional mappings and led indicator for caps lock

### DIFF
--- a/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
+++ b/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
@@ -72,7 +72,6 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 #endif
 
 void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
-
     static uint32_t cycle_led_timer = 0;
     static uint8_t  current_value   = 0;
     static uint8_t  left_side_leds[8] = {68, 71, 74, 77, 81, 84, 88, 92};

--- a/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
+++ b/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
@@ -1,0 +1,107 @@
+/* Copyright 2021 Glorious, LLC <salman@pcgamingrace.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+//      ESC      F1       F2       F3       F4       F5       F6       F7       F8       F9       F10      F11      F12	     Prt           Rotary(Mute)
+//      ~        1        2        3        4        5        6        7        8        9        0         -       (=)	     BackSpc           Del
+//      Tab      Q        W        E        R        T        Y        U        I        O        P        [        ]                          PgUp
+//      Caps     A        S        D        F        G        H        J        K        L        ;        "        #        Enter             PgDn
+//      Sh_L     /        Z        X        C        V        B        N        M        ,        .        ?                 Sh_R     Up       End
+//      Ct_L     Win_L    Alt_L                               SPACE                               Alt_R    FN       Ct_R     Left     Down     Right
+
+
+    // The FN key by default maps to a momentary toggle to layer 1 to provide access to the RESET key (to put the board into bootloader mode). Without
+    // this mapping, you have to open the case to hit the button on the bottom of the PCB (near the USB cable attachment) while plugging in the USB
+    // cable to get the board into bootloader mode - definitely not fun when you're working on your QMK builds. Remove this and put it back to KC_RGUI
+    // if that's your preference.
+    //
+    // To put the keyboard in bootloader mode, use FN+backspace. If you accidentally put it into bootloader, you can just unplug the USB cable and
+    // it'll be back to normal when you plug it back in.
+    //
+    // This keyboard defaults to 6KRO instead of NKRO for compatibility reasons (some KVMs and BIOSes are incompatible with NKRO).
+    // Since this is, among other things, a "gaming" keyboard, a key combination to enable NKRO on the fly is provided for convenience.
+    // Press Fn+N to toggle between 6KRO and NKRO. This setting is persisted to the EEPROM and thus persists between restarts.
+    [0] = LAYOUT(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_HOME,          KC_MUTE,
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          KC_DEL,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,                   KC_PGUP,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,           KC_PGDN,
+        KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_UP,   KC_END,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [1] = LAYOUT(
+        _______, KC_MYCM, KC_WHOM, KC_CALC, KC_MSEL, KC_MPRV, KC_MNXT, KC_MPLY, KC_MSTP, KC_MUTE, KC_VOLD, KC_VOLU, _______, KC_PSCR,          _______,
+        _______, RGB_TOG, RGB_M_P, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RESET,            _______,
+        _______, RGB_SAI, RGB_VAI, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   _______,
+        _______, _______, RGB_VAD, _______, _______, _______, _______, _______, _______, _______, _______, _______,  KC_INS, _______,          _______,
+        _______, _______, _______, RGB_HUI, _______, _______, _______, NK_TOGG, _______, _______, _______, _______,          _______, RGB_MOD, _______,
+        _______, _______, _______,                            _______,                            _______, _______, _______, RGB_SPD, RGB_RMOD, RGB_SPI
+    ),
+
+
+};
+// clang-format on
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    if (clockwise) {
+      tap_code(KC_VOLU);
+    } else {
+      tap_code(KC_VOLD);
+    }
+    return true;
+}
+#endif
+
+void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+
+    static uint32_t cycle_led_timer = 0;
+    static uint8_t  current_value   = 0;
+    static uint8_t  left_side_leds[8] = {68, 71, 74, 77, 81, 84, 88, 92};
+    static uint8_t  right_side_leds[8] = {69, 72, 75, 78, 82, 85, 89, 93};
+
+    if (host_keyboard_led_state().caps_lock) {
+        if (timer_elapsed32(cycle_led_timer) > 500) {
+            current_value = current_value == 0 ? 255 : 0;
+	    cycle_led_timer = timer_read32();
+        }
+	HSV tempHSV = {.h = 0, .s = 255, .v = current_value};
+	RGB tempRGB = hsv_to_rgb(tempHSV);
+	for (uint8_t i = 0; i < sizeof(left_side_leds) / sizeof(left_side_leds[0]); i++) {
+	    rgb_matrix_set_color(left_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
+	    rgb_matrix_set_color(right_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
+	}
+    }
+
+    static uint8_t l2_functions[26] = {6, 7, 8, 12, 13, 14, 15, 16, 18, 23, 28, 34, 38, 39, 44, 50, 56, 61, 66, 70, 80, 86, 94, 95, 96, 98}; 
+    switch(get_highest_layer(layer_state)){  // special handling per layer
+       case 2:  //layer one
+          break;
+       case 1:
+	  for (uint8_t i = 0; i < sizeof(l2_functions) / sizeof(l2_functions[0]); i++) {
+             RGB_MATRIX_INDICATOR_SET_COLOR(l2_functions[i], 255, 0, 0);
+	  }
+          break;
+       default:
+          break;
+       break;
+    }
+}

--- a/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
+++ b/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
@@ -81,27 +81,27 @@ void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
     if (host_keyboard_led_state().caps_lock) {
         if (timer_elapsed32(cycle_led_timer) > 500) {
             current_value = current_value == 0 ? 255 : 0;
-	    cycle_led_timer = timer_read32();
+            cycle_led_timer = timer_read32();
         }
-	HSV tempHSV = {.h = 0, .s = 255, .v = current_value};
-	RGB tempRGB = hsv_to_rgb(tempHSV);
-	for (uint8_t i = 0; i < sizeof(left_side_leds) / sizeof(left_side_leds[0]); i++) {
-	    rgb_matrix_set_color(left_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
-	    rgb_matrix_set_color(right_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
-	}
+    HSV tempHSV = {.h = 0, .s = 255, .v = current_value};
+    RGB tempRGB = hsv_to_rgb(tempHSV);
+    for (uint8_t i = 0; i < sizeof(left_side_leds) / sizeof(left_side_leds[0]); i++) {
+        rgb_matrix_set_color(left_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
+        rgb_matrix_set_color(right_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
+        }
     }
 
-    static uint8_t l2_functions[26] = {6, 7, 8, 12, 13, 14, 15, 16, 18, 23, 28, 34, 38, 39, 44, 50, 56, 61, 66, 70, 80, 86, 94, 95, 96, 98}; 
+    static uint8_t l2_functions[26] = {6, 7, 8, 12, 13, 14, 15, 16, 18, 23, 28, 34, 38, 39, 44, 50, 56, 61, 66, 70, 80, 86, 94, 95, 96, 98};
     switch(get_highest_layer(layer_state)){  // special handling per layer
        case 2:  //layer one
-          break;
+         break;
        case 1:
-	  for (uint8_t i = 0; i < sizeof(l2_functions) / sizeof(l2_functions[0]); i++) {
+         for (uint8_t i = 0; i < sizeof(l2_functions) / sizeof(l2_functions[0]); i++) {
              RGB_MATRIX_INDICATOR_SET_COLOR(l2_functions[i], 255, 0, 0);
-	  }
-          break;
+         }
+         break;
        default:
-          break;
+         break;
        break;
     }
 }

--- a/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
+++ b/keyboards/gmmk/pro/iso/keymaps/chofstede/keymap.c
@@ -67,7 +67,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     } else {
       tap_code(KC_VOLD);
     }
-    return true;
+    return false;
 }
 #endif
 

--- a/keyboards/gmmk/pro/iso/keymaps/chofstede/readme.md
+++ b/keyboards/gmmk/pro/iso/keymaps/chofstede/readme.md
@@ -1,0 +1,8 @@
+# chofstede GMMK Pro layout
+
+- Added Print-Screen to FN+POS1
+- Added Insert to FN+#
+- The LED bars on the left and right side of the keyboard blink red when CAPS Lock is enabled
+- All mapped keys light up red when FN is being pressed
+
+


### PR DESCRIPTION
## Description

New Keymap for GMMK ISO
- Added Print-Screen to FN+POS1
- Added Insert to FN+#
- The LED bars on the left and right side of the keyboard blink red when CAPS Lock is enabled
- All mapped keys light up red when FN is being pressed

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
