### PR TITLE
[Core] Use a mutex guard for split shared memory

### DIFF
--- a/platforms/chibios/drivers/serial.c
+++ b/platforms/chibios/drivers/serial.c
@@ -5,6 +5,7 @@
 #include "quantum.h"
 #include "serial.h"
 #include "wait.h"
+#include "synchronization_util.h"
 
 #include <hal.h>
 
@@ -86,7 +87,10 @@ static THD_FUNCTION(Thread1, arg) {
     chRegSetThreadName("blinker");
     while (true) {
         palWaitLineTimeout(SOFT_SERIAL_PIN, TIME_INFINITE);
+
+        split_shared_memory_lock();
         interrupt_handler(NULL);
+        split_shared_memory_unlock();
     }
 }
 
@@ -204,14 +208,9 @@ void interrupt_handler(void *arg) {
     chSysUnlockFromISR();
 }
 
-/////////
-//  start transaction by initiator
-//
-// bool  soft_serial_transaction(int sstd_index)
-//
-// this code is very time dependent, so we need to disable interrupts
-bool soft_serial_transaction(int sstd_index) {
+static inline bool initiate_transaction(uint8_t sstd_index) {
     if (sstd_index > NUM_TOTAL_TRANSACTIONS) return false;
+
     split_transaction_desc_t *trans = &split_transaction_table[sstd_index];
 
     // TODO: remove extra delay between transactions
@@ -238,8 +237,7 @@ bool soft_serial_transaction(int sstd_index) {
         return false;
     }
 
-    // if the slave is present syncronize with it
-
+    // if the slave is present synchronize with it
     uint8_t checksum = 0;
     // send data to the slave
     serial_write_byte(sstd_index); // first chunk is transaction id
@@ -284,4 +282,17 @@ bool soft_serial_transaction(int sstd_index) {
 
     chSysUnlock();
     return true;
+}
+
+/////////
+//  start transaction by initiator
+//
+// bool  soft_serial_transaction(int sstd_index)
+//
+// this code is very time dependent, so we need to disable interrupts
+bool soft_serial_transaction(int sstd_index) {
+    split_shared_memory_lock();
+    bool result = initiate_transaction((uint8_t)sstd_index);
+    split_shared_memory_unlock();
+    return result;
 }

--- a/platforms/chibios/platform.mk
+++ b/platforms/chibios/platform.mk
@@ -265,7 +265,8 @@ PLATFORM_SRC = \
         $(STREAMSSRC) \
         $(CHIBIOS)/os/various/syscalls.c \
         $(PLATFORM_COMMON_DIR)/syscall-fallbacks.c \
-        $(PLATFORM_COMMON_DIR)/wait.c
+        $(PLATFORM_COMMON_DIR)/wait.c \
+        $(PLATFORM_COMMON_DIR)/synchronization_util.c
 
 # Ensure the ASM files are not subjected to LTO -- it'll strip out interrupt handlers otherwise.
 QUANTUM_LIB_SRC += $(STARTUPASM) $(PORTASM) $(OSALASM) $(PLATFORMASM)
@@ -419,6 +420,9 @@ LDFLAGS  += $(SHARED_LDFLAGS) $(SHARED_LDSYMBOLS) $(TOOLCHAIN_LDFLAGS) $(TOOLCHA
 
 # Tell QMK that we are hosting it on ChibiOS.
 OPT_DEFS += -DPROTOCOL_CHIBIOS
+
+# ChibiOS supports synchronization primitives like a Mutex
+OPT_DEFS += -DPLATFORM_SUPPORTS_SYNCHRONIZATION
 
 # Workaround to stop ChibiOS from complaining about new GCC -- it's been fixed for 7/8/9 already
 OPT_DEFS += -DPORT_IGNORE_GCC_VERSION_CHECK=1

--- a/platforms/chibios/synchronization_util.c
+++ b/platforms/chibios/synchronization_util.c
@@ -1,0 +1,26 @@
+// Copyright 2022 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "synchronization_util.h"
+#include "ch.h"
+
+#if defined(SPLIT_KEYBOARD)
+static MUTEX_DECL(SPLIT_SHARED_MEMORY_MUTEX);
+
+/**
+ * @brief Acquire exclusive access to the split keyboard shared memory, by
+ * locking the mutex guarding it. If the mutex is already held, the calling
+ * thread will be suspended until the mutex currently owning thread releases the
+ * mutex again.
+ */
+void split_shared_memory_lock(void) {
+    chMtxLock(&SPLIT_SHARED_MEMORY_MUTEX);
+}
+
+/**
+ * @brief Release the split shared memory mutex that has been acquired before.
+ */
+void split_shared_memory_unlock(void) {
+    chMtxUnlock(&SPLIT_SHARED_MEMORY_MUTEX);
+}
+#endif

--- a/platforms/synchronization_util.h
+++ b/platforms/synchronization_util.h
@@ -1,0 +1,14 @@
+// Copyright 2022 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#if defined(PLATFORM_SUPPORTS_SYNCHRONIZATION)
+#    if defined(SPLIT_KEYBOARD)
+void split_shared_memory_lock(void);
+void split_shared_memory_unlock(void);
+#    endif
+#else
+inline void split_shared_memory_lock(void){};
+inline void split_shared_memory_unlock(void){};
+#endif


### PR DESCRIPTION
## Description

...on platforms that support it, which is only ChibiOS at this point. Further more the wrong usage of the API would result in lockups on the RP2040 QMK port. With these changes ChibiOS no longer halts with a critical system error when enabling the state check.

### The problem:

The shared memory on the ChibiOS platform can be accessed concurrently on the secondary device. This happens when the serial transaction thread reacts to transactions requests by the main side of the keyboard. This can lead to race conditions and corrupted transactions.

### The solution:

The access to the split shared memory is made exclusive at any given time by guarding it with a mutex.

The previous solution using a critical section didn't really work out because serial functions like send and receive would disable and enable interrupts on their own, thus leaving the system with enabled interrupts after the first transaction. The same was true for slave transaction handlers for e.g. sync timers, those functions effectively broke the critical section as well.

**Tested succesfully with RP2040 and STM32F411 splits using the usart and bitbang driver**


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Part of #14877

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
