### PR TITLE
Misc size regression script improvements.

### DIFF
--- a/util/size_regression.sh
+++ b/util/size_regression.sh
@@ -67,7 +67,6 @@ function build_executor() {
 
         make distclean >/dev/null 2>&1
 
-        git clean -xfd >/dev/null 2>&1 || true
         git checkout -f $revision >/dev/null 2>&1 || { echo "Failed to check out revision ${revision}" >&2 ; exit 1 ; }
         make -j${job_count} $keyboard_target >/dev/null 2>&1 || true
         file_size=$(arm-none-eabi-size .build/*.elf 2>/dev/null | awk '/elf/ {print $1}' 2>/dev/null || true)

--- a/util/size_regression.sh
+++ b/util/size_regression.sh
@@ -11,6 +11,8 @@ dest_ref="develop"
 ignore_ref="master"
 unset skip_zero
 
+export SIZE_REGRESSION_EXECUTING=1
+
 function usage() {
     echo "Usage: $(basename "$0") [-h] [-j <jobs>] [-s <source>] [-d <dest>] [-n] planck/rev6:default"
     echo "    -h           : Shows this usage page."
@@ -23,8 +25,23 @@ function usage() {
 }
 
 if [[ ${#} -eq 0 ]]; then
-   usage
+    usage
+    exit 0
 fi
+
+unset cleanup_completed
+_internal_cleanup() {
+    if [[ -z "${cleanup_completed:-}" ]] ; then
+        echo
+        echo
+        echo 'Your git repository is in an indeterminate state!' >&2
+        echo 'Make sure you swap to your intended branch.' >&2
+        echo
+        unset SIZE_REGRESSION_EXECUTING
+    fi
+    cleanup_completed=1
+}
+trap _internal_cleanup EXIT HUP INT
 
 while getopts "hj:s:d:i:n" opt "$@" ; do
     case "$opt" in
@@ -49,7 +66,9 @@ function build_executor() {
         revision=$(echo $line | cut -d' ' -f1)
 
         make distclean >/dev/null 2>&1
-        git checkout $revision >/dev/null 2>&1 || { echo "Failed to check out revision ${revision}" >&2 ; exit 1 ; }
+
+        git clean -xfd >/dev/null 2>&1 || true
+        git checkout -f $revision >/dev/null 2>&1 || { echo "Failed to check out revision ${revision}" >&2 ; exit 1 ; }
         make -j${job_count} $keyboard_target >/dev/null 2>&1 || true
         file_size=$(arm-none-eabi-size .build/*.elf 2>/dev/null | awk '/elf/ {print $1}' 2>/dev/null || true)
 


### PR DESCRIPTION
## Description

- Sets environment variable SIZE_REGRESSION_EXECUTING during execution
  so hook scripts like `post-checkout` may skip processing.
- Forces checkout of the target branch, including removal of all
  temporary object files in the process.
- Prints out a warning on exit stating that the git repository is in an
  indeterminate state, and the user needs to swap back to whatever
  intended branch they were working with originally.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
