### PR TITLE
Move mousekey keycodes into newly freed up keycode block

### DIFF
--- a/quantum/keycode.h
+++ b/quantum/keycode.h
@@ -510,11 +510,11 @@ enum mouse_keys {
 #ifdef VIA_ENABLE
     KC_MS_UP = 0xF0,
 #else
-    KC_MS_UP = 0xED,
+    KC_MS_UP = 0xCD,
 #endif
     KC_MS_DOWN,
     KC_MS_LEFT,
-    KC_MS_RIGHT, // 0xF0
+    KC_MS_RIGHT,
     KC_MS_BTN1,
     KC_MS_BTN2,
     KC_MS_BTN3,

--- a/quantum/keycode.h
+++ b/quantum/keycode.h
@@ -539,7 +539,7 @@ enum mouse_keys {
     /* Acceleration */
     KC_MS_ACCEL0,
     KC_MS_ACCEL1,
-    KC_MS_ACCEL2 // 0xFF
+    KC_MS_ACCEL2 // 0xDF, or 0xFF if via enabled
 };
 
 #include "keycode_legacy.h"


### PR DESCRIPTION
## Description

The reason for this move is because ACTION LAYER reserves 0xE0-0xFF for internal usage.
Namely, for other layer functions.  This means that LT is limited to 0x00-0xDF keycodes,
and effectively blocks mousekeys from being used.

By moving the mousekeys, this allows them to be used as part of LT.

This leaves C0-CC usable, still.


## Types of Changes

- [x] Core
- [x] Enhancement/optimization



## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
