### PR TITLE
process_terminal: added api to allow user to register custom commands…

### DIFF
--- a/quantum/process_keycode/process_terminal.c
+++ b/quantum/process_keycode/process_terminal.c
@@ -29,7 +29,7 @@ char buffer[80]       = "";
 char cmd_buffer[CMD_BUFF_SIZE][80];
 bool cmd_buffer_enabled = true;  // replace with ifdef?
 char newline[2]         = "\n";
-bool firstTime = true;
+bool firstTime          = true;
 
 short int current_cmd_buffer_pos = 0;  // used for up/down arrows - keeps track of where you are in the command buffer
 
@@ -50,7 +50,6 @@ float terminal_song[][2] = TERMINAL_SONG;
 __attribute__((weak)) const char keycode_to_ascii_lut[58] = {0, 0, 0, 0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 0, 0, 0, '\t', ' ', '-', '=', '[', ']', '\\', 0, ';', '\'', '`', ',', '.', '/'};
 
 __attribute__((weak)) const char shifted_keycode_to_ascii_lut[58] = {0, 0, 0, 0, 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', 0, 0, 0, '\t', ' ', '_', '+', '{', '}', '|', 0, ':', '\'', '~', '<', '>', '?'};
-
 
 void enable_terminal(void) {
     terminal_enabled = true;
@@ -108,7 +107,6 @@ static void terminal_about(terminal_ctx_t *ctx) {
     }
 #endif
 }
-
 
 extern const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS];
 
@@ -183,16 +181,7 @@ void terminal_help(terminal_ctx_t *ctx);
 
 static stringcase_t *user_terminal_cases;
 
