### PR TITLE
Re-add call to `suspend_power_down_kb()`.

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -488,6 +488,7 @@ __attribute__((weak)) void suspend_power_down_user(void) {}
 __attribute__((weak)) void suspend_power_down_kb(void) { suspend_power_down_user(); }
 
 void suspend_power_down_quantum(void) {
+    suspend_power_down_kb();
 #ifndef NO_SUSPEND_POWER_DOWN
 // Turn off backlight
 #    ifdef BACKLIGHT_ENABLE


### PR DESCRIPTION
## Description

In #14210, all previous calls to `suspend_power_down_kb()` were replaced with calls to `suspend_power_down_quantum()`, together with some much needed deduplication. However, the `_kb` function was never called from the `_quantum` one (unlike `suspend_wakeup_init_kb()`).

I followed the example of how it was implemented for AVR before #14210, i.e. called before the rest of the suspend functions, regardless of the `NO_SUSPEND_POWER_DOWN` setting.

## Types of Changes
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #16279

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).