### PR TITLE
`qmk doctor`: display qmk_firmware version tag

### DIFF
--- a/lib/python/qmk/cli/doctor/main.py
+++ b/lib/python/qmk/cli/doctor/main.py
@@ -11,7 +11,7 @@ from milc.questions import yesno
 from qmk import submodules
 from qmk.constants import QMK_FIRMWARE, QMK_FIRMWARE_UPSTREAM
 from .check import CheckStatus, check_binaries, check_binary_versions, check_submodules
-from qmk.commands import git_check_repo, git_get_branch, git_is_dirty, git_get_remotes, git_check_deviation, in_virtualenv
+from qmk.commands import git_check_repo, git_get_branch, git_get_tag, git_is_dirty, git_get_remotes, git_check_deviation, in_virtualenv
 
 
 def os_tests():
@@ -47,6 +47,11 @@ def git_tests():
         git_branch = git_get_branch()
         if git_branch:
             cli.log.info('Git branch: %s', git_branch)
+
+            repo_version = git_get_tag()
+            if repo_version:
+                cli.log.info('Repo version: %s', repo_version)
+
             git_dirty = git_is_dirty()
             if git_dirty:
                 cli.log.warning('{fg_yellow}Git has unstashed/uncommitted changes.')

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -295,6 +295,14 @@ def git_get_branch():
         return git_branch.stdout.strip()
 
 
+def git_get_tag():
+    """Returns the current tag for a repo, or None.
+    """
+    git_tag = cli.run(['git', 'describe', '--abbrev=0', '--tags'])
+    if git_tag.returncode == 0:
+        return git_tag.stdout.strip()
+
+
 def git_is_dirty():
     """Returns 1 if repo is dirty, or 0 if clean
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Also handles the case where the repo has no tags (as I prefer it):

```
fauxpark@JUNE:qmk_firmware$ git tag 0.15.18

fauxpark@JUNE:qmk_firmware$ qmk doctor
Ψ QMK Doctor is checking your environment.
Ψ CLI version: 1.0.0
Ψ QMK home: D:/Git/qmk_firmware
Ψ Detected Windows 10 (10.0.19043).
Ψ Git branch: master
Ψ Repo version: 0.15.18
⚠ Git has unstashed/uncommitted changes.
Ψ All dependencies are installed.
Ψ Found arm-none-eabi-gcc version 10.1.0
Ψ Found avr-gcc version 8.4.0
Ψ Found avrdude version 6.3
Ψ Found dfu-util version 0.11
Ψ Found dfu-programmer version 0.7.2
Ψ Submodules are up to date.
Ψ QMK is ready to go, but minor problems were found

1 fauxpark@JUNE:qmk_firmware$ git tag -d 0.15.18
Deleted tag '0.15.18' (was 59f37bb710)

fauxpark@JUNE:qmk_firmware$ qmk doctor
Ψ QMK Doctor is checking your environment.
Ψ CLI version: 1.0.0
Ψ QMK home: D:/Git/qmk_firmware
Ψ Detected Windows 10 (10.0.19043).
Ψ Git branch: master
⚠ Git has unstashed/uncommitted changes.
Ψ All dependencies are installed.
Ψ Found arm-none-eabi-gcc version 10.1.0
Ψ Found avr-gcc version 8.4.0
Ψ Found avrdude version 6.3
Ψ Found dfu-util version 0.11
Ψ Found dfu-programmer version 0.7.2
Ψ Submodules are up to date.
Ψ QMK is ready to go, but minor problems were found
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
