### PR TITLE
Add uqs' keymaps for various boards and ploopy mouse

### DIFF
--- a/keyboards/handwired/dactyl_manuform/5x6/keymaps/uqs/config.h
+++ b/keyboards/handwired/dactyl_manuform/5x6/keymaps/uqs/config.h
@@ -1,0 +1,11 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#define USE_SERIAL
+
+#define RGBLED_NUM 12
+#define RGBLED_SPLIT {6,6}
+#define RGBLIGHT_LIMIT_VAL 127
+
+#define EE_HANDS

--- a/keyboards/handwired/dactyl_manuform/5x6/keymaps/uqs/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/5x6/keymaps/uqs/keymap.c
@@ -1,0 +1,170 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+// vi:et sw=4 cc=5,15,25,35,45,55,65:
+
+#include "uqs.h"
+
+/*
+ * My custom layout macro that allows for easy diff(1) operations between
+ * various keyboards. It probably doesn't make sense to you.
+ */
+#define LAYOUT_uqs(               \
+    L00, L01, L02, L03, L04, L05, \
+    L10, L11, L12, L13, L14, L15, \
+    L20, L21, L22, L23, L24, L25, \
+    L30, L31, L32, L33, L34, L35, \
+              L42, L43,           \
+         L44, L45, L54,           \
+         L55, L52, L53,           \
+    R00, R01, R02, R03, R04, R05, \
+    R10, R11, R12, R13, R14, R15, \
+    R20, R21, R22, R23, R24, R25, \
+    R30, R31, R32, R33, R34, R35, \
+              R42, R43,           \
+         R51, R40, R41,           \
+         R50, R52, R53            \
+)                                 \
+LAYOUT_5x6(                       \
+  L00, L01, L02, L03, L04, L05,                          R00, R01, R02, R03, R04, R05, \
+  L10, L11, L12, L13, L14, L15,                          R10, R11, R12, R13, R14, R15, \
+  L20, L21, L22, L23, L24, L25,                          R20, R21, R22, R23, R24, R25, \
+  L30, L31, L32, L33, L34, L35,                          R30, R31, R32, R33, R34, R35, \
+            L42, L43,                                              R42, R43,           \
+                      L44, L45,                          R40, R41,                     \
+                                L54, L55,      R50, R51,                               \
+                                L52, L53,      R52, R53                                \
+)
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [L_QWER] = LAYOUT_uqs(
+     KC_GESC,  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,
+     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,
+     KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,
+     KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,
+                         KC_LBRC,  KC_RBRC,
+     /*thumb*/ LT_EXTD_ESC, KC_SPC, LT_MOUSE_ALT_SHIFT_INS,
+      /*aux*/  KC_LEAD,  OSM_GUI,  KC_LALT,
+     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINUS,
+     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSLS,
+     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
+     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  RSFT_T(KC_GRV),
+                         KC_MINS,  KC_EQL,
+     /*thumb*/ LT_FUNC_SHIFT_INS, KC_ENT, LT_NUM_BSPC,
+      /*aux*/  KC_RALT,  KC_APP,   KC_LEAD
+  ),
+
+  [L_WASD] = LAYOUT_uqs(
+     KC_ESC,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,
+     KC_T,     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,
+     KC_G,     KC_LSFT,  KC_A,     KC_S,     KC_D,     KC_F,
+     KC_B,     KC_GRV,   KC_Z,     KC_X,     KC_C,     KC_V,
+                         KC_LBRC,  KC_RBRC,
+     /*thumb*/ KC_LCTL,  KC_SPC,   KC_R,
+      /*aux*/  A(KC_M),  KC_LGUI,  KC_LALT,
+     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_BSPC,
+     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSLS,
+     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
+     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  RSFT_T(KC_GRV),
+                         KC_MINS,  KC_EQL,
+     /*thumb*/ DF(L_COLM), KC_ENT, KC_BSPC,
+      /*aux*/  KC_F5,    KC_RALT,  KC_APP
+  ),
+
+  [L_COLM] = LAYOUT_uqs(
+     KC_NO,    KC_NO,    KC_BTN2,  KC_BTN3,  KC_BTN1,  KC_NO,
+     KC_BTN2,  KC_Q,     KC_W,     KC_F,     KC_P,     KC_B,
+     KC_BTN1,  KC_G_A,   KC_A_R,   KC_S_S,   KC_C_T,   KC_G,
+     KC_BTN3,  KC_Z,     KC_X,     KC_C,     KC_D,     KC_V,
+                         MS_WHUP,  MS_WHDN,
+     /*thumb*/ LT_EXTD_ESC, SFT_T(KC_SPC), LT(L_MOUSE, KC_TAB),
+      /*aux*/  KC_LEAD,  OSM_GUI,  KC_LALT,
+     KC_NO,    KC_BTN1,  KC_BTN2,  KC_BTN3,  KC_NO,    KC_NO,
+     KC_J,     KC_L,     KC_U,     KC_Y,     KC_QUOT,  KC_NO,
+     KC_M,     KC_C_N,   KC_S_E,   KC_A_I,   KC_G_O,   KC_NO,
+     KC_K,     KC_H,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_NO,
+                         KC_NO,    KC_NO,
+     /*thumb*/ LT_FUNC_SHIFT_INS, KC_ENT, LT_NUM_BSPC,
+      /*aux*/  KC_LEAD,  KC_RALT,  KC_APP
+  ),
+
+  // Updated with inspiration from https://forum.colemak.com/topic/2014-extend-extra-extreme/
+  // I like the AltGr trick from https://stevep99.github.io/seniply/ and should probably incorporate some stuff from it.
+  [L_EXTD] = LAYOUT_uqs(
+     _______,  _______,  _______,  _______,  _______,  _______,
+     _______,  KC_BTN1,  KC_SCTAB, KC_PGUP,  KC_CTAB,  KC_LEAD,
+     _______,  OSM_GUI,  OSM_ALT,  OSM_SFT,  OSM_CTL,  KC_RALT,
+     _______,  ALT_TAB,  MS_WHUP,  MS_WHDN,  KC_PGDN,  INS_HARD,
+                         _______,  _______,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ can't be used */
+     _______,  _______,  _______,  _______,  _______,  _______,
+     KC_HOME,  KC_PGDN,  KC_PGUP,  KC_END,   KC_INS,   KC_NO,
+     KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  KC_DEL,   KC_NO,
+     WIN_LEFT, WIN_DN,   WIN_UP,   WIN_RGHT, KC_PSTE,  KC_NO,  // KC_PSTE works in XTerm to emulate middle-click
+                         _______,  _______,
+     /*thumb*/ _______,  _______,  KC_BSPC,
+      /*aux*/  _______,  _______,  _______
+               /* ^^^^ use these */
+  ),
+
+  // TODO: maybe swap # with ;, that way I can roll :w or :wq which I need
+  // often ... probably better to add a combo?
+  [L_NUM] = LAYOUT_uqs(
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,
+     _______,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,
+     _______,  KC_SCLN,  KC_COLN,  KC_LCBR,  KC_LPRN,  KC_LBRC,
+     _______,  KC_CIRC,  KC_AMPR,  KC_RCBR,  KC_RPRN,  KC_RBRC,
+                         KC_GRV,   KC_TILDE,
+     /*thumb*/ KC_ESC,   KC_SPC,   KC_0,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ use these */
+     KC_NUMLOCK,KC_NO,   KC_NO,    KC_NO,    KC_NO,    KC_NO,
+     KC_EQUAL, KC_7,     KC_8,     KC_9,     KC_KP_PLUS,_______,
+     KC_KP_ASTERISK,KC_4,KC_5,     KC_6,     MINS_UNDSCR,_______,
+     KC_COMM,  KC_1,     KC_2,     KC_3,     KC_KP_SLASH,KC_KP_ENTER,  // Enter here, because thumb is occupied
+                         KC_0,     KC_KP_DOT,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______,  _______
+               /* ^^^^ can't be used */
+  ),
+
+  [L_FUNC] = LAYOUT_uqs(
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,
+     _______,  KC_NO,    KC_MUTE,  KC_VOLD,  KC_VOLU,  DF(L_WASD),
+     _______,  KC_LGUI,  KC_LALT,  KC_LSFT,  KC_LCTL,  DF(L_QWER),
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    DF(L_COLM),
+                         KC_NO,    KC_NO,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ use these */
+     KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,
+     KC_PSCR,  KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_NO,
+     KC_SLCK,  KC_F4,    KC_F5,    KC_F6,    KC_F11,   KC_NO,
+     KC_PAUS,  KC_F1,    KC_F2,    KC_F3,    KC_F12,   KC_NO,
+                         KC_NO,    KC_NO,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______,  _______
+               /* ^^^^ can't be used */
+  ),
+
+  [L_MOUSE] = LAYOUT_uqs(
+     _______,  _______,  _______,  _______,  _______,  _______,
+     _______,  KC_NO,    KC_BTN2,  KC_BTN3,  KC_BTN1,  KC_VOLU,
+     _______,  KC_NO,    KC_ACL0,  KC_ACL1,  KC_ACL2,  KC_VOLD,
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_MUTE,
+                         KC_NO,    KC_NO,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ can't be used */
+     _______,  _______,  _______,  _______,  _______,  _______,
+     _______,  _______,  KC_MS_UP, MS_WHUP,  _______,  _______,
+     MS_WHLEFT,KC_MS_L,  KC_MS_D,  KC_MS_R,  MS_WHRGHT,_______,
+     _______,  MS_WHDN,  KC_BTN3,  KC_BTN4,  KC_BTN5,  _______,
+                         KC_NO,    KC_NO,
+     /*thumb*/ KC_NO,    KC_BTN1,  KC_BTN2,
+      /*aux*/  _______,  _______,  _______
+               /* use these ^^^^ */
+  ),
+};

