### PR TITLE
Change helix:edvorakjp keymap to use split_common

### DIFF
--- a/keyboards/helix/rev2/keymaps/edvorakjp/rules.mk
+++ b/keyboards/helix/rev2/keymaps/edvorakjp/rules.mk
@@ -5,6 +5,7 @@
 #   See TOP/keyboards/helix/rules.mk for a list of options that can be set.
 #   See TOP/docs/config_options.md for more information.
 #
+SPLIT_KEYBOARD = yes
 LTO_ENABLE = no  # if firmware size over limit, try this option
 TAP_DANCE_ENABLE = yes
 


### PR DESCRIPTION
## Description

Changed helix:edvorakjp keymap to use split_common.

@epaew, This PR needs to be tested and approved by you.

The Helix keyboard is currently in the process of changing from its original implementation of split_util to using split_common. (#16388)
As a first step, we are switching to split_common for each keymap one by one to make sure that each keymap is working properly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #16388

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
