### PR TITLE
Fix a couple of boards being wrongly identified as AVR

### DIFF
--- a/keyboards/mlego/m60_split/info.json
+++ b/keyboards/mlego/m60_split/info.json
@@ -1,6 +1,5 @@
 {
     "keyboard_name": "mlego/m60_split",
-    "keyboard_folder": "mlego/m60_split",
     "url": "https://gitlab.com/m-lego/m65",
     "maintainer": "alin elena",
     "layouts": {

--- a/keyboards/splitkb/kyria/rev1/proton_c/rules.mk
+++ b/keyboards/splitkb/kyria/rev1/proton_c/rules.mk
@@ -1,3 +1,10 @@
+# MCU name
+MCU = STM32F303
+BOARD = QMK_PROTON_C
+
+# Bootloader selection
+BOOTLOADER = stm32-dfu
+
 WS2812_DRIVER = pwm
 SERIAL_DRIVER = usart
 AUDIO_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

These two boards fail to build in Configurator, because the ChibiOS submodules are not being pulled down.

`qmk info` misidentifies `mlego/m60_split/rev1` and `rev2` as AVR due to `keyboard_folder` pointing at the root, which has no rules.mk, causing `_extract_rules_mk()` to pull absolutely nothing and defaulting to 32u4/atmel-dfu.

For `splitkb/kyria/rev1/proton_c`, this has to do with the fact that `qmk info` doesn't understand `CONVERT_TO_PROTON_C`. Might be a bodge, but explicitly overriding the MCU and bootloader should do the job - CTPC can do the rest at compile time.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
