### PR TITLE
`develop` changelog generator: skip code formatting in listing

### DIFF
--- a/lib/python/qmk/cli/generate/develop_pr_list.py
+++ b/lib/python/qmk/cli/generate/develop_pr_list.py
@@ -12,6 +12,14 @@ fix_expr = re.compile(r'fix', flags=re.IGNORECASE)
 clean1_expr = re.compile(r'\[(develop|keyboard|keymap|core|cli|bug|docs|feature)\]', flags=re.IGNORECASE)
 clean2_expr = re.compile(r'^(develop|keyboard|keymap|core|cli|bug|docs|feature):', flags=re.IGNORECASE)
 
+ignored_titles = ["Format code according to conventions"]
+
+
+def _is_ignored(title):
+    for ignore in ignored_titles:
+        if ignore in title:
+            return
+
 
 def _get_pr_info(cache, gh, pr_num):
     pull = cache.get(f'pull:{pr_num}')
@@ -81,7 +89,9 @@ def generate_develop_pr_list(cli):
             else:
                 normal_collection.append(info)
 
-        if "dependencies" in commit_info['pr_labels']:
+        if _is_ignored(commit_info['title']):
+            return
+        elif "dependencies" in commit_info['pr_labels']:
             fix_or_normal(commit_info, pr_list_bugs, pr_list_dependencies)
         elif "core" in commit_info['pr_labels']:
             fix_or_normal(commit_info, pr_list_bugs, pr_list_core)


### PR DESCRIPTION
## Description

As it says on the tin.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
