### PR TITLE
Added SPLIT_LAYER_STATE_SET option to invoke layer_state_set_kb and default_layer_state_set_kb on slave keyboard when state changes.

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -244,6 +244,12 @@ This mirrors the master side matrix to the slave side for features that react or
 This enables syncing of the layer state between both halves of the split keyboard. The main purpose of this feature is to enable support for use of things like OLED display of the currently active layer.
 
 ```c
+#define SPLIT_LAYER_STATE_SET
+```
+
+This enables calling of `layer_state_set_kb` and `default_layer_set_kb` on the slave side of the keyboard when the layer changes. This allows actions to be triggered on layer change, such as LED changes or haptic feedback.
+
+```c
 #define SPLIT_LED_STATE_ENABLE
 ```
 

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -264,8 +264,20 @@ static bool layer_state_handlers_master(matrix_row_t master_matrix[], matrix_row
 }
 
 static void layer_state_handlers_slave(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) {
-    layer_state         = split_shmem->layers.layer_state;
-    default_layer_state = split_shmem->layers.default_layer_state;
+    if (layer_state != split_shmem->layers.layer_state) {
+        layer_state         = split_shmem->layers.layer_state;
+
+#if defined(SPLIT_LAYER_STATE_SET)
+        layer_state         = layer_state_set_kb(layer_state);
+#endif 
+    }
+    if (default_layer_state != split_shmem->layers.default_layer_state) {
+        default_layer_state = split_shmem->layers.default_layer_state;
+
+#if defined(SPLIT_LAYER_STATE_SET)
+        default_layer_state = default_layer_state_set_kb(default_layer_state);
+#endif
+    }
 }
 
 // clang-format off


### PR DESCRIPTION
Added an new #define SPLIT_LAYER_STATE_SET to invoke the layer_state_set_kb and default_layer_set_state_kb functions on the slave keyboard half when the state changes.

## Description

I have code in layer_state_set_kb which changes rgbled settings, and triggers haptic feedback when the state changes. Without this patch, I could only make this occur on the master keyboard half. When SPLIT_LAYER_STATE_SET is defined, I now get these functions invoked on both halves.

It was necessary to check if the state is actually changing before triggering the layer_state_set functions, otherwise I saw repeated activations when the layer had not changed.

I couldn't find an existing way of causing these functions to be invoked on the slave half; apologies if I missed something.

I have tested this code on my keyboard, and it works succesfully.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
