### PR TITLE
Add multilayer VIA support to Hasu usb_usb

### DIFF
--- a/keyboards/converter/usb_usb/custom_matrix.cpp
+++ b/keyboards/converter/usb_usb/custom_matrix.cpp
@@ -39,6 +39,67 @@ extern "C" {
 #include "quantum.h"
 }
 
+/* see keymaps/via/keymap.c and keymaps/via/config.h
+   for matrix compression implementation details */
+#ifdef COMPRESS_MATRIX
+/* Maps value encoding a (row, col) index in a scan matrix
+   val = ((row) << 4) + (col))
+   to a 1-byte HID keycode.  There are only 142 HID keycodes of interest in the LAYOUT macro,
+   so a 9x16 (144-element) array is sufficient.
+
+Esc  F13  F14  F15  F16  F17  F18  F19  F20  F21  F22  F23  F24  F1   F2   F3
+F4   F5   F6   F7   F8   F9   F10  F11  F12  Prn  Scr  Pau  VDn  VUp  Mut  Pwr
+Hlp  `    1    2    3    4    5    6    7    8    9    0    -    =    JPY  Bsp
+Ins  Hom  PgU  NmL  /    *    -    Stp  Agn  Tab  Q    W    E    R    T    Y
+U    I    O    P    [    ]    \    Del  End  PgD  7    8    9    +    Mnu  Und
+CLk  A    S    D    F    G    H    J    K    L    ;    :    #    Ent  4    5
+6    KP,  Sel  Cpy  <    Z    X    C    V    B    N    M    ,    .    /    R0
+Up   1    2    3    KP=  Exe  Pst  MHN  HNJ  Spc  H/E  HNK  KAN  App  Lft  Dn
+LCt  LSh  LAl  LGu  Rct  RSh  Ral  RGu  Rt   0    .    Ent  Fnd  Cut
+ */
+static const uint8_t hidindex[144] PROGMEM = {
+  /* 0     1     2     3     4     5     6     7     8     9     A     B     C     D     E     F */
+  0x29, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x3A, 0x3B, 0x3C, /* 0 */
+  0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x81, 0x80, 0x7F, 0x66, /* 1 */
+  0x75, 0x35, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x2D, 0x2E, 0x89, 0x2A, /* 2 */
+  0x49, 0x4A, 0x4B, 0x53, 0x54, 0x55, 0x56, 0x78, 0x79, 0x2B, 0x14, 0x1A, 0x08, 0x15, 0x17, 0x1C, /* 3 */
+  0x18, 0x0C, 0x12, 0x13, 0x2F, 0x30, 0x31, 0x4C, 0x4D, 0x4E, 0x5F, 0x60, 0x61, 0x57, 0x76, 0x7A, /* 4 */
+  0x39, 0x04, 0x16, 0x07, 0x09, 0x0A, 0x0B, 0x0D, 0x0E, 0x0F, 0x33, 0x34, 0x32, 0x28, 0x5C, 0x5D, /* 5 */
+  0x5E, 0x85, 0x77, 0x7C, 0x64, 0x1D, 0x1B, 0x06, 0x19, 0x05, 0x11, 0x10, 0x36, 0x37, 0x38, 0x87, /* 6 */
+  0x52, 0x59, 0x5A, 0x5B, 0x67, 0x74, 0x7D, 0x8B, 0x91, 0x2C, 0x90, 0x8A, 0x88, 0x65, 0x50, 0x51, /* 7 */
+  0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0x4F, 0x62, 0x63, 0x58, 0x7E, 0x7B, 0x00, 0x00  /* 8 */
+};
+
+
+/* Maps 1-byte HID keycode to a value encoding a (row, col) index in a 9x16 scan matrix:
+   val = ((row) << 4) + (col)) */
+#define XBAD 0xFF
+static const uint8_t matrixindex[256] PROGMEM = {
+/*  0     1     2     3     4     5     6     7     8     9     A     B     C     D     E     F   */
+  XBAD, XBAD, XBAD, XBAD, 0x51, 0x69, 0x67, 0x53, 0x3C, 0x54, 0x55, 0x56, 0x41, 0x57, 0x58, 0x59, /* 0 */
+  0x6B, 0x6A, 0x42, 0x43, 0x3A, 0x3D, 0x52, 0x3E, 0x40, 0x68, 0x3B, 0x66, 0x3F, 0x65, 0x22, 0x23, /* 1 */
+  0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x5D, 0x00, 0x2F, 0x39, 0x79, 0x2C, 0x2D, 0x44, /* 2 */
+  0x45, 0x46, 0x5C, 0x5A, 0x5B, 0x21, 0x6C, 0x6D, 0x6E, 0x50, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, /* 3 */
+  0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x30, 0x31, 0x32, 0x47, 0x48, 0x49, 0x88, /* 4 */
+  0x7E, 0x7F, 0x70, 0x33, 0x34, 0x35, 0x36, 0x4D, 0x8B, 0x71, 0x72, 0x73, 0x5E, 0x5F, 0x60, 0x4A, /* 5 */
+  0x4B, 0x4C, 0x89, 0x8A, 0x64, 0x7D, 0x1F, 0x74, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, /* 6 */
+  0x09, 0x0A, 0x0B, 0x0C, 0x75, 0x20, 0x4E, 0x62, 0x37, 0x38, 0x4F, 0x8D, 0x63, 0x76, 0x8C, 0x1E, /* 7 */
+  0x1D, 0x1C, XBAD, XBAD, XBAD, 0x61, XBAD, 0x6F, 0x7C, 0x2E, 0x7B, 0x77, XBAD, XBAD, XBAD, XBAD, /* 8 */
+  0x7A, 0x78, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, /* 9 */
+  XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, /* A */
+  XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, /* B */
+  XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, /* C */
+  XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, /* D */
+  0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, /* E */
+  XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, XBAD, /* F */
+};
+#define ROW_MASK 0xF0
+#define COL_MASK 0x0F
+#define CODE(row, col) (pgm_read_byte(&hidindex[(((row) << 4) | (col))]))
+#define ROW(code)      ((pgm_read_byte(&matrixindex[(code)]) & ROW_MASK) >> 4)
+#define COL(code)      (pgm_read_byte(&matrixindex[(code)]) & COL_MASK)
+#define ROW_BITS(code) (1 << COL(code))
+#else // NOT COMPRESS_MATRIX
 /* KEY CODE to Matrix
  *
  * HID keycode(1 byte):
@@ -62,17 +123,18 @@ extern "C" {
 #define ROW(code)      (((code) & ROW_MASK) >> 4)
 #define COL(code)      ((code) & COL_MASK)
 #define ROW_BITS(code) (1 << COL(code))
+#endif // COMPRESS_MATRIX
 
 // Integrated key state of all keyboards
 static report_keyboard_t local_keyboard_report;
+
+static bool matrix_is_mod = false;
 
 /*
  * USB Host Shield HID keyboards
  * This supports two cascaded hubs and four keyboards
  */
 USB usb_host;
