### PR TITLE
[Core] Fix flipped logic bug with One Shot `OS_ON` / `OS_OFF` keys

### DIFF
--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -202,8 +202,9 @@ bool is_oneshot_layer_active(void) {
  * FIXME: needs doc
  */
 void oneshot_set(bool active) {
-    if (keymap_config.oneshot_disable != active) {
-        keymap_config.oneshot_disable = active;
+    const bool disable = !active;
+    if (keymap_config.oneshot_disable != disable) {
+        keymap_config.oneshot_disable = disable;
         eeconfig_update_keymap(keymap_config.raw);
         clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
         dprintf("Oneshot: active: %d\n", active);
@@ -235,7 +236,7 @@ void oneshot_disable(void) {
 }
 
 bool is_oneshot_enabled(void) {
-    return keymap_config.oneshot_disable;
+    return !keymap_config.oneshot_disable;
 }
 
 #endif


### PR DESCRIPTION
The One Shot documentation says key `OS_ON` turns one-shot keys on and `OS_OFF` turns them off. The actual behavior is flipped: `OS_ON` turns them _**off**_ and `OS_OFF` turns them _**on**_.  This PR fixes this.

## Description

This bug was discovered by reddit user [u/Dutchnesss1](https://www.reddit.com/user/Dutchnesss1). I can reproduce it on my keyboards. We were troubleshooting a problem where one-shot keys weren't work on Dutchnesss1's keyboard, and confusingly, `OS_ON` disabled one-shot keys when we thought we were enabling them.

The underlying problem is the logic for functions `oneshot_set()`, `oneshot_enable()`, `oneshot_disabled()`, and `is_oneshot_enabled()` are similarly flipped. The bug is rather obvious once looking at their implementation ([code link](https://github.com/qmk/qmk_firmware/blob/003231aaf25facf7437caa32f3e8bc2a2e9cbe7d/quantum/action_util.c#L204)):

```c
void oneshot_set(bool active) {
    if (keymap_config.oneshot_disable != active) {
        keymap_config.oneshot_disable = active;
        eeconfig_update_keymap(keymap_config.raw);
        clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
        dprintf("Oneshot: active: %d\n", active);
    }
}

void oneshot_enable(void) {
    oneshot_set(true);
}
```

Calling `oneshot_enable()` calls `oneshot_set(true)`, which sets `keymap_config.oneshot_disable = true`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