--- a/keyboards/handwired/dactyl_manuform/5x6/keymaps/uqs/rules.mk
+++ b/keyboards/handwired/dactyl_manuform/5x6/keymaps/uqs/rules.mk
@@ -1,0 +1,1 @@
+#VIA_ENABLE = yes  # doesn't fit with 7 layers :/

--- a/keyboards/ploopyco/mouse/keymaps/uqs/keymap.c
+++ b/keyboards/ploopyco/mouse/keymaps/uqs/keymap.c
@@ -1,0 +1,36 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+// vi:et sw=4:
+
+#include QMK_KEYBOARD_H
+
+enum custom_keycodes {
+    DBL_CLK_NO = SAFE_RANGE,
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        // This works fine in xev(1) or a browser, but not in the game where I
+        // would want it. Maybe need to increase the delay? Also needs to be
+        // rewritten to use Deferred Execution.
+        case DBL_CLK_NO:
+            if (record->event.pressed) {
+                tap_code(KC_BTN2);
+                wait_ms(150);
+                tap_code(KC_BTN2);
+                wait_ms(300);
+                tap_code(KC_N);
+            }
+            return false;
+    }
+    return true;
+}
+
+
+// Layout is:
+// left-most, M1, M3, M2, right-most, fwd, back (on side), tiny middle one
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(KC_E, KC_BTN1, KC_BTN3, KC_BTN2, KC_LSFT, KC_BTN4, KC_BTN5, DF(1)),  // shooters
+    [1] = LAYOUT(KC_1, KC_BTN1, KC_Y, KC_BTN2, DBL_CLK_NO, KC_N, KC_Y, DF(0)),        // stardew valley, sword on 1
+};

--- a/keyboards/ploopyco/mouse/keymaps/uqs/rules.mk
+++ b/keyboards/ploopyco/mouse/keymaps/uqs/rules.mk
@@ -1,0 +1,1 @@
+#VIA_ENABLE = yes

