### PR TITLE
Add support for Q-series on the ckled2001 LED driver

### DIFF
--- a/drivers/led/ckled2001.c
+++ b/drivers/led/ckled2001.c
@@ -125,7 +125,16 @@ void CKLED2001_init(uint8_t addr) {
     // Set CURRENT PAGE (Page 4)
     CKLED2001_write_register(addr, CONFIGURE_CMD_PAGE, CURRENT_TUNE_PAGE);
     for (int i = 0; i < LED_CURRENT_TUNE_LENGTH; i++) {
-        CKLED2001_write_register(addr, i, 0xFF);
+        switch (i) {
+            case 2:
+            case 5:
+            case 8:
+            case 11:
+                CKLED2001_write_register(addr, i, 0xA0);
+                break;
+            default:
+                CKLED2001_write_register(addr, i, 0xFF);
+        }
     }
 
     // Enable LEDs ON/OFF


### PR DESCRIPTION
## Description

This PR adds a slight alteration of the Keychron CKLED2001 led driver initialisation code in core where in the Keychron Q-series keyboards require the initialization bit to be set to 0xA0 instead of 0xFF on certain tune lengths *(as implemented in the working copy of the Q-series hosted on the `keychron/qmk_firmware:playground` repo, and a follow up of PR #14872)*.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
