### PR TITLE
LFK78 VIA support and Updated to compile to the latest QMK

### DIFF
--- a/keyboards/lfkeyboards/lfk78/config.h
+++ b/keyboards/lfkeyboards/lfk78/config.h
@@ -20,8 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0xFEED
-#define PRODUCT_ID      0x6060
+#define VENDOR_ID       0x4C46 // LF
+#define PRODUCT_ID      0x3738 // 78
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    LFKeyboards
 #define PRODUCT         LFK78

--- a/keyboards/lfkeyboards/lfk78/keymaps/via/keymap.c
+++ b/keyboards/lfkeyboards/lfk78/keymaps/via/keymap.c
@@ -1,3 +1,19 @@
+/* Copyright 2021 Matt Bautista (@nayoshi)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/keyboards/lfkeyboards/lfk78/keymaps/via/keymap.c
+++ b/keyboards/lfkeyboards/lfk78/keymaps/via/keymap.c
@@ -1,0 +1,56 @@
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Keymap VANILLA: (Base Layer) Default Layer
+     * ,---------.  ,------------------------------------------------------------.  ,---------.
+     * | F1 | F2 |  |Esc~| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |  0| - | = |Backspa|  | Ins|PgUp|
+     * |---------|  |------------------------------------------------------------|  |---------|
+     * | F3 | F4 |  |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|     \|  | Del|PgDn|
+     * |---------|  |------------------------------------------------------------|  `---------'
+     * | F5 | F6 |  |CAPS   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '| Return |
+     * |---------|  |------------------------------------------------------------|  ,----.
+     * | F7 | F8 |  |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift      |  | Up |
+     * |---------|  |-------------------------------------------------------------------------.
+     * | F9 | F10|  |Ctrl|Win |Alt |      Space            |Alt |Ctrl|Func |    |Lft| Dn |Rig |
+     * `---------'  `------------------------------------------------------'    `-------------'
+     */
+
+    [0] = LAYOUT(
+        KC_F1,   KC_F2,   KC_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,   KC_BSPC,          KC_INS,  KC_PGUP,
+        KC_F3,   KC_F4,   KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,  KC_BSLS,          KC_DEL,  KC_PGDN,
+        KC_F5,   KC_F6,   KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,           KC_ENT,
+        KC_F7,   KC_F8,   KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,           KC_RSFT,          KC_UP,
+        KC_F9,   KC_F10,  KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, KC_RCTL, MO(1),          KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+
+    [1] = LAYOUT(
+        KC_TRNS, KC_TRNS, KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,                KC_TRNS, KC_HOME,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_HOME, KC_UP,   KC_END,  KC_PGUP, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS, KC_END,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_LEFT, KC_DOWN, KC_RGHT, KC_PGDN, KC_TRNS, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_TRNS, KC_TRNS,          KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_MUTE, KC_VOLD, KC_VOLU, KC_TRNS,          TG(2),          KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                            KC_ENT,                             KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+
+    [2] = LAYOUT(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, BL_DEC,  BL_INC,  BL_TOGG,          RGB_TOG, RGB_VAI,
+        KC_TRNS, KC_TRNS, MU_MOD,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          RGB_MOD, RGB_VAD,
+        KC_TRNS, KC_TRNS, AU_TOG,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          RESET,
+        KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, MU_TOG,  KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,          RGB_HUI,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS,          RGB_SAD, RGB_HUD, RGB_SAI
+    ),
+    [3] = LAYOUT(
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, BL_DEC,  BL_INC,  BL_TOGG,          RGB_TOG, RGB_VAI,
+        KC_TRNS, KC_TRNS, MU_MOD,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          RGB_MOD, RGB_VAD,
+        KC_TRNS, KC_TRNS, AU_TOG,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          RESET,
+        KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, MU_TOG,  KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,          RGB_HUI,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                            KC_TRNS, KC_TRNS, KC_TRNS,          RGB_SAD, RGB_HUD, RGB_SAI
+    )
+};
+
+void matrix_init_user(void) {
+    // This keymap only has a single base layer, so reset the default if needed
+    if (eeconfig_read_default_layer() > 1) {
+        eeconfig_update_default_layer(1);
+        default_layer_set(1);
+    }
+}

--- a/keyboards/lfkeyboards/lfk78/keymaps/via/readme.md
+++ b/keyboards/lfkeyboards/lfk78/keymaps/via/readme.md
@@ -1,0 +1,1 @@
+# The via keymap for LFK78

--- a/keyboards/lfkeyboards/lfk78/keymaps/via/rules.mk
+++ b/keyboards/lfkeyboards/lfk78/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes

--- a/keyboards/lfkeyboards/lfk78/lfk78.c
+++ b/keyboards/lfkeyboards/lfk78/lfk78.c
@@ -110,7 +110,7 @@ void matrix_scan_kb(void) {
     matrix_scan_user();
 }
 
-void click(uint16_t freq, uint16_t duration) {
+void clickingNotes(uint16_t freq, uint16_t duration) {
 #ifdef AUDIO_ENABLE
     if (freq >= 100 && freq <= 20000 && duration < 100) {
         play_note(freq, 10);
@@ -124,7 +124,7 @@ void click(uint16_t freq, uint16_t duration) {
 
 bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     if (click_toggle && record->event.pressed) {
-        click(click_hz, click_time);
+        clickingNotes(click_hz, click_time);
     }
 
     if (keycode == RESET) {

--- a/keyboards/lfkeyboards/lfk78/lfk78.c
+++ b/keyboards/lfkeyboards/lfk78/lfk78.c
@@ -110,7 +110,7 @@ void matrix_scan_kb(void) {
     matrix_scan_user();
 }
 
-void clickingNotes(uint16_t freq, uint16_t duration) {
+void clicking_notes(uint16_t freq, uint16_t duration) {
 #ifdef AUDIO_ENABLE
     if (freq >= 100 && freq <= 20000 && duration < 100) {
         play_note(freq, 10);
@@ -124,7 +124,7 @@ void clickingNotes(uint16_t freq, uint16_t duration) {
 
 bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     if (click_toggle && record->event.pressed) {
-        clickingNotes(click_hz, click_time);
+        clicking_notes(click_hz, click_time);
     }
 
     if (keycode == RESET) {

--- a/keyboards/lfkeyboards/lfk78/lfk78.h
+++ b/keyboards/lfkeyboards/lfk78/lfk78.h
@@ -30,4 +30,4 @@ extern const Layer_Info layer_info[];
 #define CLICK_ENABLED 0
 
 void reset_keyboard_kb(void);
-void click(uint16_t freq, uint16_t duration);
+void clickingNotes(uint16_t freq, uint16_t duration);

--- a/keyboards/lfkeyboards/lfk78/lfk78.h
+++ b/keyboards/lfkeyboards/lfk78/lfk78.h
@@ -30,4 +30,4 @@ extern const Layer_Info layer_info[];
 #define CLICK_ENABLED 0
 
 void reset_keyboard_kb(void);
-void clickingNotes(uint16_t freq, uint16_t duration);
+void clicking_notes(uint16_t freq, uint16_t duration);


### PR DESCRIPTION
## Description
Fixed LFK78 firmware to be able to compile in the latest version of QMK. Added VIA support to LFK78.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
* Changed Vendor ID to 0x4C46 = LF
* Changed Product ID to 0x3738 = 78
* Added VIA keymap to LFK78
* Changed function name from click to clickingNotes (As click is a qmk variable and throws error when compiled)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
