### PR TITLE
Add matrix.c to sources for Keychron Q2

### DIFF
--- a/keyboards/keychron/q2/rev_0110/rules.mk
+++ b/keyboards/keychron/q2/rev_0110/rules.mk
@@ -21,3 +21,4 @@ EEPROM_DRIVER = i2c
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+SRC += matrix.c

--- a/keyboards/keychron/q2/rev_0111/rules.mk
+++ b/keyboards/keychron/q2/rev_0111/rules.mk
@@ -21,3 +21,4 @@ EEPROM_DRIVER = i2c
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+SRC += matrix.c

--- a/keyboards/keychron/q2/rev_0112/rules.mk
+++ b/keyboards/keychron/q2/rev_0112/rules.mk
@@ -21,3 +21,4 @@ EEPROM_DRIVER = i2c
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+SRC += matrix.c

--- a/keyboards/keychron/q2/rev_0113/rules.mk
+++ b/keyboards/keychron/q2/rev_0113/rules.mk
@@ -21,3 +21,4 @@ EEPROM_DRIVER = i2c
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+SRC += matrix.c


### PR DESCRIPTION
## Description

This change simply re-adds `matrix.c` to `SRC` in the Keychron Q2's rules.mk file for all keyboard revisions. It was removed in #15946, although I don't fully understand why. The PR comment says:

> Delete matrix.c, Because we have replaced the resistor R7 from 10KΩ to 100KΩ on hardware so that we can reuse the boot pin of stm32l432 as a gerneral IO.

However without this file included the arrow keys no longer work (as reported in #16097). It would be ideal if @lalalademaxiya1 could confirm this file shouldn't have been removed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes one issue in 16097

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
