### PR TITLE
Standardise error output.

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -140,7 +140,7 @@ ifeq ("$(wildcard $(KEYMAP_PATH))", "")
         # If we haven't found a keymap yet fall back to community layouts
         include build_layout.mk
     else
-        $(error Could not find keymap)
+        $(call CATASTROPHIC_ERROR,Invalid keymap,Could not find keymap)
         # this state should never be reached
     endif
 endif

--- a/build_layout.mk
+++ b/build_layout.mk
@@ -25,7 +25,7 @@ ifneq ($(FORCE_LAYOUT),)
         $(info Forcing layout: $(FORCE_LAYOUT))
         LAYOUTS := $(FORCE_LAYOUT)
     else
-        $(error Forced layout does not exist)
+        $(call CATASTROPHIC_ERROR,Invalid layout,Forced layout does not exist)
     endif
 endif
 

--- a/builddefs/bootloader.mk
+++ b/builddefs/bootloader.mk
@@ -204,5 +204,5 @@ ifeq ($(strip $(BOOTLOADER)), md-boot)
 endif
 
 ifeq ($(strip $(BOOTLOADER_TYPE)),)
-    $(error No bootloader specified. Please set an appropriate 'BOOTLOADER' in your keyboard's 'rules.mk' file)
+    $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,No bootloader specified. Please set an appropriate 'BOOTLOADER' in your keyboard's 'rules.mk' file.)
 endif

--- a/builddefs/message.mk
+++ b/builddefs/message.mk
@@ -101,3 +101,8 @@ MSG_FLASH_ARCH = $(WARN_COLOR)WARNING:$(NO_COLOR) This board's architecture is n
 MSG_BOOTLOADER_NOT_FOUND = $(ERROR_COLOR)ERROR:$(NO_COLOR) $(MSG_BOOTLOADER_NOT_FOUND_BASE) Trying again in 5s (Ctrl+C to cancel)\n
 BOOTLOADER_RETRY_TIME ?= 0.5
 MSG_BOOTLOADER_NOT_FOUND_QUICK_RETRY = $(MSG_BOOTLOADER_NOT_FOUND_BASE) Trying again every $(BOOTLOADER_RETRY_TIME)s (Ctrl+C to cancel)
+
+define CATASTROPHIC_ERROR
+    $(shell printf "\n * %-99s $(ERROR_STRING)\n" "$2" >&2)
+    $(error $1)
+endef

--- a/common_features.mk
+++ b/common_features.mk
@@ -112,7 +112,7 @@ VALID_POINTING_DEVICE_DRIVER_TYPES := adns5050 adns9800 analog_joystick cirque_p
 POINTING_DEVICE_DRIVER ?= custom
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
     ifeq ($(filter $(POINTING_DEVICE_DRIVER),$(VALID_POINTING_DEVICE_DRIVER_TYPES)),)
-        $(error POINTING_DEVICE_DRIVER="$(POINTING_DEVICE_DRIVER)" is not a valid pointing device type)
+        $(call CATASTROPHIC_ERROR,Invalid POINTING_DEVICE_DRIVER,POINTING_DEVICE_DRIVER="$(POINTING_DEVICE_DRIVER)" is not a valid pointing device type)
     else
         OPT_DEFS += -DPOINTING_DEVICE_ENABLE
         MOUSE_ENABLE := yes
@@ -153,7 +153,7 @@ endif
 VALID_EEPROM_DRIVER_TYPES := vendor custom transient i2c spi
 EEPROM_DRIVER ?= vendor
 ifeq ($(filter $(EEPROM_DRIVER),$(VALID_EEPROM_DRIVER_TYPES)),)
-  $(error EEPROM_DRIVER="$(EEPROM_DRIVER)" is not a valid EEPROM driver)
+  $(call CATASTROPHIC_ERROR,Invalid EEPROM_DRIVER,EEPROM_DRIVER="$(EEPROM_DRIVER)" is not a valid EEPROM driver)
 else
   OPT_DEFS += -DEEPROM_ENABLE
   ifeq ($(strip $(EEPROM_DRIVER)), custom)
@@ -231,7 +231,7 @@ ifeq ($(strip $(RGBLIGHT_ENABLE)), yes)
     RGBLIGHT_DRIVER ?= WS2812
 
     ifeq ($(filter $(RGBLIGHT_DRIVER),$(VALID_RGBLIGHT_TYPES)),)
-        $(error RGBLIGHT_DRIVER="$(RGBLIGHT_DRIVER)" is not a valid RGB type)
+        $(call CATASTROPHIC_ERROR,Invalid RGBLIGHT_DRIVER,RGBLIGHT_DRIVER="$(RGBLIGHT_DRIVER)" is not a valid RGB type)
     else
         COMMON_VPATH += $(QUANTUM_DIR)/rgblight
         POST_CONFIG_H += $(QUANTUM_DIR)/rgblight/rgblight_post_config.h
@@ -261,7 +261,7 @@ VALID_LED_MATRIX_TYPES := IS31FL3731 custom
 
 ifeq ($(strip $(LED_MATRIX_ENABLE)), yes)
     ifeq ($(filter $(LED_MATRIX_DRIVER),$(VALID_LED_MATRIX_TYPES)),)
-        $(error "$(LED_MATRIX_DRIVER)" is not a valid matrix type)
+        $(call CATASTROPHIC_ERROR,Invalid LED_MATRIX_DRIVER,LED_MATRIX_DRIVER="$(LED_MATRIX_DRIVER)" is not a valid matrix type)
     endif
     OPT_DEFS += -DLED_MATRIX_ENABLE
 ifneq (,$(filter $(MCU), atmega16u2 atmega32u2 at90usb162))
@@ -290,7 +290,7 @@ VALID_RGB_MATRIX_TYPES := AW20216 IS31FL3731 IS31FL3733 IS31FL3737 IS31FL3741 CK
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)
     ifeq ($(filter $(RGB_MATRIX_DRIVER),$(VALID_RGB_MATRIX_TYPES)),)
