### PR TITLE
qmk.path.FileType: fix argument handling

### DIFF
--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -70,9 +70,11 @@ def normpath(path):
 
 
 class FileType(argparse.FileType):
-    def __init__(self, mode='r', encoding='UTF-8'):
+    def __init__(self, *args, **kwargs):
         # Use UTF8 by default for stdin
-        return super().__init__(mode=mode, encoding=encoding)
+        if not 'encoding' in kwargs:
+            kwargs['encoding'] = 'UTF-8'
+        return super().__init__(*args, **kwargs)
 
     def __call__(self, string):
         """normalize and check exists

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -72,7 +72,7 @@ def normpath(path):
 class FileType(argparse.FileType):
     def __init__(self, *args, **kwargs):
         # Use UTF8 by default for stdin
-        if not 'encoding' in kwargs:
+        if 'encoding' not in kwargs:
             kwargs['encoding'] = 'UTF-8'
         return super().__init__(*args, **kwargs)
 

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -70,9 +70,9 @@ def normpath(path):
 
 
 class FileType(argparse.FileType):
-    def __init__(self, encoding='UTF-8'):
+    def __init__(self, mode='r', encoding='UTF-8'):
         # Use UTF8 by default for stdin
-        return super().__init__(encoding=encoding)
+        return super().__init__(mode=mode, encoding=encoding)
 
     def __call__(self, string):
         """normalize and check exists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixes an issue where the mode string passed to `qmk.path.FileType` is mistakenly given to the `encoding` argument of the superclass if it is not explicitly named (eg. `qmk.path.FileType('r')`).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