--- a/keyboards/preonic/keymaps/uqs/keymap.c
+++ b/keyboards/preonic/keymaps/uqs/keymap.c
@@ -1,0 +1,117 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+// vi:et sw=4 cc=5,15,25,35,45,55,65:
+
+#include "uqs.h"
+
+/*
+ * My custom layout macro that allows for easy diff(1) operations between
+ * various keyboards. It probably doesn't make sense to you.
+ */
+#define LAYOUT_uqs(               \
+    k00, k01, k02, k03, k04, k05, \
+    k10, k11, k12, k13, k14, k15, \
+    k20, k21, k22, k23, k24, k25, \
+    k30, k31, k32, k33, k34, k35, \
+         k43, k44,                \
+    k40, k41, k42,                \
+    k06, k07, k08, k09, k0a, k0b, \
+    k16, k17, k18, k19, k1a, k1b, \
+    k26, k27, k28, k29, k2a, k2b, \
+    k36, k37, k38, k39, k3a, k3b, \
+              k46, k48,           \
+                   k49, k4a, k4b  \
+)                                 \
+LAYOUT_preonic_2x2u( \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, \
+    k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, \
+    k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, \
+    k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, \
+    k40, k41, k42, k43, k44,      k46,      k48, k49, k4a, k4b \
+)
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [L_QWER] = LAYOUT_uqs(
+     KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,
+     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,
+     KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,
+     KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,
+
+     /*thumb*/ LT_EXTD_ESC, KC_SPC,
+      /*aux*/  KC_NO,    KC_LGUI,  KC_LALT,
+     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINUS,
+     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSLS,
+     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
+     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,
+     /*thumb*/ KC_ENT,   LT_NUM_BSPC,
+      /*aux*/  MO(L_FUNC), KC_NO,  KC_NO
+  ),
+  [L_EXTD] = LAYOUT_uqs(
+     KC_F11,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,
+     _______,  KC_BTN1,  KC_SCTAB, KC_PGUP,  KC_CTAB,  KC_LEAD,
+     _______,  OSM_GUI,  OSM_ALT,  OSM_SFT,  OSM_CTL,  KC_RALT,
+     _______,  ALT_TAB,  MS_WHUP,  MS_WHDN,  KC_PGDN,  INS_HARD,
+     /*thumb*/ _______,  _______,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ can't be used */
+     KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F12,
+     KC_HOME,  KC_PGDN,  KC_PGUP,  KC_END,   KC_INS,   KC_NO,
+     KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  KC_DEL,   KC_NO,
+     WIN_LEFT, WIN_DN,   WIN_UP,   WIN_RGHT, KC_PSTE,  KC_NO,
+     /*thumb*/ _______,  KC_BSPC,
+      /*aux*/  _______,  _______,  KC_ENTER
+               /* ^^^^ use these */
+  ),
+
+  [L_NUM] = LAYOUT_uqs(
+     KC_F11,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,
+     _______,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,
+     _______,  KC_SCLN,  KC_COLN,  KC_LCBR,  KC_LPRN,  KC_LBRC,
+     _______,  KC_CIRC,  KC_AMPR,  KC_RCBR,  KC_RPRN,  KC_RBRC,
+     /*thumb*/ KC_ESC,   _______,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ use these */
+     KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F12,
+     KC_EQUAL, KC_7,     KC_8,     KC_9,     KC_KP_PLUS,_______,
+     KC_KP_ASTERISK,KC_4,KC_5,     KC_6,     MINS_UNDSCR,_______,
+     KC_COMM,  KC_1,     KC_2,     KC_3,     KC_KP_SLASH,KC_KP_ENTER,  // Enter here, because thumb is occupied
+     /*thumb*/ _______,  _______,
+      /*aux*/  KC_0,     KC_KP_DOT, _______
+               /* ^^^^ can't be used */
+  ),
+
+  [L_FUNC] = LAYOUT_uqs(
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,
+     _______,  KC_NO,    KC_MUTE,  KC_VOLD,  KC_VOLU,  KC_NO,
+     _______,  KC_LGUI,  KC_LALT,  KC_LSFT,  KC_LCTL,  KC_NO,
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,
+     /*thumb*/ _______,  _______,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ use these */
+     KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,
+     KC_PSCR,  KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_NO,
+     KC_SLCK,  KC_F4,    KC_F5,    KC_F6,    KC_F11,   KC_NO,
+     KC_PAUS,  KC_F1,    KC_F2,    KC_F3,    KC_F12,   KC_NO,
+     /*thumb*/ _______,  _______,
+      /*aux*/  _______,  _______,  _______
+               /* ^^^^ can't be used */
+  ),
+
+  [L_MOUSE] = LAYOUT_uqs(
+     KC_NO,    _______,  _______,  _______,  _______,  _______,
+     KC_NO,    KC_NO,    KC_BTN2,  KC_BTN3,  KC_BTN1,  KC_VOLU,
+     KC_NO,    KC_NO,    KC_ACL0,  KC_ACL1,  KC_ACL2,  KC_VOLD,
+     KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_MUTE,
+     /*thumb*/ _______,  _______,
+      /*aux*/  _______,  _______,  _______,
+               /* ^^^^ can't be used */
+     _______,  _______,  _______,  _______,  _______,  _______,
+     _______,  _______,  KC_MS_UP, MS_WHUP,  _______,  _______,
+     MS_WHLEFT,KC_MS_L,  KC_MS_D,  KC_MS_R,  MS_WHRGHT,_______,
+     _______,  MS_WHDN,  KC_BTN3,  KC_BTN4,  KC_BTN5,  _______,
+     /*thumb*/ KC_BTN1,  KC_BTN2,
+      /*aux*/  KC_NO,    KC_NO,    KC_NO
+               /* use these ^^^^ */
+  ),
+};

--- a/keyboards/preonic/keymaps/uqs/rules.mk
+++ b/keyboards/preonic/keymaps/uqs/rules.mk
@@ -1,0 +1,14 @@
+LTO_ENABLE=no
+AUDIO_ENABLE=no
+ENCODER_ENABLE=no
+
+# Broken with gcc >6, see https://github.com/qmk/qmk_firmware/issues/6753
+# (yes, different option, but I suspect the code has moved around)
+# This produces working firmware on Arch Linux with GCC 11, but is still broken
+# on Debian with 8.3.1
+RGBLIGHT_ENABLE=no
+RGB_MATRIX_ENABLE=no
+
+# not required, but helps on debian where there is a soft/hard float confusion.
+# but see above, gcc 8.3.1 still fucks up the firmware.
+USE_FPU=no

--- a/keyboards/splitkb/kyria/keymaps/uqs/config.h
+++ b/keyboards/splitkb/kyria/keymaps/uqs/config.h
@@ -1,0 +1,13 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#ifdef RGBLIGHT_ENABLE
+  //#define RGBLIGHT_ANIMATIONS
+  #define RGBLIGHT_HUE_STEP 8
+  #define RGBLIGHT_SAT_STEP 8
+  #define RGBLIGHT_VAL_STEP 8
+  #define RGBLIGHT_LIMIT_VAL 150
+#endif
+
+#define EE_HANDS

