### PR TITLE
[PoC] Matrix: Support optical switches

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -46,6 +46,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define SPLIT_MUTABLE_COL const
 #endif
 
+#if defined(OPTICAL_MATRIX)
+#    ifndef PRESSED_KEY_PIN_STATE
+#        define PRESSED_KEY_PIN_STATE 1
+#    endif
+#else
+#    ifndef PRESSED_KEY_PIN_STATE
+#        define PRESSED_KEY_PIN_STATE 0
+#    endif
+#endif
+
 #ifdef DIRECT_PINS
 static SPLIT_MUTABLE pin_t direct_pins[ROWS_PER_HAND][MATRIX_COLS] = DIRECT_PINS;
 #elif (DIODE_DIRECTION == ROW2COL) || (DIODE_DIRECTION == COL2ROW)
@@ -122,7 +132,7 @@ __attribute__((weak)) void matrix_read_cols_on_row(matrix_row_t current_matrix[]
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++, row_shifter <<= 1) {
         pin_t pin = direct_pins[current_row][col_index];
         if (pin != NO_PIN) {
-            current_row_value |= readPin(pin) ? 0 : row_shifter;
+            current_row_value |= readPin(pin) ? PRESSED_KEY_PIN_STATE : row_shifter;
         }
     }
 
@@ -184,12 +194,12 @@ __attribute__((weak)) void matrix_read_cols_on_row(matrix_row_t current_matrix[]
         uint8_t pin_state = readMatrixPin(col_pins[col_index]);
 
         // Populate the matrix row with the state of the col pin
-        current_row_value |= pin_state ? 0 : row_shifter;
+        current_row_value |= pin_state ? PRESSED_KEY_PIN_STATE : row_shifter;
     }
 
     // Unselect row
     unselect_row(current_row);
-    matrix_output_unselect_delay(current_row, current_row_value != 0); // wait for all Col signals to go HIGH
+    matrix_output_unselect_delay(current_row, current_row_value != PRESSED_KEY_PIN_STATE); // wait for all Col signals to go HIGH
 
     // Update the matrix
     current_matrix[current_row] = current_row_value;
@@ -244,7 +254,7 @@ __attribute__((weak)) void matrix_read_rows_on_col(matrix_row_t current_matrix[]
     // For each row...
     for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {
         // Check row pin state
-        if (readMatrixPin(row_pins[row_index]) == 0) {
+        if (readMatrixPin(row_pins[row_index]) == PRESSED_KEY_PIN_STATE) {
             // Pin LO, set col bit
             current_matrix[row_index] |= row_shifter;
             key_pressed = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Optical switches have inverted logic. If a keyboard is equipped with those, defining `OPTICAL_MATRIX` will enable output.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