-        $(error "$(RGB_MATRIX_DRIVER)" is not a valid matrix type)
+        $(call CATASTROPHIC_ERROR,Invalid RGB_MATRIX_DRIVER,RGB_MATRIX_DRIVER="$(RGB_MATRIX_DRIVER)" is not a valid matrix type)
     endif
     OPT_DEFS += -DRGB_MATRIX_ENABLE
 ifneq (,$(filter $(MCU), atmega16u2 atmega32u2 at90usb162))
@@ -404,7 +404,7 @@ else
 endif
 ifeq ($(strip $(BACKLIGHT_ENABLE)), yes)
     ifeq ($(filter $(BACKLIGHT_DRIVER),$(VALID_BACKLIGHT_TYPES)),)
-        $(error BACKLIGHT_DRIVER="$(BACKLIGHT_DRIVER)" is not a valid backlight type)
+        $(call CATASTROPHIC_ERROR,Invalid BACKLIGHT_DRIVER,BACKLIGHT_DRIVER="$(BACKLIGHT_DRIVER)" is not a valid backlight type)
     endif
 
     COMMON_VPATH += $(QUANTUM_DIR)/backlight
@@ -429,7 +429,7 @@ VALID_WS2812_DRIVER_TYPES := bitbang pwm spi i2c
 WS2812_DRIVER ?= bitbang
 ifeq ($(strip $(WS2812_DRIVER_REQUIRED)), yes)
     ifeq ($(filter $(WS2812_DRIVER),$(VALID_WS2812_DRIVER_TYPES)),)
-        $(error WS2812_DRIVER="$(WS2812_DRIVER)" is not a valid WS2812 driver)
+        $(call CATASTROPHIC_ERROR,Invalid WS2812_DRIVER,WS2812_DRIVER="$(WS2812_DRIVER)" is not a valid WS2812 driver)
     endif
 
     OPT_DEFS += -DWS2812_DRIVER_$(strip $(shell echo $(WS2812_DRIVER) | tr '[:lower:]' '[:upper:]'))
@@ -484,7 +484,7 @@ VALID_MAGIC_TYPES := yes
 BOOTMAGIC_ENABLE ?= no
 ifneq ($(strip $(BOOTMAGIC_ENABLE)), no)
   ifeq ($(filter $(BOOTMAGIC_ENABLE),$(VALID_MAGIC_TYPES)),)
-    $(error BOOTMAGIC_ENABLE="$(BOOTMAGIC_ENABLE)" is not a valid type of magic)
+    $(call CATASTROPHIC_ERROR,Invalid BOOTMAGIC_ENABLE,BOOTMAGIC_ENABLE="$(BOOTMAGIC_ENABLE)" is not a valid type of magic)
   endif
   ifneq ($(strip $(BOOTMAGIC_ENABLE)), no)
       OPT_DEFS += -DBOOTMAGIC_LITE
@@ -500,7 +500,7 @@ CUSTOM_MATRIX ?= no
 
 ifneq ($(strip $(CUSTOM_MATRIX)), yes)
     ifeq ($(filter $(CUSTOM_MATRIX),$(VALID_CUSTOM_MATRIX_TYPES)),)
