### PR TITLE
Ploopy Trackball Mini: only define DPI options as needed

### DIFF
--- a/keyboards/ploopyco/trackball_mini/trackball_mini.c
+++ b/keyboards/ploopyco/trackball_mini/trackball_mini.c
@@ -37,9 +37,16 @@
 #    define OPT_SCALE 1  // Multiplier for wheel
 #endif
 
-#define PLOOPY_DPI_OPTIONS \
-    { 375, 750, 1375 }
-#define PLOOPY_DPI_DEFAULT 2
+#ifndef PLOOPY_DPI_OPTIONS
+#    define PLOOPY_DPI_OPTIONS \
+        { 375, 750, 1375 }
+#    ifndef PLOOPY_DPI_DEFAULT
+#       define PLOOPY_DPI_DEFAULT 1
+#    endif
+#endif
+#ifndef PLOOPY_DPI_DEFAULT
+#    define PLOOPY_DPI_DEFAULT 0
+#endif
 
 #ifndef PLOOPY_DRAGSCROLL_DPI
 #    define PLOOPY_DRAGSCROLL_DPI 375  // Fixed-DPI Drag Scroll


### PR DESCRIPTION
## Description
Only define `PLOOPY_DPI_*` if they are not already defined (ie. via a keymap).

Without this, customizing the DPI options in a `config.h` will cause
redefinition errors.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
