### PR TITLE
Add Via-compatible keymap for Koolertron AMAG23

### DIFF
--- a/keyboards/amag23/keymaps/via/keymap.c
+++ b/keyboards/amag23/keymaps/via/keymap.c
@@ -1,0 +1,53 @@
+/* Copyright 2022
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Defines names for use in layer keycodes and the keymap
+enum layer_names {
+    BASE,
+    FN1,
+    FN2,
+    FN3
+};
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [BASE] = LAYOUT_all(
+      KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,
+      KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,
+      MO(FN1), KC_A,    KC_S,    KC_D,    KC_F,    KC_G,
+      KC_LSFT, KC_Z,    KC_X,    KC_C,             KC_SPC
+  ),
+  [FN1] = LAYOUT_all(
+      _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,
+      _______, RGB_TOG, RGB_VAI, RGB_MOD, RGB_HUI, _______,
+      _______, _______, RGB_VAD, RGB_RMOD,RGB_HUD, _______,
+      _______, _______, _______, _______,          _______
+  ),
+  [FN2] = LAYOUT_all(
+      _______, _______, _______, _______, _______, _______,
+      _______, _______, _______, _______, _______, _______,
+      _______, _______, _______, _______, _______, _______,
+      _______, _______, _______, _______,          _______
+  ),
+  [FN3] = LAYOUT_all(
+      _______, _______, _______, _______, _______, _______,
+      _______, _______, _______, _______, _______, _______,
+      _______, _______, _______, _______, _______, _______,
+      _______, _______, _______, _______,          _______
+  ),
+};
+// clang-format on

--- a/keyboards/amag23/keymaps/via/rules.mk
+++ b/keyboards/amag23/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
## Description

Add Via-compatible keymap for Koolertron AMAG23

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
