### PR TITLE
More validation of declared LAYOUT macro names

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -109,6 +109,7 @@
         },
         "layouts": {
             "type": "object",
+            "propertyNames": {"$ref": "qmk.definitions.v1#/layout_macro"},
             "additionalProperties": {
                 "type": "object",
                 "additionalProperties": false,

--- a/lib/python/qmk/cli/generate/api.py
+++ b/lib/python/qmk/cli/generate/api.py
@@ -34,7 +34,7 @@ def generate_api(cli):
 
     # Generate and write keyboard specific JSON files
     for keyboard_name in list_keyboards():
-        kb_all[keyboard_name] = info_json(keyboard_name)
+        kb_all[keyboard_name] = info_json(keyboard_name, exit_on_failure=False)
         keyboard_dir = v1_dir / 'keyboards' / keyboard_name
         keyboard_info = keyboard_dir / 'info.json'
         keyboard_readme = keyboard_dir / 'readme.md'

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -92,7 +92,7 @@ def lint(cli):
         # Gather data about the keyboard.
         ok = True
         keyboard_path = keyboard(kb)
-        keyboard_info = info_json(kb)
+        keyboard_info = info_json(kb, exit_on_failure=False)
 
         # Check for errors in the info.json
         if keyboard_info['parse_errors']:

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -32,7 +32,7 @@ def _remove_newlines_from_labels(layouts):
                 key['label'] = key['label'].split('\n')[0]
 
 
-def info_json(keyboard):
+def info_json(keyboard, exit_on_failure=True):
     """Generate the info.json data for a specific keyboard.
     """
     cur_dir = Path('keyboards')
@@ -80,8 +80,11 @@ def info_json(keyboard):
 
     except jsonschema.ValidationError as e:
         json_path = '.'.join([str(p) for p in e.absolute_path])
-        cli.log.error('Invalid API data: %s: %s: %s', keyboard, json_path, e.message)
-        exit(1)
+        if exit_on_failure:
+            cli.log.error('Invalid API data: %s: %s: %s', keyboard, json_path, e.message)
+            exit(1)
+        else:
+            _log_error(info_data, 'Invalid API data: %s: %s: %s' % (keyboard, json_path, e.message))
 
     # Make sure we have at least one layout
     if not info_data.get('layouts'):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Should help catch 16141 where it attempts to include `LAYOUT_ANSI`

Currently produces **a lot** of lint failures on the existing keyboards....

```
☒ Lint check failed for: 0_sixty, 0_sixty/underglow, 7c8/framework, bkf, cannonkeys/atlas, cannonkeys/ortho48, cannonkeys/ortho60, checkerboards/quark_lp, ealdin/quadrant, gboards/gergoplex, handwired/ms_sculpt_mobile, handwired/ortho_brass, helix/pico/qmk_conf, helix/rev2/qmk_conf, hhkb/jp, keycapsss/o4l_5x12, kprepublic/jj40, maxipad/promicro, maxipad/teensy2, mechlovin/adelais/standard_led/avr/rev1, ogurec/left_pm, ogurec/right_pm, ortho5by12, planck/rev6, planck/rev6_drop, preonic/rev1, preonic/rev2, preonic/rev3, preonic/rev3_drop, reviung/reviung34, subatomic, viktus/sp_mini, ymdk/ymd40/v2
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
