### PR TITLE
Add layout change callbacks to VIA

### DIFF
--- a/keyboards/work_louder/work_board/work_board.c
+++ b/keyboards/work_louder/work_board/work_board.c
@@ -100,15 +100,15 @@ led_config_t g_led_config = { {
 } };
 // clang-format on
 
+#    ifdef VIA_ENABLE
+bool via_layout_2u = false;
+
+void via_set_layout_options_kb(uint32_t value) { via_layout_2u = (bool)value; }
+#    endif  // VIA_ENABLE
+
 __attribute__((weak)) void rgb_matrix_indicators_user(void) {
 #    ifdef VIA_ENABLE
-    static bool     layout_2u = false;
-    static uint16_t timer = 0;
-    if (timer_elapsed(timer) > 500) {
-        timer     = timer_read();
-        layout_2u = (bool)via_get_layout_options();
-    }
-    if (layout_2u) {
+    if (via_layout_2u) {
         rgb_matrix_set_color(5, 0, 0, 0);
         rgb_matrix_set_color(7, 0, 0, 0);
     } else {

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -96,6 +96,7 @@ void via_init(void) {
     // Let keyboard level test EEPROM valid state,
     // but not set it valid, it is done here.
     via_init_kb();
+    via_set_layout_options_kb(via_get_layout_options());
 
     // If the EEPROM has the magic, the data is good.
     // OK to load from EEPROM.
@@ -131,7 +132,10 @@ uint32_t via_get_layout_options(void) {
     return value;
 }
 
+__attribute__((weak)) void via_set_layout_options_kb(uint32_t value) {}
+
 void via_set_layout_options(uint32_t value) {
+    via_set_layout_options_kb(value);
     // Start at the least significant byte
     void *target = (void *)(VIA_EEPROM_LAYOUT_OPTIONS_ADDR + VIA_EEPROM_LAYOUT_OPTIONS_SIZE - 1);
     for (uint8_t i = 0; i < VIA_EEPROM_LAYOUT_OPTIONS_SIZE; i++) {

--- a/quantum/via.h
+++ b/quantum/via.h
@@ -159,6 +159,7 @@ void via_init(void);
 // Used by VIA to store and retrieve the layout options.
 uint32_t via_get_layout_options(void);
 void     via_set_layout_options(uint32_t value);
+void     via_set_layout_options_kb(uint32_t value);
 
 // Called by QMK core to process VIA-specific keycodes.
 bool process_record_via(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION
## Description

Provides a way for keyboards to get the layout options, without having to constantly querying the eeprom.  what/how to implement that is left up to users.

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
