### PR TITLE
Move projectcain encoder logic to keyboard level

### DIFF
--- a/keyboards/projectcain/vault35/config.h
+++ b/keyboards/projectcain/vault35/config.h
@@ -44,6 +44,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
+#define ENCODERS_PAD_A { D6 }
+#define ENCODERS_PAD_B { D7 }
+#define ENCODER_RESOLUTION 2
+
 /*
  * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
  */

--- a/keyboards/projectcain/vault35/keymaps/default/config.h
+++ b/keyboards/projectcain/vault35/keymaps/default/config.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-#define ENCODERS_PAD_A { D6 }
-#define ENCODERS_PAD_B { D7 }
-#define ENCODER_RESOLUTION 2
 #define COMBO_COUNT 2
 #define COMBO_TERM 50
 #define TAPPING_FORCE_HOLD

--- a/keyboards/projectcain/vault35/keymaps/default/rules.mk
+++ b/keyboards/projectcain/vault35/keymaps/default/rules.mk
@@ -1,2 +1,1 @@
-ENCODER_ENABLE = yes
 COMBO_ENABLE = yes

--- a/keyboards/projectcain/vault35/rules.mk
+++ b/keyboards/projectcain/vault35/rules.mk
@@ -16,3 +16,4 @@ NKRO_ENABLE = no            # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
+ENCODER_ENABLE = yes

--- a/keyboards/projectcain/vault45/config.h
+++ b/keyboards/projectcain/vault45/config.h
@@ -47,6 +47,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL */
 #define DIODE_DIRECTION COL2ROW
 
+#define ENCODERS_PAD_A { B3, D1 }
+#define ENCODERS_PAD_B { B2, D2 }
+#define ENCODER_RESOLUTION 2
+
 /*
  * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
  */

--- a/keyboards/projectcain/vault45/keymaps/default/config.h
+++ b/keyboards/projectcain/vault45/keymaps/default/config.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-#define ENCODERS_PAD_A { B3, D1 }
-#define ENCODERS_PAD_B { B2, D2 }
-#define ENCODER_RESOLUTION 2
 #define COMBO_COUNT 2
 #define COMBO_TERM 50
 #define TAPPING_FORCE_HOLD

--- a/keyboards/projectcain/vault45/keymaps/default/rules.mk
+++ b/keyboards/projectcain/vault45/keymaps/default/rules.mk
@@ -1,2 +1,1 @@
-ENCODER_ENABLE = yes
 COMBO_ENABLE = yes

--- a/keyboards/projectcain/vault45/rules.mk
+++ b/keyboards/projectcain/vault45/rules.mk
@@ -16,3 +16,4 @@ NKRO_ENABLE = no            # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
+ENCODER_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
From https://yanfali.github.io/qmk_error_page/
```
Ψ Compiling keymap with make -s --jobs=1 -r -R -f builddefs/build_keyboard.mk KEYBOARD=projectcain/vault35 KEYMAP=default_configurator KEYBOARD_FILESAFE=projectcain_vault35 TARGET=projectcain_vault35_default_configurator KEYBOARD_OUTPUT=.build/obj_projectcain_vault35 KEYMAP_OUTPUT=.build/obj_projectcain_vault35_default_configurator MAIN_KEYMAP_PATH_1=.build/obj_projectcain_vault35_default_configurator MAIN_KEYMAP_PATH_2=.build/obj_projectcain_vault35_default_configurator MAIN_KEYMAP_PATH_3=.build/obj_projectcain_vault35_default_configurator MAIN_KEYMAP_PATH_4=.build/obj_projectcain_vault35_default_configurator MAIN_KEYMAP_PATH_5=.build/obj_projectcain_vault35_default_configurator KEYMAP_C=.build/obj_projectcain_vault35_default_configurator/src/keymap.c KEYMAP_PATH=.build/obj_projectcain_vault35_default_configurator/src VERBOSE=false COLOR=true SILENT=false QMK_BIN="qmk"


avr-gcc (GCC) 5.4.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Compiling: keyboards/projectcain/vault35/vault35.c                                                 [01m[Kkeyboards/projectcain/vault35/vault35.c:[m[K In function ‘[01m[Kencoder_update_kb[m[K’:
[01m[Kkeyboards/projectcain/vault35/vault35.c:20:10:[m[K [01;31m[Kerror: [m[Kimplicit declaration of function ‘[01m[Kencoder_update_user[m[K’ [-Werror=implicit-function-declaration]
     if (!encoder_update_user(index, clockwise)) { return false; }
[01;32m[K          ^[m[K
cc1: all warnings being treated as errors
 [31;01m[ERRORS][0m
 | 
 | 
 | 
make: *** [builddefs/common_rules.mk:456: .build/obj_projectcain_vault35_default_configurator/keyboards/projectcain/vault35/vault35.o] Error 1
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
