### PR TITLE
Change helix:five_rows_jis keymap to use split_common

### DIFF
--- a/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
@@ -1,4 +1,5 @@
 LTO_ENABLE = no  # if firmware size over limit, try this option
+SPLIT_KEYBOARD = yes
 
 # Helix Spacific Build Options
 # you can uncomment and edit follows 7 Variables

--- a/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
+++ b/keyboards/helix/rev2/keymaps/five_rows_jis/rules.mk
@@ -10,3 +10,11 @@ HELIX_ROWS = 5              # Helix Rows is 4 or 5
 # LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 # LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
+
+# OLED_ENABLE が yes のとき
+#   OLED_SELECT が core ならば QMK 標準の oled_dirver.c を使用します。
+#   OLED_SELECT が core 以外ならば従来どおり helix/local_drivers/ssd1306.c を使用します。
+# If OLED_ENABLE is 'yes'
+#   If OLED_SELECT is 'core', use QMK standard oled_dirver.c.
+#   If OLED_SELECT is other than 'core', use helix/local_drivers/ssd1306.c.
+OLED_SELECT = core


### PR DESCRIPTION
## Description

* Change helix:five_rows_jis keymap to use split_common
* Makes QMK standerd OLED driver used by the helix:five_rows_jis keymap switchable.

@marksard, This PR needs to be tested and approved by you.

The Helix keyboard is currently in the process of changing from its original implementation of split_util to using split_common. (#16388)
As a first step, we are switching to split_common for each keymap one by one to make sure that each keymap is working properly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #16388

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
