### PR TITLE
PoC: Swap Escape and Caps

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -337,6 +337,9 @@ See also: [Magic Keycodes](keycodes_magic.md)
 |`MAGIC_SWAP_CONTROL_CAPSLOCK`     |`CL_SWAP`|Swap Caps Lock and Left Control                                           |
 |`MAGIC_UNSWAP_CONTROL_CAPSLOCK`   |`CL_NORM`|Unswap Caps Lock and Left Control                                         |
 |`MAGIC_TOGGLE_CONTROL_CAPSLOCK`   |`CL_TOGG`|Toggle Caps Lock and Left Control swap                                    |
+|`MAGIC_SWAP_ESCAPE_CAPSLOCK`      |`EC_SWAP`|Swap Caps Lock and Escape                                                 |
+|`MAGIC_UNSWAP_ESCAPE_CAPSLOCK`    |`EC_NORM`|Unswap Caps Lock and Escape                                               |
+|`MAGIC_TOGGLE_ESCAPE_CAPSLOCK`    |`EC_TOGG`|Toggle Caps Lock and Escape swap                                          |
 |`MAGIC_CAPSLOCK_TO_CONTROL`       |`CL_CTRL`|Treat Caps Lock as Control                                                |
 |`MAGIC_UNCAPSLOCK_TO_CONTROL`     |`CL_CAPS`|Stop treating Caps Lock as Control                                        |
 |`MAGIC_SWAP_LCTL_LGUI`            |`LCG_SWP`|Swap Left Control and GUI                                                 |

--- a/docs/keycodes_magic.md
+++ b/docs/keycodes_magic.md
@@ -7,6 +7,9 @@
 |`MAGIC_SWAP_CONTROL_CAPSLOCK`     |`CL_SWAP`|Swap Caps Lock and Left Control                                           |
 |`MAGIC_UNSWAP_CONTROL_CAPSLOCK`   |`CL_NORM`|Unswap Caps Lock and Left Control                                         |
 |`MAGIC_TOGGLE_CONTROL_CAPSLOCK`   |`CL_TOGG`|Toggle Caps Lock and Left Control swap                                    |
