### PR TITLE
maxr1998/pulse4k: Move Combo code to keymap level

### DIFF
--- a/keyboards/maxr1998/pulse4k/keymaps/default/keymap.c
+++ b/keyboards/maxr1998/pulse4k/keymaps/default/keymap.c
@@ -27,18 +27,24 @@ enum combo_events {
 
 const uint16_t PROGMEM led_adjust_combo[] = {KC_LEFT, KC_RGHT, COMBO_END};
 
-combo_t key_combos[COMBO_COUNT] = {
-    [LED_ADJUST] = COMBO_ACTION(led_adjust_combo)
-};
-
-bool led_adjust_active = false;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [DEFAULT] = LAYOUT(
         KC_END,  KC_UP,   KC_MUTE,
         KC_LEFT, KC_DOWN, KC_RGHT
     )
 };
+
+combo_t key_combos[COMBO_COUNT] = {
+    [LED_ADJUST] = COMBO_ACTION(led_adjust_combo)
+};
+
+bool led_adjust_active = false;
+
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    if (combo_index == LED_ADJUST) {
+        led_adjust_active = pressed;
+    }
+}
 
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) {
@@ -62,10 +68,4 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     }
 
     return true;
-}
-
-void process_combo_event(uint16_t combo_index, bool pressed) {
-    if (combo_index == LED_ADJUST) {
-        led_adjust_active = pressed;
-    }
 }

--- a/keyboards/maxr1998/pulse4k/keymaps/default/keymap.c
+++ b/keyboards/maxr1998/pulse4k/keymaps/default/keymap.c
@@ -21,7 +21,17 @@ enum layers {
     DEFAULT
 };
 
+enum combo_events {
+    LED_ADJUST
+};
+
 const uint16_t PROGMEM led_adjust_combo[] = {KC_LEFT, KC_RGHT, COMBO_END};
+
+combo_t key_combos[COMBO_COUNT] = {
+    [LED_ADJUST] = COMBO_ACTION(led_adjust_combo)
+};
+
+bool led_adjust_active = false;
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [DEFAULT] = LAYOUT(
@@ -29,3 +39,33 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_LEFT, KC_DOWN, KC_RGHT
     )
 };
