### PR TITLE
fix v-usb connection enumeration, ifdef workaround

### DIFF
--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -270,6 +270,11 @@ void send_keyboard_report(void) {
     keyboard_report->mods |= weak_override_mods;
 #endif
 
+
+
+#ifdef PROTOCOL_VUSB
+        host_keyboard_send(keyboard_report);
+#else
     static report_keyboard_t last_report;
 
     /* Only send the report if there are changes to propagate to the host. */
@@ -277,6 +282,9 @@ void send_keyboard_report(void) {
         memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
         host_keyboard_send(keyboard_report);
     }
+#endif
+
+
 }
 
 /** \brief Get mods

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -270,10 +270,8 @@ void send_keyboard_report(void) {
     keyboard_report->mods |= weak_override_mods;
 #endif
 
-
-
 #ifdef PROTOCOL_VUSB
-        host_keyboard_send(keyboard_report);
+    host_keyboard_send(keyboard_report);
 #else
     static report_keyboard_t last_report;
 

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -281,8 +281,6 @@ void send_keyboard_report(void) {
         host_keyboard_send(keyboard_report);
     }
 #endif
-
-
 }
 
 /** \brief Get mods


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

fix v-usb  usb reporting by enabling empty reports for vusb

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

fixes vusb enumeration issues 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
