### PR TITLE
Ensure `version.h` is recreated each build.

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -45,6 +45,9 @@ ifdef SKIP_GIT
 VERSION_H_FLAGS := --skip-git
 endif
 
+# Generate the board's version.h file.
+$(shell $(QMK_BIN) generate-version-h $(VERSION_H_FLAGS) -q -o $(KEYMAP_OUTPUT)/src/version.h)
+
 # Determine which subfolders exist.
 KEYBOARD_FOLDER_PATH_1 := $(KEYBOARD)
 KEYBOARD_FOLDER_PATH_2 := $(patsubst %/,%,$(dir $(KEYBOARD_FOLDER_PATH_1)))
@@ -165,13 +168,8 @@ generated-files: $(KEYMAP_OUTPUT)/src/config.h $(KEYMAP_OUTPUT)/src/keymap.c
 
 endif
 
-generated-files: $(KEYMAP_OUTPUT)/src/version.h
-$(KEYMAP_OUTPUT)/src/version.h:
-	[ -d $(KEYMAP_OUTPUT)/src ] || mkdir -p $(KEYMAP_OUTPUT)/src
-	$(QMK_BIN) generate-version-h $(VERSION_H_FLAGS) -q -o $(KEYMAP_OUTPUT)/src/version.h
-
 ifeq ($(strip $(CTPC)), yes)
-  CONVERT_TO_PROTON_C=yes
+    CONVERT_TO_PROTON_C=yes
 endif
 
 ifeq ($(strip $(CONVERT_TO_PROTON_C)), yes)
@@ -397,6 +395,7 @@ VPATH += $(KEYMAP_PATH)
 VPATH += $(USER_PATH)
 VPATH += $(KEYBOARD_PATHS)
 VPATH += $(COMMON_VPATH)
+VPATH += $(KEYBOARD_OUTPUT)/src
 VPATH += $(KEYMAP_OUTPUT)/src
 
 include common_features.mk

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -20,6 +20,9 @@ def generate_version_h(cli):
     version_h = create_version_h(cli.args.skip_git, cli.args.skip_all)
 
     if cli.args.output:
+        cli.args.output.parent.mkdir(parents=True, exist_ok=True)
+        if cli.args.output.exists():
+            cli.args.output.replace(cli.args.output.parent / (cli.args.output.name + '.bak'))
         cli.args.output.write_text(version_h)
 
         if not cli.args.quiet:


### PR DESCRIPTION
## Description

Last attempt at moving version.h to a different location resulted in a one-time generation without a clean. This makes sure it's recreated each time.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