+
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    if (index == 0) {
+        if (led_adjust_active) {
+            if (clockwise) {
+                rgblight_increase_val();
+            } else {
+                rgblight_decrease_val();
+            }
+            return false;
+        }
+    } else if (index == 1) {
+        if (led_adjust_active) {
+            if (clockwise) {
+                rgblight_increase_hue();
+            } else {
+                rgblight_decrease_hue();
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    if (combo_index == LED_ADJUST) {
+        led_adjust_active = pressed;
+    }
+}

--- a/keyboards/maxr1998/pulse4k/keymaps/default/rules.mk
+++ b/keyboards/maxr1998/pulse4k/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+COMBO_ENABLE = yes

--- a/keyboards/maxr1998/pulse4k/keymaps/maxr1998/keymap.c
+++ b/keyboards/maxr1998/pulse4k/keymaps/maxr1998/keymap.c
@@ -27,18 +27,24 @@ enum combo_events {
 
 const uint16_t PROGMEM led_adjust_combo[] = {KC_F22, KC_F24, COMBO_END};
 
-combo_t key_combos[COMBO_COUNT] = {
-    [LED_ADJUST] = COMBO_ACTION(led_adjust_combo)
-};
-
-bool led_adjust_active = false;
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [DEFAULT] = LAYOUT(
         KC_F20,  KC_F21,  KC_MUTE,
         KC_F22,  KC_F23,  KC_F24
     )
 };
+
+combo_t key_combos[COMBO_COUNT] = {
+    [LED_ADJUST] = COMBO_ACTION(led_adjust_combo)
+};
+
+bool led_adjust_active = false;
+
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    if (combo_index == LED_ADJUST) {
+        led_adjust_active = pressed;
+    }
+}
 
 bool encoder_update_user(uint8_t index, bool clockwise) {
     if (index == 0) {
@@ -62,12 +68,6 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     }
 
     return true;
-}
-
-void process_combo_event(uint16_t combo_index, bool pressed) {
-    if (combo_index == LED_ADJUST) {
-        led_adjust_active = pressed;
-    }
 }
 
 void encoder_one_update(bool clockwise) {

--- a/keyboards/maxr1998/pulse4k/keymaps/maxr1998/keymap.c
+++ b/keyboards/maxr1998/pulse4k/keymaps/maxr1998/keymap.c
@@ -21,7 +21,17 @@ enum layers {
     DEFAULT
 };
 
+enum combo_events {
+    LED_ADJUST
+};
+
 const uint16_t PROGMEM led_adjust_combo[] = {KC_F22, KC_F24, COMBO_END};
+
+combo_t key_combos[COMBO_COUNT] = {
+    [LED_ADJUST] = COMBO_ACTION(led_adjust_combo)
+};
+
+bool led_adjust_active = false;
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [DEFAULT] = LAYOUT(
@@ -29,6 +39,36 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_F22,  KC_F23,  KC_F24
     )
 };
+
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    if (index == 0) {
+        if (led_adjust_active) {
+            if (clockwise) {
+                rgblight_increase_val();
+            } else {
+                rgblight_decrease_val();
+            }
+            return false;
+        }
+    } else if (index == 1) {
+        if (led_adjust_active) {
+            if (clockwise) {
+                rgblight_increase_hue();
+            } else {
+                rgblight_decrease_hue();
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    if (combo_index == LED_ADJUST) {
+        led_adjust_active = pressed;
+    }
+}
 
 void encoder_one_update(bool clockwise) {
     tap_code(!clockwise ? KC_F18 : KC_F19);

--- a/keyboards/maxr1998/pulse4k/keymaps/maxr1998/rules.mk
+++ b/keyboards/maxr1998/pulse4k/keymaps/maxr1998/rules.mk
@@ -1,0 +1,1 @@
+COMBO_ENABLE = yes

--- a/keyboards/maxr1998/pulse4k/pulse4k.c
+++ b/keyboards/maxr1998/pulse4k/pulse4k.c
@@ -16,44 +16,14 @@
  */
 
 #include "pulse4k.h"
-#include "rgblight.h"
-
-enum combo_events {
-    LED_ADJUST
-};
-
-extern const uint16_t PROGMEM led_adjust_combo[3];
-
-combo_t key_combos[COMBO_COUNT] = {
-    [LED_ADJUST] = COMBO_ACTION(led_adjust_combo)
-};
-
-bool led_adjust_active = false;
-
-void process_combo_event(uint16_t combo_index, bool pressed) {
-    if (combo_index == LED_ADJUST) {
-        led_adjust_active = pressed;
-    }
-}
 
 bool encoder_update_kb(uint8_t index, bool clockwise) {
     if (!encoder_update_user(index, clockwise)) return false;
+
     if (index == 0) {
-        if (led_adjust_active) {
-            if (clockwise) {
-                rgblight_increase_val();
-            } else {
-                rgblight_decrease_val();
-            }
-        } else encoder_one_update(clockwise);
+        encoder_one_update(clockwise);
     } else if (index == 1) {
-        if (led_adjust_active) {
-            if (clockwise) {
-                rgblight_increase_hue();
-            } else {
-                rgblight_decrease_hue();
-            }
-        } else encoder_two_update(clockwise);
+        encoder_two_update(clockwise);
     }
     return true;
 }

--- a/keyboards/maxr1998/pulse4k/rules.mk
+++ b/keyboards/maxr1998/pulse4k/rules.mk
@@ -13,7 +13,6 @@ ENCODER_ENABLE = yes       # Rotary encoders
 EXTRAKEY_ENABLE = yes      # Audio control and System control
 CONSOLE_ENABLE = yes       # Console for debug
 COMMAND_ENABLE = no        # Commands for debug and configuration
-COMBO_ENABLE = yes         # Key combo feature
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 AUDIO_ENABLE = no          # Audio output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The Combo feature cannot be enabled at the keyboard level, as it requires code that will not exist when compiling a Configurator JSON or in the Configurator itself, producing a linker error:

```
Linking: .build/maxr1998_pulse4k_maxr1998_pulse4k_layout_mine.elf
                    [ERRORS]
 |
 | c:/msys64/mingw64/bin/../lib/gcc/avr/8.4.0/../../../../avr/bin/ld.exe: .build/obj_maxr1998_pulse4k_maxr1998_pulse4k_layout_mine/keyboards/maxr1998/pulse4k/pulse4k.o:D:\Git\qmk_firmware_develop/keyboards/maxr1998/pulse4k/pulse4k.c:27: undefined reference to `led_adjust_combo'
 | collect2.exe: error: ld returned 1 exit status
 |
make: *** [tmk_core/rules.mk:364: .build/maxr1998_pulse4k_maxr1998_pulse4k_layout_mine.elf] Error 1
```

This moves the Combo code into the keymaps, allowing users to customize it more freely, and preventing the build failure.

CC @Maxr1998

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
