### PR TITLE
Fix westm/westm68

### DIFF
--- a/keyboards/westm/westm68/config.h
+++ b/keyboards/westm/westm68/config.h
@@ -23,6 +23,8 @@
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x574D // WM
+#define PRODUCT_ID      0x0001
+#define DEVICE_VER      0x0001
 #define MANUFACTURER    WestM
 #define PRODUCT         WestM68
 
@@ -41,7 +43,3 @@
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
-
-/* Hold ESC key (first key of first column) to trigger bootloader */
-#define BOOTMAGIC_LITE_ROW 0
-#define BOOTMAGIC_LITE_COLUMN 0

--- a/keyboards/westm/westm68/rev1/config.h
+++ b/keyboards/westm/westm68/rev1/config.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-#define PRODUCT_ID      0x0001
-#define DEVICE_VER      0x0001
-
 // The pin connected to the data pin of the LEDs
 #define RGB_DI_PIN A8
 #define RGBLED_NUM 16

--- a/keyboards/westm/westm68/rev1/rules.mk
+++ b/keyboards/westm/westm68/rev1/rules.mk
@@ -1,0 +1,1 @@
+RGBLIGHT_ENABLE = yes

--- a/keyboards/westm/westm68/rules.mk
+++ b/keyboards/westm/westm68/rules.mk
@@ -17,5 +17,5 @@ CONSOLE_ENABLE = yes        # Console for debug
 COMMAND_ENABLE = yes        # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = yes       # Enable keyboard RGB underglow
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

From #16528 seems like `RGBLIGHT` should not be enabled at root keyboard level and is still a WIP...
It being enabled causes compilation errors.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
