### PR TITLE
Layout aimed at easy transition between Idobo and standard 60%

### DIFF
--- a/keyboards/idobo/keymaps/savaged/keymap.c
+++ b/keyboards/idobo/keymaps/savaged/keymap.c
@@ -1,0 +1,71 @@
+/* Copyright 2018 Milton Griffin
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include QMK_KEYBOARD_H
+
+// Keyboard Layers
+#define _QW 0
+#define _FN 1
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* QWERTY
+ * .--------------------------------------------------------------------------------------------------------------------------------------.
+ * | ESC    | 1      | 2      | 3      | 4      | 5      | MENU   | CAP LK | 6      | 7      | 8      | 9      | 0      | -      | BACKSP |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------------------------|
+ * | TAB    | Q      | W      | E      | R      | T      | INS    | DEL    | Y      | U      | I      | O      | P      | \      | =      |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+-----------------+--------+--------|
+ * | `      | A      | S      | D      | F      | G      | LALT   | MENU   | H      | J      | K      | L      | ;      | '      | ENTER  |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------------------------+--------+--------|
+ * | LSHIFT | Z      | X      | C      | V      | B      | [      | ]      | N      | M      | ,      | .      | /      | RSHIFT | RSHIFT |
+ * |--------+--------+--------+--------+--------+-----------------+--------+--------+--------+-----------------+--------+--------+--------|
+ * | LCTRL  | PG UP  | PG DN  | BACKSP | FN     | SPACE  | LGUI   | LGUI   | SPACE  | FN     | ENTER  | HOME   | END    | RALT   | RCTRL  |
+ * '--------------------------------------------------------------------------------------------------------------------------------------'
+ */
+
+ [_QW] = LAYOUT_ortho_5x15( /* QWERTY */
+    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_APP,  KC_CAPS, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_BSPC,
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_INS,  KC_DEL,  KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSLS, KC_EQL,
+    KC_GRV,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_LALT, KC_APP,  KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LBRC, KC_RBRC, KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_RSFT,
+    KC_LCTL, KC_PGUP, KC_PGDN, KC_BSPC, MO(_FN), KC_SPC,  KC_LGUI, KC_LGUI, KC_SPC,  MO(_FN), KC_ENT,  KC_HOME, KC_END,  KC_RALT, KC_RCTL
+ ),
+
+/* FUNCTION
+ * .--------------------------------------------------------------------------------------------------------------------------------------.
+ * |        | F1     | F2     | F3     | F4     | F5     |        |        | F6     | F7     | F8     | F9     | F10    | F11    | F12    |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * |        |        | UP     | RGB TG | RGB HD | RGB HI |        |        |        |        |        |        | PR SCR | SCR LK | PAUSE  |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * |        | LEFT   | DOWN   | RIGHT  | RGB SD | RGB SI |        |        | LEFT   | DOWN   | UP     | RIGHT  |        |        |        |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * | PREV   | PLAY   | NEXT   | STOP   | RGB VD | RGB VI |        |        |        |        | CALC   | MYCOMP | MAIL   |        |        |
+ * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
+ * | VOL-   | MUTE   | VOL+   |        | RGB RMD| RGB MD |        |        |        |        |        | RALT   |        |        |        |
+ * '--------------------------------------------------------------------------------------------------------------------------------------'
+ */
+
+ [_FN] = LAYOUT_ortho_5x15( /* FUNCTION */
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   _______, _______, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,
+    _______, _______, KC_UP,   RGB_TOG, RGB_HUD, RGB_HUI, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS,
+    _______, KC_LEFT, KC_DOWN, KC_RGHT, RGB_SAD, RGB_SAI, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______, _______,
+    KC_MPRV, KC_MPLY, KC_MNXT, KC_MSTP, RGB_VAD, RGB_VAI, _______, _______, _______, _______, KC_CALC, KC_MYCM, KC_MAIL, _______, _______,
+    KC_VOLD, KC_MUTE, KC_VOLU, _______, RGB_RMOD,RGB_MOD, _______, _______, _______, _______, _______, _______, _______, _______, _______
+ ),
+};
+
+

