### PR TITLE
Fix one-shot locked modifiers

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -353,7 +353,7 @@ void process_action(keyrecord_t *record, action_t action) {
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 dprint("MODS_TAP: Toggling oneshot");
                                 clear_oneshot_mods();
-                                set_oneshot_locked_mods(mods);
+                                set_oneshot_locked_mods(mods | get_oneshot_locked_mods());
                                 register_mods(mods);
 #        endif
                             } else {
@@ -367,8 +367,8 @@ void process_action(keyrecord_t *record, action_t action) {
                                 // Retain Oneshot mods
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                                 if (mods & get_mods()) {
-                                    clear_oneshot_locked_mods();
                                     clear_oneshot_mods();
+                                    set_oneshot_locked_mods(~mods & get_oneshot_locked_mods());
                                     unregister_mods(mods);
                                 }
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -572,7 +572,6 @@ void process_action(keyrecord_t *record, action_t action) {
 #            if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                         do_release_oneshot = false;
                         if (event.pressed) {
-                            del_mods(get_oneshot_locked_mods());
                             if (get_oneshot_layer_state() == ONESHOT_TOGGLED) {
                                 reset_oneshot_layer();
                                 layer_off(action.layer_tap.val);
@@ -582,10 +581,8 @@ void process_action(keyrecord_t *record, action_t action) {
                                 set_oneshot_layer(action.layer_tap.val, ONESHOT_START);
                             }
                         } else {
-                            add_mods(get_oneshot_locked_mods());
                             if (tap_count >= ONESHOT_TAP_TOGGLE) {
                                 reset_oneshot_layer();
-                                clear_oneshot_locked_mods();
                                 set_oneshot_layer(action.layer_tap.val, ONESHOT_TOGGLED);
                             } else {
                                 clear_oneshot_layer_state(ONESHOT_PRESSED);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

- Fix state updates of one-shot locked modifiers
Activating additional one-shot locked modifiers removed previously enabled locked modifiers from the state.
`get_oneshot_locked_mods` returned zero when two or more one-shot locked modifiers were enabled and then one was disabled.

- Do not delete one-shot locked modifiers on a one-shot layer toggle
Non-locked one-shot modifiers are not removed so this behavior adds inconsistency.
Also the one-shot locked modifiers state was reset without unregistering any modifiers.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #10921

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
