### PR TITLE
CLI: Fix 'cd' subcommand on Windows

### DIFF
--- a/lib/python/qmk/cli/cd.py
+++ b/lib/python/qmk/cli/cd.py
@@ -2,6 +2,7 @@
 """
 import sys
 import os
+import subprocess
 
 from milc import cli
 
@@ -41,6 +42,6 @@ def cd(cli):
             # Set the prompt for the new shell
             qmk_env['MSYS2_PS1'] = qmk_env['PS1']
             # Start the new subshell
-            cli.run([os.environ.get('SHELL', '/usr/bin/bash')], env=qmk_env)
+            subprocess.run([os.environ.get('SHELL', '/usr/bin/bash')], env=qmk_env)
     else:
         cli.log.info("Already within qmk_firmware directory.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The `cd` subcommand was failing as the current shell's Windows path was
mangled while milc processed it.
Using `subprocess` directly avoids this issue and an extra layer of
subshell.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