--- a/keyboards/splitkb/kyria/keymaps/uqs/keymap.c
+++ b/keyboards/splitkb/kyria/keymaps/uqs/keymap.c
@@ -1,0 +1,158 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+// vi:et sw=4 cc=5,15,25,35,45,55,65:
+
+#include "uqs.h"
+
+/*
+ * My custom layout macro that allows for easy diff(1) operations between
+ * various keyboards. It probably doesn't make sense to you.
+ */
+#define LAYOUT_uqs(               \
+    L00, L01, L02, L03, L04, L05, \
+    L12, L13, L14, L15, L16, L17, \
+    L24, L25, L26, L27, L28, L29, \
+              L40, L41,           \
+         L42, L43, L44,           \
+         L30, L31,                \
+    R06, R07, R08, R09, R10, R11, \
+    R18, R19, R20, R21, R22, R23, \
+    R34, R35, R36, R37, R38, R39, \
+              R48, R49,           \
+         R45, R46, R47,           \
+         R32, R33                 \
+)                                 \
+LAYOUT_stack(                     \
+    L00, L01, L02, L03, L04, L05,                   \
+    L12, L13, L14, L15, L16, L17,                   \
+    L24, L25, L26, L27, L28, L29, L30, L31,         \
+                   L40, L41, L42, L43, L44,         \
+                                                    \
+                  R06, R07, R08, R09, R10, R11,     \
+                  R18, R19, R20, R21, R22, R23,     \
+        R32, R33, R34, R35, R36, R37, R38, R39,     \
+        R45, R46, R47, R48, R49                     \
+)
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [L_QWER] = LAYOUT_uqs(
+     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,
+     KC_LCTL,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,
+     KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,
+                         KC_LBRC,  KC_RBRC,
+     /*thumb*/ LT_EXTD_ESC, KC_SPC, LT_MOUSE_ALT_SHIFT_INS,
+      /*aux*/  OSM_GUI,  KC_LALT,
+     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSLS,
+     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
+     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  RSFT_T(KC_GRV),
+                         KC_MINS,  KC_EQL,
+     /*thumb*/ LT_FUNC_SHIFT_INS, KC_ENT, LT_NUM_BSPC,
+      /*aux*/  KC_RALT,  KC_APP
+  ),
+
+  [L_WASD] = LAYOUT_uqs(
+     KC_T,     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,
+     KC_G,     KC_LSFT,  KC_A,     KC_S,     KC_D,     KC_F,
+     KC_B,     KC_GRV,   KC_Z,     KC_X,     KC_C,     KC_V,
+                         KC_LBRC,  KC_RBRC,
+     /*thumb*/ KC_LCTL,  KC_SPC,   KC_R,
+      /*aux*/  OSM_GUI,  KC_LALT,
+     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_BSLS,
+     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
+     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  RSFT_T(KC_GRV),
+                         KC_MINS,  KC_EQL,
+     /*thumb*/ DF(L_COLM), KC_ENT, KC_BSPC,
+      /*aux*/  KC_RALT,  KC_APP
+  ),
+
+  [L_COLM] = LAYOUT_uqs(
+     KC_BTN2,  KC_Q,     KC_W,     KC_F,     KC_P,     KC_B,
+     KC_BTN1,  KC_G_A,   KC_A_R,   KC_S_S,   KC_C_T,   KC_G,
+     KC_BTN3,  KC_Z,     KC_X,     KC_C,     KC_D,     KC_V,
+                         MS_WHUP,  MS_WHDN,
+     /*thumb*/ LT_EXTD_ESC, SFT_T(KC_SPC), LT(L_MOUSE, KC_TAB),
+      /*aux*/  OSM_GUI,  KC_LALT,
+     KC_J,     KC_L,     KC_U,     KC_Y,     KC_QUOT,  KC_NO,
+     KC_M,     KC_C_N,   KC_S_E,   KC_A_I,   KC_G_O,   KC_NO,
+     KC_K,     KC_H,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_NO,
+                         KC_NO,    KC_NO,
+     /*thumb*/ LT_FUNC_SHIFT_INS, KC_ENT, LT_NUM_BSPC,
+      /*aux*/  KC_RALT,  KC_APP
+  ),
+
+  // Updated with inspiration from https://forum.colemak.com/topic/2014-extend-extra-extreme/
+  // I like the AltGr trick from https://stevep99.github.io/seniply/ and should probably incorporate some stuff from it.
+  [L_EXTD] = LAYOUT_uqs(
+     _______,  KC_BTN1,  KC_SCTAB, KC_PGUP,  KC_CTAB,  KC_LEAD,
+     _______,  OSM_GUI,  OSM_ALT,  OSM_SFT,  OSM_CTL,  KC_RALT,
+     _______,  ALT_TAB,  MS_WHUP,  MS_WHDN,  KC_PGDN,  INS_HARD,
+                         _______,  _______,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______,
+               /* ^^^^ can't be used */
+     KC_HOME,  KC_PGDN,  KC_PGUP,  KC_END,   KC_INS,   KC_NO,
+     KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  KC_DEL,   KC_NO,
+     WIN_LEFT, WIN_DN,   WIN_UP,   WIN_RGHT, KC_PSTE,  KC_NO,  // KC_PSTE works in XTerm to emulate middle-click
+                         _______,  _______,
+     /*thumb*/ _______,  _______,  KC_BSPC,
+      /*aux*/  _______,  _______
+               /* ^^^^ use these */
+  ),
+
+  // TODO: maybe swap # with ;, that way I can roll :w or :wq which I need
+  // often ... probably better to add a combo?
+  [L_NUM] = LAYOUT_uqs(
+     _______,  KC_EXLM,  KC_AT,    KC_HASH,  KC_DLR,   KC_PERC,
+     _______,  KC_SCLN,  KC_COLN,  KC_LCBR,  KC_LPRN,  KC_LBRC,
+     _______,  KC_CIRC,  KC_AMPR,  KC_RCBR,  KC_RPRN,  KC_RBRC,
+                         KC_GRV,   KC_TILDE,
+     /*thumb*/ KC_ESC,   KC_SPC,   KC_0,
+      /*aux*/  _______,_______,
+               /* ^^^^ use these */
+
+     KC_EQUAL, KC_7,     KC_8,     KC_9,     KC_KP_PLUS,_______,
+     KC_KP_ASTERISK,KC_4,KC_5,     KC_6,     MINS_UNDSCR,_______,
+     KC_COMM,  KC_1,     KC_2,     KC_3,     KC_KP_SLASH,KC_KP_ENTER,  // Enter here, because thumb is occupied
+                         KC_0,     KC_KP_DOT,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______
+               /* ^^^^ can't be used */
+  ),
+
+  [L_FUNC] = LAYOUT_uqs(
+     _______,  KC_NO,    KC_MUTE,  KC_VOLD,  KC_VOLU,  DF(L_WASD),
+     _______,  KC_LGUI,  KC_LALT,  KC_LSFT,  KC_LCTL,  DF(L_QWER),
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    DF(L_COLM),
+                         KC_NO,    KC_NO,
+     /*thumb*/ KC_NO,    KC_NO,    KC_NO,
+      /*aux*/  _______,  _______,
+               /* ^^^^ use these */
+
+     KC_PSCR,  KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_NO,
+     KC_SLCK,  KC_F4,    KC_F5,    KC_F6,    KC_F11,   KC_NO,
+     KC_PAUS,  KC_F1,    KC_F2,    KC_F3,    KC_F12,   KC_NO,
+                         KC_NO,    KC_NO,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______
+               /* ^^^^ can't be used */
+  ),
+
+  [L_MOUSE] = LAYOUT_uqs(
+     _______,  KC_NO,    KC_BTN2,  KC_BTN3,  KC_BTN1,  KC_VOLU,
+     _______,  KC_NO,    KC_ACL0,  KC_ACL1,  KC_ACL2,  KC_VOLD,
+     _______,  KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_MUTE,
+                         KC_NO,    KC_NO,
+     /*thumb*/ _______,  _______,  _______,
+      /*aux*/  _______,  _______,
+               /* ^^^^ can't be used */
+
+     _______,  _______,  KC_MS_UP, MS_WHUP,  _______,  _______,
+     MS_WHLEFT,KC_MS_L,  KC_MS_D,  KC_MS_R,  MS_WHRGHT,_______,
+     _______,  MS_WHDN,  KC_BTN3,  KC_BTN4,  KC_BTN5,  _______,
+                         KC_NO,    KC_NO,
+     /*thumb*/ KC_NO,    KC_BTN1,  KC_BTN2,
+      /*aux*/  _______,  _______
+               /* use these ^^^^ */
+  ),
+};

--- a/keyboards/splitkb/kyria/keymaps/uqs/rules.mk
+++ b/keyboards/splitkb/kyria/keymaps/uqs/rules.mk
@@ -1,0 +1,1 @@
+OLED_ENABLE = no

--- a/users/uqs/config.h
+++ b/users/uqs/config.h
@@ -1,0 +1,40 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#ifdef RGBLIGHT_ENABLE
+#    define RGBLIGHT_SLEEP
+//#    define RGBLIGHT_ANIMATIONS      // disabled to save space
+#    define RGBLIGHT_LAYERS
+#    define RGBLIGHT_MAX_LAYERS 8      // default is 16
+#    define RGBLIGHT_DISABLE_KEYCODES  // RGB_foo keys no longer work, saves 600 bytes
+#    define RGBLIGHT_DEFAULT_HUE 15
+#endif
+
+#define DYNAMIC_KEYMAP_LAYER_COUNT 6  // default is 4 for VIA builds
+
+#define TAPPING_TOGGLE 2  // number of taps for a toggle-on-tap
+#define TAPPING_TERM 170  // ms to trigger tap
+// https://precondition.github.io/home-row-mods
+#define TAPPING_FORCE_HOLD  // make tap-then-hold _not_ do key auto repeat
+#define IGNORE_MOD_TAP_INTERRUPT
+#define PERMISSIVE_HOLD  // I don't think this works for me, hence I rolled my own implementation.
+
+#define LEADER_TIMEOUT 400
+#define LEADER_PER_KEY_TIMING
+
+#define UNICODE_SELECTED_MODES UC_LNX
+
+// make KC_ACL0 et al work when held.
+#define MK_COMBINED
+#define MOUSEKEY_WHEEL_INTERVAL 40  // default is 50, lower means more scroll events, 40 works ok.
+
+// From https://michael.stapelberg.ch/posts/2021-05-08-keyboard-input-latency-qmk-kinesis/
+#define USB_POLLING_INTERVAL_MS 1
+
+#ifdef KEYBOARD_preonic_rev3
+// Some games seem to not register Esc otherwise when tapped, maybe try with this delay?
+#    define TAP_CODE_DELAY 30
+#else
+#    define TAP_CODE_DELAY 10
+#endif

