### PR TITLE
Add GET_TAPPING_TERM macro to reduce duplicate code

### DIFF
--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -112,7 +112,7 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-The reason being that `TAPPING_TERM` is a macro that expands to a constant integer and thus cannot be changed at runtime whereas `g_tapping_term` is a variable whose value can be changed at runtime. If you want, you can temporarily enable `DYNAMIC_TAPPING_TERM_ENABLE` to find a suitable tapping term value and then disable that feature and revert back to using the classic syntax for per-key tapping term settings.
+The reason being that `TAPPING_TERM` is a macro that expands to a constant integer and thus cannot be changed at runtime whereas `g_tapping_term` is a variable whose value can be changed at runtime. If you want, you can temporarily enable `DYNAMIC_TAPPING_TERM_ENABLE` to find a suitable tapping term value and then disable that feature and revert back to using the classic syntax for per-key tapping term settings. In case you need to access the tapping term from elsewhere in your code, you can use the `GET_TAPPING_TERM(keycode, record)` macro. This macro will expand to whatever is the appropriate access pattern given the current configuration.
 
 ## Tap-Or-Hold Decision Modes
 

--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -24,17 +24,20 @@
 #    else
 #        define IS_TAPPING_RECORD(r) (IS_TAPPING() && KEYEQ(tapping_key.event.key, (r->event.key)) && tapping_key.keycode == r->keycode)
 #    endif
+#    define WITHIN_TAPPING_TERM(e) (TIMER_DIFF_16(e.time, tapping_key.event.time) < GET_TAPPING_TERM(get_record_keycode(&tapping_key, false), &tapping_key))
 
+#    ifdef DYNAMIC_TAPPING_TERM_ENABLE
 uint16_t g_tapping_term = TAPPING_TERM;
-
-__attribute__((weak)) uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
-    return g_tapping_term;
-}
+#    endif
 
 #    ifdef TAPPING_TERM_PER_KEY
-#        define WITHIN_TAPPING_TERM(e) (TIMER_DIFF_16(e.time, tapping_key.event.time) < get_tapping_term(get_record_keycode(&tapping_key, false), &tapping_key))
-#    else
-#        define WITHIN_TAPPING_TERM(e) (TIMER_DIFF_16(e.time, tapping_key.event.time) < g_tapping_term)
+__attribute__((weak)) uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+#        ifdef DYNAMIC_TAPPING_TERM_ENABLE
+    return g_tapping_term;
+#        else
+    return TAPPING_TERM;
+#        endif
+}
 #    endif
 
 #    ifdef TAPPING_FORCE_HOLD_PER_KEY
