### PR TITLE
Change helix:yshrsmz keymap to use split_common

### DIFF
--- a/keyboards/helix/rev2/keymaps/yshrsmz/keymap.c
+++ b/keyboards/helix/rev2/keymaps/yshrsmz/keymap.c
@@ -1,23 +1,9 @@
 #include QMK_KEYBOARD_H
-#include "bootloader.h"
-#ifdef PROTOCOL_LUFA
-#include "lufa.h"
-#include "split_util.h"
-#endif
-#ifdef AUDIO_ENABLE
-  #include "audio.h"
-#endif
+#include <stdio.h>
+#include <string.h>
 #ifdef SSD1306OLED
   #include "ssd1306.h"
 #endif
-
-
-#ifdef RGBLIGHT_ENABLE
-//Following line allows macro to read current RGB settings
-extern rgblight_config_t rgblight_config;
-#endif
-
-extern uint8_t is_master;
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
@@ -415,7 +401,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         if (record->event.pressed) {
           rgblight_mode(RGB_current_mode);
           rgblight_step();
-          RGB_current_mode = rgblight_config.mode;
+          RGB_current_mode = rgblight_get_mode();
         }
       #endif
       return false;
@@ -449,7 +435,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         if (record->event.pressed) {
           eeconfig_update_rgblight_default();
           rgblight_enable();
-          RGB_current_mode = rgblight_config.mode;
+          RGB_current_mode = rgblight_get_mode();
         }
       #endif
       break;
