### PR TITLE
clueboard/card: disable Command to reduce size

### DIFF
--- a/keyboards/clueboard/card/info.json
+++ b/keyboards/clueboard/card/info.json
@@ -10,7 +10,7 @@
     "backlight": true,
     "bluetooth": false,
     "bootmagic": false,
-    "command": true,
+    "command": false,
     "console": true,
     "extrakey": true,
     "lto": true,

--- a/keyboards/clueboard/card/keymaps/default/rules.mk
+++ b/keyboards/clueboard/card/keymaps/default/rules.mk
@@ -1,9 +1,4 @@
-BOOTMAGIC_ENABLE = no       # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = no        # Audio control and System control
-CONSOLE_ENABLE = yes        # Console for debug
-COMMAND_ENABLE = yes        # Commands for debug and configuration
+MOUSEKEY_ENABLE = no
+EXTRAKEY_ENABLE = no
 NKRO_ENABLE = yes
-BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
-AUDIO_ENABLE = no           # Audio output
-RGBLIGHT_ENABLE = yes       # Enable WS2812 RGB underlight.
+AUDIO_ENABLE = no

--- a/keyboards/clueboard/card/keymaps/rgb_effects/rules.mk
+++ b/keyboards/clueboard/card/keymaps/rgb_effects/rules.mk
@@ -1,9 +1,4 @@
-BOOTMAGIC_ENABLE = no       # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys(+4700)
-EXTRAKEY_ENABLE = no        # Audio control and System control(+450)
-CONSOLE_ENABLE = yes        # Console for debug(+400)
-COMMAND_ENABLE = yes        # Commands for debug and configuration
+MOUSEKEY_ENABLE = no
+EXTRAKEY_ENABLE = no
 NKRO_ENABLE = yes
-BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
-AUDIO_ENABLE = no           # Audio output
-RGBLIGHT_ENABLE = yes       # Enable WS2812 RGB underlight.
+AUDIO_ENABLE = no


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Command makes no sense with the form factor of this board, and is oversize by 732 bytes according to qmk_error_page.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
