### PR TITLE
Add encoder defaults for Keebio boards

### DIFF
--- a/keyboards/keebio/bdn9/keymaps/default/keymap.c
+++ b/keyboards/keebio/bdn9/keymaps/default/keymap.c
@@ -67,5 +67,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_PGUP);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/bdn9/keymaps/via/keymap.c
+++ b/keyboards/keebio/bdn9/keymaps/via/keymap.c
@@ -40,28 +40,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 )
 
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == _LEFT) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    }
-    else if (index == _MIDDLE) {
-        if (clockwise) {
-            tap_code(KC_DOWN);
-        } else {
-            tap_code(KC_UP);
-        }
-    }
-    else if (index == _RIGHT) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    }
-    return false;
-}

--- a/keyboards/keebio/bdn9/keymaps/via/keymap.c
+++ b/keyboards/keebio/bdn9/keymaps/via/keymap.c
@@ -63,5 +63,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_PGUP);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/bdn9/rev1/rev1.c
+++ b/keyboards/keebio/bdn9/rev1/rev1.c
@@ -16,3 +16,29 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_DOWN);
+        } else {
+            tap_code(KC_UP);
+        }
+    }
+    else if (index == 2) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/bdn9/rev2/rev2.c
+++ b/keyboards/keebio/bdn9/rev2/rev2.c
@@ -37,3 +37,29 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_DOWN);
+        } else {
+            tap_code(KC_UP);
+        }
+    }
+    else if (index == 2) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/dsp40/keymaps/default/keymap.c
+++ b/keyboards/keebio/dsp40/keymaps/default/keymap.c
@@ -113,5 +113,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLD);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/dsp40/keymaps/via/keymap.c
+++ b/keyboards/keebio/dsp40/keymaps/via/keymap.c
@@ -63,14 +63,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
     )
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    }
-    return false;
-}

--- a/keyboards/keebio/dsp40/keymaps/via/keymap.c
+++ b/keyboards/keebio/dsp40/keymaps/via/keymap.c
@@ -72,5 +72,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLD);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/dsp40/rev1/rev1.c
+++ b/keyboards/keebio/dsp40/rev1/rev1.c
@@ -24,3 +24,15 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/foldkb/keymaps/default/keymap.c
+++ b/keyboards/keebio/foldkb/keymaps/default/keymap.c
@@ -32,20 +32,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_VOLD,          _______, _______, _______, _______, _______, _______,     _______, KC_0,    _______, _______, _______, _______
   ),
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    } else if (index == 1) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    }
-    return true;
-}

--- a/keyboards/keebio/foldkb/keymaps/via/keymap.c
+++ b/keyboards/keebio/foldkb/keymaps/via/keymap.c
@@ -46,20 +46,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______,          _______, _______, _______, _______, _______, _______,     _______, _______, _______, _______, _______, _______
   )
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    } else if (index == 1) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    }
-    return true;
-}

--- a/keyboards/keebio/foldkb/rev1/rev1.c
+++ b/keyboards/keebio/foldkb/rev1/rev1.c
@@ -24,3 +24,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/iris/keymaps/default/keymap.c
+++ b/keyboards/keebio/iris/keymaps/default/keymap.c
@@ -127,5 +127,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_PGUP);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/iris/keymaps/via/keymap.c
+++ b/keyboards/keebio/iris/keymaps/via/keymap.c
@@ -81,5 +81,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_PGUP);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/iris/keymaps/via/keymap.c
+++ b/keyboards/keebio/iris/keymaps/via/keymap.c
@@ -65,21 +65,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                 // └────────┴────────┴────────┘                 └────────┴────────┴────────┘
   )
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    }
-    else if (index == 1) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    }
-    return false;
-}

--- a/keyboards/keebio/iris/rev3/rev3.c
+++ b/keyboards/keebio/iris/rev3/rev3.c
@@ -35,3 +35,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/iris/rev4/rev4.c
+++ b/keyboards/keebio/iris/rev4/rev4.c
@@ -16,3 +16,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/iris/rev5/rev5.c
+++ b/keyboards/keebio/iris/rev5/rev5.c
@@ -12,3 +12,21 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "rev5.h"
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/iris/rev6/config.h
+++ b/keyboards/keebio/iris/rev6/config.h
@@ -36,10 +36,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS_RIGHT { D4, D6, D7, C7, F1, F4 }
 #define SPLIT_HAND_PIN D5
 