--- a/users/uqs/rules.mk
+++ b/users/uqs/rules.mk
@@ -1,0 +1,24 @@
+# don't include for keyboards/ploopyco/mouse/keymaps/uqs
+ifeq ($(filter $(strip $(KEYBOARD)),ploopyco/mouse),)
+    SRC += uqs.c
+
+    RGBLIGHT_ENABLE ?= yes      # Enable keyboard RGB underglow
+    LTO_ENABLE ?= yes  # disables the legacy TMK Macros and Functions features
+
+    UCIS_ENABLE = yes
+    LEADER_ENABLE = yes
+    COMBO_ENABLE = yes
+    MOUSEKEY_ENABLE = yes
+
+    # Disable all the unused stuff.
+    SPACE_CADET_ENABLE = no
+    COMMAND_ENABLE = no
+    MAGIC_ENABLE = no
+endif
+
+# From https://michael.stapelberg.ch/posts/2021-05-08-keyboard-input-latency-qmk-kinesis/
+# adds about 900 bytes! Don't use it on puny AVR though.
+# ifeq (,$(filter $(MCU), atmega16u2 atmega32u2 at90usb162)) # doesn't work MCU not set yet
+ifneq (,$(filter $(KEYBOARD),ploopyco/mouse preonic/rev3))
+    DEBOUNCE_TYPE = asym_eager_defer_pk
+endif

