### PR TITLE
Heatmap incorrect matrix effect workaround

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -543,16 +543,17 @@ You can enable a single effect by defining `ENABLE_[EFFECT_NAME]` in your `confi
 
 ### RGB Matrix Effect Typing Heatmap :id=rgb-matrix-effect-typing-heatmap
 
-This effect will color the RGB matrix according to a heatmap of recently pressed
-keys. Whenever a key is pressed its "temperature" increases as well as that of
-its neighboring keys. The temperature of each key is then decreased
-automatically every 25 milliseconds by default.
+This effect will color the RGB matrix according to a heatmap of recently pressed keys. Whenever a key is pressed its "temperature" increases as well as that of its neighboring keys. The temperature of each key is then decreased automatically every 25 milliseconds by default.
 
-In order to change the delay of temperature decrease define
-`RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS`:
+In order to change the delay of temperature decrease define `RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS`:
 
 ```c
 #define RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS 50
+```
+
+Heatmap effect may not light up the correct adjacent LEDs for certain key matrix layout such as split keyboards. The following define will limit the effect to just pressed keys:
+```c
+#define RGB_MATRIX_TYPING_HEATMAP_SLIM
 ```
 
 ## Custom RGB Matrix Effects :id=custom-rgb-matrix-effects

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -551,7 +551,7 @@ In order to change the delay of temperature decrease define `RGB_MATRIX_TYPING_H
 #define RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS 50
 ```
 
-Heatmap effect may not light up the correct adjacent LEDs for certain key matrix layout such as split keyboards. The following define will limit the effect to just pressed keys:
+Heatmap effect may not light up the correct adjacent LEDs for certain key matrix layout such as split keyboards. The following define will limit the effect to pressed keys only:
 ```c
 #define RGB_MATRIX_TYPING_HEATMAP_SLIM
 ```

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -7,6 +7,10 @@ RGB_MATRIX_EFFECT(TYPING_HEATMAP)
 #        endif
 
 void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
+#ifdef RGB_MATRIX_TYPING_HEATMAP_SLIM
+    // Limit effect to pressed keys
+    g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
+#else
     uint8_t m_row = row - 1;
     uint8_t p_row = row + 1;
     uint8_t m_col = col - 1;
@@ -27,6 +31,7 @@ void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
         g_rgb_frame_buffer[m_row][col] = qadd8(g_rgb_frame_buffer[m_row][col], 16);
         if (p_col < MATRIX_COLS) g_rgb_frame_buffer[m_row][p_col] = qadd8(g_rgb_frame_buffer[m_row][p_col], 13);
     }
+#endif
 }
 
 // A timer to track the last time we decremented all heatmap values.

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -7,10 +7,10 @@ RGB_MATRIX_EFFECT(TYPING_HEATMAP)
 #        endif
 
 void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
-#ifdef RGB_MATRIX_TYPING_HEATMAP_SLIM
+#        ifdef RGB_MATRIX_TYPING_HEATMAP_SLIM
     // Limit effect to pressed keys
     g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
-#else
+#        else
     uint8_t m_row = row - 1;
     uint8_t p_row = row + 1;
     uint8_t m_col = col - 1;
@@ -31,7 +31,7 @@ void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
         g_rgb_frame_buffer[m_row][col] = qadd8(g_rgb_frame_buffer[m_row][col], 16);
         if (p_col < MATRIX_COLS) g_rgb_frame_buffer[m_row][p_col] = qadd8(g_rgb_frame_buffer[m_row][p_col], 13);
     }
-#endif
+#        endif
 }
 
 // A timer to track the last time we decremented all heatmap values.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is a simple override to limit heatmap effect to pressed keys. It is a stop gap workaround of incorrect columns and rows lighting for non-rectangle key matrix. (And reformatted both paragraphs in the heatmap section)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
