### PR TITLE
Disable line ending conversion on format workflow

### DIFF
--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -17,6 +17,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Disable automatic eol conversion
+      run: |
+        echo "* -text" > .git/info/attributes
+
     - name: Install dependencies
       run: |
         pip3 install -r requirements-dev.txt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<https://github.com/qmk/qmk_firmware/runs/5039520207?check_suite_focus=true>

```
  /usr/bin/git checkout --progress -B bugfix/format_master 8b723f43-9d66-470f-bb09-7e845ba49beb --
  error: Your local changes to the following files would be overwritten by checkout:
  	keyboards/keyten/kt60_m/kt60_m.c
  Please commit your changes or stash them before you switch branches.
```

A bit of a guess, but it looks like automatic conversion is kicking in....?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