--- a/users/uqs/uqs.c
+++ b/users/uqs/uqs.c
@@ -1,0 +1,584 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+// vi:et sw=4:
+
+#include "uqs.h"
+
+// LOG:
+// late Jan 2020, got Ohkeycaps Dactyl Manuform 5x6
+// https://play.typeracer.com shows about 75-80wpm (en) or ~400cpm (de) on my classic keeb.
+// Never did proper touch typing, basically didn't use ring finger much, mostly index/middle and pinky (only to hold down modifiers, really).
+// Feb 2020, switching to Colemak DH after 30 years of Qwerty, uh oh...
+// mid Feb, 20wpm/87% on monkeytype.com (no punct, numbers)
+// early March, 28wpm/90% on MT (plus punct./numbers from here on); 25wpm on typeracer
+// early April, 35wpm/92% on MT; 41wpm on typeracer
+// early May, 45wpm/96% on MT; 46wpm on typeracer; my qwerty is deteriorating, I need to look at the keys more and more o_O
+// early June, 49wpm/95% on MT (sigh ...); 50wpm on typeracer;
+// early July, 50wpm/96% on MT (...); 52wpm/96% on typeracer;
+// early August, 55wpm/96% on MT; 55wpm/98% on typeracer;
+// early September, 57wpm/97% on MT; 58wpm/97% on typeracer;
+// early October, 59wpm/96% on MT; 61wpm/97% on typeracer;
+// November, 56wpm/97% on MT; 62wpm/98% on typeracer;
+// December, 62wpm/96% on MT; 66wpm/98% on typeracer;
+// January, 61wpm/97% on MT; 65wpm/98% on typeracer;
+// February, 64wpm/97% on MT; 67wpm/98% on typeracer; my qwerty on the laptop is still fine, but I miss my shortcuts badly.
+//
+// So that's one year on Colemak. Was it worth the switch? Probably not, though
+// I also had to first learn proper technique, but that was actually swift, as
+// the keyboard nicely forces that on you. I really like home row mods though,
+// they are so comfy. Need to rethink my combos some more, still.
+
+
+#ifdef RGBLIGHT_LAYERS
+layer_state_t default_layer_state_set_user(layer_state_t state) {
+    rgblight_set_layer_state(L_QWER, layer_state_cmp(state, L_QWER));
+    rgblight_set_layer_state(L_WASD, layer_state_cmp(state, L_WASD));
+    rgblight_set_layer_state(L_COLM, layer_state_cmp(state, L_COLM));
+    return state;
+}
+#endif
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+#if 0
+    // defining layer L_FUNC when both keys are pressed
+    state = update_tri_layer_state(state, L_EXTD, L_NUM, L_FUNC);
+#endif
+#ifdef RGBLIGHT_LAYERS
+    rgblight_set_layer_state(L_EXTD, layer_state_cmp(state, L_EXTD));
+    rgblight_set_layer_state(L_NUM, layer_state_cmp(state, L_NUM));
+    rgblight_set_layer_state(L_FUNC, layer_state_cmp(state, L_FUNC));
+    rgblight_set_layer_state(L_MOUSE, layer_state_cmp(state, L_MOUSE));
+#else
+#endif
+    return state;
+}
+
+#ifdef RGBLIGHT_LAYERS
+// NOTE: at most 2 elements, last one needs to be RGBLIGHT_END_SEGMENTS
+typedef rgblight_segment_t rgblight_layer_t[3];
+
+const rgblight_layer_t PROGMEM my_rgb_segments[] = {
+    [L_QWER] = {{0, RGBLED_NUM, HSV_WHITE},  RGBLIGHT_END_SEGMENTS},
+    [L_WASD] = {{0, RGBLED_NUM/2, HSV_RED}, {RGBLED_NUM/2, RGBLED_NUM/2, HSV_OFF}, RGBLIGHT_END_SEGMENTS},
+    [L_COLM] = {{0, RGBLED_NUM, HSV_GREEN},  RGBLIGHT_END_SEGMENTS},
+    [L_EXTD] = {{0, RGBLED_NUM, HSV_BLUE},   RGBLIGHT_END_SEGMENTS},
+    [L_NUM] =  {{0, RGBLED_NUM, HSV_ORANGE}, RGBLIGHT_END_SEGMENTS},
+    [L_FUNC] = {{0, RGBLED_NUM, HSV_YELLOW}, RGBLIGHT_END_SEGMENTS},
+    [L_MOUSE]= {{0, RGBLED_NUM, HSV_PURPLE}, RGBLIGHT_END_SEGMENTS},
+};
+
+// This array needs pointers, :/
+const rgblight_segment_t* const PROGMEM my_rgb_layers[] = {
+    my_rgb_segments[L_QWER],
+    my_rgb_segments[L_WASD],
+    my_rgb_segments[L_COLM],
+    my_rgb_segments[L_EXTD],
+    my_rgb_segments[L_NUM],
+    my_rgb_segments[L_FUNC],
+    my_rgb_segments[L_MOUSE],
+};
+
+_Static_assert(sizeof(my_rgb_layers) / sizeof(my_rgb_layers[0]) ==
+        sizeof(my_rgb_segments) / sizeof(my_rgb_segments[0]),
+        "Number of rgb_segment definitions does not match up!");
+#endif
+
+#ifdef COMBO_ENABLE
+enum combo_events {
+  C_AUML,
+  C_OUML,
+  C_UUML,
+  C_SZ,
+  C_CBR,
+  C_PRN,
+  C_BRC,
+};
+
+// Maybe use this?
+// #define COMBO_ONLY_FROM_LAYER L_COLM
+
+// The official way has way too much duplication and intermediate names for my taste...
+const uint16_t PROGMEM my_action_combos[][3] = {
+    [C_AUML] = {KC_G_A, KC_W, COMBO_END},
+    [C_OUML] = {KC_G_O, KC_Y, COMBO_END},
+    [C_UUML] = {KC_C_N, KC_U, COMBO_END},
+    [C_SZ]   = {KC_S_S, KC_Z, COMBO_END},
+    [C_CBR]  = {KC_COLN, KC_LCBR, COMBO_END},
+    [C_PRN]  = {KC_LCBR, KC_LPRN, COMBO_END},
+    [C_BRC]  = {KC_LPRN, KC_LBRC, COMBO_END},
+};
+const uint16_t PROGMEM my_combos[][4] = {
+    {KC_LPRN, KC_F, KC_P, COMBO_END},
+    {KC_RPRN, KC_C, KC_D, COMBO_END},
+    {KC_LCBR, KC_W, KC_F, COMBO_END},
+    {KC_RCBR, KC_X, KC_C, COMBO_END},
+    {KC_TAB,  KC_G_A, KC_A_R, COMBO_END},
+    {KC_BSLS, KC_B, KC_J, COMBO_END},  // remove this?
+    {KC_BSLS, KC_F, KC_U, COMBO_END},
+    {LSFT(KC_BSLS), KC_P, KC_L, COMBO_END},
+    {KC_MINUS, KC_C_T, KC_C_N, COMBO_END},
+    {LSFT(KC_MINUS), KC_D, KC_H, COMBO_END},
+    {KC_GRV,  KC_Q, KC_W, COMBO_END},  // remove this?
+    {KC_GRV,  KC_C, KC_COMM, COMBO_END},
+    {LSFT(KC_GRV), KC_G, KC_M, COMBO_END},
+    {KC_BTN3, KC_BTN1, KC_BTN2, COMBO_END},
+    {KC_BTN1, KC_BTN2, KC_BTN3, COMBO_END},
+};
+
+const uint16_t COMBO_LEN = sizeof(my_action_combos) / sizeof(my_action_combos[0]) + sizeof(my_combos) / sizeof(my_combos[0]);
+
+#define MY_ACTION_COMBO(ck) \
+    [ck] = { .keys = &(my_action_combos[ck][0]) }
+#define MY_COMBO(ck) \
+    { .keys = &(my_combos[ck][1]), .keycode = my_combos[ck][0] }
+
+// NOTE: while my_combos can live in PROGMEM, the key_combos data also
+// contains state that is tweaked at runtime, so we need to indirect. Ugh.
+#define COMBO_STATICALLY
+#ifdef COMBO_STATICALLY
+// TODO: fill this at runtime with a loop?
+combo_t key_combos[] = {
+  MY_ACTION_COMBO(0),
+  MY_ACTION_COMBO(1),
+  MY_ACTION_COMBO(2),
+  MY_ACTION_COMBO(3),
+  MY_ACTION_COMBO(4),
+  MY_ACTION_COMBO(5),
+  MY_ACTION_COMBO(6),
+  MY_COMBO(0),
+  MY_COMBO(1),
+  MY_COMBO(2),
+  MY_COMBO(3),
+  MY_COMBO(4),
+  MY_COMBO(5),
+  MY_COMBO(6),
+  MY_COMBO(7),
+  MY_COMBO(8),
+  MY_COMBO(9),
+  MY_COMBO(10),
+  MY_COMBO(11),
+  MY_COMBO(12),
+  MY_COMBO(13),
+  MY_COMBO(14),
+};
+
+_Static_assert(sizeof(key_combos) / sizeof(key_combos[0]) ==
+        (sizeof(my_action_combos) / sizeof(my_action_combos[0]) + sizeof(my_combos) / sizeof(my_combos[0])),
+        "Number of combo definitions does not match up!");
+#else
+combo_t key_combos[sizeof(my_action_combos) / sizeof(my_action_combos[0]) + sizeof(my_combos) / sizeof(my_combos[0])];
+#endif
+
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    switch (combo_index) {
+        case C_AUML:
+            if (pressed) {
+                tap_code16(KC_RALT);
+                tap_code16(LSFT(KC_QUOT));
+                tap_code16(KC_A);
+            }
+            break;
+        case C_OUML:
+            if (pressed) {
+                tap_code16(KC_RALT);
+                tap_code16(LSFT(KC_QUOT));
+                tap_code16(KC_O);
+            }
+            break;
+        case C_UUML:
+            if (pressed) {
+                tap_code16(KC_RALT);
+                tap_code16(LSFT(KC_QUOT));
+                tap_code16(KC_U);
+            }
+            break;
+        case C_SZ:
+            if (pressed) {
+                tap_code16(KC_RALT);
+                tap_code16(KC_S);
+                tap_code16(KC_S);
+            }
+            break;
+        case C_CBR:
+            if (pressed) {
+                tap_code16(KC_LCBR);
+                tap_code16(KC_RCBR);
+                tap_code16(KC_LEFT);
+            }
+            break;
+        case C_PRN:
+            if (pressed) {
+                tap_code16(KC_LPRN);
+                tap_code16(KC_RPRN);
+                tap_code16(KC_LEFT);
+            }
+            break;
+        case C_BRC:
+            if (pressed) {
+                tap_code16(KC_LBRC);
+                tap_code16(KC_RBRC);
+                tap_code16(KC_LEFT);
+            }
+            break;
+    }
+}
+#endif
+
+void keyboard_post_init_user(void) {
+#ifndef KEYBOARD_preonic_rev3
+    default_layer_set(1ul << L_COLM);
+#endif
+#ifdef RGBLIGHT_LAYERS
+    // Enable the LED layers
+    rgblight_layers = my_rgb_layers;
+    rgblight_set_layer_state(0, true);
+#endif
+#if defined(COMBO_ENABLE) && !defined(COMBO_STATICALLY)
+    uint8_t i = 0;
+    for (; i < sizeof(my_action_combos) / sizeof(my_action_combos[0]); i++) {
+        key_combos[i].keys = &(my_action_combos[i][0]);
+    }
+    for (uint8_t j = 0; j < sizeof(my_combos) / sizeof(my_combos[0]); j++, i++) {
+        key_combos[i].keycode = my_combos[j][0];
+        key_combos[i].keys = &(my_combos[j][1]);
+    }
+#endif
+}
+
+uint16_t key_timer;
+bool delkey_registered;
+bool num_layer_was_used;
+bool extd_layer_was_used;
+// These keep state about the long-press-means-umlaut keys.
+bool auml_pressed;
+bool ouml_pressed;
+bool uuml_pressed;
+
+void maybe_send_umlaut(uint16_t keycode, bool *is_pressed) {
+    // Some other key did _not_ already re-arm this key, so now we need to do
+    // that ourselves.
+    if (*is_pressed) {
+        *is_pressed = false;
+        // If released within the timer, then just KC_A, KC_O, KC_U
+        if (timer_elapsed(key_timer) < TAPPING_TERM) {
+            tap_code16(keycode);
+        } else {
+            tap_code16(KC_RALT);
+            tap_code16(LSFT(KC_QUOT));
+            tap_code16(keycode);
+        }
+    }
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    // TODO: why not use key_timer here? is it dynamic or not?
+    static uint16_t extd_layer_timer;
+    if (layer_state_is(L_EXTD) && record->event.pressed) {
+        extd_layer_was_used = true;
+    }
+    if (layer_state_is(L_NUM) && record->event.pressed) {
+        num_layer_was_used = true;
+    }
+
+    // An umlaut key was pressed previously (but will only emit the key on
+    // release), but we've pressed a different key now, so fire the regular key,
+    // re-arm it and continue with whatever actual key was pressed just now.
+    if (record->event.pressed) {
+        if (auml_pressed) {
+            tap_code16(KC_A);
+            auml_pressed = false;
+        }
+        if (ouml_pressed) {
+            tap_code16(KC_O);
+            ouml_pressed = false;
+        }
+        if (uuml_pressed) {
+            tap_code16(KC_U);
+            uuml_pressed = false;
+        }
+    }
+
+    switch (keycode) {
+        // From https://github.com/qmk/qmk_firmware/issues/6053
+    case LT_EXTD_ESC:
+        if (record->event.pressed) {
+            extd_layer_was_used = false;
+            extd_layer_timer = timer_read();
+            layer_on(L_EXTD);
+        } else {
+            layer_off(L_EXTD);
+            unregister_mods(MOD_BIT(KC_LALT));   // undo what ALT_TAB might've set
+            // NOTE: need to track whether we made use of the extd layer and
+            // that all happened within the tapping term. Otherwise we'd emit
+            // that layer key code _plus_ an extra Esc.
+            if (timer_elapsed(extd_layer_timer) < TAPPING_TERM && !extd_layer_was_used) {
+                tap_code(KC_ESC);
+            }
+        }
+        return true;
+    case LT_NUM_BSPC:
+        if (record->event.pressed){
+            num_layer_was_used = false;
+            extd_layer_timer = timer_read();
+            layer_on(L_NUM);
+        } else {
+            layer_off(L_NUM);
+            // NOTE: Custom LT method so that any press of a key on that layer will prevent the backspace.
+            if (timer_elapsed(extd_layer_timer) < TAPPING_TERM && !num_layer_was_used) {
+                tap_code(KC_BSPC);
+            }
+        }
+        return true;
+    case LT_MOUSE_ALT_SHIFT_INS:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            layer_on(L_MOUSE);
+        } else {
+            layer_off(L_MOUSE);
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                tap_code16(LALT(LSFT(KC_INS)));
+            }
+        }
+        return true;
+    case LT_FUNC_SHIFT_INS:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            layer_on(L_FUNC);
+        } else {
+            layer_off(L_FUNC);
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                tap_code16(LSFT(KC_INS));
+            }
+        }
+        return true;
+#if 1
+        /* Looks like PERMISSIVE_HOLD on LT and OSM doesn't work properly. This
+         * is probaby https://github.com/qmk/qmk_firmware/issues/8971
+         */
+    case OSM_GUI:
+        /* OSM(MOD_LGUI) is delaying the event, but I need immediate triggering
+         * of the modifier to move windows around with the mouse. If only
+         * tapped, however, have it be a win OSM */
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            register_mods(MOD_BIT(KC_LGUI));
+        } else {
+            unregister_mods(MOD_BIT(KC_LGUI));
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                add_oneshot_mods(MOD_BIT(KC_LGUI));
+            } else {
+                del_oneshot_mods(MOD_BIT(KC_LGUI));
+            }
+        }
+        return true;
+        // Why do I have to roll my own? It seems the original ones work on
+        // keyrelease, at which time I might have let go of the layer tap
+        // already, so I cannot roll them fast...
+    case OSM_SFT:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            register_mods(MOD_BIT(KC_LSFT));
+        } else {
+            unregister_mods(MOD_BIT(KC_LSFT));
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                add_oneshot_mods(MOD_BIT(KC_LSFT));
+            } /*else {
+                del_oneshot_mods(MOD_BIT(KC_LSFT));
+            }*/
+        }
+        return true;
+    case OSM_CTL:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            register_mods(MOD_BIT(KC_LCTL));
+        } else {
+            unregister_mods(MOD_BIT(KC_LCTL));
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                add_oneshot_mods(MOD_BIT(KC_LCTL));
+            } /*else {
+                del_oneshot_mods(MOD_BIT(KC_LCTL));
+            }*/
+        }
+        return true;
+    case OSM_ALT:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            register_mods(MOD_BIT(KC_LALT));
+        } else {
+            unregister_mods(MOD_BIT(KC_LALT));
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                add_oneshot_mods(MOD_BIT(KC_LALT));
+            } /*else {
+                del_oneshot_mods(MOD_BIT(KC_LALT));
+            }*/
+        }
+        return true;
+#else
+#define OSM_ALT OSM(MOD_LALT)
+#define OSM_CTL OSM(MOD_LCTL)
+#define OSM_GUI OSM(MOD_LGUI)
+#define OSM_SFT OSM(MOD_LSFT)
+#endif
+    // Obsoleted by using combos for umlauts now.
+    case KC_A_AE:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            auml_pressed = true;
+        } else {
+            maybe_send_umlaut(KC_A, &auml_pressed);
+        }
+        break;
+    case KC_O_OE:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            ouml_pressed = true;
+        } else {
+            maybe_send_umlaut(KC_O, &ouml_pressed);
+        }
+        break;
+    case KC_U_UE:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            uuml_pressed = true;
+        } else {
+            maybe_send_umlaut(KC_U, &uuml_pressed);
+        }
+        break;
+    case MINS_UNDSCR:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+        } else {
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                // Can't send KC_KP_MINUS, it doesn't compose to, say →
+                tap_code16(KC_MINUS);
+            } else {
+                tap_code16(KC_UNDERSCORE);
+            }
+        }
+        break;
+    case ALT_TAB:
+        if (record->event.pressed) {
+            register_mods(MOD_BIT(KC_LALT));
+            tap_code16(KC_TAB);
+        }
+        break;
+    case INS_HARD:
+        // Do Alt-Shift-Ins first to have xdotool copy from SELECTION to CLIPBOARD, then Shift-Ins to paste.
+        if (record->event.pressed) {
+            tap_code16(LSFT(LALT(KC_INS)));
+        } else {
+            tap_code16(LSFT(KC_INS));
+        }
+        break;
+    case SHIFT_INS:
+        if (record->event.pressed) {
+            // when keycode is pressed
+            key_timer = timer_read();
+            // Shift when held ...
+            register_mods(MOD_BIT(KC_RSFT));
+        } else {
+            // If released within the timer, then Shift+Ins
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                tap_code16(KC_INS);
+            }
+            unregister_mods(MOD_BIT(KC_RSFT));
+        }
+        break;
+    case ALT_SHIFT_INS:
+        if (record->event.pressed) {
+            key_timer = timer_read();
+            // Shift when held ...
+            register_mods(MOD_BIT(KC_LSFT));
+        } else {
+            // If released within the timer, then Shift+Alt+Ins
+            if (timer_elapsed(key_timer) < TAPPING_TERM) {
+                register_mods(MOD_BIT(KC_LALT));
+                tap_code16(KC_INS);
+            }
+            // Note: this makes xev(1) see KeyPress for Meta_L but KeyRelease for Alt_L
+            unregister_mods(MOD_BIT(KC_LSFT) | MOD_BIT(KC_LALT));
+        }
+        break;
+/*
+ * Obsoleted by making tmux understand Ctrl-(Shift)-Tab natively.
+    case TM_NEXT:
+        if (record->event.pressed) SEND_STRING(SS_LCTRL("a") "n");
+        break;
+    case TM_PREV:
+        if (record->event.pressed) SEND_STRING(SS_LCTRL("a") "p");
+        break;
+*/
+        // TODO: use key overrides to turn, e.g. Win+Ctrl-Tab into VIM_NEXT.
+        // Not sure why Ctrl-Pgup works in vim, but not in vim-inside-tmux.
+    case VIM_NEXT:
+        if (record->event.pressed) SEND_STRING(SS_TAP(X_ESC) SS_TAP(X_G) SS_TAP(X_T));
+        break;
+    case VIM_PREV:
+        if (record->event.pressed) SEND_STRING(SS_TAP(X_ESC) SS_TAP(X_G) SS_LSFT("t"));
+        break;
+    case WIN_LEFT:
+        if (record->event.pressed) SEND_STRING(SS_LCTRL("w") SS_TAP(X_H));
+        break;
+    case WIN_DN:
+        if (record->event.pressed) SEND_STRING(SS_LCTRL("w") SS_TAP(X_J));
+        break;
+    case WIN_UP:
+        if (record->event.pressed) SEND_STRING(SS_LCTRL("w") SS_TAP(X_K));
+        break;
+    case WIN_RGHT:
+        if (record->event.pressed) SEND_STRING(SS_LCTRL("w") SS_TAP(X_L));
+        break;
+    }
+
+    return true;
+}
+
+#ifdef LEADER_ENABLE
+LEADER_EXTERNS();
+
+void matrix_scan_user(void) {
+  LEADER_DICTIONARY() {
+    leading = false;
+    leader_end();
+
+#ifdef UCIS_ENABLE
+    SEQ_ONE_KEY(KC_U) {
+      qk_ucis_start();
+    }
+#endif
+    SEQ_ONE_KEY(KC_H) {
+      send_unicode_string("ᕕ( ᐛ )ᕗ");  // happy
+    }
+    SEQ_ONE_KEY(KC_D) {
+      send_unicode_string("ಠ_ಠ");  // disapproval
+    }
+    SEQ_ONE_KEY(KC_L) {
+      send_unicode_string("( ͡° ͜ʖ ͡°)");  // lenny
+    }
+    SEQ_ONE_KEY(KC_S) {
+      send_unicode_string("¯\\_(ツ)_/¯");  // shrug
+    }
+    // tableflip (LEADER - TF)
+    SEQ_TWO_KEYS(KC_T, KC_F) {
+      //set_unicode_input_mode(UC_LNX);
+      //send_unicode_hex_string("0028 30CE 0CA0 75CA 0CA0 0029 30CE 5F61 253B 2501 253B");
+      send_unicode_string("(╯°□°）╯︵ ┻━┻");
+    }
+    // untableflip
+    SEQ_THREE_KEYS(KC_U, KC_T, KC_F) {
+      //set_unicode_input_mode(UC_LNX);
+      //send_unicode_hex_string("0028 30CE 0CA0 75CA 0CA0 0029 30CE 5F61 253B 2501 253B");
+      send_unicode_string("┬─┬ノ( º _ ºノ)");
+    }
+  }
+}
+#endif
+
+#ifdef UCIS_ENABLE
+// 3 codepoints at most, otherwise increase UCIS_MAX_CODE_POINTS
+const qk_ucis_symbol_t ucis_symbol_table[] = UCIS_TABLE(
+    UCIS_SYM("poop", 0x1F4A9),                // 💩
+    UCIS_SYM("rofl", 0x1F923),                // 🤣
+    UCIS_SYM("look", 0x0CA0, 0x005F, 0x0CA0)  // ಠ_ಠ
+);
+#endif

