### PR TITLE
Fix a potential bug in encoder_init().

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -59,6 +59,8 @@ static uint8_t thisHand, thatHand;
 static uint8_t encoder_value[NUMBER_OF_ENCODERS] = {0};
 #endif
 
+__attribute__((weak)) void encoder_wait_pullup_charge(void) { wait_us(100); }
+
 __attribute__((weak)) bool encoder_update_user(uint8_t index, bool clockwise) { return true; }
 
 __attribute__((weak)) bool encoder_update_kb(uint8_t index, bool clockwise) { return encoder_update_user(index, clockwise); }
@@ -84,7 +86,9 @@ void encoder_init(void) {
     for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
         setPinInputHigh(encoders_pad_a[i]);
         setPinInputHigh(encoders_pad_b[i]);
-
+    }
+    encoder_wait_pullup_charge();
+    for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
         encoder_state[i] = (readPin(encoders_pad_a[i]) << 0) | (readPin(encoders_pad_b[i]) << 1);
     }
 


### PR DESCRIPTION
## Description

After executing `setPinInputHigh(pin)`, it is necessary to wait for the charging time to read from the corresponding pin. This is the same as requiring `matrix_output_unselect_delay()` after doing `unselect_row()` in matrix.c.

In #15311
> Currently, it causes the encoder update function to be spammed 

This phenomenon can be expected to be resolved by this PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