@@ -462,7 +448,7 @@ void matrix_init_user(void) {
         startup_user();
     #endif
     #ifdef RGBLIGHT_ENABLE
-      RGB_current_mode = rgblight_config.mode;
+      RGB_current_mode = rgblight_get_mode();
     #endif
     //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
     #ifdef SSD1306OLED
@@ -533,15 +519,15 @@ static void render_logo(struct CharacterMatrix *matrix) {
 static void render_rgbled_status(bool full, struct CharacterMatrix *matrix) {
 #ifdef RGBLIGHT_ENABLE
   char buf[30];
-  if (RGBLIGHT_MODES > 1 && rgblight_config.enable) {
+  if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
       if (full) {
           snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
-                   rgblight_config.mode,
-                   rgblight_config.hue/RGBLIGHT_HUE_STEP,
-                   rgblight_config.sat/RGBLIGHT_SAT_STEP,
-                   rgblight_config.val/RGBLIGHT_VAL_STEP);
+                   rgblight_get_mode(),
+                   rgblight_get_hue()/RGBLIGHT_HUE_STEP,
+                   rgblight_get_sat()/RGBLIGHT_SAT_STEP,
+                   rgblight_get_val()/RGBLIGHT_VAL_STEP);
       } else {
-          snprintf(buf, sizeof(buf), "[%2d] ",rgblight_config.mode);
+          snprintf(buf, sizeof(buf), "[%2d] ", rgblight_get_mode());
       }
       matrix_write(matrix, buf);
   }
@@ -613,9 +599,9 @@ void iota_gfx_task_user(void) {
 #endif
 
   matrix_clear(&matrix);
-  if(is_master){
+  if (is_keyboard_master()) {
     render_status(&matrix);
-  }else{
+  } else {
     render_logo(&matrix);
     render_rgbled_status(false, &matrix);
     render_layer_status(&matrix);
@@ -623,4 +609,121 @@ void iota_gfx_task_user(void) {
   matrix_update(&display, &matrix);
 }
 
-#endif
+#endif // end of SSD1306OLED
+
+#ifdef OLED_ENABLE
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    if (is_keyboard_master()) {
+        return OLED_ROTATION_0;
+    } else {
+        return OLED_ROTATION_180;
+    }
+}
+
+//assign the right code to your layers for OLED display
+#define L_BASE 0
+#define L_LOWER (1<<_LOWER)
+#define L_RAISE (1<<_RAISE)
+#define L_ADJUST (1<<_ADJUST)
+#define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
+
+static void render_logo(void) {
+
+  static const char helix_logo[] PROGMEM ={
+    0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
+    0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
+    0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
+    0};
+  oled_write_P(helix_logo, false);
+  //matrix_write_P(&matrix, PSTR(" Split keyboard kit"));
+}
+
+static void render_rgbled_status(bool full) {
+#    ifdef RGBLIGHT_ENABLE
+  char buf[30];
+  if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
+      if (full) {
+          snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
+                   rgblight_get_mode(),
+                   rgblight_get_hue()/RGBLIGHT_HUE_STEP,
+                   rgblight_get_sat()/RGBLIGHT_SAT_STEP,
+                   rgblight_get_val()/RGBLIGHT_VAL_STEP);
+      } else {
+          snprintf(buf, sizeof(buf), "[%2d] ", rgblight_get_mode());
+      }
+      oled_write(buf, false);
+  }
+#    endif
+}
+
+static void render_layer_status(void) {
+  // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
+  char buf[10];
+  oled_write_P(PSTR("Layer: "), false);
+    switch (layer_state) {
+        case L_BASE:
+           oled_write_P(PSTR("Default"), false);
+           break;
+        case L_RAISE:
+           oled_write_P(PSTR("Raise"), false);
+           break;
+        case L_LOWER:
+           oled_write_P(PSTR("Lower"), false);
+           break;
+        case L_ADJUST:
+        case L_ADJUST_TRI:
+           oled_write_P(PSTR("Adjust"), false);
+           break;
+        default:
+           oled_write_P(PSTR("Undef-"), false);
+           snprintf(buf,sizeof(buf), "%ld", layer_state);
+           oled_write(buf, false);
+    }
+    oled_write_P(PSTR("\n"), false);
+}
+
+void render_status(void) {
+  // Render to mode icon
+  static const char os_logo[][2][3] PROGMEM  ={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
+  if (keymap_config.swap_lalt_lgui==false) {
+    oled_write_P(os_logo[0][0], false);
+    oled_write_P(PSTR("\n"), false);
+    oled_write_P(os_logo[0][1], false);
+  } else {
+    oled_write_P(os_logo[1][0], false);
+    oled_write_P(PSTR("\n"), false);
+    oled_write_P(os_logo[1][1], false);
+  }
+
+  oled_write_P(PSTR(" "), false);
+  render_layer_status();
+
+  // Host Keyboard LED Status
+  oled_write_P((host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ?
+                 PSTR("NUMLOCK") : PSTR("       "), false);
+  oled_write_P((host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ?
+                 PSTR("CAPS") : PSTR("    "), false);
+  oled_write_P((host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ?
+                 PSTR("SCLK") : PSTR("    "), false);
+  oled_write_P(PSTR("\n"), false);
+  render_rgbled_status(true);
+  oled_write_P(PSTR("\n"), false);
+}
+
+bool oled_task_user(void) {
+#    if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#    endif
+
+    if (is_keyboard_master()) {
+        render_status();
+    } else {
+        render_logo();
+        render_rgbled_status(false);
+        render_layer_status();
+    }
+    return false;
+}
+#endif // end of OLED_ENABLE

--- a/keyboards/helix/rev2/keymaps/yshrsmz/rules.mk
+++ b/keyboards/helix/rev2/keymaps/yshrsmz/rules.mk
@@ -6,6 +6,7 @@
 #   See TOP/docs/config_options.md for more information.
 #
 LTO_ENABLE = no  # if firmware size over limit, try this option
+SPLIT_KEYBOARD = yes
 
 # Helix Spacific Build Options
 # you can uncomment and edit follows 7 Variables

--- a/keyboards/helix/rev2/keymaps/yshrsmz/rules.mk
+++ b/keyboards/helix/rev2/keymaps/yshrsmz/rules.mk
@@ -17,3 +17,11 @@ OLED_ENABLE = yes            # OLED_ENABLE
 # LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = no        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
+
+# OLED_ENABLE が yes のとき
+#   OLED_SELECT が core ならば QMK 標準の oled_dirver.c を使用します。
+#   OLED_SELECT が core 以外ならば従来どおり helix/local_drivers/ssd1306.c を使用します。
+# If OLED_ENABLE is 'yes'
+#   If OLED_SELECT is 'core', use QMK standard oled_dirver.c.
+#   If OLED_SELECT is other than 'core', use helix/local_drivers/ssd1306.c.
+OLED_SELECT = core


### PR DESCRIPTION
## Description

* Change helix:yshrsmz keymap to use split_common
* Makes QMK standerd OLED driver used by the helix:yshrsmz keymap switchable.

@yshrsmz, This PR needs to be tested and approved by you.

The Helix keyboard is currently in the process of changing from its original implementation of split_util to using split_common. (#16388)
As a first step, we are switching to split_common for each keymap one by one to make sure that each keymap is working properly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #16388

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
