### PR TITLE
[Bug] Fix unused variable error when using ChibiOS Bitbang serial driver

### DIFF
--- a/platforms/chibios/drivers/serial.c
+++ b/platforms/chibios/drivers/serial.c
@@ -171,7 +171,8 @@ void interrupt_handler(void *arg) {
         checksum_computed += split_trans_initiator2target_buffer(trans)[i];
     }
     checksum_computed ^= 7;
-    uint8_t checksum_received = serial_read_byte();
+
+    serial_read_byte();
     sync_send();
 
     // wait for the sync to finish sending


### PR DESCRIPTION

## Description

The bitbang serial driver for chibiOS doesn't compile, currently.  (shows how often it is used)

Specifically, #16023 removed this line of code, which is the only place that checksum received was being called in that function. 

```c
    *trans->status = (checksum_computed == checksum_received) ? TRANSACTION_ACCEPTED : TRANSACTION_DATA_ERROR;
```

This removes the variable and just calls the function, "fixing" the error. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* reddit

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
