### PR TITLE
Remove parent-relative paths from keyboards.

### DIFF
--- a/keyboards/capsunlocked/cu75/rules.mk
+++ b/keyboards/capsunlocked/cu75/rules.mk
@@ -9,4 +9,6 @@ BOOTLOADER = atmel-dfu
 #
 BACKLIGHT_DRIVER = custom
 
-SRC = ../lfkeyboards/TWIlib.c ../lfkeyboards/issi.c ../lfkeyboards/lighting.c
+# TODO: This needs to be refactored -- keyboards should not be referencing files from other manufacturers
+VPATH += keyboards/lfkeyboards
+SRC = TWIlib.c issi.c lighting.c

--- a/keyboards/capsunlocked/cu75/rules.mk
+++ b/keyboards/capsunlocked/cu75/rules.mk
@@ -9,6 +9,6 @@ BOOTLOADER = atmel-dfu
 #
 BACKLIGHT_DRIVER = custom
 
-# TODO: This needs to be refactored -- keyboards should not be referencing files from other manufacturers
+# TODO: These boards need to be converted to RGB Matrix
 VPATH += keyboards/lfkeyboards
 SRC = TWIlib.c issi.c lighting.c

--- a/keyboards/ergodox_ez/keymaps/default_glow/rules.mk
+++ b/keyboards/ergodox_ez/keymaps/default_glow/rules.mk
@@ -1,4 +1,4 @@
 RGBLIGHT_ENABLE = no
 RGB_MATRIX_ENABLE = yes # enable later
 
-SRC += ../default/keymap.c
+SRC += keymaps/default/keymap.c

--- a/keyboards/hhkb/ansi/post_rules.mk
+++ b/keyboards/hhkb/ansi/post_rules.mk
@@ -4,14 +4,14 @@ OPT_DEFS += -DHHKB_RN42_ENABLE
 
 # Support for the RN42 Bluetooth module. This is the BT module in Hasu's BT
 # HHKB Alt controller.
-RN42_DIR = ../rn42
+RN42_DIR = keyboards/hhkb/rn42
 
 SRC +=  serial_uart.c \
-	../rn42/suart.S \
-	../rn42/rn42.c \
-	../rn42/rn42_task.c \
-	../rn42/battery.c \
-	../rn42/main.c
+	suart.S \
+	rn42.c \
+	rn42_task.c \
+	battery.c \
+	main.c
 
 VPATH += $(RN42_DIR)
 

--- a/keyboards/hhkb/jp/post_rules.mk
+++ b/keyboards/hhkb/jp/post_rules.mk
@@ -4,14 +4,14 @@ OPT_DEFS += -DHHKB_RN42_ENABLE
 
 # Support for the RN42 Bluetooth module. This is the BT module in Hasu's BT
 # HHKB Alt controller.
-RN42_DIR = ../rn42
+RN42_DIR = keyboards/hhkb/rn42
 
 SRC +=  serial_uart.c \
-	../rn42/suart.S \
-	../rn42/rn42.c \
-	../rn42/rn42_task.c \
-	../rn42/battery.c \
-	../rn42/main.c
+	suart.S \
+	rn42.c \
+	rn42_task.c \
+	battery.c \
+	main.c
 
 VPATH += $(RN42_DIR)
 

--- a/keyboards/rgbkb/mun/rules.mk
+++ b/keyboards/rgbkb/mun/rules.mk
@@ -5,8 +5,9 @@ MCU = STM32F303
 BOOTLOADER = stm32-dfu
 
 # Touch encoder needs
-SRC += ../common/touch_encoder.c
-SRC += ../common/common_oled.c
+VPATH += keyboards/rgbkb/common
+SRC += touch_encoder.c
+SRC += common_oled.c
 QUANTUM_LIB_SRC += i2c_master.c
 
 # Build Options
@@ -35,8 +36,7 @@ SERIAL_DRIVER = usart
 LTO_ENABLE = yes
 OPT = 3
 
-OPT_DEFS += -DOLED_FONT_H=\"../common/glcdfont.c\"
-OPT_DEFS += -Ikeyboards/rgbkb/common
+OPT_DEFS += -DOLED_FONT_H=\"keyboards/rgbkb/common/glcdfont.c\"
 
 # matrix optimisations
 SRC += matrix.c

--- a/keyboards/rgbkb/sol3/rules.mk
+++ b/keyboards/rgbkb/sol3/rules.mk
@@ -5,8 +5,9 @@ MCU = STM32F303
 BOOTLOADER = stm32-dfu
 
 # Touch encoder needs
-SRC += ../common/touch_encoder.c
-SRC += ../common/common_oled.c
+VPATH += keyboards/rgbkb/common
+SRC += touch_encoder.c
+SRC += common_oled.c
 QUANTUM_LIB_SRC += i2c_master.c
 
 # Build Options
@@ -39,8 +40,7 @@ SERIAL_DRIVER = usart
 LTO_ENABLE = yes
 OPT = 3
 
-OPT_DEFS += -DOLED_FONT_H=\"../common/glcdfont.c\"
-OPT_DEFS += -Ikeyboards/rgbkb/common
+OPT_DEFS += -DOLED_FONT_H=\"keyboards/rgbkb/common/glcdfont.c\"
 
 # TODO: Implement fast matrix scanning
 # matrix optimisations


### PR DESCRIPTION
## Description

Cleanup, relative paths were being defined in a few keyboards, messing with the relative locations in `.build/` during build. 

In one case, CI was showing issues with intermediate files being removed due to multiple boards from the same manufacturer resulting in the same output file.

For example, rgbkb/sol3 and rgbkb/mun were both targeting:
```
.build/obj_rgbkb_sol3_rev1/../common/touch_encoder.o   =>   .build/common/touch_encoder.o
.build/obj_rgbkb_mun_rev1/../common/touch_encoder.o    =>   .build/common/touch_encoder.o
```

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