@@ -165,15 +168,7 @@ bool process_tapping(keyrecord_t *keyp) {
                 else if (
                     (
                         (
-                            (
-#        ifdef TAPPING_TERM_PER_KEY
-                                get_tapping_term(tapping_keycode, &tapping_key)
-#        else
-                                g_tapping_term
-#        endif
-                                >= 500
-                            )
-
+                            GET_TAPPING_TERM(tapping_keycode, &tapping_key) >= 500
 #        ifdef PERMISSIVE_HOLD_PER_KEY
                             || get_permissive_hold(tapping_keycode, &tapping_key)
 #        elif defined(PERMISSIVE_HOLD)

--- a/quantum/action_tapping.h
+++ b/quantum/action_tapping.h
@@ -44,3 +44,11 @@ bool     get_retro_tapping(uint16_t keycode, keyrecord_t *record);
 #ifdef DYNAMIC_TAPPING_TERM_ENABLE
 extern uint16_t g_tapping_term;
 #endif
+
+#ifdef TAPPING_TERM_PER_KEY
+#    define GET_TAPPING_TERM(keycode, record) get_tapping_term(keycode, record)
+#elif defined(DYNAMIC_TAPPING_TERM_ENABLE)
+#    define GET_TAPPING_TERM(keycode, record) g_tapping_term
+#else
+#    define GET_TAPPING_TERM(keycode, record) (TAPPING_TERM)
+#endif

--- a/quantum/pointing_device_drivers.c
+++ b/quantum/pointing_device_drivers.c
@@ -98,17 +98,9 @@ const pointing_device_driver_t pointing_device_driver = {
 // clang-format on
 #elif defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_i2c) || defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_spi)
 #    ifndef CIRQUE_PINNACLE_TAPPING_TERM
-#        ifdef TAPPING_TERM_PER_KEY
-#            include "action.h"
-#            include "action_tapping.h"
-#            define CIRQUE_PINNACLE_TAPPING_TERM get_tapping_term(KC_BTN1, &(keyrecord_t){})
-#        else
-#            ifdef TAPPING_TERM
-#                define CIRQUE_PINNACLE_TAPPING_TERM TAPPING_TERM
-#            else
-#                define CIRQUE_PINNACLE_TAPPING_TERM 200
-#            endif
-#        endif
+#        include "action.h"
+#        include "action_tapping.h"
+#        define CIRQUE_PINNACLE_TAPPING_TERM GET_TAPPING_TERM(KC_BTN1, &(keyrecord_t){})
 #    endif
 #    ifndef CIRQUE_PINNACLE_TOUCH_DEBOUNCE
 #        define CIRQUE_PINNACLE_TOUCH_DEBOUNCE (CIRQUE_PINNACLE_TAPPING_TERM * 8)

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -182,12 +182,7 @@ static bool autoshift_press(uint16_t keycode, uint16_t now, keyrecord_t *record)
 #            endif
         ) &&
 #        endif
-        TIMER_DIFF_16(now, autoshift_time) <
-#        ifdef TAPPING_TERM_PER_KEY
-        get_tapping_term(autoshift_lastkey, record)
-#        else
-        TAPPING_TERM
-#        endif
+        TIMER_DIFF_16(now, autoshift_time) < GET_TAPPING_TERM(autoshift_lastkey, record)
     ) {
         // clang-format on
         // Allow a tap-then-hold for keyrepeat.

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -93,12 +93,7 @@ void perform_space_cadet(keyrecord_t *record, uint16_t sc_keycode, uint8_t holdM
             register_mods(MOD_BIT(holdMod));
         }
     } else {
-#ifdef TAPPING_TERM_PER_KEY
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < get_tapping_term(sc_keycode, record))
-#else
-        if (sc_last == holdMod && timer_elapsed(sc_timer) < TAPPING_TERM)
-#endif
-        {
+        if (sc_last == holdMod && timer_elapsed(sc_timer) < GET_TAPPING_TERM(sc_keycode, record)) {
             if (holdMod != tapMod) {
                 if (IS_MOD(holdMod)) {
                     unregister_mods(MOD_BIT(holdMod));

--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -174,11 +174,7 @@ void tap_dance_task() {
         if (action->custom_tapping_term > 0) {
             tap_user_defined = action->custom_tapping_term;
         } else {
-#ifdef TAPPING_TERM_PER_KEY
-            tap_user_defined = get_tapping_term(action->state.keycode, &(keyrecord_t){});
-#else
-            tap_user_defined = TAPPING_TERM;
-#endif
+            tap_user_defined = GET_TAPPING_TERM(action->state.keycode, &(keyrecord_t){});
         }
         if (action->state.count && timer_elapsed(action->state.timer) > tap_user_defined) {
             process_tap_dance_action_on_dance_finished(action);


### PR DESCRIPTION
The macro gives the right tapping term depending on whether per-key
tapping terms and/or dynamic tapping terms are enabled. Unnecessary
function calls and variable resolution are avoided.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The time when `TAPPING_TERM` was _the_ tapping term is over. Per-key and dynamic tapping terms are possible now. This makes using the correct tapping term tricky and it requires some preprocessor-fu. Let's abstract all of that away in a `GET_TAPPING_TERM` macro modeled after the `get_tapping_term` function. Using this macro instead of `TAPPING_TERM` will produce the optimal and correct code for getting the tapping term.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix (_edit_: partially, as a dynamic tapping term is now respected more broadly)
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #16472

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