--- a/keyboards/idobo/keymaps/savaged/keymap.c
+++ b/keyboards/idobo/keymaps/savaged/keymap.c
@@ -33,9 +33,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+-----------------+--------+--------|
  * | `      | A      | S      | D      | F      | G      | MENU   | VOL-   | H      | J      | K      | L      | ;      | '      | ENTER  |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------------------------+--------+--------|
- * | LSHIFT | Z      | X      | C      | V      | B      | [      | ]      | N      | M      | ,      | .      | /      | CAP LK | RSHIFT |
+ * | LSHIFT | Z      | X      | C      | V      | B      | [      | ]      | N      | M      | ,      | .      | /      | RALT   | RSHIFT |
  * |--------+--------+--------+--------+--------+-----------------+--------+--------+--------+-----------------+--------+--------+--------|
- * | LCTRL  | PG UP  | PG DN  | BACKSP | FN     | SPACE  | LGUI   | LGUI   | SPACE  | FN     | ENTER  | HOME   | END    | RALT   | RCTRL  |
+ * | LCTRL  | PG UP  | PG DN  | BACKSP | FN     | SPACE  | LGUI   | LGUI   | SPACE  | FN     | ENTER  | END    | HOME   | CAP LK | RCTRL  |
  * '--------------------------------------------------------------------------------------------------------------------------------------'
  */
 
@@ -43,8 +43,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_DEL,  KC_VOLU, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_BSPC,
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_LALT, KC_MUTE, KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSLS, KC_EQL,
     KC_GRV,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_APP,  KC_VOLD, KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
-    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LBRC, KC_RBRC, KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_CAPS, KC_RSFT,
-    KC_LCTL, KC_PGUP, KC_PGDN, KC_BSPC, MO(_FN), KC_SPC,  KC_LGUI, KC_LGUI, KC_SPC,  MO(_FN), KC_ENT,  KC_HOME, KC_END,  KC_RALT, KC_RCTL
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LBRC, KC_RBRC, KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RALT, KC_RSFT,
+    KC_LCTL, KC_PGUP, KC_PGDN, KC_BSPC, MO(_FN), KC_SPC,  KC_LGUI, KC_LGUI, KC_SPC,  MO(_FN), KC_ENT,  KC_END,  KC_HOME, KC_CAPS, KC_RCTL
  ),
 
 /* FUNCTION

--- a/keyboards/idobo/keymaps/savaged/keymap.c
+++ b/keyboards/idobo/keymaps/savaged/keymap.c
@@ -25,23 +25,23 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 /* QWERTY
  * .--------------------------------------------------------------------------------------------------------------------------------------.
- * | ESC    | 1      | 2      | 3      | 4      | 5      | MENU   | CAP LK | 6      | 7      | 8      | 9      | 0      | -      | BACKSP |
+ * | ESC    | 1      | 2      | 3      | 4      | 5      | DEL    | VOL+   | 6      | 7      | 8      | 9      | 0      | -      | BACKSP |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------------------------|
- * | TAB    | Q      | W      | E      | R      | T      | INS    | DEL    | Y      | U      | I      | O      | P      | \      | =      |
+ * | TAB    | Q      | W      | E      | R      | T      | LALT   | MUTE   | Y      | U      | I      | O      | P      | \      | =      |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+-----------------+--------+--------|
- * | `      | A      | S      | D      | F      | G      | LALT   | MENU   | H      | J      | K      | L      | ;      | '      | ENTER  |
+ * | `      | A      | S      | D      | F      | G      | MENU   | VOL-   | H      | J      | K      | L      | ;      | '      | ENTER  |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------------------------+--------+--------|
- * | LSHIFT | Z      | X      | C      | V      | B      | [      | ]      | N      | M      | ,      | .      | /      | RSHIFT | RSHIFT |
+ * | LSHIFT | Z      | X      | C      | V      | B      | [      | ]      | N      | M      | ,      | .      | /      | CAP LK | RSHIFT |
  * |--------+--------+--------+--------+--------+-----------------+--------+--------+--------+-----------------+--------+--------+--------|
  * | LCTRL  | PG UP  | PG DN  | BACKSP | FN     | SPACE  | LGUI   | LGUI   | SPACE  | FN     | ENTER  | HOME   | END    | RALT   | RCTRL  |
  * '--------------------------------------------------------------------------------------------------------------------------------------'
  */
 
  [_QW] = LAYOUT_ortho_5x15( /* QWERTY */
-    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_APP,  KC_CAPS, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_BSPC,
-    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_INS,  KC_DEL,  KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSLS, KC_EQL,
-    KC_GRV,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_LALT, KC_APP,  KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
-    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LBRC, KC_RBRC, KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_RSFT,
+    KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_DEL,  KC_VOLU, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_BSPC,
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_LALT, KC_MUTE, KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSLS, KC_EQL,
+    KC_GRV,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_APP,  KC_VOLD, KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_LBRC, KC_RBRC, KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_CAPS, KC_RSFT,
     KC_LCTL, KC_PGUP, KC_PGDN, KC_BSPC, MO(_FN), KC_SPC,  KC_LGUI, KC_LGUI, KC_SPC,  MO(_FN), KC_ENT,  KC_HOME, KC_END,  KC_RALT, KC_RCTL
  ),
 
@@ -49,19 +49,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * .--------------------------------------------------------------------------------------------------------------------------------------.
  * |        | F1     | F2     | F3     | F4     | F5     |        |        | F6     | F7     | F8     | F9     | F10    | F11    | F12    |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
- * |        |        | UP     | RGB TG | RGB HD | RGB HI |        |        |        |        |        |        | PR SCR | SCR LK | PAUSE  |
+ * |        |        | UP     | RGB TG | RGB HD | RGB HI |        |        |        |        |        | PR SCR | SCR LK | PAUSE  | INS    |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
  * |        | LEFT   | DOWN   | RIGHT  | RGB SD | RGB SI |        |        | LEFT   | DOWN   | UP     | RIGHT  |        |        |        |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
  * | PREV   | PLAY   | NEXT   | STOP   | RGB VD | RGB VI |        |        |        |        | CALC   | MYCOMP | MAIL   |        |        |
  * |--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------|
- * | VOL-   | MUTE   | VOL+   |        | RGB RMD| RGB MD |        |        |        |        |        | RALT   |        |        |        |
+ * | VOL-   | MUTE   | VOL+   |        | RGB RMD| RGB MD |        |        |        |        |        |        |        |        |        |
  * '--------------------------------------------------------------------------------------------------------------------------------------'
  */
 
  [_FN] = LAYOUT_ortho_5x15( /* FUNCTION */
     _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   _______, _______, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,
-    _______, _______, KC_UP,   RGB_TOG, RGB_HUD, RGB_HUI, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS,
+    _______, _______, KC_UP,   RGB_TOG, RGB_HUD, RGB_HUI, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS, KC_INS,
     _______, KC_LEFT, KC_DOWN, KC_RGHT, RGB_SAD, RGB_SAI, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______, _______,
     KC_MPRV, KC_MPLY, KC_MNXT, KC_MSTP, RGB_VAD, RGB_VAI, _______, _______, _______, _______, KC_CALC, KC_MYCM, KC_MAIL, _______, _______,
     KC_VOLD, KC_MUTE, KC_VOLU, _______, RGB_RMOD,RGB_MOD, _______, _______, _______, _______, _______, _______, _______, _______, _______

--- a/keyboards/idobo/keymaps/savaged/pr-16161.md
+++ b/keyboards/idobo/keymaps/savaged/pr-16161.md
@@ -1,0 +1,35 @@
+# Layout aimed at easy transition between Idobo and standard 60%
+
+An adaption from the default Idobo layout aimed at making an easy transition between the ortholinear 75 layout and a standard 60% layout, one where the arrow keys are with WSDA and/or 'Vim HJKL'.
+
+## Description
+
+The changes are exclusively confined to altering the layout of keys. The only file changed is the `keymap.c` in `keyboards/idobo/keymaps/[my user name]/`
+
+## Types of Changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
+- [ ] Core
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Enhancement/optimization
+- [ ] Keyboard (addition or update)
+- [x] Keymap/layout/userspace (addition or update)
+- [ ] Documentation
+
+## Issues Fixed or Closed by This PR
+
+*
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
+- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
+- [ ] I have added tests to cover my changes.
+- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
+

--- a/keyboards/idobo/keymaps/savaged/pr.md
+++ b/keyboards/idobo/keymaps/savaged/pr.md
@@ -1,0 +1,35 @@
+# Layout aimed at easy transition between Idobo and standard 60% keyboard
+
+An adaption from the default Idobo layout aimed at making an easy transition between the ortholinear 75 layout and a standard layout, albeit one where the arrow keys are with WSDA and/or 'Vim HJKL'.
+
+## Description
+
+The changes are exclusively confined to altering the layout of keys. The only file changed is the `keymap.c` in `keyboards/idobo/keymaps/[my user name]/`
+
+## Types of Changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
+- [ ] Core
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Enhancement/optimization
+- [ ] Keyboard (addition or update)
+- [x] Keymap/layout/userspace (addition or update)
+- [ ] Documentation
+
+## Issues Fixed or Closed by This PR
+
+*
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
+- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
+- [ ] I have added tests to cover my changes.
+- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
+

--- a/keyboards/idobo/keymaps/savaged/readme.md
+++ b/keyboards/idobo/keymaps/savaged/readme.md
@@ -1,0 +1,1 @@
+# The savaged keymap for idobo

--- a/savaged-keymap.c
+++ b/savaged-keymap.c
@@ -1,0 +1,1 @@
+keyboards/idobo/keymaps/savaged/keymap.c


### PR DESCRIPTION
An adaption from the default Idobo layout aimed at making an easy transition between the ortholinear 75 layout and a standard 60% layout, one where the arrow keys are with WSDA and/or 'Vim HJKL'.

## Description

The changes are exclusively confined to altering the layout of keys. The only file changed is the `keymap.c` in `keyboards/idobo/keymaps/[my user name]/`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
