### PR TITLE
Remove default pointing device driver.

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -109,7 +109,6 @@ ifeq ($(strip $(MOUSEKEY_ENABLE)), yes)
 endif
 
 VALID_POINTING_DEVICE_DRIVER_TYPES := adns5050 adns9800 analog_joystick cirque_pinnacle_i2c cirque_pinnacle_spi pmw3360 pmw3389 pimoroni_trackball custom
-POINTING_DEVICE_DRIVER ?= custom
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
     ifeq ($(filter $(POINTING_DEVICE_DRIVER),$(VALID_POINTING_DEVICE_DRIVER_TYPES)),)
         $(call CATASTROPHIC_ERROR,Invalid POINTING_DEVICE_DRIVER,POINTING_DEVICE_DRIVER="$(POINTING_DEVICE_DRIVER)" is not a valid pointing device type)

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -2,7 +2,7 @@
 
 Pointing Device is a generic name for a feature intended to be generic: moving the system pointer around.  There are certainly other options for it - like mousekeys - but this aims to be easily modifiable and hardware driven.  You can implement custom keys to control functionality, or you can gather information from other peripherals and insert it directly here - let QMK handle the processing for you.
 
-To enable Pointing Device, uncomment the following line in your rules.mk:
+To enable Pointing Device, add the following line in your rules.mk and specify one of the driver options below.
 
 ```make
 POINTING_DEVICE_ENABLE = yes
@@ -181,7 +181,13 @@ The CPI range is 50-16000, in increments of 50. Defaults to 2000 CPI.
 
 ### Custom Driver
 
-If you have a sensor type that isn't supported here, you can manually implement it, by adding these functions (with the correct implementation for your device):
+If you have a sensor type that isn't supported above, a custom option is available by adding the following to your `rules.mk`
+
+```make
+POINTING_DEVICE_DRIVER = custom
+```
+
+Using the custom driver will require implementing the following functions:
 
 ```c
 void           pointing_device_driver_init(void) {}

--- a/keyboards/3w6/rev2/keymaps/default_pimoroni/rules.mk
+++ b/keyboards/3w6/rev2/keymaps/default_pimoroni/rules.mk
@@ -1,3 +1,4 @@
 POINTING_DEVICE_ENABLE = yes
+POINTING_DEVICE_DRIVER = custom
 SRC += pimoroni_trackball.c
 MOUSEKEY_ENABLE = no

--- a/keyboards/crkbd/keymaps/vlukash_trackpad_right/rules.mk
+++ b/keyboards/crkbd/keymaps/vlukash_trackpad_right/rules.mk
@@ -1,5 +1,6 @@
 # Build Options
 POINTING_DEVICE_ENABLE = yes # Generic Pointer, not as big as mouse keys hopefully.
+POINTING_DEVICE_DRIVER = custom
 MOUSEKEY_ENABLE = yes        # Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes        # Audio control and System control(+450)
 RGBLIGHT_ENABLE = yes        # Enable WS2812 RGB underlight.

--- a/keyboards/dichotomy/rules.mk
+++ b/keyboards/dichotomy/rules.mk
@@ -10,6 +10,7 @@ BOOTLOADER = caterina
 BOOTMAGIC_ENABLE = no       # Enable Bootmagic Lite
 #MOUSEKEY_ENABLE = yes	# Mouse keys
 POINTING_DEVICE_ENABLE = yes # Generic Pointer, not as big as mouse keys hopefully.
+POINTING_DEVICE_DRIVER = custom
 EXTRAKEY_ENABLE = yes	# Audio control and System control
 CONSOLE_ENABLE = yes	# Console for debug
 COMMAND_ENABLE = yes   # Commands for debug and configuration

--- a/keyboards/gergo/keymaps/abstractkb/rules.mk
+++ b/keyboards/gergo/keymaps/abstractkb/rules.mk
@@ -27,6 +27,7 @@ ifneq ($(strip $(SCROLLSTEP)),)
 endif
 ifeq ($(strip $(BALLER)), yes)
 	POINTING_DEVICE_ENABLE	= yes
+    POINTING_DEVICE_DRIVER = custom
     OPT_DEFS += -DBALLER
 endif
 ifeq ($(strip $(DEBUG_BALLER)), yes)

