### PR TITLE
Added SPLIT_HAPTIC_ENABLE to trigger haptic feedback on the slave keyboard half

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -273,6 +273,12 @@ This enables transmitting the current OLED on/off status to the slave side of th
 
 This enables transmitting the current ST7565 on/off status to the slave side of the split keyboard. The purpose of this feature is to support state (on/off state only) syncing.
 
+```c
+#define SPLIT_HAPTIC_ENABLE
+```
+
+This enables triggering of haptic feedback on the slave side of the split keyboard. For DRV2605L this will send the mode, but for solenoids it is expected that the desired mode is already set up on the slave.
+
 ### Custom data sync between sides :id=custom-data-sync
 
 QMK's split transport allows for arbitrary data transactions at both the keyboard and user levels. This is modelled on a remote procedure call, with the master invoking a function on the slave side, with the ability to send data from master to slave, process it slave side, and send data back from slave to master.

--- a/quantum/haptic.c
+++ b/quantum/haptic.c
@@ -25,6 +25,9 @@
 #ifdef SOLENOID_ENABLE
 #    include "solenoid.h"
 #endif
+#if defined(SPLIT_KEYBOARD) && !defined(NO_ACTION_LAYER) && defined(SPLIT_HAPTIC_ENABLE)
+#    include "transactions.h"
+#endif
 
 haptic_config_t haptic_config;
 
@@ -317,9 +320,15 @@ void haptic_play(void) {
     uint8_t play_eff = 0;
     play_eff         = haptic_config.mode;
     DRV_pulse(play_eff);
+#if defined(SPLIT_KEYBOARD) && !defined(NO_ACTION_LAYER) && defined(SPLIT_HAPTIC_ENABLE)
+    split_haptic_play = haptic_config.mode;
+#endif
 #endif
 #ifdef SOLENOID_ENABLE
     solenoid_fire();
+#if defined(SPLIT_KEYBOARD) && !defined(NO_ACTION_LAYER) && defined(SPLIT_HAPTIC_ENABLE)
+    split_haptic_play = 1;
+#endif
 #endif
 }
 

--- a/quantum/split_common/transaction_id_define.h
+++ b/quantum/split_common/transaction_id_define.h
@@ -78,6 +78,10 @@ enum serial_transaction_id {
     PUT_ST7565,
 #endif  // defined(ST7565_ENABLE) && defined(SPLIT_ST7565_ENABLE)
 
+#if defined(HAPTIC_ENABLE) && defined(SPLIT_HAPTIC_ENABLE)
+    PUT_HAPTIC,
+#endif  // defined(HAPTIC_ENABLE) && defined(SPLIT_HAPTIC_ENABLE)
+
 #if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
     PUT_RPC_INFO,
     PUT_RPC_REQ_DATA,

--- a/quantum/split_common/transactions.h
+++ b/quantum/split_common/transactions.h
@@ -52,3 +52,7 @@ bool transaction_rpc_exec(int8_t transaction_id, uint8_t initiator2target_buffer
 
 #define transaction_rpc_send(transaction_id, initiator2target_buffer_size, initiator2target_buffer) transaction_rpc_exec(transaction_id, initiator2target_buffer_size, initiator2target_buffer, 0, NULL)
 #define transaction_rpc_recv(transaction_id, target2initiator_buffer_size, target2initiator_buffer) transaction_rpc_exec(transaction_id, 0, NULL, target2initiator_buffer_size, target2initiator_buffer)
+
+#if defined(SPLIT_HAPTIC_ENABLE)
+extern uint8_t split_haptic_play;
+#endif

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -173,6 +173,10 @@ typedef struct _split_shared_memory_t {
     uint8_t current_st7565_state;
 #endif  // ST7565_ENABLE(OLED_ENABLE) && defined(SPLIT_ST7565_ENABLE)
 
+#if defined(HAPTIC_ENABLE) && defined(SPLIT_HAPTIC_ENABLE)
+    uint8_t haptic_play;
+#endif  // defined(HAPTIC_ENABLE) && defined(SPLIT_HAPTIC_ENABLE)
+
 #if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
     rpc_sync_info_t rpc_info;
     uint8_t         rpc_m2s_buffer[RPC_M2S_BUFFER_SIZE];


### PR DESCRIPTION
For DRV2505L boards, this will send the feedback mode from master to slave. For solenoids, it will simply trigger
with the current settings - it is expected that the slave half sets its own solenoid settings.

## Description

When a haptic event is triggered haptic_play() is invoked. When SPLIT_HAPTIC_ENABLE is set, a new global variable split_haptic_enable is set to the current play mode (for DRV2605L boards) or 1 (for solenoid). This then gets sent across to the slave half, where it triggers haptic_play(). split_haptic_enable is then reset to 0xFF, which is an unused waveform in the DRV2605L library, until the next haptic event.

I have tested this on my keyboard with DRV2605L boards, and it works as expected. I do not have a solenoid to test with.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
