### PR TITLE
[Core] Allow usage of AVRs minimal printf library

### DIFF
--- a/docs/squeezing_avr.md
+++ b/docs/squeezing_avr.md
@@ -30,6 +30,19 @@ MAGIC_ENABLE = no
 These features are enabled by default, but may not be needed. Double check to make sure, though. 
 Largest in size is "magic" -- the QMK magic keycodes -- which control things like NKRO toggling, GUI and ALT/CTRL swapping, etc. Disabling it will disable those functions.
 
+If you use `sprintf` or `snprintf` functions you can save around ~400 Bytes by enabling this option.
+```make
+AVR_USE_MINIMAL_PRINTF = yes
+```
+
+This will include smaller implementations from AVRs libc into your Firmware. They are [not fully featured](https://www.nongnu.org/avr-libc/user-manual/group__avr__stdio.html#gaa3b98c0d17b35642c0f3e4649092b9f1), for instance zero padding and field width specifiers are not supported. So if you use `sprintf` or `snprintf` like this:
+```c
+sprintf(wpm_str, "%03d", get_current_wpm());
+snprintf(keylog_str, sizeof(keylog_str), "%dx%d, k%2d : %c");
+```
+
+you will still need the standard implementation.
+
 ## `config.h` Settings
 
 If you've done all of that, and you don't want to disable features like RGB, Audio, OLEDs, etc, there are some additional options that you can add to your config.h that can help.

--- a/platforms/avr/platform.mk
+++ b/platforms/avr/platform.mk
@@ -30,6 +30,15 @@ CXXFLAGS += -fno-exceptions -std=c++11
 
 LDFLAGS +=-Wl,--gc-sections
 
+# Use AVR's libc minimal printf implementation which has less features
+# and thus can shave ~400 bytes. Usually we use the xprintf
+# implementation but keyboards that use s(n)printf automatically
+# pull in the AVR libc implementation, which is ~900 bytes heavy.
+AVR_USE_MINIMAL_PRINTF ?= no
+ifeq ($(strip $(AVR_USE_MINIMAL_PRINTF)), yes)
+	LDFLAGS += -Wl,--whole-archive -lprintf_min -Wl,--no-whole-archive
+endif
+
 OPT_DEFS += -DF_CPU=$(F_CPU)UL
 
 MCUFLAGS = -mmcu=$(MCU)


### PR DESCRIPTION
## Description

Introduce new AVR specific make variable `AVR_USE_MINIMAL_PRINTF`  which includes AVR's libc minimal printf implementation. It [has less features](https://www.nongnu.org/avr-libc/user-manual/group__avr__stdio.html#gaa3b98c0d17b35642c0f3e4649092b9f1) and thus can shave ~400 bytes. 

Usually we use the xprintf implementation but keyboards that use `s(n)printf` automatically pull in the normal AVR libc implementation, which is ~900 bytes heavy.

**Size impact: -390 Bytes**

```
./util/size_regression.sh -d feature/avr_minimal_printf crkbd/rev1:default
Size:    26564, delta:   -390 -- 03900d6e53 Enable for crkbd (not actually in PR)
Size:    26954, delta:     +0 -- 3eb1f765a1 [Core] Allow usage of AVR minimal printf library
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