--- a/keyboards/gergo/keymaps/default/rules.mk
+++ b/keyboards/gergo/keymaps/default/rules.mk
@@ -27,6 +27,7 @@ ifneq ($(strip $(SCROLLSTEP)),)
 endif
 ifeq ($(strip $(BALLER)), yes)
 	POINTING_DEVICE_ENABLE	= yes
+    POINTING_DEVICE_DRIVER = custom
     OPT_DEFS += -DBALLER
 endif
 ifeq ($(strip $(DEBUG_BALLER)), yes)

--- a/keyboards/gergo/keymaps/germ/rules.mk
+++ b/keyboards/gergo/keymaps/germ/rules.mk
@@ -28,6 +28,7 @@ endif
 ifeq ($(strip $(BALLER)), yes)
     OPT_DEFS += -DBALLER
 	POINTING_DEVICE_ENABLE = yes
+    POINTING_DEVICE_DRIVER = custom
 endif
 ifeq ($(strip $(DEBUG_BALLER)), yes)
     OPT_DEFS += -DDEBUG_BALLER

--- a/keyboards/gergo/keymaps/gotham/rules.mk
+++ b/keyboards/gergo/keymaps/gotham/rules.mk
@@ -27,6 +27,7 @@ ifneq ($(strip $(SCROLLSTEP)),)
 endif
 ifeq ($(strip $(BALLER)), yes)
 	POINTING_DEVICE_ENABLE	= yes
+    POINTING_DEVICE_DRIVER = custom
     OPT_DEFS += -DBALLER
 endif
 ifeq ($(strip $(DEBUG_BALLER)), yes)

--- a/keyboards/gergo/keymaps/oled/rules.mk
+++ b/keyboards/gergo/keymaps/oled/rules.mk
@@ -29,6 +29,7 @@ ifneq ($(strip $(SCROLLSTEP)),)
 endif
 ifeq ($(strip $(BALLER)), yes)
 	POINTING_DEVICE_ENABLE	= yes
+    POINTING_DEVICE_DRIVER = custom
     OPT_DEFS += -DBALLER
 endif
 ifeq ($(strip $(DEBUG_BALLER)), yes)

--- a/keyboards/honeycomb/rules.mk
+++ b/keyboards/honeycomb/rules.mk
@@ -10,6 +10,7 @@ BOOTLOADER = caterina
 BOOTMAGIC_ENABLE = no       # Enable Bootmagic Lite
 #MOUSEKEY_ENABLE = yes	# Mouse keys
 POINTING_DEVICE_ENABLE = yes # Generic Pointer, not as big as mouse keys hopefully.
+POINTING_DEVICE_DRIVER = custom
 EXTRAKEY_ENABLE = yes	# Audio control and System control
 CONSOLE_ENABLE = yes	# Console for debug
 COMMAND_ENABLE = yes   # Commands for debug and configuration

--- a/keyboards/molecule/rules.mk
+++ b/keyboards/molecule/rules.mk
@@ -19,5 +19,6 @@ AUDIO_ENABLE = no           # Audio output
 
 # Add trackball support
 POINTING_DEVICE_ENABLE = yes
+POINTING_DEVICE_DRIVER = custom
 SRC += adns.c
 QUANTUM_LIB_SRC += spi_master.c

--- a/keyboards/splitkb/kyria/keymaps/gotham/rules.mk
+++ b/keyboards/splitkb/kyria/keymaps/gotham/rules.mk
@@ -16,6 +16,7 @@ endif
 
 ifeq ($(strip $(THUMBSTICK_ENABLE)), yes)
     POINTING_DEVICE_ENABLE = yes
+    POINTING_DEVICE_DRIVER = custom
     OPT_DEFS += -DTHUMBSTICK_ENABLE
 	SRC += analog.c
 	SRC += thumbstick.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A typo like `POINTING_DEIVCE_DRIVER = adns5050` now produces an error when compiling rather than using `POINTING_DEVICE_DRIVER = custom`.

I've included the required rules.mk changes, so keymaps/keyboards that were missing the rule still have the same behaviour as before this change.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
