### PR TITLE
fix helix/rev2:edvorakjp build error

### DIFF
--- a/keyboards/helix/rev2/keymaps/edvorakjp/oled.h
+++ b/keyboards/helix/rev2/keymaps/edvorakjp/oled.h
@@ -9,4 +9,4 @@ void            render_layer_state(void);
 void            render_logo(void);
 void            render_mode_icon(bool is_windows);
 oled_rotation_t oled_init_user(oled_rotation_t rotation);
-void            oled_task_user(void);
+bool            oled_task_user(void);


### PR DESCRIPTION
## Description

'helix/rev2/keymaps/edvorakjp' was no longer buildable due to changes made by #14864.
The reason is that the prototype of `oled_task_user()` was changed in keymaps/edvorakjp/oled.c, but keymaps/edvorakjp/oled.h was not changed.
Therefore, I modified the prototype in keymaps/edvorakjp/oled.h.

## Types of Changesq

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #14864

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