--- a/users/uqs/uqs.h
+++ b/users/uqs/uqs.h
@@ -1,0 +1,77 @@
+// Copyright 2022 Ulrich Spörlein (@uqs)
+// SPDX-License-Identifier: GPL-2.0-or-later
+// vi:et sw=4:
+#pragma once
+
+#include QMK_KEYBOARD_H
+
+enum layers {
+    L_QWER = 0,
+    L_WASD,  // wasd gaming
+    L_COLM,  // Colemak DHm
+    L_EXTD,
+    L_NUM,
+    L_FUNC,
+    L_MOUSE,
+    L_LAST, // unused
+};
+
+#ifdef VIA_ENABLE
+_Static_assert(DYNAMIC_KEYMAP_LAYER_COUNT >= L_LAST, "VIA enabled, but not enough DYNAMIC_KEYMAP_LAYER_COUNT for all layers");
+#endif
+
+#define KC_CTAB LCTL(KC_TAB)
+#define KC_SCTAB LCTL(LSFT(KC_TAB))
+
+// Custom single-key codes, see uqs.c for the combos.
+enum custom_keycodes {
+    SHIFT_INS = SAFE_RANGE,
+    ALT_SHIFT_INS,
+    INS_HARD,
+    KC_A_AE,
+    KC_O_OE,
+    KC_U_UE,
+    MINS_UNDSCR,  // obsoleted by combos, remove this!
+    TM_NEXT,
+    TM_PREV,
+    VIM_NEXT,
+    VIM_PREV,
+    WIN_LEFT,
+    WIN_RGHT,
+    WIN_UP,
+    WIN_DN,
+    LT_EXTD_ESC,
+    LT_NUM_BSPC,
+    LT_MOUSE_ALT_SHIFT_INS,
+    LT_FUNC_SHIFT_INS,
+    OSM_GUI,
+    OSM_SFT,
+    OSM_CTL,
+    OSM_ALT,
+    ALT_TAB,
+};
+
+#ifndef LEADER_ENABLE
+#define KC_LEAD KC_NO
+#endif
+
+// Shorter names
+#define MS_WHDN KC_MS_WH_DOWN
+#define MS_WHUP KC_MS_WH_UP
+#define MS_WHLEFT KC_MS_WH_LEFT
+#define MS_WHRGHT KC_MS_WH_RIGHT
+
+// GASC/◆⎇⇧⎈ home row mod, read all about it here:
+// https://precondition.github.io/home-row-mods
+// Left-hand home row mods
+#define KC_G_A LGUI_T(KC_A)
+#define KC_A_R LALT_T(KC_R)
+#define KC_S_S LSFT_T(KC_S)
+#define KC_C_T LCTL_T(KC_T)
+
+// Right-hand home row mods
+#define KC_C_N RCTL_T(KC_N)
+#define KC_S_E RSFT_T(KC_E)
+#define KC_A_I LALT_T(KC_I)  // RALT is special, it's AltGr and my compose key under Win (layout UScmpse) and *nix (setxkbmap -option compose:ralt)
+#define KC_G_O RGUI_T(KC_O)
+


### PR DESCRIPTION
This contains a log of my 1 year journey to switch to ColemakDH. Some
other features are:
- nice Alt+Tab using the layer hold as Alt hold
- OSM that work (for me)
- ugly but significantly less verbose way to set combos
- some _Static_asserts to stop me from being silly

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
