### PR TITLE
Fix tap-hold per key callback invocations.

### DIFF
--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -124,7 +124,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
             || (
 #        ifdef RETRO_TAPPING_PER_KEY
-                get_retro_tapping(tapping_keycode, keyp) &&
+                get_retro_tapping(tapping_keycode, &tapping_key) &&
 #        endif
                 (RETRO_SHIFT + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_SHIFT + 0)
             )
@@ -158,7 +158,7 @@ bool process_tapping(keyrecord_t *keyp) {
                         (
                             (
 #        ifdef TAPPING_TERM_PER_KEY
-                                get_tapping_term(tapping_keycode, keyp)
+                                get_tapping_term(tapping_keycode, &tapping_key)
 #        else
                                 g_tapping_term
 #        endif
@@ -166,7 +166,7 @@ bool process_tapping(keyrecord_t *keyp) {
                             )
 
 #        ifdef PERMISSIVE_HOLD_PER_KEY
-                            || get_permissive_hold(tapping_keycode, keyp)
+                            || get_permissive_hold(tapping_keycode, &tapping_key)
 #        elif defined(PERMISSIVE_HOLD)
                             || true
 #        endif
@@ -177,7 +177,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     || (
 #            ifdef RETRO_TAPPING_PER_KEY
-                        get_retro_tapping(tapping_keycode, keyp) &&
+                        get_retro_tapping(tapping_keycode, &tapping_key) &&
 #            endif
                         (
                             // Rolled over the two keys.
@@ -188,7 +188,7 @@ bool process_tapping(keyrecord_t *keyp) {
                                     || (
                                         IS_LT(tapping_keycode)
 #                ifdef HOLD_ON_OTHER_KEY_PRESS_PER_KEY
-                                        && get_hold_on_other_key_press(tapping_keycode, keyp)
+                                        && get_hold_on_other_key_press(tapping_keycode, &tapping_key)
 #                endif
                                     )
 #            endif
@@ -196,7 +196,7 @@ bool process_tapping(keyrecord_t *keyp) {
                                     || (
                                         IS_MT(tapping_keycode)
 #                ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
-                                        && !get_ignore_mod_tap_interrupt(tapping_keycode, keyp)
+                                        && !get_ignore_mod_tap_interrupt(tapping_keycode, &tapping_key)
 #                endif
                                     )
 #            endif
@@ -252,7 +252,7 @@ bool process_tapping(keyrecord_t *keyp) {
                         tapping_key.tap.interrupted = true;
 #    if defined(HOLD_ON_OTHER_KEY_PRESS) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
 #        if defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
-                        if (get_hold_on_other_key_press(tapping_keycode, keyp))
+                        if (get_hold_on_other_key_press(tapping_keycode, &tapping_key))
 #        endif
                         {
                             debug("Tapping: End. No tap. Interfered by pressed key\n");
@@ -360,7 +360,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #    if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
             || (
 #        ifdef RETRO_TAPPING_PER_KEY
-                get_retro_tapping(tapping_keycode, keyp) &&
+                get_retro_tapping(tapping_keycode, &tapping_key) &&
 #        endif
                 (RETRO_SHIFT + 0) != 0 && TIMER_DIFF_16(event.time, tapping_key.event.time) < (RETRO_SHIFT + 0)
             )
@@ -373,7 +373,7 @@ bool process_tapping(keyrecord_t *keyp) {
 #    if !defined(TAPPING_FORCE_HOLD) || defined(TAPPING_FORCE_HOLD_PER_KEY)
                     if (
 #        ifdef TAPPING_FORCE_HOLD_PER_KEY
-                        !get_tapping_force_hold(tapping_keycode, keyp) &&
+                        !get_tapping_force_hold(tapping_keycode, &tapping_key) &&
 #        endif
                         !tapping_key.tap.interrupted && tapping_key.tap.count > 0) {
                         // sequential tap.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixed per key functions invocation during tap processing. The issue was in record argument of those invocations. Current event was passed instead of tapping_key event so you could not make tap-hold decision as stated in the docs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
