### PR TITLE
Add support for STM32L072 and STM32L073 variants

### DIFF
--- a/builddefs/mcu_selection.mk
+++ b/builddefs/mcu_selection.mk
@@ -502,6 +502,56 @@ ifneq ($(findstring STM32G474, $(MCU)),)
   STM32_BOOTLOADER_ADDRESS ?= 0x1FFF0000
 endif
 
+ifneq (,$(filter $(MCU),STM32L072 STM32L072x8 STM32L072xB STM32L072xZ STM32L073 STM32L073x8 STM32L073xB STM32L073xZ)) 
+  # This sections adds support for STM32L072xx and STM32L073xx processors, which have different memory configurations:
+  # STM32L072x8 and STM32L073x8: 64 kByte flash,  20 kByte RAM
+  # STM32L072xB and STM32L073xB: 128 kByte flash, 20 kByte RAM
+  # STM32L072xZ and STM32L073xZ: 192 kByte flash, 20 kByte RAM
+  #
+  # Memory layouts on STM32L072xx and STM32L073xx processors are identical.
+
+  # Linker script to use, depending on MCU model
+  # - it should exist either in <chibios>/os/common/startup/ARMCMx/compilers/GCC/ld/
+  #   or <keyboard_dir>/ld/
+  ifneq (,$(filter $(MCU),STM32L072x8 STM32L073x8))
+    MCU_LDSCRIPT ?= STM32L073x8
+  else ifneq (,$(filter $(MCU),STM32L072xB STM32L072xB))
+    MCU_LDSCRIPT ?= STM32L073xB
+  else ifneq (,$(filter $(MCU),STM32L072xZ STM32L073xZ))
+    MCU_LDSCRIPT ?= STM32L073xZ
+  else
+    $(error Specify the exact MCU model, not only the base type $(MCU). $(MCU)x8, $(MCU)xB or $(MCU)xZ are valid options and differ in memory size)
+  endif
+
+  # Cortex version
+  MCU = cortex-m0plus
+
+  # ARM version, CORTEX-M0/M1 are 6, CORTEX-M3/M4/M7 are 7
+  ARMV = 6
+
+  ## chip/board settings
+  # - the next two should match the directories in
+  #   <chibios>/os/hal/ports/$(MCU_FAMILY)/$(MCU_SERIES)
+  MCU_FAMILY = STM32
+  MCU_SERIES = STM32L0xx
+
+  # Startup code to use
+  #  - it should exist in <chibios>/os/common/startup/ARMCMx/compilers/GCC/mk/
+  MCU_STARTUP ?= stm32l0xx
+
+  # Board: it should exist either in <chibios>/os/hal/boards/,
+  # <keyboard_dir>/boards/, or drivers/boards/
+  BOARD ?= GENERIC_STM32_L073XZ
+
+  USE_FPU ?= no
+
+  # UF2 settings
+  UF2_FAMILY ?= STM32L0
+
+  # Bootloader address for STM32 DFU
+  STM32_BOOTLOADER_ADDRESS ?= 0x1FF00000
+endif
+
 ifneq (,$(filter $(MCU),STM32L432 STM32L442))
   # Cortex version
   MCU = cortex-m4

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -13,7 +13,7 @@
         },
         "processor": {
             "type": "string",
-            "enum": ["cortex-m0", "cortex-m0plus", "cortex-m3", "cortex-m4", "MKL26Z64", "MK20DX128", "MK20DX256", "MK66FX1M0", "STM32F042", "STM32F072", "STM32F103", "STM32F303", "STM32F401", "STM32F405", "STM32F407", "STM32F411", "STM32F446", "STM32G431", "STM32G474", "STM32L412", "STM32L422", "STM32L432", "STM32L433", "STM32L442", "STM32L443", "GD32VF103", "WB32F3G71", "atmega16u2", "atmega32u2", "atmega16u4", "atmega32u4", "at90usb162", "at90usb646", "at90usb647", "at90usb1286", "at90usb1287", "atmega32a", "atmega328p", "atmega328", "attiny85", "unknown"]
+            "enum": ["cortex-m0", "cortex-m0plus", "cortex-m3", "cortex-m4", "MKL26Z64", "MK20DX128", "MK20DX256", "MK66FX1M0", "STM32F042", "STM32F072", "STM32F103", "STM32F303", "STM32F401", "STM32F405", "STM32F407", "STM32F411", "STM32F446", "STM32G431", "STM32G474", "STM32L072", "STM32L072x8", "STM32L072xB", "STM32L072xZ", "STM32L073", "STM32L073x8", "STM32L073xB", "STM32L073xZ", "STM32L412", "STM32L422", "STM32L432", "STM32L433", "STM32L442", "STM32L443", "GD32VF103", "WB32F3G71", "atmega16u2", "atmega32u2", "atmega16u4", "atmega32u4", "at90usb162", "at90usb646", "at90usb647", "at90usb1286", "at90usb1287", "atmega32a", "atmega328p", "atmega328", "attiny85", "unknown"]
         },
         "audio": {
             "type": "object",

--- a/docs/compatible_microcontrollers.md
+++ b/docs/compatible_microcontrollers.md
@@ -28,6 +28,8 @@ You can also use any ARM chip with USB that [ChibiOS](https://www.chibios.org) s
 ### STMicroelectronics (STM32)
 
  * [STM32F0x2](https://www.st.com/en/microcontrollers-microprocessors/stm32f0x2.html)
+ * [STM32L072](https://www.st.com/en/microcontrollers-microprocessors/stm32l0x2.html)
+ * [STM32L073](https://www.st.com/en/microcontrollers-microprocessors/stm32l0x3.html)
  * [STM32F103](https://www.st.com/en/microcontrollers-microprocessors/stm32f103.html)
    * Bluepill (with STM32duino bootloader)
  * [STM32F303](https://www.st.com/en/microcontrollers-microprocessors/stm32f303.html)

--- a/keyboards/handwired/onekey/stm32l072/config.h
+++ b/keyboards/handwired/onekey/stm32l072/config.h
@@ -1,0 +1,25 @@
+/* Copyright 2022
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config_common.h"
+
+#define PRODUCT Onekey STM32L072
+
+#define MATRIX_COL_PINS { B4 }
+#define MATRIX_ROW_PINS { B5 }
+#define UNUSED_PINS

--- a/keyboards/handwired/onekey/stm32l072/readme.md
+++ b/keyboards/handwired/onekey/stm32l072/readme.md
@@ -1,0 +1,5 @@
+# STM32L072 onekey
+
+To trigger a keypress, short together pins *B4* and *B5*.
+
+This will run on any STM32L072 or STM32L073, as it is compiled for the smallest memory configuration (64k).

--- a/keyboards/handwired/onekey/stm32l072/rules.mk
+++ b/keyboards/handwired/onekey/stm32l072/rules.mk
@@ -1,0 +1,5 @@
+# MCU name
+MCU = STM32L072x8
+
+# Bootloader selection
+BOOTLOADER = stm32-dfu

--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -13,7 +13,7 @@ QMK_FIRMWARE_UPSTREAM = 'qmk/qmk_firmware'
 MAX_KEYBOARD_SUBFOLDERS = 5
 
 # Supported processor types
-CHIBIOS_PROCESSORS = 'cortex-m0', 'cortex-m0plus', 'cortex-m3', 'cortex-m4', 'MKL26Z64', 'MK20DX128', 'MK20DX256', 'MK66FX1M0', 'STM32F042', 'STM32F072', 'STM32F103', 'STM32F303', 'STM32F401', 'STM32F405', 'STM32F407', 'STM32F411', 'STM32F446', 'STM32G431', 'STM32G474', 'STM32L412', 'STM32L422', 'STM32L432', 'STM32L433', 'STM32L442', 'STM32L443', 'GD32VF103', 'WB32F3G71'
+CHIBIOS_PROCESSORS = 'cortex-m0', 'cortex-m0plus', 'cortex-m3', 'cortex-m4', 'MKL26Z64', 'MK20DX128', 'MK20DX256', 'MK66FX1M0', 'STM32F042', 'STM32F072', 'STM32F103', 'STM32F303', 'STM32F401', 'STM32F405', 'STM32F407', 'STM32F411', 'STM32F446', 'STM32G431', 'STM32G474', 'STM32L072', 'STM32L072x8', 'STM32L072xB', 'STM32L072xZ', 'STM32L073', 'STM32L073x8', 'STM32L073xB', 'STM32L073xZ', 'STM32L412', 'STM32L422', 'STM32L432', 'STM32L433', 'STM32L442', 'STM32L443', 'GD32VF103', 'WB32F3G71'
 LUFA_PROCESSORS = 'at90usb162', 'atmega16u2', 'atmega32u2', 'atmega16u4', 'atmega32u4', 'at90usb646', 'at90usb647', 'at90usb1286', 'at90usb1287', None
 VUSB_PROCESSORS = 'atmega32a', 'atmega328p', 'atmega328', 'attiny85'
 
@@ -34,6 +34,14 @@ MCU2BOOTLOADER = {
     "STM32F446": "stm32-dfu",
     "STM32G431": "stm32-dfu",
     "STM32G474": "stm32-dfu",
+    "STM32L072": "stm32-dfu",
+    "STM32L072x8": "stm32-dfu",
+    "STM32L072xB": "stm32-dfu",
+    "STM32L072xZ": "stm32-dfu",
+    "STM32L073": "stm32-dfu",
+    "STM32L073x8": "stm32-dfu",
+    "STM32L073xB": "stm32-dfu",
+    "STM32L073xZ": "stm32-dfu",
     "STM32L412": "stm32-dfu",
     "STM32L422": "stm32-dfu",
     "STM32L432": "stm32-dfu",

--- a/platforms/chibios/boards/GENERIC_STM32_L073XZ/board/board.mk
+++ b/platforms/chibios/boards/GENERIC_STM32_L073XZ/board/board.mk
@@ -1,0 +1,9 @@
+# List of all the board related files.
+BOARDSRC = $(CHIBIOS)/os/hal/boards/ST_NUCLEO64_L073RZ/board.c
+
+# Required include directories
+BOARDINC = $(CHIBIOS)/os/hal/boards/ST_NUCLEO64_L073RZ
+
+# Shared variables
+ALLCSRC += $(BOARDSRC)
+ALLINC  += $(BOARDINC)

--- a/platforms/chibios/boards/GENERIC_STM32_L073XZ/configs/board.h
+++ b/platforms/chibios/boards/GENERIC_STM32_L073XZ/configs/board.h
@@ -1,0 +1,20 @@
+/* Copyright 2022 Adrian (elagil)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include_next "board.h"
+
+#undef STM32_HSE_BYPASS

--- a/platforms/chibios/boards/GENERIC_STM32_L073XZ/configs/config.h
+++ b/platforms/chibios/boards/GENERIC_STM32_L073XZ/configs/config.h
@@ -1,0 +1,23 @@
+/* Copyright 2022 Adrian (elagil)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+// This MCU does only have 16 bit timers.
+#define CH_CFG_ST_RESOLUTION 16
+
+#ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
+#    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
+#endif

--- a/platforms/chibios/boards/GENERIC_STM32_L073XZ/configs/mcuconf.h
+++ b/platforms/chibios/boards/GENERIC_STM32_L073XZ/configs/mcuconf.h
@@ -1,0 +1,242 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * STM32L0xx drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in halconf.h.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...3        Lowest...Highest.
+ */
+
+#define STM32L0xx_MCUCONF
+#define STM32L072_MCUCONF
+#define STM32L073_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define STM32_NO_INIT                       FALSE
+#define STM32_VOS                           STM32_VOS_1P8
+#define STM32_PVD_ENABLE                    FALSE
+#define STM32_PLS                           STM32_PLS_LEV0
+#define STM32_HSI16_ENABLED                 TRUE
+#define STM32_HSI16_DIVIDER_ENABLED         FALSE
+#define STM32_LSI_ENABLED                   FALSE
+#define STM32_HSE_ENABLED                   FALSE
+#define STM32_LSE_ENABLED                   TRUE
+#define STM32_ADC_CLOCK_ENABLED             TRUE
+#define STM32_USB_CLOCK_ENABLED             TRUE
+#define STM32_MSIRANGE                      STM32_MSIRANGE_2M
+#define STM32_SW                            STM32_SW_PLL
+#define STM32_PLLSRC                        STM32_PLLSRC_HSI16
+#define STM32_PLLMUL_VALUE                  4
+#define STM32_PLLDIV_VALUE                  2
+#define STM32_HPRE                          STM32_HPRE_DIV1
+#define STM32_PPRE1                         STM32_PPRE1_DIV1
+#define STM32_PPRE2                         STM32_PPRE2_DIV1
+#define STM32_MCOSEL                        STM32_MCOSEL_NOCLOCK
+#define STM32_MCOPRE                        STM32_MCOPRE_DIV1
+
+/*
+ * Peripherals clock sources.
+ */
+#define STM32_USART1SEL                     STM32_USART1SEL_APB
+#define STM32_USART2SEL                     STM32_USART2SEL_APB
+#define STM32_LPUART1SEL                    STM32_LPUART1SEL_APB
+#define STM32_I2C1SEL                       STM32_I2C1SEL_APB
+#define STM32_I2C3SEL                       STM32_I2C3SEL_APB
+#define STM32_LPTIM1SEL                     STM32_LPTIM1SEL_APB
+#define STM32_HSI48SEL                      STM32_HSI48SEL_HSI48
+#define STM32_RTCSEL                        STM32_RTCSEL_LSE
+#define STM32_RTCPRE                        STM32_RTCPRE_DIV2
+
+/*
+ * IRQ system settings.
+ */
+#define STM32_IRQ_EXTI0_1_PRIORITY          3
+#define STM32_IRQ_EXTI2_3_PRIORITY          3
+#define STM32_IRQ_EXTI4_15_PRIORITY         3
+#define STM32_IRQ_EXTI16_PRIORITY           3
+#define STM32_IRQ_EXTI17_20_PRIORITY        3
+#define STM32_IRQ_EXTI21_22_PRIORITY        3
+
+#define STM32_IRQ_USART1_PRIORITY           3
+#define STM32_IRQ_USART2_PRIORITY           3
+#define STM32_IRQ_USART4_5_PRIORITY         3
+#define STM32_IRQ_LPUART1_PRIORITY          3
+
+#define STM32_IRQ_TIM2_PRIORITY             1
+#define STM32_IRQ_TIM3_PRIORITY             1
+#define STM32_IRQ_TIM6_PRIORITY             1
+#define STM32_IRQ_TIM7_PRIORITY             1
+#define STM32_IRQ_TIM21_PRIORITY            1
+#define STM32_IRQ_TIM22_PRIORITY            1
+
+/*
+ * ADC driver system settings.
+ * Note, IRQ is shared with EXT channels 21 and 22.
+ */
+#define STM32_ADC_USE_ADC1                  FALSE
+#define STM32_ADC_ADC1_CKMODE               STM32_ADC_CKMODE_ADCCLK
+#define STM32_ADC_ADC1_DMA_PRIORITY         2
+#define STM32_ADC_ADC1_DMA_IRQ_PRIORITY     2
+#define STM32_ADC_ADC1_DMA_STREAM           STM32_DMA_STREAM_ID(1, 1)
+#define STM32_ADC_PRESCALER_VALUE           2
+
+/*
+ * DAC driver system settings.
+ */
+#define STM32_DAC_DUAL_MODE                 FALSE
+#define STM32_DAC_USE_DAC1_CH1              FALSE
+#define STM32_DAC_USE_DAC1_CH2              FALSE
+#define STM32_DAC_DAC1_CH1_IRQ_PRIORITY     3
+#define STM32_DAC_DAC1_CH2_IRQ_PRIORITY     3
+#define STM32_DAC_DAC1_CH1_DMA_PRIORITY     2
+#define STM32_DAC_DAC1_CH2_DMA_PRIORITY     2
+#define STM32_DAC_DAC1_CH1_DMA_STREAM       STM32_DMA_STREAM_ID(1, 2)
+#define STM32_DAC_DAC1_CH2_DMA_STREAM       STM32_DMA_STREAM_ID(1, 4)
+
+/*
+ * GPT driver system settings.
+ */
+#define STM32_GPT_USE_TIM2                  FALSE
+#define STM32_GPT_USE_TIM3                  FALSE
+#define STM32_GPT_USE_TIM6                  FALSE
+#define STM32_GPT_USE_TIM7                  FALSE
+#define STM32_GPT_USE_TIM21                 FALSE
+#define STM32_GPT_USE_TIM22                 FALSE
+
+/*
+ * I2C driver system settings.
+ */
+#define STM32_I2C_USE_I2C1                  FALSE
+#define STM32_I2C_USE_I2C2                  FALSE
+#define STM32_I2C_USE_I2C3                  FALSE
+#define STM32_I2C_BUSY_TIMEOUT              50
+#define STM32_I2C_I2C1_IRQ_PRIORITY         3
+#define STM32_I2C_I2C2_IRQ_PRIORITY         3
+#define STM32_I2C_I2C3_IRQ_PRIORITY         3
+#define STM32_I2C_USE_DMA                   TRUE
+#define STM32_I2C_I2C1_DMA_PRIORITY         1
+#define STM32_I2C_I2C2_DMA_PRIORITY         1
+#define STM32_I2C_I2C3_DMA_PRIORITY         1
+#define STM32_I2C_I2C1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 7)
+#define STM32_I2C_I2C1_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 2)
+#define STM32_I2C_I2C2_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 5)
+#define STM32_I2C_I2C2_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 4)
+#define STM32_I2C_I2C3_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 3)
+#define STM32_I2C_I2C3_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 6)
+#define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
+
+/*
+ * ICU driver system settings.
+ */
+#define STM32_ICU_USE_TIM2                  FALSE
+#define STM32_ICU_USE_TIM3                  FALSE
+#define STM32_ICU_USE_TIM21                 FALSE
+#define STM32_ICU_USE_TIM22                 FALSE
+
+/*
+ * PWM driver system settings.
+ */
+#define STM32_PWM_USE_TIM2                  FALSE
+#define STM32_PWM_USE_TIM3                  FALSE
+#define STM32_PWM_USE_TIM21                 FALSE
+#define STM32_PWM_USE_TIM22                 FALSE
+
+/*
+ * SERIAL driver system settings.
+ */
+#define STM32_SERIAL_USE_USART1             FALSE
+#define STM32_SERIAL_USE_USART2             TRUE
+#define STM32_SERIAL_USE_UART4              FALSE
+#define STM32_SERIAL_USE_UART5              FALSE
+#define STM32_SERIAL_USE_LPUART1            FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define STM32_SPI_USE_SPI1                  FALSE
+#define STM32_SPI_USE_SPI2                  FALSE
+#define STM32_SPI_SPI1_DMA_PRIORITY         1
+#define STM32_SPI_SPI2_DMA_PRIORITY         1
+#define STM32_SPI_SPI1_IRQ_PRIORITY         1
+#define STM32_SPI_SPI2_IRQ_PRIORITY         1
+#define STM32_SPI_SPI1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 2)
+#define STM32_SPI_SPI1_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 3)
+#define STM32_SPI_SPI2_RX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 4)
+#define STM32_SPI_SPI2_TX_DMA_STREAM        STM32_DMA_STREAM_ID(1, 5)
+#define STM32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
+
+/*
+ * ST driver system settings.
+ */
+#define STM32_ST_IRQ_PRIORITY               2
+#define STM32_ST_USE_TIMER                  21
+
+/*
+ * TRNG driver system settings.
+ */
+#define STM32_TRNG_USE_RNG1                 FALSE
+
+/*
+ * UART driver system settings.
+ */
+#define STM32_UART_USE_USART1               FALSE
+#define STM32_UART_USE_USART2               FALSE
+#define STM32_UART_USE_UART4                FALSE
+#define STM32_UART_USE_UART5                FALSE
+#define STM32_UART_USART1_DMA_PRIORITY      0
+#define STM32_UART_USART2_DMA_PRIORITY      0
+#define STM32_UART_UART4_DMA_PRIORITY       0
+#define STM32_UART_UART5_DMA_PRIORITY       0
+#define STM32_UART_USART1_IRQ_PRIORITY      3
+#define STM32_UART_USART2_IRQ_PRIORITY      3
+#define STM32_UART_USART4_5_IRQ_PRIORITY    3
+#define STM32_UART_USART1_RX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 5)
+#define STM32_UART_USART1_TX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 4)
+#define STM32_UART_USART2_RX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 6)
+#define STM32_UART_USART2_TX_DMA_STREAM     STM32_DMA_STREAM_ID(1, 7)
+#define STM32_UART_UART4_RX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 2)
+#define STM32_UART_UART4_TX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 3)
+#define STM32_UART_UART5_RX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 6)
+#define STM32_UART_UART5_TX_DMA_STREAM      STM32_DMA_STREAM_ID(1, 7)
+#define STM32_UART_DMA_ERROR_HOOK(uartp)    osalSysHalt("DMA failure")
+
+/*
+ * USB driver system settings.
+ */
+#define STM32_USB_USE_USB1                  TRUE
+#define STM32_USB_LOW_POWER_ON_SUSPEND      FALSE
+#define STM32_USB_USB1_HP_IRQ_PRIORITY      0
+#define STM32_USB_USB1_LP_IRQ_PRIORITY      0
+
+/*
+ * WDG driver system settings.
+ */
+#define STM32_WDG_USE_IWDG                  FALSE
+
+#endif /* MCUCONF_H */


### PR DESCRIPTION
## Description

This adds support for the STM32L072 and STM32L073 chips in various memory configurations.

**Note**: I added granular support for each memory variant, which requires the user to specify their particular variant. For example, simply setting `STM32L072` as the `MCU` will throw an error message, asking to specify the type. Valid types are 

- STM32L072x8 or STM32L073x8
- STM32L072xB or STM32L073xB 
- STM32L072xZ or STM32L073xZ

and are also presented to the user when linking fails.

STM32L072 and STM32L073 chipsets with the same final letter share the same memory layout. Thus, there only exist linker files for STM32L073 chips that shall be used for both.

Finally, the STM32L07x only has 16 bit timers, meaning that the `SYSTICK` timer is set up to be only 16 bit long.

I did not test the changes with hardware yet, but I will soon. Compilation and linking works as expected.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation. In the web document that specifies supported MCUs?
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
