### PR TITLE
updating osx_whiskey_tango_foxtrot_capslock to use process_record_user

### DIFF
--- a/layouts/community/ergodox/osx_whiskey_tango_foxtrot_capslock/keymap.c
+++ b/layouts/community/ergodox/osx_whiskey_tango_foxtrot_capslock/keymap.c
@@ -15,6 +15,10 @@ enum layer_names {
 
 typedef enum onoff_t {OFF, ON} onoff;
 
+#define caps_led_on  ergodox_right_led_2_on
+#define caps_led_off ergodox_right_led_2_off
+
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 0: Basic layer
  *
@@ -123,7 +127,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
     // MEDIA AND TENKEY
     [MDIA] = LAYOUT_ergodox(
-       KC_NO,   KC_NO,   KC_MUTE, KC_VOLD, KC_VOLU, KC_F14,  KC_F15,
+       QK_BOOT, KC_NO,   KC_MUTE, KC_VOLD, KC_VOLU, KC_F14,  KC_F15,
        KC_TRNS, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
        KC_TRNS, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
@@ -142,6 +146,45 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
        KC_TRNS, KC_TRNS, KC_TRNS
     ),
 };
+#ifndef NO_FAKE_CAPS
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    static onoff caps_state = OFF;
+
+    switch (keycode) {
+        case KC_CAPS:
+            if (record->event.pressed) {
+                if (caps_state == OFF) {
+                    caps_led_on();
+                    caps_state = ON;
+                } else {
+                    caps_led_off();
+                    caps_state = OFF;
+                }
+            }
+            break;
+        default:
+            if (keycode < KC_A || keycode > KC_Z) {
+                // This isn't an alpha or a KC_CAPS, continue on as usual.
+                return true;
+            }
+            if (record->event.pressed) {
+                bool shifted = (caps_state == ON && get_mods() == 0);
+                if (shifted) {
+                    register_code(KC_LSFT);
+                }
+                register_code(keycode);
+                if (shifted) {
+                    unregister_code(KC_LSFT);
+                }
+            } else {
+                unregister_code(keycode);
+            }
+            break;
+    }
+    // If we get here, we've already handled the keypresses.
+    return false;
+}
+#endif
 
 // Runs constantly in the background, in a loop.
 void matrix_scan_user(void) {

--- a/layouts/community/ergodox/osx_whiskey_tango_foxtrot_capslock/rules.mk
+++ b/layouts/community/ergodox/osx_whiskey_tango_foxtrot_capslock/rules.mk
@@ -1,0 +1,2 @@
+# uncomment below to disable fake capslock
+# OPT_DEFS += -DNO_FAKE_CAPS


### PR DESCRIPTION
## Description

The osx_whiskey_tango_foxtrot_capslock layout for ergodox initially handled faking the caps lock keypress because of macOS's delay on caps key presses.  This functionality was previously implemented as an action_get_macro , and since that functionality seems to be deprecated / removed this functionality was lost in the shuffle.  This is an attempt to re-implement the same functionality with a process_record_user instead.  I have tested this on an original OG ergodox (massdrop kit) and seems to work pretty well. 

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Restore caps lock fakery

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
