### PR TITLE
Fix qwertykeys/qk65

### DIFF
--- a/keyboards/qwertykeys/qk65/hotswap/hotswap.h
+++ b/keyboards/qwertykeys/qk65/hotswap/hotswap.h
@@ -31,3 +31,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	{ K300,  K301,  K302,  K303,  K304,  K305,  K306,  K307,  K308,  K309,  K310,  K311,  KC_NO, K313,  K314 }, \
 	{ K400,  K401,  K402,  KC_NO, K404,  KC_NO, KC_NO, K407,  K408,  KC_NO, KC_NO, KC_NO, K412,  K413,  K414 }  \
 }
+

--- a/keyboards/qwertykeys/qk65/solder/solder.h
+++ b/keyboards/qwertykeys/qk65/solder/solder.h
@@ -47,3 +47,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	{ K300,  K301,  K302,  K303,  K304,  K305,  K306,  K307,  K308,  K309,  K310,  K311,  K312,  K313,  K314 },  \
 	{ K400,  K401,  K402,  KC_NO, K404,  KC_NO, KC_NO, K407,  K408,  KC_NO, KC_NO, KC_NO, K412,  K413,  K414 }   \
 }
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Some files were missing newlines, causing 
```Compiling: keyboards/qwertykeys/qk65/hotswap/hotswap.c                                             In file included from keyboards/qwertykeys/qk65/hotswap/hotswap.c:17:
keyboards/qwertykeys/qk65/hotswap/hotswap.h:21:25: error: backslash-newline at end of file [-Werror]                                                                    
 #define LAYOUT_hotswap( \
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