+|`MAGIC_SWAP_ESCAPE_CAPSLOCK`      |`EC_SWAP`|Swap Caps Lock and Escape                                                 |
+|`MAGIC_UNSWAP_ESCAPE_CAPSLOCK`    |`EC_NORM`|Unswap Caps Lock and Escape                                               |
+|`MAGIC_TOGGLE_ESCAPE_CAPSLOCK`    |`EC_TOGG`|Toggle Caps Lock and Escape swap                                          |
 |`MAGIC_CAPSLOCK_TO_CONTROL`       |`CL_CTRL`|Treat Caps Lock as Control                                                |
 |`MAGIC_UNCAPSLOCK_TO_CONTROL`     |`CL_CAPS`|Stop treating Caps Lock as Control                                        |
 |`MAGIC_SWAP_LCTL_LGUI`            |`LCG_SWP`|Swap Left Control and GUI                                                 |

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -282,6 +282,7 @@ static void print_eeconfig(void) {
         ".swap_grave_esc: %u\n"
         ".swap_backslash_backspace: %u\n"
         ".nkro: %u\n"
+        ".swap_escape_capslock: %u\n"
 
         , kc.raw
         , kc.swap_control_capslock
@@ -294,6 +295,7 @@ static void print_eeconfig(void) {
         , kc.swap_grave_esc
         , kc.swap_backslash_backspace
         , kc.nkro
+        , kc.swap_escape_capslock
     ); /* clang-format on */
 
 #    ifdef BACKLIGHT_ENABLE

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -29,6 +29,8 @@ uint16_t keycode_config(uint16_t keycode) {
         case KC_LOCKING_CAPS_LOCK:
             if (keymap_config.swap_control_capslock || keymap_config.capslock_to_control) {
                 return KC_LEFT_CTRL;
+            } else if (keymap_config.swap_escape_capslock) {
+                return KC_ESCAPE;
             }
             return keycode;
         case KC_LEFT_CTRL:
@@ -96,6 +98,8 @@ uint16_t keycode_config(uint16_t keycode) {
         case KC_ESCAPE:
             if (keymap_config.swap_grave_esc) {
                 return KC_GRAVE;
+            } else if (keymap_config.swap_escape_capslock) {
+                return KC_CAPS_LOCK;
             }
             return KC_ESCAPE;
         case KC_BACKSLASH:

--- a/quantum/keycode_config.h
+++ b/quantum/keycode_config.h
@@ -38,6 +38,7 @@ typedef union {
         bool swap_lctl_lgui : 1;
         bool swap_rctl_rgui : 1;
         bool oneshot_enable : 1;
+        bool swap_escape_capslock : 1;
     };
 } keymap_config_t;
 

--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -45,11 +45,15 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
             case MAGIC_SWAP_LCTL_LGUI ... MAGIC_EE_HANDS_RIGHT:
             case MAGIC_TOGGLE_GUI:
             case MAGIC_TOGGLE_CONTROL_CAPSLOCK:
+            case MAGIC_SWAP_ESCAPE_CAPSLOCK ... MAGIC_TOGGLE_ESCAPE_CAPSLOCK:
                 /* keymap config */
                 keymap_config.raw = eeconfig_read_keymap();
                 switch (keycode) {
                     case MAGIC_SWAP_CONTROL_CAPSLOCK:
                         keymap_config.swap_control_capslock = true;
+                        break;
+                    case MAGIC_SWAP_ESCAPE_CAPSLOCK:
+                        keymap_config.swap_escape_capslock = true;
                         break;
                     case MAGIC_CAPSLOCK_TO_CONTROL:
                         keymap_config.capslock_to_control = true;
@@ -93,6 +97,9 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
                         break;
                     case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
                         keymap_config.swap_control_capslock = false;
+                        break;
+                    case MAGIC_UNSWAP_ESCAPE_CAPSLOCK:
+                        keymap_config.swap_escape_capslock = false;
                         break;
                     case MAGIC_UNCAPSLOCK_TO_CONTROL:
                         keymap_config.capslock_to_control = false;
@@ -171,6 +178,9 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
                         break;
                     case MAGIC_TOGGLE_CONTROL_CAPSLOCK:
                         keymap_config.swap_control_capslock = !keymap_config.swap_control_capslock;
+                        break;
+                    case MAGIC_TOGGLE_ESCAPE_CAPSLOCK:
+                        keymap_config.swap_escape_capslock = !keymap_config.swap_escape_capslock;
                         break;
                 }
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -605,6 +605,10 @@ enum quantum_keycodes {
 
     CAPS_WORD,
 
+    MAGIC_SWAP_ESCAPE_CAPSLOCK,
+    MAGIC_UNSWAP_ESCAPE_CAPSLOCK,
+    MAGIC_TOGGLE_ESCAPE_CAPSLOCK,
+
     // Start of custom keycode range for keyboards and keymaps - always leave at the end
     SAFE_RANGE
 };
@@ -755,6 +759,10 @@ enum quantum_keycodes {
 #define CL_CTRL MAGIC_CAPSLOCK_TO_CONTROL
 #define CL_CAPS MAGIC_UNCAPSLOCK_TO_CONTROL
 #define CL_TOGG MAGIC_TOGGLE_CONTROL_CAPSLOCK
+
+#define EC_SWAP MAGIC_SWAP_ESCAPE_CAPSLOCK
+#define EC_NORM MAGIC_UNSWAP_ESCAPE_CAPSLOCK
+#define EC_TOGG MAGIC_TOGGLE_ESCAPE_CAPSLOCK
 
 #define LCG_SWP MAGIC_SWAP_LCTL_LGUI
 #define LCG_NRM MAGIC_UNSWAP_LCTL_LGUI


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add "Swap Escape and CapsLock" and "Unswap ..." capability dynamically via magic key.

## Description
This is just a proof-of-concept patch to swap Escape and Caps
* Adding flag in between existing bit field causes bug (BS \ swap)
* Adding quantum code in more proper comment requires to update comment.

It worked on my QMK keyboard (handwired 4x14 ortholinear compact.) When a host PC with GNOME tweak sets to swap Escape and Caps, I had to do this to obtain in sane key location on my QMK keyboard while keeping that note PC usable with vim.

If you like this idea, I will add needed things for general consumption.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [X] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* NEW FEATURE added to swap Escape and Caps.  (Different machine, different OS config, so it will be nice it is dynamically changed.
* GPL2+ /GPL3+
* Documentation is not updated yet
* Aesthetically ugly location for qantum keycodes ... funny thin happend as I tried to insert...  so this is least invasive patch as was the recent commit by others : 
    * 2726856cde ("Implement MAGIC_TOGGLE_CONTROL_CAPSLOCK (#15368)", 2021-12-01)

This patch is tested on my branch containing my handwired keyboard.
* https://github.com/osamuaoki/qmk_firmware (osamu1 stable branch)
* https://github.com/osamuaoki/qmk_firmware/tree/osamu2 (osamu2 branch rebased to develop)
Both are working fine with AT90USB1286 based project (Rev 02)
* https://github.com/osamuaoki/cg56  (More on case design memo.)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Osamu Aoki <osamu@debian.org>