### PR TITLE
ps2/avr: use the correct file name

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -707,7 +707,7 @@ endif
 ifeq ($(strip $(PS2_USE_BUSYWAIT)), yes)
     PS2_ENABLE := yes
     SRC += ps2_busywait.c
-    SRC += ps2_io_avr.c
+    SRC += ps2_io.c
     OPT_DEFS += -DPS2_USE_BUSYWAIT
 endif
 


### PR DESCRIPTION
This was missed in https://github.com/qmk/qmk_firmware/pull/14895.

Thanks to fauxpark for spotting this.

## Description

Fixes PS2 busywait compilation.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
