### PR TITLE
Add split keyboard example for Bootmagic Lite

### DIFF
--- a/docs/feature_bootmagic.md
+++ b/docs/feature_bootmagic.md
@@ -44,7 +44,7 @@ When [handedness](feature_split_keyboard.md#setting-handedness) is predetermined
     }
 ```
 
-If you choose the top right key on the right side, it is `R05` on the top layout. Within the key matrix below, `R05` is on row 4, columnn 4. To set that key as Bootmagic Lite trigger for the right halve, add these entries to your `config.h` file:
+If you pick the top right key for the right halve, it is `R05` on the top layout. Within the key matrix below, `R05` is located on row 4 columnn 4. To use that key as the right halve's Bootmagic Lite trigger, add these entries to your `config.h` file:
 
 ```c
 #define BOOTMAGIC_LITE_ROW_RIGHT 4

--- a/docs/feature_bootmagic.md
+++ b/docs/feature_bootmagic.md
@@ -23,14 +23,35 @@ And to trigger the bootloader, you hold this key down when plugging the keyboard
 
 ## Split Keyboards
 
-When handedness is predetermined via an option like `SPLIT_HAND_PIN`, you might need to configure a different key between halves. To do so, add these entries to your `config.h` file:
+When handedness is predetermined via options like `SPLIT_HAND_PIN` or `EE_HANDS`, you might need to configure a different key between halves. To identify the correct key for the right halve, examine the split key matrix defined in the `<keyboard>.h` file, e.g.:
+
+```c
+#define LAYOUT_split_3x5_2( \
+        L01, L02, L03, L04, L05,   R01, R02, R03, R04, R05, \
+        L06, L07, L08, L09, L10,   R06, R07, R08, R09, R10, \
+        L11, L12, L13, L14, L15,   R11, R12, R13, R14, R15, \
+                       L16, L17,   R16, R17                 \
+    ) \
+    { \
+        { L01, L02, L03, L04, L05 }, \
+        { L06, L07, L08, L09, L10 }, \
+        { L11, L12, L13, L14, L15 }, \
+        { L16, L17, KC_NO, KC_NO, KC_NO }, \
+        { R01, R02, R03, R04, R05 }, \
+        { R06, R07, R08, R09, R10 }, \
+        { R11, R12, R13, R14, R15 }, \
+        { R16, R17, KC_NO, KC_NO, KC_NO }  \
+    }
+```
+
+If you choose the top right key on the right side, it is `R05` on the top layout. Within the key matrix below, `R05` is on row 4, columnn 4. To set that key as Bootmagic Lite trigger for the right halve, add these entries to your `config.h` file:
 
 ```c
 #define BOOTMAGIC_LITE_ROW_RIGHT 4
-#define BOOTMAGIC_LITE_COLUMN_RIGHT 1
+#define BOOTMAGIC_LITE_COLUMN_RIGHT 4
 ```
 
-By default, these values are not set.
+?> These values are not set by default.
 
 ## Advanced Bootmagic Lite
 

--- a/docs/feature_bootmagic.md
+++ b/docs/feature_bootmagic.md
@@ -23,7 +23,7 @@ And to trigger the bootloader, you hold this key down when plugging the keyboard
 
 ## Split Keyboards
 
-When [handedness](feature_split_keyboard.md#setting-handedness) is predetermined via options like `SPLIT_HAND_PIN` or `EE_HANDS`, you might need to configure a different key between halves. To identify the correct key for the right halve, examine the split key matrix defined in the `<keyboard>.h` file, e.g.:
+When [handedness](feature_split_keyboard.md#setting-handedness) is predetermined via options like `SPLIT_HAND_PIN` or `EE_HANDS`, you might need to configure a different key between halves. To identify the correct key for the right half, examine the split key matrix defined in the `<keyboard>.h` file, e.g.:
 
 ```c
 #define LAYOUT_split_3x5_2( \
@@ -44,7 +44,7 @@ When [handedness](feature_split_keyboard.md#setting-handedness) is predetermined
     }
 ```
 
-If you pick the top right key for the right halve, it is `R05` on the top layout. Within the key matrix below, `R05` is located on row 4 columnn 4. To use that key as the right halve's Bootmagic Lite trigger, add these entries to your `config.h` file:
+If you pick the top right key for the right half, it is `R05` on the top layout. Within the key matrix below, `R05` is located on row 4 columnn 4. To use that key as the right half's Bootmagic Lite trigger, add these entries to your `config.h` file:
 
 ```c
 #define BOOTMAGIC_LITE_ROW_RIGHT 4

--- a/docs/feature_bootmagic.md
+++ b/docs/feature_bootmagic.md
@@ -23,7 +23,7 @@ And to trigger the bootloader, you hold this key down when plugging the keyboard
 
 ## Split Keyboards
 
-When handedness is predetermined via options like `SPLIT_HAND_PIN` or `EE_HANDS`, you might need to configure a different key between halves. To identify the correct key for the right halve, examine the split key matrix defined in the `<keyboard>.h` file, e.g.:
+When [handedness](feature_split_keyboard.md#setting-handedness) is predetermined via options like `SPLIT_HAND_PIN` or `EE_HANDS`, you might need to configure a different key between halves. To identify the correct key for the right halve, examine the split key matrix defined in the `<keyboard>.h` file, e.g.:
 
 ```c
 #define LAYOUT_split_3x5_2( \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It is not immediately obvious how to set the `*_RIGHT` values for a split keyboard. Added an example that will help explain its values better.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
