### PR TITLE
`qmk info`: Nicer rendering of big-ass enter

### DIFF
--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -178,6 +178,8 @@ def render_layout(layout_data, render_ascii, key_labels=None):
 
         if x >= 0.25 and w == 1.25 and h == 2:
             render_key_isoenter(textpad, x, y, w, h, label, style)
+        elif w == 2.25 and h == 2:
+            render_key_baenter(textpad, x, y, w, h, label, style)
         else:
             render_key_rect(textpad, x, y, w, h, label, style)
 
@@ -259,4 +261,35 @@ def render_key_isoenter(textpad, x, y, w, h, label, style):
     textpad[y + 2][x - 1:x + w] = crn_line
     textpad[y + 3][x:x + w] = mid_line
     textpad[y + 4][x:x + w] = mid_line
-    textpad[y + h - 1][x:x + w] = bot_line
+    textpad[y + 5][x:x + w] = bot_line
+
+def render_key_baenter(textpad, x, y, w, h, label, style):
+    box_chars = BOX_DRAWING_CHARACTERS[style]
+    x = ceil(x * 4)
+    y = ceil(y * 3)
+    w = ceil(w * 4)
+    h = ceil(h * 3)
+
+    label_len = w - 2
+    label_leftover = label_len - len(label)
+
+    if len(label) > label_len:
+        label = label[:label_len]
+
+    label_blank = ' ' * (label_len-3)  # noqa: yapf insists there be no whitespace around - and *
+    label_border_top = box_chars['h'] * (label_len-3) # noqa
+    label_border_bottom = box_chars['h'] * label_len
+    label_middle = label + ' '*label_leftover  # noqa
+
+    top_line = array('u', box_chars['tl'] + label_border_top + box_chars['tr'])
+    mid_line = array('u', box_chars['v'] + label_blank + box_chars['v'])
+    crn_line = array('u', box_chars['tl'] + box_chars['h'] + box_chars['h'] + box_chars['br'] + label_blank + box_chars['v'])
+    lab_line = array('u', box_chars['v'] + label_middle + box_chars['v'])
+    bot_line = array('u', box_chars['bl'] + label_border_bottom + box_chars['br'])
+
+    textpad[y][x + 3:x + w] = top_line
+    textpad[y + 1][x + 3:x + w] = mid_line
+    textpad[y + 2][x + 3:x + w] = mid_line
+    textpad[y + 3][x:x + w] = crn_line
+    textpad[y + 4][x:x + w] = lab_line
+    textpad[y + 5][x:x + w] = bot_line

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -263,6 +263,7 @@ def render_key_isoenter(textpad, x, y, w, h, label, style):
     textpad[y + 4][x:x + w] = mid_line
     textpad[y + 5][x:x + w] = bot_line
 
+
 def render_key_baenter(textpad, x, y, w, h, label, style):
     box_chars = BOX_DRAWING_CHARACTERS[style]
     x = ceil(x * 4)
@@ -277,7 +278,7 @@ def render_key_baenter(textpad, x, y, w, h, label, style):
         label = label[:label_len]
 
     label_blank = ' ' * (label_len-3)  # noqa: yapf insists there be no whitespace around - and *
-    label_border_top = box_chars['h'] * (label_len-3) # noqa
+    label_border_top = box_chars['h'] * (label_len-3)  # noqa
     label_border_bottom = box_chars['h'] * label_len
     label_middle = label + ' '*label_leftover  # noqa
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

#16466 

`qmk info -kb gvalchca/spaccboard -l`

![image](https://user-images.githubusercontent.com/4781841/156903061-e6f72f41-3dd2-491a-8753-bf330713ea98.png)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
