### PR TITLE
dip_switch: Add DIP_SWITCH_INVERT for active-high switches

### DIFF
--- a/docs/feature_dip_switch.md
+++ b/docs/feature_dip_switch.md
@@ -107,3 +107,14 @@ One side of the DIP switch should be wired directly to the pin on the MCU, and t
 ### Connect each switch in the DIP switch to an unused intersections in the key matrix.
 
 As with the keyswitch, a diode and DIP switch connect the ROW line to the COL line.
+
+### Dip switches connected to +V instead of ground
+
+When hardware requires dip switches to be tied to +V instead of ground, you can define a array of pin inversions
+
+```c
+// This example would invert only the second of three dip switches
+#define DIP_SWITCH_INVERT { 0, 1, 0 }
+// For split keyboards, you can also define DIP_SWITCH_INVERT_RIGHT
+#define DIP_SWITCH_INVERT_RIGHT { 0, 1, 0 }
+```

--- a/quantum/dip_switch.c
+++ b/quantum/dip_switch.c
@@ -34,21 +34,20 @@
 
 #ifdef DIP_SWITCH_PINS
 #    define NUMBER_OF_DIP_SWITCHES (sizeof(dip_switch_pad) / sizeof(pin_t))
-#    ifndef DIP_SWITCH_INVERT
-#       define DIP_SWITCH_INVERT {0}
-#    endif
 static pin_t dip_switch_pad[] = DIP_SWITCH_PINS;
+#    if defined(DIP_SWITCH_INVERT) || (defined(SPLIT_KEYBOARD) && defined(DIP_SWITCH_INVERT_RIGHT))
+#        ifndef DIP_SWITCH_INVERT
+#            define DIP_SWITCH_INVERT \
+                { 0 }
+#        endif
 static uint8_t dip_switch_invert[NUMBER_OF_DIP_SWITCHES] = DIP_SWITCH_INVERT;
-
-#    if defined(SPLIT_KEYBOARD) && defined(DIP_SWITCH_PINS_RIGHT)
-#       ifndef DIP_SWITCH_INVERT_RIGHT
-#           define DIP_SWITCH_INVERT_RIGHT DIP_SWITCH_INVERT
-#       endif
-static pin_t dip_switch_pad_right[] = DIP_SWITCH_PINS_RIGHT;
-static uint8_t dip_switch_invert_right[NUMBER_OF_DIP_SWITCHES] = DIP_SWITCH_INVERT_RIGHT;
 #    endif
-#   ifdef DIP_SWITCH_INVERT_RIGHT
-#   endif
+#    if defined(SPLIT_KEYBOARD) && defined(DIP_SWITCH_PINS_RIGHT)
+static pin_t dip_switch_pad_right[] = DIP_SWITCH_PINS_RIGHT;
+#        ifdef DIP_SWITCH_INVERT_RIGHT
+static uint8_t dip_switch_invert_right[NUMBER_OF_DIP_SWITCHES] = DIP_SWITCH_INVERT_RIGHT;
+#        endif
+#    endif
 #endif
 
 #ifdef DIP_SWITCH_MATRIX_GRID
@@ -82,22 +81,25 @@ __attribute__((weak)) bool dip_switch_update_mask_kb(uint32_t state) {
     return dip_switch_update_mask_user(state);
 }
 
-void dip_switch_init(void) {
+__attribute__((weak)) void dip_switch_init(void) {
 #ifdef DIP_SWITCH_PINS
-#   ifdef SPLIT_KEYBOARD
+#    ifdef SPLIT_KEYBOARD
     if (!isLeftHand) {
         for (uint8_t i = 0; i < NUMBER_OF_DIP_SWITCHES; i++) {
             dip_switch_pad[i] = dip_switch_pad_right[i];
-#           if defined(SPLIT_KEYBOARD) && defined(DIP_SWITCH_INVERT_RIGHT)
-                dip_switch_invert[i] = dip_switch_invert_right[i];
-#           endif
+#        if defined(SPLIT_KEYBOARD) && defined(DIP_SWITCH_INVERT_RIGHT)
+            dip_switch_invert[i] = dip_switch_invert_right[i];
+#        endif
         }
     }
-#   endif
+#    endif
     for (uint8_t i = 0; i < NUMBER_OF_DIP_SWITCHES; i++) {
+#    ifdef DIP_SWITCH_INVERT
         if (dip_switch_invert[i]) {
             setPinInputLow(dip_switch_pad[i]);
-        } else {
+        } else
+#    endif
+        {
             setPinInputHigh(dip_switch_pad[i]);
         }
     }
@@ -128,9 +130,12 @@ void dip_switch_read(bool forced) {
 
     for (uint8_t i = 0; i < NUMBER_OF_DIP_SWITCHES; i++) {
 #ifdef DIP_SWITCH_PINS
+#    ifdef DIP_SWITCH_INVERT
         if (dip_switch_invert[i]) {
             dip_switch_state[i] = readPin(dip_switch_pad[i]);
-        } else {
+        } else
+#    endif
+        {
             dip_switch_state[i] = !readPin(dip_switch_pad[i]);
         }
 #endif


### PR DESCRIPTION
## Description

Add a `#define DIP_SWITCH_INVERT` array that will switch specific dip switches to pull-down instead of pull-up

This allows hardware with dip switches tied high to function simply as pull-down switches

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
