### PR TITLE
[Keymap] Add hachetman layout for GMMK Pro

### DIFF
--- a/keyboards/gmmk/pro/ansi/keymaps/hachetman/config.h
+++ b/keyboards/gmmk/pro/ansi/keymaps/hachetman/config.h
@@ -1,0 +1,22 @@
+/* Copyright 2021 Andre Brait
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef RGB_MATRIX_ENABLE
+    #define RGB_DISABLE_TIMEOUT 1200000     // 20 minutes (20 * 60 * 1000ms)
+    #define RGB_DISABLE_WHEN_USB_SUSPENDED
+#endif

--- a/keyboards/gmmk/pro/ansi/keymaps/hachetman/keymap.c
+++ b/keyboards/gmmk/pro/ansi/keymaps/hachetman/keymap.c
@@ -1,0 +1,298 @@
+/* Copyright 2021 Glorious, LLC <salman@pcgamingrace.com>
+   Copyright 2021 Andre Brait <andrebrait@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+#ifdef RGB_MATRIX_ENABLE
+    #ifndef RGB_CONFIRMATION_BLINKING_TIME
+        #define RGB_CONFIRMATION_BLINKING_TIME 2000 // 2 seconds
+    #endif
+#endif // RGB_MATRIX_ENABLE
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+//      ESC      F1       F2       F3       F4       F5       F6       F7       F8       F9       F10      F11      F12	     Del          Rotary(Play/Pause)
+//      ~        1        2        3        4        5        6        7        8        9        0         -       (=)	     BackSpc           Home
+//      Tab      Q        W        E        R        T        Y        U        I        O        P        [        ]        \                 PgUp
+//      Caps     A        S        D        F        G        H        J        K        L        ;        "                 Enter             PgDn
+//      Sh_L              Z        X        C        V        B        N        M        ,        .        ?                 Sh_R     Up       End
+//      Ct_L     Win_L    Alt_L                               SPACE                               Alt_R    FN       Ct_R     Left     Down     Right
+
+
+    // The FN key by default maps to a momentary toggle to layer 1 to provide access to the RESET key (to put the board into bootloader mode). Without
+    // this mapping, you have to open the case to hit the button on the bottom of the PCB (near the USB cable attachment) while plugging in the USB
+    // cable to get the board into bootloader mode - definitely not fun when you're working on your QMK builds. Remove this and put it back to KC_RGUI
+    // if that's your preference.
+    //
+    // To put the keyboard in bootloader mode, use FN+backslash. If you accidentally put it into bootloader, you can just unplug the USB cable and
+    // it'll be back to normal when you plug it back in.
+    //
+    // This keyboard defaults to 6KRO instead of NKRO for compatibility reasons (some KVMs and BIOSes are incompatible with NKRO).
+    // Since this is, among other things, a "gaming" keyboard, a key combination to enable NKRO on the fly is provided for convenience.
+    // Press Fn+N to toggle between 6KRO and NKRO. This setting is persisted to the EEPROM and thus persists between restarts.
+    [0] = LAYOUT(
+        KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,           KC_MUTE,
+        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          KC_HOME,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,          KC_PGUP,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,           KC_PGDN,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_RSFT, KC_UP,   KC_END,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [1] = LAYOUT(
+        _______, KC_MYCM, KC_WHOM, KC_CALC, KC_MSEL, KC_MPRV, KC_MNXT, KC_MPLY, KC_MSTP, KC_MUTE, KC_VOLD, KC_VOLU, _______, KC_INS,           _______,
+        _______, RGB_TOG, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          KC_PSCR,
+        _______, _______, RGB_VAI, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RESET,            _______,
+        _______, _______, RGB_VAD, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,          _______,
+        _______,          _______, RGB_HUI, _______, _______, _______, NK_TOGG, _______, _______, _______, _______,          _______, RGB_MOD, _______,
+        _______, _______, _______,                            _______,                            _______, _______, _______, RGB_SPD, RGB_RMOD, RGB_SPI
+    ),
+
+
+};
+// clang-format on
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    if (clockwise) {
+      tap_code(KC_VOLU);
+    } else {
+      tap_code(KC_VOLD);
+    }
+    return true;
+}
+#endif // ENCODER_ENABLE
+
+#ifdef RGB_MATRIX_ENABLE
+
+/* Renaming those to make the purpose on this keymap clearer */
+#define LED_FLAG_CAPS LED_FLAG_NONE
+#define LED_FLAG_EFFECTS LED_FLAG_INDICATOR
+
+static void set_rgb_caps_leds(void);
+
+#if RGB_CONFIRMATION_BLINKING_TIME > 0
+static uint16_t effect_started_time = 0;
+static uint8_t r_effect = 0x0, g_effect = 0x0, b_effect = 0x0;
+static void start_effects(void);
+
+/* The higher this is, the slower the blinking will be */
+#ifndef TIME_SELECTED_BIT
+    #define TIME_SELECTED_BIT 8
+#endif
+#if TIME_SELECTED_BIT < 0 || TIME_SELECTED_BIT >= 16
+    #error "TIME_SELECTED_BIT must be a positive integer smaller than 16"
+#endif
+#define effect_red() r_effect = 0xFF, g_effect = 0x0, b_effect = 0x0
+#define effect_green() r_effect = 0x0, g_effect = 0xFF, b_effect = 0x0
+#endif // RGB_CONFIRMATION_BLINKING_TIME > 0
+
+bool led_update_user(led_t led_state) {
+    if (led_state.caps_lock) {
+        if (!rgb_matrix_is_enabled()) {
+            /* Turn ON the RGB Matrix for CAPS LOCK */
+            rgb_matrix_set_flags(LED_FLAG_CAPS);
+            rgb_matrix_enable();
+        }
+    } else if (rgb_matrix_get_flags() == LED_FLAG_CAPS) {
+        /* RGB Matrix was only ON because of CAPS LOCK. Turn it OFF. */
+        rgb_matrix_set_flags(LED_FLAG_ALL);
+        rgb_matrix_disable();
+    }
+    return true;
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+    #ifdef NKRO_ENABLE
+    #if RGB_CONFIRMATION_BLINKING_TIME > 0
+        case NK_TOGG:
+            if (record->event.pressed) {
+                if (keymap_config.nkro) {
+                    /* Turning NKRO OFF */
+                    effect_red();
+                } else {
+                    /* Turning NKRO ON */
+                    effect_green();
+                }
+                start_effects();
+            }
+            break;
+        case NK_ON:
+            if (record->event.pressed) {
+                if (!keymap_config.nkro) {
+                    /* Turning NKRO ON */
+                    effect_green();
+                    start_effects();
+                }
+            }
+            break;
+        case NK_OFF:
+            if (record->event.pressed) {
+                if (keymap_config.nkro) {
+                    /* Turning NKRO OFF */
+                    effect_red();
+                    start_effects();
+                }
+            }
+            break;
+    #endif // RGB_CONFIRMATION_BLINKING_TIME > 0
+    #endif // NKRO_ENABLE
+        case RGB_MOD:
+        case RGB_RMOD:
+        case RGB_HUI:
+        case RGB_HUD:
+        case RGB_SAI:
+        case RGB_SAD:
+        case RGB_VAI:
+        case RGB_VAD:
+        case RGB_SPI:
+        case RGB_SPD:
+            if (record->event.pressed) {
+                if (rgb_matrix_get_flags() != LED_FLAG_ALL) {
+                    /* Ignore changes to RGB settings while only it's supposed to be OFF */
+                    return false;
+                }
+            }
+            break;
+        case RGB_TOG:
+            if (record->event.pressed) {
+                if (rgb_matrix_is_enabled()) {
+                    switch (rgb_matrix_get_flags()) {
+                        #if RGB_CONFIRMATION_BLINKING_TIME > 0
+                        case LED_FLAG_EFFECTS:
+                        #endif
+                        case LED_FLAG_CAPS:
+                            /* Turned ON because of EFFECTS or CAPS, is actually OFF */
+                            /* Change to LED_FLAG_ALL to signal it's really ON */
+                            rgb_matrix_set_flags(LED_FLAG_ALL);
+                            /* Will be re-enabled by the processing of the toggle */
+                            rgb_matrix_disable_noeeprom();
+                            break;
+                        case LED_FLAG_ALL:
+                            /* Is actually ON */
+                            #if RGB_CONFIRMATION_BLINKING_TIME > 0
+                            if (effect_started_time > 0) {
+                                /* Signal EFFECTS */
+                                rgb_matrix_set_flags(LED_FLAG_EFFECTS);
+                                /* Will be re-enabled by the processing of the toggle */
+                                rgb_matrix_disable_noeeprom();
+                            } else
+                            #endif
+                            if (host_keyboard_led_state().caps_lock) {
+                                /* Signal CAPS */
+                                rgb_matrix_set_flags(LED_FLAG_CAPS);
+                                /* Will be re-enabled by the processing of the toggle */
+                                rgb_matrix_disable_noeeprom();
+                            }
+                            break;
+                    }
+                }
+            }
+            break;
+    }
+    return true;
+}
+
+
+void rgb_matrix_indicators_user() {
+    #if RGB_CONFIRMATION_BLINKING_TIME > 0
+    if (effect_started_time > 0) {
+        /* Render blinking EFFECTS */
+        const uint16_t deltaTime = sync_timer_elapsed(effect_started_time);
+        if (deltaTime <= RGB_CONFIRMATION_BLINKING_TIME) {
+            const uint8_t led_state = ((~deltaTime) >> TIME_SELECTED_BIT) & 0x01;
+            const uint8_t val_r = led_state * r_effect;
+            const uint8_t val_g = led_state * g_effect;
+            const uint8_t val_b = led_state * b_effect;
+            rgb_matrix_set_color_all(val_r, val_g, val_b);
+            if (host_keyboard_led_state().caps_lock) {
+                set_rgb_caps_leds();
+            }
+            return;
+        } else {
+            /* EFFECTS duration is finished */
+            effect_started_time = 0;
+            if (rgb_matrix_get_flags() == LED_FLAG_EFFECTS) {
+                /* It was turned ON because of EFFECTS */
+                if (host_keyboard_led_state().caps_lock) {
+                    /* CAPS is still ON. Demote to CAPS */
+                    rgb_matrix_set_flags(LED_FLAG_CAPS);
+                } else {
+                    /* There is nothing else keeping RGB enabled. Reset flags and turn if off. */
+                    rgb_matrix_set_flags(LED_FLAG_ALL);
+                    rgb_matrix_disable_noeeprom();
+                }
+            }
+        }
+    }
+    #endif // RGB_CONFIRMATION_BLINKING_TIME > 0
+    if (rgb_matrix_get_flags() == LED_FLAG_CAPS) {
+        rgb_matrix_set_color_all(0x0, 0x0, 0x0);
+    }
+    if (host_keyboard_led_state().caps_lock) {
+        set_rgb_caps_leds();
+    }
+}
+
+#if RGB_CONFIRMATION_BLINKING_TIME > 0
+static void start_effects() {
+    effect_started_time = sync_timer_read();
+    if (!rgb_matrix_is_enabled()) {
+        /* Turn it ON, signal the cause (EFFECTS) */
+        rgb_matrix_set_flags(LED_FLAG_EFFECTS);
+        rgb_matrix_enable_noeeprom();
+    } else if (rgb_matrix_get_flags() == LED_FLAG_CAPS) {
+        /* It's already ON, promote the cause from CAPS to EFFECTS */
+        rgb_matrix_set_flags(LED_FLAG_EFFECTS);
+    }
+}
+#endif // RGB_CONFIRMATION_BLINKING_TIME > 0
+
+// RGB led number layout, function of the key
+
+//  67, led 01   0, ESC    6, F1      12, F2      18, F3   23, F4   28, F5      34, F6   39, F7   44, F8      50, F9   56, F10   61, F11    66, F12    69, Prt       Rotary(Mute)   68, led 12
+//  70, led 02   1, ~      7, 1       13, 2       19, 3    24, 4    29, 5       35, 6    40, 7    45, 8       51, 9    57, 0     62, -_     78, (=+)   85, BackSpc   72, Home       71, led 13
+//  73, led 03   2, Tab    8, Q       14, W       20. E    25, R    30, T       36, Y    41, U    46, I       52, O    58, P     63, [{     89, ]}     93, \|        75, PgUp       74, led 14
+//  76, led 04   3, Caps   9, A       15, S       21, D    26, F    31, G       37, H    42, J    47, K       53, L    59, ;:    64, '"                96, Enter     86, PgDn       77, led 15
+//  80, led 05   4, Sh_L   10, Z      16, X       22, C    27, V    32, B       38, N    43, M    48, ,<      54, .<   60, /?               90, Sh_R   94, Up        82, End        81, led 16
+//  83, led 06   5, Ct_L   11,Win_L   17, Alt_L                     33, SPACE                     49, Alt_R   55, FN             65, Ct_R   95, Left   97, Down      79, Right      84, led 17
+//  87, led 07                                                                                                                                                                      88, led 18
+//  91, led 08                                                                                                                                                                      92, led 19
+
+static void set_rgb_caps_leds() {
+    rgb_matrix_set_color(67, 0xFF, 0x0, 0x0); // Left side LED 1
+    rgb_matrix_set_color(68, 0xFF, 0x0, 0x0); // Right side LED 1
+    rgb_matrix_set_color(70, 0xFF, 0x0, 0x0); // Left side LED 2
+    rgb_matrix_set_color(71, 0xFF, 0x0, 0x0); // Right side LED 2
+    rgb_matrix_set_color(73, 0xFF, 0x0, 0x0); // Left side LED 3
+    rgb_matrix_set_color(74, 0xFF, 0x0, 0x0); // Right side LED 3
+    rgb_matrix_set_color(76, 0xFF, 0x0, 0x0); // Left side LED 4
+    rgb_matrix_set_color(77, 0xFF, 0x0, 0x0); // Right side LED 4
+    rgb_matrix_set_color(80, 0xFF, 0x0, 0x0); // Left side LED 5
+    rgb_matrix_set_color(81, 0xFF, 0x0, 0x0); // Right side LED 5
+    rgb_matrix_set_color(83, 0xFF, 0x0, 0x0); // Left side LED 6
+    rgb_matrix_set_color(84, 0xFF, 0x0, 0x0); // Right side LED 6
+    rgb_matrix_set_color(87, 0xFF, 0x0, 0x0); // Left side LED 7
+    rgb_matrix_set_color(88, 0xFF, 0x0, 0x0); // Right side LED 7
+    rgb_matrix_set_color(91, 0xFF, 0x0, 0x0); // Left side LED 8
+    rgb_matrix_set_color(92, 0xFF, 0x0, 0x0); // Right side LED 8
+    rgb_matrix_set_color(3, 0xFF, 0x0, 0x0); // CAPS LED
+}
+
+#endif // RGB_MATRIX_ENABLE

