### PR TITLE
Convert Wasdat Code custom matrix to SN74x138 driver

### DIFF
--- a/keyboards/evyd13/wasdat/matrix.c
+++ b/keyboards/evyd13/wasdat/matrix.c
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 
-/* Columns 6-12 use a 74HC138 3 to 8 bit demultiplexer.
+/* Columns 6-12 use a 74HC138 3-to-8 demultiplexer.
  *
  * 0:  C7
  * 1:  B6
@@ -118,10 +118,10 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 }
 
 void matrix_init_custom(void) {
-    // initialize key pins
-    init_pins();
     // initialize demultiplexer
     sn74x138_init();
+    // initialize key pins
+    init_pins();
 }
 
 bool matrix_scan_custom(matrix_row_t current_matrix[]) {

--- a/keyboards/evyd13/wasdat/matrix.c
+++ b/keyboards/evyd13/wasdat/matrix.c
@@ -24,27 +24,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 
-/* col 0: C7
- * col 1: B6
- * col 2: C6
- * col 3: B4
- * col 4: B5
- * col 5: D7
+/* Columns 6-12 use a 74HC138 3 to 8 bit demultiplexer.
  *
- * These columns use a 74HC138 3 to 8 bit demultiplexer.
- *                A2   A1   A0
- * col / pin:    PD0  PD1  PD2
- * 6:              1    1    1
- * 7:              1    1    0
- * 8:              1    0    1
- * 9:              1    0    0
- * 10:             0    1    1
- * 11:             0    1    0
- * 12:             0    0    1
+ * 0:  C7
+ * 1:  B6
+ * 2:  C6
+ * 3:  B4
+ * 4:  B5
+ * 5:  D7
  *
- * col 13: D3
- * col 14: B7
- * col 15: B3
+ *     A2   A1   A0
+ *     D0   D1   D2
+ * 6:   1    1    1
+ * 7:   1    1    0
+ * 8:   1    0    1
+ * 9:   1    0    0
+ * 10:  0    1    1
+ * 11:  0    1    0
+ * 12:  0    0    1
+ *
+ * 13: D3
+ * 14: B7
+ * 15: B3
  */
 static void select_col(uint8_t col) {
     if (col_pins[col] != NO_PIN) {

--- a/keyboards/evyd13/wasdat_code/config.h
+++ b/keyboards/evyd13/wasdat_code/config.h
@@ -41,21 +41,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
 */
 #define MATRIX_ROW_PINS { E6, C7, C6, B6, B5, B4, D7, D6 }
-#define MATRIX_COL_PINS { }
+#define MATRIX_COL_PINS { F7, F5, F6, F1, F4, F0, NO_PIN, D5, D3, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
 #define UNUSED_PINS
 
-/* COL2ROW, ROW2COL*/
-#define DIODE_DIRECTION ROW2COL
+#define SN74X138_ADDRESS_PINS { D2, D1, D0 }
+#define SN74X138_E3_PIN D4
 
 // For QMK DFU
 #define QMK_ESC_OUTPUT E6
 #define QMK_ESC_INPUT F0
 #define QMK_LED B1
-
-/*
- * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
- */
-//#define SOFT_SERIAL_PIN D0 // or D1, D2, D3, E6
 
 #define LED_NUM_LOCK_PIN B3
 #define LED_CAPS_LOCK_PIN B1

--- a/keyboards/evyd13/wasdat_code/config.h
+++ b/keyboards/evyd13/wasdat_code/config.h
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
 */
 #define MATRIX_ROW_PINS { E6, C7, C6, B6, B5, B4, D7, D6 }
-#define MATRIX_COL_PINS { F7, F5, F6, F1, F4, F0, NO_PIN, D5, D3, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN }
+#define MATRIX_COL_PINS { F7, F5, F6, F1, F4, F0, NO_PIN, D5, D3, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN, NO_PIN } // Columns 6 and 9-15 controlled by demux
 #define UNUSED_PINS
 
 #define SN74X138_ADDRESS_PINS { D2, D1, D0 }

--- a/keyboards/evyd13/wasdat_code/matrix.c
+++ b/keyboards/evyd13/wasdat_code/matrix.c
@@ -14,280 +14,70 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <stdint.h>
 #include <stdbool.h>
-#include "wait.h"
-#include "util.h"
 #include "matrix.h"
-#include "debounce.h"
 #include "quantum.h"
+#include "sn74x138.h"
 
-#ifdef DIRECT_PINS
-static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;
-#elif (DIODE_DIRECTION == ROW2COL) || (DIODE_DIRECTION == COL2ROW)
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
-//static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
-#endif
+static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 
-// matrix code
-
-#ifdef DIRECT_PINS
-
-static void init_pins(void) {
-    for (int row = 0; row < MATRIX_ROWS; row++) {
-        for (int col = 0; col < MATRIX_COLS; col++) {
-            pin_t pin = direct_pins[row][col];
-            if (pin != NO_PIN) {
-                setPinInputHigh(pin);
-            }
-        }
-    }
-}
-
-static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
-    matrix_row_t last_row_value = current_matrix[current_row];
-    current_matrix[current_row] = 0;
-
-    for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
-        pin_t pin = direct_pins[current_row][col_index];
-        if (pin != NO_PIN) {
-            current_matrix[current_row] |= readPin(pin) ? 0 : (MATRIX_ROW_SHIFTER << col_index);
-        }
-    }
-
-    return (last_row_value != current_matrix[current_row]);
-}
-
-#elif (DIODE_DIRECTION == COL2ROW)
-
-static void select_row(uint8_t row) {
-    setPinOutput(row_pins[row]);
-    writePinLow(row_pins[row]);
-}
-
-static void unselect_row(uint8_t row) { setPinInputHigh(row_pins[row]); }
-
-static void unselect_rows(void) {
-    for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInputHigh(row_pins[x]);
-    }
-}
-
-static void init_pins(void) {
-    unselect_rows();
-    for (uint8_t x = 0; x < MATRIX_COLS; x++) {
-        setPinInputHigh(col_pins[x]);
-    }
-}
-
-static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
-    // Store last value of row prior to reading
-    matrix_row_t last_row_value = current_matrix[current_row];
-
-    // Clear data in matrix row
-    current_matrix[current_row] = 0;
-
-    // Select row and wait for row selecton to stabilize
-    select_row(current_row);
-    wait_us(30);
-
-    // For each col...
-    for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
-
-        // Select the col pin to read (active low)
-        uint8_t pin_state = readPin(col_pins[col_index]);
-
-        // Populate the matrix row with the state of the col pin
-        current_matrix[current_row] |= pin_state ? 0 : (MATRIX_ROW_SHIFTER << col_index);
-    }
-
-    // Unselect row
-    unselect_row(current_row);
-
-    return (last_row_value != current_matrix[current_row]);
-}
-
-#elif (DIODE_DIRECTION == ROW2COL)
-
-/* Cols 0 - 15
- * col 0: F7
- * col 1: F5
- * col 2: F6
- * col 3: F1
- * col 4: F4
- * col 5: F0
- * These columns use a 74HC237D 3 to 8 bit demultiplexer. D4 is the enable pin, must be set high to use it.
- *                A0   A1   A2
- * col / pin:    PD2  PD1  PD0
- * 6:             1    1    1
- * col 7:  D3
- * col 8:  B7
- * 9:             0    1    1
- * 10:            1    0    1
- * 11:            0    0    1
- * 12:            1    1    0
- * 13:            0    1    0
- * 14:            1    0    0
- * 15:            0    0    0
+/* Columns 6 and 9-15 use a 74HC138 3 to 8 bit demultiplexer.
+ * D4 is the enable pin, must be set high to use it.
+ *
+ * 0:  F7
+ * 1:  F5
+ * 2:  F6
+ * 3:  F1
+ * 4:  F4
+ * 5:  F0
+ *
+ *     A2   A1   A0
+ *     D0   D1   D2
+ * 6:   1    1    1
+ *
+ * 7:  D5
+ * 8:  D3
+ *
+ * 9:   1    1    0
+ * 10:  1    0    1
+ * 11:  1    0    0
+ * 12:  0    1    1
+ * 13:  0    1    0
+ * 14:  0    0    1
+ * 15:  0    0    0
  */
 static void select_col(uint8_t col) {
-    switch (col) {
-        case 0:
-            writePinLow(F7);
-            break;
-        case 1:
-            writePinLow(F5);
-            break;
-        case 2:
-            writePinLow(F6);
-            break;
-        case 3:
-            writePinLow(F1);
-            break;
-        case 4:
-            writePinLow(F4);
-            break;
-        case 5:
-            writePinLow(F0);
-            break;
-        case 6:
-            writePinHigh(D4);
-            writePinHigh(D2);
-            writePinHigh(D1);
-            writePinHigh(D0);
-            break;
-        case 7:
-            writePinLow(D5);
-            break;
-        case 8:
-            writePinLow(D3);
-            break;
-        case 9:
-            writePinHigh(D4);
-            writePinHigh(D1);
-            writePinHigh(D0);
-            break;
-        case 10:
-            writePinHigh(D4);
-            writePinHigh(D2);
-            writePinHigh(D0);
-            break;
-        case 11:
-            writePinHigh(D4);
-            writePinHigh(D0);
-            break;
-        case 12:
-            writePinHigh(D4);
-            writePinHigh(D2);
-            writePinHigh(D1);
-            break;
-        case 13:
-            writePinHigh(D4);
-            writePinHigh(D1);
-            break;
-        case 14:
-            writePinHigh(D4);
-            writePinHigh(D2);
-            break;
-        case 15:
-            writePinHigh(D4);
-            break;
+    if (col_pins[col] != NO_PIN) {
+        writePinLow(col_pins[col]);
+    } else {
+        sn74x138_set_addr((col == 6) ? 7 : 15 - col);
+        sn74x138_set_enabled(true);
     }
 }
 
 static void unselect_col(uint8_t col) {
-    switch (col) {
-        case 0:
-            writePinHigh(F7);
-            break;
-        case 1:
-            writePinHigh(F5);
-            break;
-        case 2:
-            writePinHigh(F6);
-            break;
-        case 3:
-            writePinHigh(F1);
-            break;
-        case 4:
-            writePinHigh(F4);
-            break;
-        case 5:
-            writePinHigh(F0);
-            break;
-        case 6:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
-        case 7:
-            writePinHigh(D5);
-            break;
-        case 8:
-            writePinHigh(D3);
-            break;
-        case 9:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
-        case 10:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
-        case 11:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
-        case 12:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
-        case 13:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
-        case 14:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
-        case 15:
-            writePinLow(D4);
-            writePinLow(D2);
-            writePinLow(D1);
-            writePinLow(D0);
-            break;
+    if (col_pins[col] != NO_PIN) {
+        setPinOutput(col_pins[col]);
+        writePinHigh(col_pins[col]);
+    } else {
+        sn74x138_set_enabled(false);
     }
 }
 
 static void unselect_cols(void) {
-    //Native
-    writePinHigh(F7);
-    writePinHigh(F5);
-    writePinHigh(F6);
-    writePinHigh(F1);
-    writePinHigh(F4);
-    writePinHigh(F0);
-    writePinHigh(D3);
-    writePinHigh(D5);
+    // Native
+    for (uint8_t x = 0; x < MATRIX_COLS; x++) {
+        if (col_pins[x] != NO_PIN) {
+            setPinOutput(col_pins[x]);
+            writePinHigh(col_pins[x]);
+        }
+    }
 
-    //Demultiplexer
-    writePinLow(D4);
-    writePinLow(D2);
-    writePinLow(D1);
-    writePinLow(D0);
+    // Demultiplexer
+    sn74x138_set_enabled(false);
 }
 
 static void init_pins(void) {
@@ -295,27 +85,14 @@ static void init_pins(void) {
     for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
         setPinInputHigh(row_pins[x]);
     }
-    setPinOutput(D0);
-    setPinOutput(D1);
-    setPinOutput(D2);
-    setPinOutput(D3);
-    setPinOutput(F7);
-    setPinOutput(F5);
-    setPinOutput(F6);
-    setPinOutput(F1);
-    setPinOutput(F4);
-    setPinOutput(F0);
-    setPinOutput(D3);
-    setPinOutput(D5);
-    setPinOutput(D4);
 }
 
 static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col) {
     bool matrix_changed = false;
 
-    // Select col and wait for col selecton to stabilize
+    // Select col and wait for col selection to stabilize
     select_col(current_col);
-    wait_us(30);
+    matrix_io_delay();
 
     // For each row...
     for (uint8_t row_index = 0; row_index < MATRIX_ROWS; row_index++) {
@@ -343,27 +120,20 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
     return matrix_changed;
 }
 
-#endif
-
 void matrix_init_custom(void) {
     // initialize key pins
     init_pins();
+    // initialize demultiplexer
+    sn74x138_init();
 }
 
 bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     bool changed = false;
 
-#if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
-    // Set row, read cols
-    for (uint8_t current_row = 0; current_row < MATRIX_ROWS; current_row++) {
-        changed |= read_cols_on_row(current_matrix, current_row);
-    }
-#elif (DIODE_DIRECTION == ROW2COL)
     // Set col, read rows
     for (uint8_t current_col = 0; current_col < MATRIX_COLS; current_col++) {
         changed |= read_rows_on_col(current_matrix, current_col);
     }
-#endif
 
     return changed;
 }

--- a/keyboards/evyd13/wasdat_code/matrix.c
+++ b/keyboards/evyd13/wasdat_code/matrix.c
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 
-/* Columns 6 and 9-15 use a 74HC138 3 to 8 bit demultiplexer.
+/* Columns 6 and 9-15 use a 74HC138 3-to-8 demultiplexer.
  * D4 is the enable pin, must be set high to use it.
  *
  * 0:  F7
@@ -121,10 +121,10 @@ static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 }
 
 void matrix_init_custom(void) {
-    // initialize key pins
-    init_pins();
     // initialize demultiplexer
     sn74x138_init();
+    // initialize key pins
+    init_pins();
 }
 
 bool matrix_scan_custom(matrix_row_t current_matrix[]) {

--- a/keyboards/evyd13/wasdat_code/rules.mk
+++ b/keyboards/evyd13/wasdat_code/rules.mk
@@ -18,6 +18,7 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 
 CUSTOM_MATRIX = lite
-SRC += matrix.c
+VPATH += drivers/gpio
+SRC += matrix.c sn74x138.c
 
 LAYOUTS = fullsize_ansi fullsize_iso tkl_ansi tkl_iso


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A followup to #16217.

This board is similar to the Wasdat, but the column setup is a little different. According to the schematic, D4 is connected to one of the 74HC138's enable pins, and all output pins are connected to a column (whereas on the Wasdat the IC is always enabled, and only 7 of the 8 outputs are connected, with address 0 being set when a non-demux column is selected).

@evyd13 if you still have one of these, would you mind testing it, or pointing someone else who has one here?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