-USBHub hub1(&usb_host);
-USBHub hub2(&usb_host);
 HIDBoot<HID_PROTOCOL_KEYBOARD> kbd1(&usb_host);
 HIDBoot<HID_PROTOCOL_KEYBOARD> kbd2(&usb_host);
 HIDBoot<HID_PROTOCOL_KEYBOARD> kbd3(&usb_host);
@@ -81,6 +143,8 @@ KBDReportParser kbd_parser1;
 KBDReportParser kbd_parser2;
 KBDReportParser kbd_parser3;
 KBDReportParser kbd_parser4;
+USBHub hub1(&usb_host);
+USBHub hub2(&usb_host);
 
 extern "C" {
     uint8_t matrix_rows(void) { return MATRIX_ROWS; }
@@ -130,7 +194,6 @@ extern "C" {
     }
 
     uint8_t matrix_scan(void) {
-        bool changed = false;
         static uint16_t last_time_stamp1 = 0;
         static uint16_t last_time_stamp2 = 0;
         static uint16_t last_time_stamp3 = 0;
@@ -154,13 +217,15 @@ extern "C" {
             or_report(kbd_parser3.report);
             or_report(kbd_parser4.report);
 
-            changed = true;
+            matrix_is_mod = true;
 
             dprintf("state:  %02X %02X", local_keyboard_report.mods, local_keyboard_report.reserved);
             for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; i++) {
                 dprintf(" %02X", local_keyboard_report.keys[i]);
             }
             dprint("\r\n");
+        } else {
+            matrix_is_mod = false;
         }
 
         uint16_t timer;
@@ -183,7 +248,7 @@ extern "C" {
             }
         }
         matrix_scan_quantum();
