### PR TITLE
Fix Xorg segfault with KeebCats PCBs

### DIFF
--- a/keyboards/cutie_club/keebcats/denis/config.h
+++ b/keyboards/cutie_club/keebcats/denis/config.h
@@ -23,7 +23,7 @@
 #define PRODUCT_ID 0xB260
 #define DEVICE_VER 0x0000
 #define MANUFACTURER Cutie Club
-#define PRODUCT Keebcats Denis 60%
+#define PRODUCT Keebcats Denis 60
 
 /* key matrix size */
 #define MATRIX_ROWS 5

--- a/keyboards/cutie_club/keebcats/dougal/config.h
+++ b/keyboards/cutie_club/keebcats/dougal/config.h
@@ -23,7 +23,7 @@
 #define PRODUCT_ID 0xB265
 #define DEVICE_VER 0x0000
 #define MANUFACTURER Cutie Club
-#define PRODUCT Keebcats Dougal 65%
+#define PRODUCT Keebcats Dougal 65
 
 /* key matrix size */
 #define MATRIX_ROWS 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Hi folks,

We have discovered a bug with xorg where it will [segfault when a USB device with a % in the product name is connected](https://gitlab.freedesktop.org/xorg/xserver/-/issues/1280). This PR removes the % from the KeebCats x Cutie Club PCBs that we have identified as affected.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