--- a/keyboards/gmmk/pro/ansi/keymaps/hachetman/keymap.c
+++ b/keyboards/gmmk/pro/ansi/keymaps/hachetman/keymap.c
@@ -67,6 +67,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
+const key_override_t up_key_override = ko_make_basic(MOD_MASK_CTRL, KC_UP, KC_PGUP);
+const key_override_t dn_key_override = ko_make_basic(MOD_MASK_CTRL, KC_DOWN, KC_PGDN);
+
+// This globally defines all key overrides to be used
+const key_override_t **key_overrides = (const key_override_t *[]){
+       &up_key_override,
+       &dn_key_override,
+       NULL // Null terminate the array of overrides!
+};
 #ifdef ENCODER_ENABLE
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (clockwise) {

--- a/keyboards/gmmk/pro/ansi/keymaps/hachetman/readme.md
+++ b/keyboards/gmmk/pro/ansi/keymaps/hachetman/readme.md
@@ -1,0 +1,24 @@
+# andrebrait's GMMK Pro layout
+
+This is pretty much the stock layout with a few things moved around.
+It basically reflects my needs for both Delete and Insert being readily available for coding, as well as a full Home/PgUp/PgDwn/End column.
+
+The differences are as follows:
+
+- Disabled Mouse Keys (to fix issues with KVM switches and also because they're not used here anyway)
+- Short DEBOUNCE time (5 ms)
+- Per-key debounce algorithm (sym_defer_pk)
+- RGB turns off after 20 minutes of inactivity
+- RGB turns off when USB is suspended
+- Layer 0:
+  - Print Screen (default) -> Delete
+  - Delete (default) -> Home
+- Layer 1 (accessed by pressing Fn):
+  - Fn + Delete -> Insert
+  - Fn + Home -> Print Screen
+
+This keymap also includes CAPS LOCK ON indicator.\
+All left and right side LEDs, and the Caps key LED will turn solid red while CAPS LOCK is ON.
+
+No other changes have been made. \
+The other keys on each layer have been kept intact.

--- a/keyboards/gmmk/pro/ansi/keymaps/hachetman/readme.md
+++ b/keyboards/gmmk/pro/ansi/keymaps/hachetman/readme.md
@@ -1,4 +1,4 @@
-# andrebrait's GMMK Pro layout
+# hachetmans's GMMK Pro layout
 
 This is pretty much the stock layout with a few things moved around.
 It basically reflects my needs for both Delete and Insert being readily available for coding, as well as a full Home/PgUp/PgDwn/End column.
@@ -16,6 +16,8 @@ The differences are as follows:
 - Layer 1 (accessed by pressing Fn):
   - Fn + Delete -> Insert
   - Fn + Home -> Print Screen
+- override CTRL + UP -> PGUP
+- override CTRL + DOWN -> PGDN
 
 This keymap also includes CAPS LOCK ON indicator.\
 All left and right side LEDs, and the Caps key LED will turn solid red while CAPS LOCK is ON.

--- a/keyboards/gmmk/pro/ansi/keymaps/hachetman/rules.mk
+++ b/keyboards/gmmk/pro/ansi/keymaps/hachetman/rules.mk
@@ -1,0 +1,4 @@
+# Enable additional features.
+
+DEBOUNCE_TYPE = sym_defer_pk
+MOUSEKEY_ENABLE = no

--- a/keyboards/gmmk/pro/ansi/keymaps/hachetman/rules.mk
+++ b/keyboards/gmmk/pro/ansi/keymaps/hachetman/rules.mk
@@ -2,3 +2,4 @@
 
 DEBOUNCE_TYPE = sym_defer_pk
 MOUSEKEY_ENABLE = no
+KEY_OVERRIDE_ENABLE = yes


### PR DESCRIPTION
## Description

Keymap to GMMK Pro added based on andrebrait with additional overrides to UP and DOWN

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
