### PR TITLE
Ignore transport defaults if SPLIT_KEYBOARD is unset

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -278,7 +278,8 @@ def _extract_split_transport(info_data, config_c):
         if 'transport' not in info_data['split']:
             info_data['split']['transport'] = {}
 
-        info_data['split']['transport']['protocol'] = 'serial'
+        if 'protocol' not in info_data['split']['transport']:
+            info_data['split']['transport']['protocol'] = 'serial'
 
 
 def _extract_split_right_pins(info_data, config_c):

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -270,7 +270,8 @@ def _extract_split_transport(info_data, config_c):
 
         info_data['split']['transport']['protocol'] = 'i2c'
 
-    elif 'protocol' not in info_data.get('split', {}).get('transport', {}):
+    # Ignore transport defaults if "SPLIT_KEYBOARD" is unset
+    elif 'enabled' in info_data.get('split', {}):
         if 'split' not in info_data:
             info_data['split'] = {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
No real point in providing a chunk of the split config, on non split keyboards 
```
 qmk info -f json -kb xd84 | grep -A2 split
    "split": {
        "transport": {
            "protocol": "serial"
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
