### PR TITLE
IC_TEENSY3_1 board config wakes from sleep successfully

### DIFF
--- a/keyboards/handwired/onekey/teensy_32/config.h
+++ b/keyboards/handwired/onekey/teensy_32/config.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-// TODO: including this causes "error: expected identifier before '(' token" errors
 //#include "config_common.h"
 
 #define PRODUCT Onekey Teensy 3.2

--- a/keyboards/handwired/onekey/teensy_32/rules.mk
+++ b/keyboards/handwired/onekey/teensy_32/rules.mk
@@ -1,5 +1,6 @@
 # MCU name
 MCU = MK20DX256
+BOARD = IC_TEENSY_3_1
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/onekey/teensy_32/rules.mk
+++ b/keyboards/handwired/onekey/teensy_32/rules.mk
@@ -1,6 +1,5 @@
 # MCU name
 MCU = MK20DX256
-BOARD = IC_TEENSY_3_1
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/handwired/onekey/teensy_32/teensy_32.c
+++ b/keyboards/handwired/onekey/teensy_32/teensy_32.c
@@ -3,12 +3,3 @@
 void restart_usb_driver(USBDriver *usbp) {
     // Do nothing. Restarting the USB driver on these boards breaks it.
 }
-
-#define WDOG_TMROUTL *(volatile uint16_t *)0x40052012
-
-void early_hardware_init_pre(void) {
-    // This is a dirty hack and should only be used as a temporary fix until this
-    // is upstreamed.
-    while (WDOG_TMROUTL < 2)
-        ;  // Must wait for WDOG timer if already running, before jumping
-}

--- a/keyboards/handwired/onekey/teensy_32/teensy_32.c
+++ b/keyboards/handwired/onekey/teensy_32/teensy_32.c
@@ -1,0 +1,14 @@
+#include QMK_KEYBOARD_H
+
+void restart_usb_driver(USBDriver *usbp) {
+    // Do nothing. Restarting the USB driver on these boards breaks it.
+}
+
+#define WDOG_TMROUTL *(volatile uint16_t *)0x40052012
+
+void early_hardware_init_pre(void) {
+    // This is a dirty hack and should only be used as a temporary fix until this
+    // is upstreamed.
+    while (WDOG_TMROUTL < 2)
+        ;  // Must wait for WDOG timer if already running, before jumping
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
The PJRC_TEENSY_3_1 board configuration will wake the computer when it's asleep, but then the keyboard wlll
lock up until it's unplugged and reconnected. Using the IC_TEENSY_3_1 board config fixes the problem. The computer will wake up, and the keyboard will continue to function.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