-        $(error CUSTOM_MATRIX="$(CUSTOM_MATRIX)" is not a valid custom matrix type)
+        $(call CATASTROPHIC_ERROR,Invalid CUSTOM_MATRIX,CUSTOM_MATRIX="$(CUSTOM_MATRIX)" is not a valid custom matrix type)
     endif
 
     # Include common stuff for all non custom matrix users
@@ -583,7 +583,7 @@ VALID_OLED_DRIVER_TYPES := SSD1306 custom
 OLED_DRIVER ?= SSD1306
 ifeq ($(strip $(OLED_ENABLE)), yes)
     ifeq ($(filter $(OLED_DRIVER),$(VALID_OLED_DRIVER_TYPES)),)
-        $(error OLED_DRIVER="$(OLED_DRIVER)" is not a valid OLED driver)
+        $(call CATASTROPHIC_ERROR,Invalid OLED_DRIVER,OLED_DRIVER="$(OLED_DRIVER)" is not a valid OLED driver)
     else
         OPT_DEFS += -DOLED_ENABLE
         COMMON_VPATH += $(DRIVER_PATH)/oled
@@ -680,7 +680,7 @@ VALID_JOYSTICK_TYPES := analog digital
 JOYSTICK_DRIVER ?= analog
 ifeq ($(strip $(JOYSTICK_ENABLE)), yes)
     ifeq ($(filter $(JOYSTICK_DRIVER),$(VALID_JOYSTICK_TYPES)),)
-        $(error "$(JOYSTICK_DRIVER)" is not a valid joystick driver)
+        $(call CATASTROPHIC_ERROR,Invalid JOYSTICK_DRIVER,JOYSTICK_DRIVER="$(JOYSTICK_DRIVER)" is not a valid joystick driver)
     endif
     OPT_DEFS += -DJOYSTICK_ENABLE
     SRC += $(QUANTUM_DIR)/process_keycode/process_joystick.c
@@ -700,7 +700,7 @@ VALID_USBPD_DRIVER_TYPES = custom vendor
 USBPD_DRIVER ?= vendor
 ifeq ($(strip $(USBPD_ENABLE)), yes)
     ifeq ($(filter $(strip $(USBPD_DRIVER)),$(VALID_USBPD_DRIVER_TYPES)),)
-        $(error USBPD_DRIVER="$(USBPD_DRIVER)" is not a valid USBPD driver)
+        $(call CATASTROPHIC_ERROR,Invalid USBPD_DRIVER,USBPD_DRIVER="$(USBPD_DRIVER)" is not a valid USBPD driver)
     else
         OPT_DEFS += -DUSBPD_ENABLE
         ifeq ($(strip $(USBPD_DRIVER)), vendor)
@@ -710,7 +710,7 @@ ifeq ($(strip $(USBPD_ENABLE)), yes)
                 OPT_DEFS += -DUSBPD_STM32G4
                 SRC += usbpd_stm32g4.c
             else
-                $(error There is no vendor-provided USBPD driver available)
+                $(call CATASTROPHIC_ERROR,Invalid USBPD_DRIVER,There is no vendor-provided USBPD driver available)
             endif
         else ifeq ($(strip $(USBPD_DRIVER)), custom)
             OPT_DEFS += -DUSBPD_CUSTOM
@@ -723,7 +723,7 @@ BLUETOOTH_ENABLE ?= no
 VALID_BLUETOOTH_DRIVER_TYPES := BluefruitLE RN42 custom
 ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
     ifeq ($(filter $(strip $(BLUETOOTH_DRIVER)),$(VALID_BLUETOOTH_DRIVER_TYPES)),)
-        $(error "$(BLUETOOTH_DRIVER)" is not a valid Bluetooth driver type)
+        $(call CATASTROPHIC_ERROR,Invalid BLUETOOTH_DRIVER,BLUETOOTH_DRIVER="$(BLUETOOTH_DRIVER)" is not a valid Bluetooth driver type)
     endif
     OPT_DEFS += -DBLUETOOTH_ENABLE
     NO_USB_STARTUP_CHECK := yes


### PR DESCRIPTION
## Description

Build errors weren't always consistently printing `[ERRORS]` in the output. `qmk multibuild` expects this in the output, so this normalises all errors in the QMK-side makefiles to print out in the correct format.

For example:
![image](https://user-images.githubusercontent.com/2985843/152622709-7434a14b-cd78-41cc-9756-1335b864868c.png)

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
