### PR TITLE
clarified the documentation to fix issue #15458

### DIFF
--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -275,6 +275,19 @@ This value (if set) must be greater than one's `TAPPING_TERM`, as the key press
 must be designated as a 'hold' by `process_tapping` before we send the modifier.
 There is no such limitation in regards to `AUTO_SHIFT_TIMEOUT` for normal keys.
 
+Note that, on top of defining `RETRO_SHIFT`, you also have to override the 
+`get_custom_auto_shifted_key` function and add the specific key codes you would
+like to have retro-shifted because they are outside the default auto-shift ranges.
+For example, if you would like all mod tap and layer tap keys to be auto-shifted, 
+you could add the following in your `keymap.c` file:
+
+```c
+bool get_custom_auto_shifted_key(uint16_t keycode, keyrecord_t *record) {
+    if (IS_RETRO(keycode)){return true;}
+    return false;
+}
+```
+
 ### Retro Shift and Tap Hold Configurations
 
 Tap Hold Configurations work a little differently when using Retro Shift.


### PR DESCRIPTION
Clarified the documentation around auto-shift for modifier keys. 

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Auto-shift has a feature called RETRO_SHIFT that allows you to do a retro-tap-style auto-shift on modifier keys. However, you also have to add a custom function to enable retro shift per modifier key you want shifted. This is not at all clear from the docs, and is the reason this issue exists.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x ] Documentation

## Issues Fixed or Closed by This PR

* issue #15458

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