-        return changed;
+        return 1;
     }
 
     bool matrix_is_on(uint8_t row, uint8_t col) {
@@ -217,6 +282,18 @@ extern "C" {
             }
         }
         return row_bits;
+    }
+
+    uint8_t matrix_key_count(void) {
+        uint8_t count = 0;
+
+        count += bitpop(local_keyboard_report.mods);
+        for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; i++) {
+            if (IS_ANY(local_keyboard_report.keys[i])) {
+                count++;
+            }
+        }
+        return count;
     }
 
     void matrix_print(void) {

--- a/keyboards/converter/usb_usb/info.json
+++ b/keyboards/converter/usb_usb/info.json
@@ -1,10 +1,10 @@
 {
-    "keyboard_name": "USB to USB Converter",
-    "manufacturer": "QMK",
+    "keyboard_name": "QMK USB to USB Converter",
+    "manufacturer": "Hasu",
     "url": "",
     "maintainer": "qmk",
     "usb": {
-        "vid": "0xFEED",
+        "vid": "0x4853",
         "pid": "0x005B",
         "device_version": "0.0.1"
     },

--- a/keyboards/converter/usb_usb/keymaps/via/config.h
+++ b/keyboards/converter/usb_usb/keymaps/via/config.h
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 Jeff Shufelt <jshuf@puppyfish.com> @jshuf
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+// place overrides here
+
+// enable compression of scan matrix in custom_matrix.cpp
+#define COMPRESS_MATRIX
+
+// size of compressed matrix
+#ifdef MATRIX_ROWS
+#undef MATRIX_ROWS
+#endif // MATRIX_ROWS
+#define MATRIX_ROWS 9
+#ifdef MATRIX_COLS
+#undef MATRIX_COLS
+#endif // MATRIX_COLS
+#define MATRIX_COLS 16
+
+// We can only fit 3 9x16(x2 byte) matrices in the available space
+#ifdef DYNAMIC_KEYMAP_LAYER_COUNT
+#undef DYNAMIC_KEYMAP_LAYER_COUNT
+#endif // DYNAMIC_KEYMAP_LAYER_COUNT
+#define DYNAMIC_KEYMAP_LAYER_COUNT 3
+
+// We have 1 2-bit layout option and 13 1-bit layout options
+// in the VIA usb_usb.json, so we need 15 bits (2 bytes)
+// of layout option storage.
+#ifdef VIA_EEPROM_LAYOUT_OPTIONS_SIZE
+#undef VIA_EEPROM_LAYOUT_OPTIONS_SIZE
+#endif // VIA_EEPROM_LAYOUT_OPTIONS_SIZE
+#define VIA_EEPROM_LAYOUT_OPTIONS_SIZE 2

--- a/keyboards/converter/usb_usb/keymaps/via/keymap.c
+++ b/keyboards/converter/usb_usb/keymaps/via/keymap.c
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 Jeff Shufelt <jshuf@puppyfish.com> @jshuf
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+/* Matrix compression for the usb_usb converter - a brief primer
+
+   First, a quick look at how the converter works.
+   Instead of looking for connected I/O pins on the PCB's MCU
+   to set/unset cells in the scan matrix, the usb_usb converter uses
+   USB HID codes coming from the keyboard as indices into the
+   scan matrix - specifically, a 16x16 scan matrix, where the first
+   4 bits of the USB HID code are used as a row index into the scan
+   matrix, and the second 4 bits index are used as a column index.
+   This is the default implementation in usb_usb/custom_matrix.cpp.
+
+   However, using a scan matrix of this size will be limiting in VIA,
+   which stores its dynamic keymap in EEPROM.  The Atmega32U4
+   used by the usb_usb converter has 1K=1024 bytes of EEPROM storage.
+   Each cell of a scan matrix is 2 bytes wide, so a single keymap layer
+   for a 16x16 scan matrix consumes 16x16x2 = 512 bytes.
+   Taking VIA as an example dynamic keymap implementation:
+   since VIA needs a small additional amount of EEPROM for its
+   own internal state, above and beyond the dynamic keymaps,
+   the use of a 16x16 scan matrix would mean that we only have
+   enough room for one keymap layer in VIA.
+
+   We can improve upon this by observing that only 142 USB HID codes
+   are actually handled by the converter in the LAYOUT macro, leaving
+   256-142=114 unused entries (228 bytes) in the scan matrix.  So, if we
+   can somehow use the 142 codes to index into a smaller scan matrix,
+   say a 9x16=144 (288 byte) scan matrix, then we can pack up to three
+   dynamic keymap layers into the EEPROM.
+
+   To do that, we just need to establish a mapping from USB HID
+   hex codes to row,col indices into the 9x16 scan matrix, and use
+   that mapping whenever we need to index into the scan matrix using
+   a USB HID code.  Since this mapping is fixed, it doesn't need
+   to reside in EEPROM, and can instead be stored in flash.
+   That mapping (and its inverse) are defined as PROGMEM in
+   usb_usb/custom_matrix.cpp.
+*/
+
+/* This layout macro uses 9x16 scan matrix, for use
+   only when COMPRESS_MATRIX is defined, so it is placed here
+   to avoid confusion with the standard set of LAYOUT macros
+   in usb_usb.h. */
+#define LAYOUT_via( \
+            K01,K02,K03,K04,K05,K06,K07,K08,K09,K0A,K0B,K0C,                                              \
+    K00,    K0D,K0E,K0F,K10,K11,K12,K13,K14,K15,K16,K17,K18,      K19,K1A,K1B,  K1C,K1D,K1E,K1F, K20,     \
+    K21,K22,K23,K24,K25,K26,K27,K28,K29,K2A,K2B,K2C,K2D,K2E,K2F,  K30,K31,K32,  K33,K34,K35,K36, K37,K38, \
+    K39,K3A,K3B,K3C,K3D,K3E,K3F,K40,K41,K42,K43,K44,K45,    K46,  K47,K48,K49,  K4A,K4B,K4C,K4D, K4E,K4F, \
+    K50,K51,K52,K53,K54,K55,K56,K57,K58,K59,K5A,K5B,    K5C,K5D,                K5E,K5F,K60,K61, K62,K63, \
+    K81,K64,K65,K66,K67,K68,K69,K6A,K6B,K6C,K6D,K6E,    K6F,K85,      K70,      K71,K72,K73,K74, K75,K76, \
+    K80,K83,K82,K77,K78,    K79,    K7A,K7B,K7C,K86,K87,K7D,K84,  K7E,K7F,K88,  K89,    K8A,K8B, K8C,K8D  \
+) { \
+   { K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F}, \
+   { K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E, K1F}, \
+   { K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K2D, K2E, K2F}, \
+   { K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, K3C, K3D, K3E, K3F}, \
+   { K40, K41, K42, K43, K44, K45, K46, K47, K48, K49, K4A, K4B, K4C, K4D, K4E, K4F}, \
+   { K50, K51, K52, K53, K54, K55, K56, K57, K58, K59, K5A, K5B, K5C, K5D, K5E, K5F}, \
+   { K60, K61, K62, K63, K64, K65, K66, K67, K68, K69, K6A, K6B, K6C, K6D, K6E, K6F}, \
+   { K70, K71, K72, K73, K74, K75, K76, K77, K78, K79, K7A, K7B, K7C, K7D, K7E, K7F}, \
+   { K80, K81, K82, K83, K84, K85, K86, K87, K88, K89, K8A, K8B, K8C, K8D, XXX, XXX}, \
+}
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* 0: plain Qwerty without layer switching
+     *         ,---------------. ,---------------. ,---------------.
+     *         |F13|F14|F15|F16| |F17|F18|F19|F20| |F21|F22|F23|F24|
+     * ,---.   |---------------| |---------------| |---------------| ,-----------. ,---------------. ,-------.
+     * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau| |VDn|VUp|Mut|Pwr| | Help  |
+     * `---'   `---------------' `---------------' `---------------' `-----------' `---------------' `-------'
+     * ,-----------------------------------------------------------. ,-----------. ,---------------. ,-------.
+     * |  `|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|JPY|Bsp| |Ins|Hom|PgU| |NmL|  /|  *|  -| |Stp|Agn|
+     * |-----------------------------------------------------------| |-----------| |---------------| |-------|
+     * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|  \  | |Del|End|PgD| |  7|  8|  9|  +| |Mnu|Und|
+     * |-----------------------------------------------------------| `-----------' |---------------| |-------|
+     * |CapsL |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  :|  #|Retn|               |  4|  5|  6|KP,| |Sel|Cpy|
+     * |-----------------------------------------------------------|     ,---.     |---------------| |-------|
+     * |Shft|  <|  Z|  X|  C|  V|  B|  N|  M|  ,|  ,|  /| RO|Shift |     |Up |     |  1|  2|  3|KP=| |Exe|Pst|
+     * |-----------------------------------------------------------| ,-----------. |---------------| |-------|
+     * |Ctl|Gui|Alt|MHEN|HNJ| Space  |H/E|HENK|KANA|Alt|Gui|App|Ctl| |Lef|Dow|Rig| |  0    |  .|Ent| |Fnd|Cut|
+     * `-----------------------------------------------------------' `-----------' `---------------' `-------'
+     */
+    [0] = LAYOUT_via(
+                      KC_F13,  KC_F14,  KC_F15,  KC_F16, KC_F17, KC_F18, KC_F19,  KC_F20,  KC_F21,  KC_F22,  KC_F23,  KC_F24,
+    KC_ESC,           KC_F1,   KC_F2,   KC_F3,   KC_F4,  KC_F5,  KC_F6,  KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,               KC_PSCR, KC_SCRL, KC_PAUS,    KC_VOLD, KC_VOLU, KC_MUTE, KC_PWR,     KC_HELP,
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,   KC_6,   KC_7,   KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_INT3, KC_BSPC,     KC_INS,  KC_HOME, KC_PGUP,    KC_NUM, KC_PSLS, KC_PAST, KC_PMNS,    KC_STOP, KC_AGIN,
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,   KC_Y,   KC_U,   KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_BSLS,     KC_DEL,  KC_END,  KC_PGDN,    KC_P7,   KC_P8,   KC_P9,   KC_PPLS,    KC_MENU, KC_UNDO,
+    KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,   KC_H,   KC_J,   KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_NUHS, KC_ENT,                                    KC_P4,   KC_P5,   KC_P6,   KC_PCMM,    KC_SLCT, KC_COPY,
+    KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,   KC_B,   KC_N,   KC_M,    KC_COMM, KC_DOT,  KC_SLSH,          KC_INT1,   KC_RSFT,              KC_UP,               KC_P1,   KC_P2,   KC_P3,   KC_PEQL,    KC_EXEC, KC_PSTE,
+    KC_LCTL, KC_LGUI, KC_LALT, KC_INT5, KC_LNG2,         KC_SPC,         KC_LNG1, KC_INT4, KC_INT2, KC_RALT, KC_RGUI, MO(1),   KC_RCTL,     KC_LEFT, KC_DOWN, KC_RGHT,    KC_P0,            KC_PDOT, KC_PENT,    KC_FIND, KC_CUT
+    ),
+    [1] = LAYOUT_via(
+                      ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,  ______,  ______,
+    ______,           ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,  ______,  ______,               ______,  ______,  ______,     ______,  ______,  ______,  ______,     ______,
+    ______,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,  KC_F6,  KC_F7,  KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  ______,  ______,      ______,  ______,  ______,     ______,  ______,  ______,  ______,     ______,  ______,
+    ______,  ______,  KC_UP,   ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,  ______,           ______,      ______,  ______,  ______,     ______,  ______,  ______,  ______,     ______,  ______,
+    ______,  KC_LEFT, KC_DOWN, KC_RGHT, ______,  ______, ______, ______, ______,  ______,  ______,  ______,           ______,  ______,                                    ______,  ______,  ______,  ______,     ______,  ______,
+    ______,  ______,  ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,           ______,  ______,               ______,              ______,  ______,  ______,  ______,     ______,  ______,
+    ______,  ______,  ______,  ______,  ______,          ______,         ______,  ______,  ______,  ______,   MO(2),  ______,  ______,      ______,  ______,  ______,     ______,           ______,  ______,     ______,  ______
+    ),
+    [2] = LAYOUT_via(
+                      ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,  ______,  ______,
+     QK_BOOT,           ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,  ______,  ______,               ______,  ______,  ______,     ______,  ______,  ______,  ______,     ______,
+    ______,  ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,  ______,  ______,  ______,  ______,      ______,  ______,  ______,     ______,  ______,  ______,  ______,     ______,  ______,
+    ______,  ______,  ______,  ______,  ______,  ______, ______, ______, ______,  ______, EE_CLR,  ______,  ______,           ______,      ______,  ______,  ______,     ______,  ______,  ______,  ______,     ______,  ______,
+    ______,  ______,  ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,           ______,  ______,                                    ______,  ______,  ______,  ______,     ______,  ______,
+    ______,  ______,  ______,  ______,  ______,  ______, ______, ______, ______,  ______,  ______,  ______,           ______,  ______,               ______,              ______,  ______,  ______,  ______,     ______,  ______,
+     DB_TOGG,  ______,  ______,  ______,  ______,          ______,         ______,  ______,  ______,  ______,  ______,  ______,  ______,      ______,  ______,  ______,     ______,           ______,  ______,     ______,  ______
+    )
+};
+

--- a/keyboards/converter/usb_usb/keymaps/via/rules.mk
+++ b/keyboards/converter/usb_usb/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Adds VIA support to the Hasu usb_usb converter.  'multilayer' comes from some additional complexity above and beyond most VIA ports - in order to fit more than one dynamic keymap layer into the atmega32u4 EEPROM, the converter's default scheme of using USB HID codes to directly index a 16x16 scan matrix is replaced with an intermediate mapping.  This mapping translates from the smaller (142-code) set of USB HID codes actually used by the existing usb_usb layout macros, to cells in a smaller 9x16 scan matrix.  This reduced matrix size allows three dynamic keymap layers to be stored in the atmega32u4 EEPROM.  A more detailed explanation can be found in the comments in keymaps/via/keymap.c.

All code changes to support this are ifdef'd under VIA_ENABLE, and hence should have no impact on existing usage of the QMK usb_usb converter code.  Because the LAYOUT macro for this VIA implementation has scan matrix dimensions that differ from the others, it lives in keymaps/via/keymap.c to avoid confusion with existing LAYOUT macros and info.json.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
