### PR TITLE
[Core] Rename TICK to TICK_EVENT

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -489,7 +489,7 @@ bool matrix_scan_task(void) {
     // we can get here with some keys processed now.
     if (!keys_processed)
 #endif
-        action_exec(TICK);
+        action_exec(TICK_EVENT);
 
 MATRIX_LOOP_END:
 

--- a/quantum/keyboard.h
+++ b/quantum/keyboard.h
@@ -74,7 +74,7 @@ static inline bool IS_RELEASED(keyevent_t event) {
 #define MAKE_KEYEVENT(row_num, col_num, press) ((keyevent_t){.key = MAKE_KEYPOS((row_num), (col_num)), .pressed = (press), .time = (timer_read() | 1)})
 
 /* Tick event */
-#define TICK MAKE_KEYEVENT(KEYLOC_TICK, KEYLOC_TICK, false)
+#define TICK_EVENT MAKE_KEYEVENT(KEYLOC_TICK, KEYLOC_TICK, false)
 
 #ifdef ENCODER_MAP_ENABLE
 /* Encoder events */


### PR DESCRIPTION
## Description

To prevent naming conflicts with external sources, especially needed for the RP2040 port which ran into this problem.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Part of #14877 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
