### PR TITLE
[Core] Move `has_mouse_report_changed` function to `report.c` 

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -209,7 +209,7 @@ static uint8_t wheel_unit(void) {
 
 void mousekey_task(void) {
     // report cursor and scroll movement independently
-    report_mouse_t const tmpmr = mouse_report;
+    report_mouse_t tmpmr = mouse_report;
 
     mouse_report.x = 0;
     mouse_report.y = 0;
@@ -251,7 +251,9 @@ void mousekey_task(void) {
         }
     }
 
-    if (mouse_report.x || mouse_report.y || mouse_report.v || mouse_report.h) mousekey_send();
+    if (has_mouse_report_changed(&mouse_report, &tmpmr)) {
+        mousekey_send();
+    }
     mouse_report = tmpmr;
 }
 
@@ -340,7 +342,7 @@ uint16_t        w_intervals[mkspd_COUNT] = {MK_W_INTERVAL_UNMOD, MK_W_INTERVAL_0
 
 void mousekey_task(void) {
     // report cursor and scroll movement independently
-    report_mouse_t const tmpmr = mouse_report;
+    report_mouse_t tmpmr = mouse_report;
     mouse_report.x             = 0;
     mouse_report.y             = 0;
     mouse_report.v             = 0;
@@ -355,7 +357,9 @@ void mousekey_task(void) {
         mouse_report.h = tmpmr.h;
     }
 
-    if (mouse_report.x || mouse_report.y || mouse_report.v || mouse_report.h) mousekey_send();
+    if (has_mouse_report_changed(&mouse_report, &tmpmr)) {
+        mousekey_send();
+    }
     mouse_report = tmpmr;
 }
 

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -343,10 +343,10 @@ uint16_t        w_intervals[mkspd_COUNT] = {MK_W_INTERVAL_UNMOD, MK_W_INTERVAL_0
 void mousekey_task(void) {
     // report cursor and scroll movement independently
     report_mouse_t tmpmr = mouse_report;
-    mouse_report.x             = 0;
-    mouse_report.y             = 0;
-    mouse_report.v             = 0;
-    mouse_report.h             = 0;
+    mouse_report.x       = 0;
+    mouse_report.y       = 0;
+    mouse_report.v       = 0;
+    mouse_report.h       = 0;
 
     if ((tmpmr.x || tmpmr.y) && timer_elapsed(last_timer_c) > c_intervals[mk_speed]) {
         mouse_report.x = tmpmr.x;

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -254,7 +254,7 @@ void mousekey_task(void) {
     if (has_mouse_report_changed(&mouse_report, &tmpmr)) {
         mousekey_send();
     }
-    mouse_report = tmpmr;
+    memcpy(&mouse_report, &tmpmr, sizeof(tmpmr));
 }
 
 void mousekey_on(uint8_t code) {
@@ -360,7 +360,7 @@ void mousekey_task(void) {
     if (has_mouse_report_changed(&mouse_report, &tmpmr)) {
         mousekey_send();
     }
-    mouse_report = tmpmr;
+    memcpy(&mouse_report, &tmpmr, sizeof(tmpmr));
 }
 
 void adjust_speed(void) {

--- a/quantum/pointing_device.c
+++ b/quantum/pointing_device.c
@@ -71,17 +71,6 @@ static report_mouse_t local_mouse_report = {};
 extern const pointing_device_driver_t pointing_device_driver;
 
 /**
- * @brief Compares 2 mouse reports for difference and returns result
- *
- * @param[in] new_report report_mouse_t
- * @param[in] old_report report_mouse_t
- * @return bool result
- */
-__attribute__((weak)) bool has_mouse_report_changed(report_mouse_t new_report, report_mouse_t old_report) {
-    return memcmp(&new_report, &old_report, sizeof(new_report));
-}
-
-/**
  * @brief Keyboard level code pointing device initialisation
  *
  */
@@ -165,7 +154,7 @@ __attribute__((weak)) void pointing_device_send(void) {
     static report_mouse_t old_report = {};
 
     // If you need to do other things, like debugging, this is the place to do it.
-    if (has_mouse_report_changed(local_mouse_report, old_report)) {
+    if (has_mouse_report_changed(&local_mouse_report, &old_report)) {
         host_mouse_send(&local_mouse_report);
     }
     // send it and 0 it out except for buttons, so those stay until they are explicity over-ridden using update_pointing_device

--- a/quantum/pointing_device.h
+++ b/quantum/pointing_device.h
@@ -80,7 +80,6 @@ void           pointing_device_task(void);
 void           pointing_device_send(void);
 report_mouse_t pointing_device_get_report(void);
 void           pointing_device_set_report(report_mouse_t mouse_report);
-bool           has_mouse_report_changed(report_mouse_t new_report, report_mouse_t old_report);
 uint16_t       pointing_device_get_cpi(void);
 void           pointing_device_set_cpi(uint16_t cpi);
 

--- a/tmk_core/protocol/report.c
+++ b/tmk_core/protocol/report.c
@@ -287,7 +287,7 @@ void clear_keys_from_report(report_keyboard_t* keyboard_report) {
  * @param[in] old_report report_mouse_t
  * @return bool result
  */
-__attribute__((weak)) bool has_mouse_report_changed(report_mouse_t *new_report, report_mouse_t *old_report) {
+__attribute__((weak)) bool has_mouse_report_changed(report_mouse_t* new_report, report_mouse_t* old_report) {
     return memcmp(new_report, old_report, sizeof(report_mouse_t));
 }
 #endif

--- a/tmk_core/protocol/report.c
+++ b/tmk_core/protocol/report.c
@@ -278,3 +278,16 @@ void clear_keys_from_report(report_keyboard_t* keyboard_report) {
 #endif
     memset(keyboard_report->keys, 0, sizeof(keyboard_report->keys));
 }
+
+#ifdef MOUSE_ENABLE
+/**
+ * @brief Compares 2 mouse reports for difference and returns result
+ *
+ * @param[in] new_report report_mouse_t
+ * @param[in] old_report report_mouse_t
+ * @return bool result
+ */
+__attribute__((weak)) bool has_mouse_report_changed(report_mouse_t *new_report, report_mouse_t *old_report) {
+    return memcmp(new_report, old_report, sizeof(report_mouse_t));
+}
+#endif

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -320,6 +320,10 @@ void add_key_to_report(report_keyboard_t* keyboard_report, uint8_t key);
 void del_key_from_report(report_keyboard_t* keyboard_report, uint8_t key);
 void clear_keys_from_report(report_keyboard_t* keyboard_report);
 
+#ifdef MOUSE_ENABLE
+bool has_mouse_report_changed(report_mouse_t* new_report, report_mouse_t* old_report);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description

Moves `has_mouse_report_changed` function to report.c, as both pointing device and mousekeys check for changes to the report to determine if to send or not. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