-static const stringcase_t terminal_cases[] = {
-    {"about"        , terminal_about}   ,
-    {"help"         , terminal_help}    ,
-    {"keycode"      , terminal_keycode} ,
-    {"keymap"       , terminal_keymap}  ,
-    {"flush-buffer" , flush_cmd_buffer} ,
-    {"print-buffer" , print_cmd_buff}   ,
-    {"exit"         , disable_terminal} ,
-    {NULL           , NULL}
-};
+static const stringcase_t terminal_cases[] = {{"about", terminal_about}, {"help", terminal_help}, {"keycode", terminal_keycode}, {"keymap", terminal_keymap}, {"flush-buffer", flush_cmd_buffer}, {"print-buffer", print_cmd_buff}, {"exit", disable_terminal}, {NULL, NULL}};
 
 void terminal_help(terminal_ctx_t *ctx) {
     SEND_STRING("commands available:\n  ");
@@ -208,9 +197,7 @@ void terminal_help(terminal_ctx_t *ctx) {
     send_string(newline);
 }
 
-void process_terminal_register_user_command(stringcase_t * table) {
-    user_terminal_cases = table;
-}
+void process_terminal_register_user_command(stringcase_t *table) { user_terminal_cases = table; }
 void command_not_found(void) {
     wait_ms(50);  // sometimes buffer isnt grabbed quick enough
     SEND_STRING("command \"");
@@ -222,7 +209,7 @@ void process_terminal_command(void) {
     // we capture return bc of the order of events, so we need to manually send a newline
     send_string(newline);
 
-    char *  pch;
+    char   *pch;
     uint8_t i = 0;
     pch       = strtok(buffer, " ");
     while (pch != NULL) {
@@ -233,8 +220,7 @@ void process_terminal_command(void) {
     }
 
     bool command_found = false;
-    for (const stringcase_t *case_p = terminal_cases;
-            case_p != terminal_cases + sizeof(terminal_cases) / sizeof(terminal_cases[0]); case_p++) {
+    for (const stringcase_t *case_p = terminal_cases; case_p != terminal_cases + sizeof(terminal_cases) / sizeof(terminal_cases[0]); case_p++) {
         if (0 == strcmp(case_p->string, buffer)) {
             command_found = true;
             (*case_p->func)(&ctx);
@@ -243,8 +229,7 @@ void process_terminal_command(void) {
     }
     // Search commands in users commands table
     if (user_terminal_cases != NULL)
-        for (stringcase_t *case_p = user_terminal_cases;
-                case_p->string != NULL && case_p->func != NULL; case_p++) {
+        for (stringcase_t *case_p = user_terminal_cases; case_p->string != NULL && case_p->func != NULL; case_p++) {
             if (0 == strcmp(case_p->string, buffer)) {
                 command_found = true;
                 (*case_p->func)(&ctx);

--- a/quantum/process_keycode/process_terminal.h
+++ b/quantum/process_keycode/process_terminal.h
@@ -18,22 +18,21 @@
 
 #include "quantum.h"
 
-#define TERMINAL_MAX_ARGS   6
-#define TERMINAL_ARGS_LEN  20
+#define TERMINAL_MAX_ARGS 6
+#define TERMINAL_ARGS_LEN 20
 
 typedef struct {
     size_t args_no;
-    char args[TERMINAL_MAX_ARGS][TERMINAL_ARGS_LEN];
+    char   args[TERMINAL_MAX_ARGS][TERMINAL_ARGS_LEN];
 } terminal_ctx_t;
 
 typedef struct {
     char *string;
-    void (*func)(terminal_ctx_t*);
-}  stringcase_t;
-
+    void (*func)(terminal_ctx_t *);
+} stringcase_t;
 
 extern const char keycode_to_ascii_lut[58];
 extern const char shifted_keycode_to_ascii_lut[58];
 extern const char terminal_prompt[8];
 bool              process_terminal(uint16_t keycode, keyrecord_t *record);
-void process_terminal_register_user_command(stringcase_t * table);
+void              process_terminal_register_user_command(stringcase_t *table);

--- a/quantum/process_keycode/process_terminal.h
+++ b/quantum/process_keycode/process_terminal.h
@@ -18,7 +18,22 @@
 
 #include "quantum.h"
 
+#define TERMINAL_MAX_ARGS   6
+#define TERMINAL_ARGS_LEN  20
+
+typedef struct {
+    size_t args_no;
+    char args[TERMINAL_MAX_ARGS][TERMINAL_ARGS_LEN];
+} terminal_ctx_t;
+
+typedef struct {
+    char *string;
+    void (*func)(terminal_ctx_t*);
+}  stringcase_t;
+
+
 extern const char keycode_to_ascii_lut[58];
 extern const char shifted_keycode_to_ascii_lut[58];
 extern const char terminal_prompt[8];
 bool              process_terminal(uint16_t keycode, keyrecord_t *record);
+void process_terminal_register_user_command(stringcase_t * table);


### PR DESCRIPTION
This pull request allow users register a custom command table to run in the terminal feature.

## Description

The terminal feature is so cool, but for now we can't have custom commands, and if we want to do that we should change qmk core code.
To allow users register custom commands, I did this patch, adding an api to extend terminal commands.

The main change of the module was:
- define `terminal_ctx_t` type
- define `stringcase_t` type
- added function `void process_terminal_register_user_command(stringcase_t * table)`

The `terminal_ctx_t`define terminal context, and hold therminal command and its arguments. This context will be passed to all terminal functions, system functions and user functions.

The `stringcase_t` defines the callback function and its terminal name. To compute the length of the table I will check when I find the table ends marker, in other words, the last element of the table. It should be a couple of NULL, like: `{NULL, NULL}`. This means that user should always add ends marker.. otherwise the fw could crash.

The function `void process_terminal_register_user_command(stringcase_t * table)`, register the user command table to the module, so the process_terminal module will also call the user callbacks.

Here I will show you an example of use:

```
static void cmd_eep_read(terminal_ctx_t *ctx) {
    uprintf("eep\n");
    SEND_STRING("eep..\n");
    for (int i = 0; i < ctx->args_no; i++)
        if (ctx->args[i])
            SEND_STRING(ctx->args[i]);
    SEND_STRING("\n");
}

stringcase_t isokey_cmd_table[] = {
    {"eep", cmd_eep_read},
    {NULL, NULL}, // Table termination
};

void settings_init(void) {
    process_terminal_register_user_command(isokey_cmd_table);
}

```

This example show also the possibilty to write your code where you want, specially in user code side.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
