### PR TITLE
Remove `matrix_key_count()`

### DIFF
--- a/keyboards/40percentclub/ut47/matrix.c
+++ b/keyboards/40percentclub/ut47/matrix.c
@@ -118,15 +118,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 /* Column pin configuration
  * col: 0   1   2   3   4   5   6   7   8   9   10  11
  * pin: D7  E6  B4  B5  B6  B2  B3  B1  F7  F6  F5  F4

--- a/keyboards/amj96/matrix.c
+++ b/keyboards/amj96/matrix.c
@@ -130,15 +130,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 /* Column pin configuration
  * col: 0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15
  * pin: F7  F6  F5  F4  F1  F0  E6  D7  D6  D5  D1  D0  B7  B6  B0  C7

--- a/keyboards/bpiphany/hid_liber/matrix.c
+++ b/keyboards/bpiphany/hid_liber/matrix.c
@@ -245,15 +245,3 @@ void matrix_print(void)
         print("\n");
     }
 }
-
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        for (uint8_t j = 0; j < MATRIX_COLS; j++) {
-            if (matrix_is_on(i, j))
-                count++;
-        }
-    }
-    return count;
-}

--- a/keyboards/bpiphany/kitten_paw/matrix.c
+++ b/keyboards/bpiphany/kitten_paw/matrix.c
@@ -132,14 +132,6 @@ void matrix_print(void) {
   }
 }
 
-uint8_t matrix_key_count(void) {
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-    count += bitpop32(matrix[i]);
-  }
-  return count;
-}
-
 static uint8_t read_rows(void) {
   return
     (PINC&(1<<7) ? 0 : (1<<0)) |

--- a/keyboards/bpiphany/pegasushoof/2013/matrix.c
+++ b/keyboards/bpiphany/pegasushoof/2013/matrix.c
@@ -132,15 +132,6 @@ void matrix_print(void)
 	}
 }
 
-uint8_t matrix_key_count(void)
-{
-	uint8_t count = 0;
-	for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-		count += bitpop16(matrix[i]);
-	}
-	return count;
-}
-
 static matrix_row_t read_cols(void)
 {
 	return

--- a/keyboards/bpiphany/pegasushoof/2015/matrix.c
+++ b/keyboards/bpiphany/pegasushoof/2015/matrix.c
@@ -111,15 +111,6 @@ void matrix_print(void)
   }
 }
 
-uint8_t matrix_key_count(void)
-{
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < matrix_rows(); i++) {
-    count += bitpop16(matrix_get_row(i));
-  }
-  return count;
-}
-
 static matrix_row_t read_cols(void)
 {
   return

--- a/keyboards/bpiphany/tiger_lily/matrix.c
+++ b/keyboards/bpiphany/tiger_lily/matrix.c
@@ -146,10 +146,3 @@ void matrix_print(void) {
     }
 	#endif
 }
-
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (uint8_t row = 0; row < MATRIX_ROWS; row++)
-        count += bitpop32(matrix[row]);
-    return count;
-}

--- a/keyboards/bpiphany/unloved_bastard/matrix.c
+++ b/keyboards/bpiphany/unloved_bastard/matrix.c
@@ -147,10 +147,3 @@ void matrix_print(void) {
     }
 #endif
 }
-
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (uint8_t row = 0; row < MATRIX_ROWS; row++)
-        count += bitpop32(matrix[row]);
-    return count;
-}

--- a/keyboards/converter/ibm_terminal/matrix.c
+++ b/keyboards/converter/ibm_terminal/matrix.c
@@ -27,7 +27,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
 #define print_matrix_header()  print("\nr/c 01234567\n")
-#define matrix_bitpop(i)       bitpop(matrix[i])
 #define ROW_SHIFTER ((uint8_t)1)
 
 

--- a/keyboards/converter/palm_usb/matrix.c
+++ b/keyboards/converter/palm_usb/matrix.c
@@ -379,12 +379,3 @@ void matrix_print(void)
         print("\n");
     }
 }
-
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop(matrix[i]);
-    }
-    return count;
-}

--- a/keyboards/converter/sun_usb/matrix.c
+++ b/keyboards/converter/sun_usb/matrix.c
@@ -179,12 +179,3 @@ void matrix_print(void)
         print("\n");
     }
 }
-
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop(matrix[i]);
-    }
-    return count;
-}

--- a/keyboards/converter/usb_usb/custom_matrix.cpp
+++ b/keyboards/converter/usb_usb/custom_matrix.cpp
@@ -225,18 +225,6 @@ extern "C"
         return row_bits;
     }
 
-    uint8_t matrix_key_count(void) {
-        uint8_t count = 0;
-
-        count += bitpop(local_keyboard_report.mods);
-        for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; i++) {
-            if (IS_ANY(local_keyboard_report.keys[i])) {
-                count++;
-            }
-        }
-        return count;
-    }
-
     void matrix_print(void) {
         print("\nr/c 0123456789ABCDEF\n");
         for (uint8_t row = 0; row < matrix_rows(); row++) {

--- a/keyboards/dc01/arrow/matrix.c
+++ b/keyboards/dc01/arrow/matrix.c
@@ -234,17 +234,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
-
 #if (DIODE_DIRECTION == COL2ROW)
 
 static void init_cols(void)

--- a/keyboards/dc01/arrow/matrix.c
+++ b/keyboards/dc01/arrow/matrix.c
@@ -48,17 +48,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/dc01/left/matrix.c
+++ b/keyboards/dc01/left/matrix.c
@@ -259,17 +259,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
-
 #if (DIODE_DIRECTION == COL2ROW)
 
 static void init_cols(void)

--- a/keyboards/dc01/left/matrix.c
+++ b/keyboards/dc01/left/matrix.c
@@ -52,17 +52,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/dc01/numpad/matrix.c
+++ b/keyboards/dc01/numpad/matrix.c
@@ -234,17 +234,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
-
 #if (DIODE_DIRECTION == COL2ROW)
 
 static void init_cols(void)

--- a/keyboards/dc01/numpad/matrix.c
+++ b/keyboards/dc01/numpad/matrix.c
@@ -48,17 +48,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/dc01/right/matrix.c
+++ b/keyboards/dc01/right/matrix.c
@@ -49,17 +49,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/dc01/right/matrix.c
+++ b/keyboards/dc01/right/matrix.c
@@ -235,17 +235,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
-
 #if (DIODE_DIRECTION == COL2ROW)
 
 static void init_cols(void)

--- a/keyboards/dichotomy/matrix.c
+++ b/keyboards/dichotomy/matrix.c
@@ -34,17 +34,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/dichotomy/matrix.c
+++ b/keyboards/dichotomy/matrix.c
@@ -215,12 +215,3 @@ void matrix_print(void)
         print("\n");
     }
 }
-
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}

--- a/keyboards/duck/jetfire/matrix.c
+++ b/keyboards/duck/jetfire/matrix.c
@@ -136,15 +136,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop32(matrix[i]);
-    }
-    return count;
-}
-
 static void init_ports(void)
 {
     // Rows are inputs (inputs are 0)

--- a/keyboards/gboards/ergotaco/matrix.c
+++ b/keyboards/gboards/ergotaco/matrix.c
@@ -221,15 +221,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 // Remember this means ROWS
 static void  init_cols(void)
 {

--- a/keyboards/gboards/georgi/matrix.c
+++ b/keyboards/gboards/georgi/matrix.c
@@ -242,15 +242,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 // Remember this means ROWS
 static void  init_cols(void)
 {

--- a/keyboards/gboards/gergo/matrix.c
+++ b/keyboards/gboards/gergo/matrix.c
@@ -286,14 +286,6 @@ void matrix_print(void) {
     }
 }
 
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 // Remember this means ROWS
 static void  init_cols(void) {
     // init on mcp23018

--- a/keyboards/gboards/gergoplex/matrix.c
+++ b/keyboards/gboards/gergoplex/matrix.c
@@ -164,13 +164,6 @@ void matrix_print(void) {
         print("\n");
     }
 }
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
 
 // Remember this means ROWS
 static void init_cols(void) {

--- a/keyboards/handwired/dactyl/matrix.c
+++ b/keyboards/handwired/dactyl/matrix.c
@@ -307,15 +307,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 #if (DIODE_DIRECTION == COL2ROW)
 
 static void init_cols(void) {

--- a/keyboards/handwired/frenchdev/matrix.c
+++ b/keyboards/handwired/frenchdev/matrix.c
@@ -196,15 +196,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 /* Column pin configuration
  *
  * Teensy

--- a/keyboards/handwired/owlet60/matrix.c
+++ b/keyboards/handwired/owlet60/matrix.c
@@ -33,17 +33,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/handwired/owlet60/matrix.c
+++ b/keyboards/handwired/owlet60/matrix.c
@@ -130,15 +130,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
 // uses standard row code
 static void select_row(uint8_t row)
 {

--- a/keyboards/handwired/promethium/matrix.c
+++ b/keyboards/handwired/promethium/matrix.c
@@ -43,17 +43,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/handwired/promethium/matrix.c
+++ b/keyboards/handwired/promethium/matrix.c
@@ -178,16 +178,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
 #define ROW_MASK 0b11100000
 
 static const uint8_t row_bit[MATRIX_ROWS] = {

--- a/keyboards/handwired/pterodactyl/matrix.c
+++ b/keyboards/handwired/pterodactyl/matrix.c
@@ -308,15 +308,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 #if (DIODE_DIRECTION == COL2ROW)
 
 static void init_cols(void) {

--- a/keyboards/helix/rev2/custom/matrix.c
+++ b/keyboards/helix/rev2/custom/matrix.c
@@ -309,15 +309,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 static void  init_cols(void)
 {
     for(int x = 0; x < MATRIX_COLS; x++) {

--- a/keyboards/hhkb/ansi/matrix.c
+++ b/keyboards/hhkb/ansi/matrix.c
@@ -189,14 +189,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (int8_t r = MATRIX_ROWS - 1; r >= 0; --r) {
-        count += bitpop16(matrix_get_row(r));
-    }
-    return count;
-}
-
 void matrix_power_up(void) {
     KEY_POWER_ON();
 }

--- a/keyboards/hhkb/jp/matrix.c
+++ b/keyboards/hhkb/jp/matrix.c
@@ -190,14 +190,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (int8_t r = MATRIX_ROWS - 1; r >= 0; --r) {
-        count += bitpop16(matrix_get_row(r));
-    }
-    return count;
-}
-
 void matrix_power_up(void) {
     KEY_POWER_ON();
 }

--- a/keyboards/honeycomb/matrix.c
+++ b/keyboards/honeycomb/matrix.c
@@ -191,12 +191,3 @@ void matrix_print(void)
         print("\n");
     }
 }
-
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}

--- a/keyboards/honeycomb/matrix.c
+++ b/keyboards/honeycomb/matrix.c
@@ -35,17 +35,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 # define print_matrix_header()  print("\nr/c 01234567\n")
 # define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-# define matrix_bitpop(i)       bitpop(matrix[i])
 # define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 # define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 # define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-# define matrix_bitpop(i)       bitpop16(matrix[i])
 # define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 # define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 # define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-# define matrix_bitpop(i)       bitpop32(matrix[i])
 # define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/hotdox/matrix.c
+++ b/keyboards/hotdox/matrix.c
@@ -160,15 +160,6 @@ void matrix_print(void)
   }
 }
 
-uint8_t matrix_key_count(void)
-{
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-    count += bitpop16(matrix[i]);
-  }
-  return count;
-}
-
 static void init_cols(void)
 {
   // Pro Micro

--- a/keyboards/kakunpc/angel64/alpha/matrix.c
+++ b/keyboards/kakunpc/angel64/alpha/matrix.c
@@ -27,17 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/kakunpc/angel64/alpha/matrix.c
+++ b/keyboards/kakunpc/angel64/alpha/matrix.c
@@ -119,15 +119,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
 static void select_row(uint8_t row)
 {
     setPinOutput(row_pins[row]);

--- a/keyboards/kakunpc/angel64/rev1/matrix.c
+++ b/keyboards/kakunpc/angel64/rev1/matrix.c
@@ -27,17 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/kakunpc/angel64/rev1/matrix.c
+++ b/keyboards/kakunpc/angel64/rev1/matrix.c
@@ -119,15 +119,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
 static void select_row(uint8_t row)
 {
     setPinOutput(row_pins[row]);

--- a/keyboards/kakunpc/thedogkeyboard/matrix.c
+++ b/keyboards/kakunpc/thedogkeyboard/matrix.c
@@ -27,17 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/kakunpc/thedogkeyboard/matrix.c
+++ b/keyboards/kakunpc/thedogkeyboard/matrix.c
@@ -119,15 +119,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
 static void select_row(uint8_t row)
 {
     setPinOutput(row_pins[row]);

--- a/keyboards/kinesis/alvicstep/matrix.c
+++ b/keyboards/kinesis/alvicstep/matrix.c
@@ -158,15 +158,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 static matrix_row_t read_row(uint8_t row)
 {
 	_delay_us(30);  // without this wait read unstable value.

--- a/keyboards/kmac/matrix.c
+++ b/keyboards/kmac/matrix.c
@@ -79,14 +79,6 @@ void matrix_print(void) {
     }
 }
 
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
 /* Columns 0 - 15
  * These columns uses two 74HC237D 3 to 8 bit demultiplexers.
  * col / pin:    PB6  PC6  PC7  PF1  PF0

--- a/keyboards/kmac/matrix.c
+++ b/keyboards/kmac/matrix.c
@@ -27,17 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header() print("\nr/c 01234567\n")
 #    define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i) bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i) bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i) bitpop32(matrix[i])
 #    define ROW_SHIFTER ((uint32_t)1)
 #endif
 

--- a/keyboards/kmini/matrix.c
+++ b/keyboards/kmini/matrix.c
@@ -132,15 +132,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop32(matrix[i]);
-    }
-    return count;
-}
-
 static bool read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col)
 {
     bool matrix_changed = false;

--- a/keyboards/ktec/ergodone/matrix.c
+++ b/keyboards/ktec/ergodone/matrix.c
@@ -158,15 +158,6 @@ void matrix_print(void)
   }
 }
 
-uint8_t matrix_key_count(void)
-{
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-    count += bitpop16(matrix[i]);
-  }
-  return count;
-}
-
 /* Column pin configuration
  *
  * Pro Micro: 6    5    4    3    2    1    0

--- a/keyboards/moon/matrix.c
+++ b/keyboards/moon/matrix.c
@@ -76,17 +76,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #  define print_matrix_header() print("\nr/c 01234567\n")
 #  define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
-#  define matrix_bitpop(i) bitpop(matrix[i])
 #  define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #  define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
 #  define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
-#  define matrix_bitpop(i) bitpop16(matrix[i])
 #  define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #  define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #  define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
-#  define matrix_bitpop(i) bitpop32(matrix[i])
 #  define ROW_SHIFTER ((uint32_t)1)
 #endif
 

--- a/keyboards/moon/matrix.c
+++ b/keyboards/moon/matrix.c
@@ -125,14 +125,6 @@ void matrix_print(void) {
   }
 }
 
-uint8_t matrix_key_count(void) {
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-    count += matrix_bitpop(i);
-  }
-  return count;
-}
-
 static void init_i2c(void) {
   pca9555_init(IC1);
   pca9555_init(IC2);

--- a/keyboards/nek_type_a/matrix.c
+++ b/keyboards/nek_type_a/matrix.c
@@ -234,17 +234,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
-
 #if (DIODE_DIRECTION == COL2ROW)
 
 static void init_cols(void)

--- a/keyboards/nek_type_a/matrix.c
+++ b/keyboards/nek_type_a/matrix.c
@@ -50,17 +50,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/redscarf_iiplus/verb/matrix.c
+++ b/keyboards/redscarf_iiplus/verb/matrix.c
@@ -123,16 +123,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
 #ifdef DIRECT_PINS
 
 static void init_pins(void) {

--- a/keyboards/redscarf_iiplus/verb/matrix.c
+++ b/keyboards/redscarf_iiplus/verb/matrix.c
@@ -27,17 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/redscarf_iiplus/verc/matrix.c
+++ b/keyboards/redscarf_iiplus/verc/matrix.c
@@ -123,16 +123,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
 #ifdef DIRECT_PINS
 
 static void init_pins(void) {

--- a/keyboards/redscarf_iiplus/verc/matrix.c
+++ b/keyboards/redscarf_iiplus/verc/matrix.c
@@ -27,17 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/redscarf_iiplus/verd/matrix.c
+++ b/keyboards/redscarf_iiplus/verd/matrix.c
@@ -123,16 +123,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
-
 #ifdef DIRECT_PINS
 
 static void init_pins(void) {

--- a/keyboards/redscarf_iiplus/verd/matrix.c
+++ b/keyboards/redscarf_iiplus/verd/matrix.c
@@ -27,17 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/sirius/unigo66/custom_matrix.cpp
+++ b/keyboards/sirius/unigo66/custom_matrix.cpp
@@ -205,18 +205,6 @@ extern "C"
         return row_bits;
     }
 
-    uint8_t matrix_key_count(void) {
-        uint8_t count = 0;
-
-        count += bitpop(local_keyboard_report.mods);
-        for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; i++) {
-            if (IS_ANY(local_keyboard_report.keys[i])) {
-                count++;
-            }
-        }
-        return count;
-    }
-
     void matrix_print(void) {
         print("\nr/c 0123456789ABCDEF\n");
         for (uint8_t row = 0; row < matrix_rows(); row++) {

--- a/keyboards/sixkeyboard/matrix.c
+++ b/keyboards/sixkeyboard/matrix.c
@@ -129,13 +129,3 @@ matrix_row_t matrix_get_row(uint8_t row)
 void matrix_print(void)
 {
 }
-
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-

--- a/keyboards/sx60/matrix.c
+++ b/keyboards/sx60/matrix.c
@@ -201,15 +201,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
 static void init_cols(void)
 {
     for(uint8_t x = 0; x < ATMEGA_COLS; x++) {

--- a/keyboards/sx60/matrix.c
+++ b/keyboards/sx60/matrix.c
@@ -42,17 +42,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/woodkeys/meira/matrix.c
+++ b/keyboards/woodkeys/meira/matrix.c
@@ -45,17 +45,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")
 #    define print_matrix_row(row)  print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop(matrix[i])
 #    define ROW_SHIFTER ((uint8_t)1)
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop16(matrix[i])
 #    define ROW_SHIFTER ((uint16_t)1)
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header()  print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row)  print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(i)       bitpop32(matrix[i])
 #    define ROW_SHIFTER  ((uint32_t)1)
 #endif
 

--- a/keyboards/woodkeys/meira/matrix.c
+++ b/keyboards/woodkeys/meira/matrix.c
@@ -183,16 +183,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
-
 static void init_rows(void)
 {
     for(uint8_t x = 0; x < MATRIX_ROWS; x++) {

--- a/keyboards/ymdk/sp64/matrix.c
+++ b/keyboards/ymdk/sp64/matrix.c
@@ -154,15 +154,6 @@ void matrix_print(void)
   }
 }
 
-uint8_t matrix_key_count(void)
-{
-  uint8_t count = 0;
-  for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-    count += bitpop16(matrix[i]);
-  }
-  return count;
-}
-
 static void matrix_select_row(uint8_t row)
 {
 #ifdef RIGHT_HALF

--- a/keyboards/yosino58/rev1/matrix.c
+++ b/keyboards/yosino58/rev1/matrix.c
@@ -311,15 +311,6 @@ void matrix_print(void)
     }
 }
 
-uint8_t matrix_key_count(void)
-{
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += bitpop16(matrix[i]);
-    }
-    return count;
-}
-
 static void  init_cols(void)
 {
     for(int x = 0; x < MATRIX_COLS; x++) {

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -94,14 +94,6 @@ void matrix_print(void) {
     }
 }
 
-uint8_t matrix_key_count(void) {
-    uint8_t count = 0;
-    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-        count += matrix_bitpop(i);
-    }
-    return count;
-}
-
 #ifdef SPLIT_KEYBOARD
 bool matrix_post_scan(void) {
     bool changed = false;

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -72,15 +72,12 @@ inline matrix_row_t matrix_get_row(uint8_t row) {
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header() print("\nr/c 01234567\n")
 #    define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
-#    define matrix_bitpop(row) bitpop(matrix_get_row(row))
 #elif (MATRIX_COLS <= 16)
 #    define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
 #    define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
-#    define matrix_bitpop(row) bitpop16(matrix_get_row(row))
 #elif (MATRIX_COLS <= 32)
 #    define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
 #    define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
-#    define matrix_bitpop(row) bitpop32(matrix_get_row(row))
 #endif
 
 void matrix_print(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`matrix_key_count()` doesn't appear to be used anywhere, and once removed, neither does `matrix_bitpop()`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
