### PR TITLE
Fix multiple definition errors for trackball "boards" with no keys

### DIFF
--- a/keyboards/handwired/aball/aball.c
+++ b/keyboards/handwired/aball/aball.c
@@ -15,4 +15,3 @@
  */
 
 #include "aball.h"
-const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = { };

--- a/keyboards/handwired/aball/aball.h
+++ b/keyboards/handwired/aball/aball.h
@@ -18,12 +18,4 @@
 
 #include "quantum.h"
 
-/* This is a shortcut to help you visually see your layout.
- *
- * The first section contains all of the arguments representing the physical
- * layout of the board and position of the keys.
- *
- * The second converts the arguments into a two-dimensional array which
- * represents the switch matrix.
- */
-#define LAYOUT(k00) {{ KC_NO }}
+#define LAYOUT(k00) {{ k00 }}

--- a/keyboards/handwired/aball/keymaps/default/keymap.c
+++ b/keyboards/handwired/aball/keymaps/default/keymap.c
@@ -15,4 +15,5 @@
  */
 #include QMK_KEYBOARD_H
 
-
+// Dummy
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {{ KC_NO }};

--- a/keyboards/ploopyco/trackball_nano/keymaps/default/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/default/keymap.c
@@ -20,4 +20,5 @@
 
 // safe range starts at `PLOOPY_SAFE_RANGE` instead.
 
-// placeholder file so it will compile
+// Dummy
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {{ KC_NO }};

--- a/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
@@ -24,6 +24,9 @@ uint8_t lock_state = 0;
 int8_t  delta_x        = 0;
 int8_t  delta_y        = 0;
 
+// Dummy
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {{ KC_NO }};
+
 void process_mouse_user(report_mouse_t *mouse_report, int8_t x, int8_t y) {
     if (scroll_enabled) {
         delta_x += x;

--- a/keyboards/ploopyco/trackball_nano/trackball_nano.c
+++ b/keyboards/ploopyco/trackball_nano/trackball_nano.c
@@ -48,8 +48,6 @@
 #    define PLOOPY_DPI_DEFAULT 2
 #endif
 
-const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = { };
-
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
 #define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))

--- a/keyboards/ploopyco/trackball_nano/trackball_nano.h
+++ b/keyboards/ploopyco/trackball_nano/trackball_nano.h
@@ -21,7 +21,7 @@
 
 #include "quantum.h"
 
-#define LAYOUT(k00) {{ KC_NO }}
+#define LAYOUT(k00) {{ k00 }}
 
 typedef union {
   uint32_t raw;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`handwired/aball` and `ploopyco/trackball_nano` both have `keymaps` at keyboard level. This was done because they have no actual keys, so there is not much point in having it at keymap level. However, this confuses the compiler when generating a keymap from JSON:

![image](https://user-images.githubusercontent.com/4781841/153802246-8de2ad8c-3fd8-416a-bbac-cb0f2c6c3e6b.png)

The simple fix is to move `keymaps` back to keymap level.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