-#define ENCODERS_PAD_A { B2 }
-#define ENCODERS_PAD_B { B3 }
-#define ENCODERS_PAD_A_RIGHT { B2 }
-#define ENCODERS_PAD_B_RIGHT { B3 }
+#define ENCODERS_PAD_A { B3 }
+#define ENCODERS_PAD_B { B2 }
+#define ENCODERS_PAD_A_RIGHT { B3 }
+#define ENCODERS_PAD_B_RIGHT { B2 }
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION COL2ROW

--- a/keyboards/keebio/iris/rev6/rev6.c
+++ b/keyboards/keebio/iris/rev6/rev6.c
@@ -63,3 +63,21 @@ led_config_t g_led_config = { {
 
 } };
 #endif
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/kbo5000/keymaps/default/keymap.c
+++ b/keyboards/keebio/kbo5000/keymaps/default/keymap.c
@@ -55,5 +55,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_UP);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/kbo5000/keymaps/via/keymap.c
+++ b/keyboards/keebio/kbo5000/keymaps/via/keymap.c
@@ -34,26 +34,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, _______, _______, _______, _______, _______, _______,                   _______, _______, _______, _______,                   _______, _______, _______, _______
   )
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == LEFT_HALF_ENC) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    } else if (index == RIGHT_HALF_ENC1) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    } else if (index == RIGHT_HALF_ENC2) {
-        if (clockwise) {
-            tap_code(KC_DOWN);
-        } else {
-            tap_code(KC_UP);
-        }
-    }
-    return true;
-}

--- a/keyboards/keebio/kbo5000/rev1/rev1.c
+++ b/keyboards/keebio/kbo5000/rev1/rev1.c
@@ -30,3 +30,27 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 2) {
+        if (clockwise) {
+            tap_code(KC_DOWN);
+        } else {
+            tap_code(KC_UP);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/quefrency/keymaps/default65/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/default65/keymap.c
@@ -46,5 +46,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLD);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/quefrency/keymaps/default65macro/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/default65macro/keymap.c
@@ -46,5 +46,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLD);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/quefrency/keymaps/via/keymap.c
+++ b/keyboards/keebio/quefrency/keymaps/via/keymap.c
@@ -33,20 +33,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
   )
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    } else if (index == 1) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    }
-    return true;
-}

--- a/keyboards/keebio/quefrency/rev2/rev2.c
+++ b/keyboards/keebio/quefrency/rev2/rev2.c
@@ -30,3 +30,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/quefrency/rev3/rev3.c
+++ b/keyboards/keebio/quefrency/rev3/rev3.c
@@ -46,3 +46,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/quefrency/rev4/rev4.c
+++ b/keyboards/keebio/quefrency/rev4/rev4.c
@@ -15,3 +15,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "quefrency.h"
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/sinc/keymaps/default/keymap.c
+++ b/keyboards/keebio/sinc/keymaps/default/keymap.c
@@ -33,5 +33,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLD);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/sinc/keymaps/via/keymap.c
+++ b/keyboards/keebio/sinc/keymaps/via/keymap.c
@@ -37,20 +37,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______, _______, _______, _______, _______, _______
   )
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    } else if (index == 1) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    }
-    return true;
-}

--- a/keyboards/keebio/sinc/rev1/rev1.c
+++ b/keyboards/keebio/sinc/rev1/rev1.c
@@ -22,3 +22,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/sinc/rev2/rev2.c
+++ b/keyboards/keebio/sinc/rev2/rev2.c
@@ -38,3 +38,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_PGDN);
+        } else {
+            tap_code(KC_PGUP);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    }
+    return false;
+}

--- a/keyboards/keebio/stick/keymaps/default/keymap.c
+++ b/keyboards/keebio/stick/keymaps/default/keymap.c
@@ -39,5 +39,5 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_UP);
         }
     }
-    return true;
+    return false;
 }

--- a/keyboards/keebio/stick/keymaps/via/keymap.c
+++ b/keyboards/keebio/stick/keymaps/via/keymap.c
@@ -35,21 +35,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______
     ),
 };
-
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    if (index == 0) {
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    }
-    else if (index == 1) {
-        if (clockwise) {
-            tap_code(KC_DOWN);
-        } else {
-            tap_code(KC_UP);
-        }
-    }
-    return true;
-}

--- a/keyboards/keebio/stick/stick.c
+++ b/keyboards/keebio/stick/stick.c
@@ -48,3 +48,21 @@ void eeconfig_init_kb(void) {
     eeconfig_update_kb(0);
     eeconfig_init_user();
 }
+
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_DOWN);
+        } else {
+            tap_code(KC_UP);
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
## Description

Add encoder defaults at the keyboard level so that encoders are still functional if some uses QMK Configurator to flash their board.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
