### PR TITLE
Fixes #16705 : digital rain follows val

### DIFF
--- a/quantum/rgb_matrix/animations/digital_rain_anim.h
+++ b/quantum/rgb_matrix/animations/digital_rain_anim.h
@@ -10,12 +10,12 @@ RGB_MATRIX_EFFECT(DIGITAL_RAIN)
 bool DIGITAL_RAIN(effect_params_t* params) {
     // algorithm ported from https://github.com/tremby/Kaleidoscope-LEDEffect-DigitalRain
     const uint8_t drop_ticks           = 28;
-    const uint8_t pure_green_intensity = (((uint16_t) rgb_matrix_config.hsv.v)*3)>>2;
-    const uint8_t max_brightness_boost = (((uint16_t) rgb_matrix_config.hsv.v)*3)>>2;
+    const uint8_t pure_green_intensity = (((uint16_t) rgb_matrix_config.hsv.v) * 3) >> 2;
+    const uint8_t max_brightness_boost = (((uint16_t) rgb_matrix_config.hsv.v) * 3) >> 2;
     const uint8_t max_intensity        = rgb_matrix_config.hsv.v;
-    const uint8_t decay_ticks = 0xff / max_intensity;
+    const uint8_t decay_ticks          = 0xff / max_intensity;
 
-    static uint8_t drop = 0;
+    static uint8_t drop  = 0;
     static uint8_t decay = 0;
 
     if (params->init) {
@@ -33,7 +33,7 @@ bool DIGITAL_RAIN(effect_params_t* params) {
                 g_rgb_frame_buffer[row][col] = max_intensity;
             } else if (g_rgb_frame_buffer[row][col] > 0 && g_rgb_frame_buffer[row][col] < max_intensity) {
                 // neither fully bright nor dark, decay it
-                if(decay == decay_ticks){
+                if (decay == decay_ticks) {
                     g_rgb_frame_buffer[row][col]--;
                 }
             }
@@ -53,7 +53,7 @@ bool DIGITAL_RAIN(effect_params_t* params) {
             }
         }
     }
-    if(decay == decay_ticks){
+    if (decay == decay_ticks) {
         decay = 0;
     }
 
@@ -67,9 +67,9 @@ bool DIGITAL_RAIN(effect_params_t* params) {
                     g_rgb_frame_buffer[row][col]--;
                 }
                 // check if the pixel above is bright
-                if (g_rgb_frame_buffer[row - 1][col] >= max_intensity) { //Note: can be larger than max_intensity if val was recently decreased
+                if (g_rgb_frame_buffer[row - 1][col] >= max_intensity) { // Note: can be larger than max_intensity if val was recently decreased
                     // allow old bright pixel to decay
-                    g_rgb_frame_buffer[row - 1][col] = max_intensity-1;
+                    g_rgb_frame_buffer[row - 1][col] = max_intensity - 1;
                     // make this pixel bright
                     g_rgb_frame_buffer[row][col] = max_intensity;
                 }
@@ -79,5 +79,5 @@ bool DIGITAL_RAIN(effect_params_t* params) {
     return false;
 }
 
-#    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
-#endif      // defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && !defined(ENABLE_RGB_MATRIX_DIGITAL_RAIN)
+#    endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif     // defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && !defined(ENABLE_RGB_MATRIX_DIGITAL_RAIN)

--- a/quantum/rgb_matrix/animations/digital_rain_anim.h
+++ b/quantum/rgb_matrix/animations/digital_rain_anim.h
@@ -10,11 +10,13 @@ RGB_MATRIX_EFFECT(DIGITAL_RAIN)
 bool DIGITAL_RAIN(effect_params_t* params) {
     // algorithm ported from https://github.com/tremby/Kaleidoscope-LEDEffect-DigitalRain
     const uint8_t drop_ticks           = 28;
-    const uint8_t pure_green_intensity = 0xd0;
-    const uint8_t max_brightness_boost = 0xc0;
-    const uint8_t max_intensity        = 0xff;
+    const uint8_t pure_green_intensity = (((uint16_t) rgb_matrix_config.hsv.v)*3)>>2;
+    const uint8_t max_brightness_boost = (((uint16_t) rgb_matrix_config.hsv.v)*3)>>2;
+    const uint8_t max_intensity        = rgb_matrix_config.hsv.v;
+	const uint8_t decay_ticks = 0xff / max_intensity;
 
     static uint8_t drop = 0;
+	static uint8_t decay = 0;
 
     if (params->init) {
         rgb_matrix_set_color_all(0, 0, 0);
@@ -22,6 +24,7 @@ bool DIGITAL_RAIN(effect_params_t* params) {
         drop = 0;
     }
 
+	decay++;
     for (uint8_t col = 0; col < MATRIX_COLS; col++) {
         for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
             if (row == 0 && drop == 0 && rand() < RAND_MAX / RGB_DIGITAL_RAIN_DROPS) {
@@ -30,7 +33,9 @@ bool DIGITAL_RAIN(effect_params_t* params) {
                 g_rgb_frame_buffer[row][col] = max_intensity;
             } else if (g_rgb_frame_buffer[row][col] > 0 && g_rgb_frame_buffer[row][col] < max_intensity) {
                 // neither fully bright nor dark, decay it
-                g_rgb_frame_buffer[row][col]--;
+				if(decay == decay_ticks){
+					g_rgb_frame_buffer[row][col]--;
+				}
             }
             // set the pixel colour
             uint8_t led[LED_HITS_TO_REMEMBER];
@@ -48,6 +53,9 @@ bool DIGITAL_RAIN(effect_params_t* params) {
             }
         }
     }
+	if(decay == decay_ticks){
+		decay = 0;
+	}
 
     if (++drop > drop_ticks) {
         // reset drop timer
@@ -59,9 +67,9 @@ bool DIGITAL_RAIN(effect_params_t* params) {
                     g_rgb_frame_buffer[row][col]--;
                 }
                 // check if the pixel above is bright
-                if (g_rgb_frame_buffer[row - 1][col] == max_intensity) {
+                if (g_rgb_frame_buffer[row - 1][col] >= max_intensity) { //Note: can be larger than max_intensity if val was recently decreased
                     // allow old bright pixel to decay
-                    g_rgb_frame_buffer[row - 1][col]--;
+                    g_rgb_frame_buffer[row - 1][col] = max_intensity-1;
                     // make this pixel bright
                     g_rgb_frame_buffer[row][col] = max_intensity;
                 }
@@ -71,5 +79,5 @@ bool DIGITAL_RAIN(effect_params_t* params) {
     return false;
 }
 
-#    endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
-#endif     // defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && !defined(ENABLE_RGB_MATRIX_DIGITAL_RAIN)
+#    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif      // defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && !defined(ENABLE_RGB_MATRIX_DIGITAL_RAIN)

--- a/quantum/rgb_matrix/animations/digital_rain_anim.h
+++ b/quantum/rgb_matrix/animations/digital_rain_anim.h
@@ -13,10 +13,10 @@ bool DIGITAL_RAIN(effect_params_t* params) {
     const uint8_t pure_green_intensity = (((uint16_t) rgb_matrix_config.hsv.v)*3)>>2;
     const uint8_t max_brightness_boost = (((uint16_t) rgb_matrix_config.hsv.v)*3)>>2;
     const uint8_t max_intensity        = rgb_matrix_config.hsv.v;
-	const uint8_t decay_ticks = 0xff / max_intensity;
+    const uint8_t decay_ticks = 0xff / max_intensity;
 
     static uint8_t drop = 0;
-	static uint8_t decay = 0;
+    static uint8_t decay = 0;
 
     if (params->init) {
         rgb_matrix_set_color_all(0, 0, 0);
@@ -24,7 +24,7 @@ bool DIGITAL_RAIN(effect_params_t* params) {
         drop = 0;
     }
 
-	decay++;
+    decay++;
     for (uint8_t col = 0; col < MATRIX_COLS; col++) {
         for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
             if (row == 0 && drop == 0 && rand() < RAND_MAX / RGB_DIGITAL_RAIN_DROPS) {
@@ -33,9 +33,9 @@ bool DIGITAL_RAIN(effect_params_t* params) {
                 g_rgb_frame_buffer[row][col] = max_intensity;
             } else if (g_rgb_frame_buffer[row][col] > 0 && g_rgb_frame_buffer[row][col] < max_intensity) {
                 // neither fully bright nor dark, decay it
-				if(decay == decay_ticks){
-					g_rgb_frame_buffer[row][col]--;
-				}
+                if(decay == decay_ticks){
+                    g_rgb_frame_buffer[row][col]--;
+                }
             }
             // set the pixel colour
             uint8_t led[LED_HITS_TO_REMEMBER];
@@ -53,9 +53,9 @@ bool DIGITAL_RAIN(effect_params_t* params) {
             }
         }
     }
-	if(decay == decay_ticks){
-		decay = 0;
-	}
+    if(decay == decay_ticks){
+        decay = 0;
+    }
 
     if (++drop > drop_ticks) {
         // reset drop timer

--- a/quantum/rgb_matrix/animations/digital_rain_anim.h
+++ b/quantum/rgb_matrix/animations/digital_rain_anim.h
@@ -10,8 +10,8 @@ RGB_MATRIX_EFFECT(DIGITAL_RAIN)
 bool DIGITAL_RAIN(effect_params_t* params) {
     // algorithm ported from https://github.com/tremby/Kaleidoscope-LEDEffect-DigitalRain
     const uint8_t drop_ticks           = 28;
-    const uint8_t pure_green_intensity = (((uint16_t) rgb_matrix_config.hsv.v) * 3) >> 2;
-    const uint8_t max_brightness_boost = (((uint16_t) rgb_matrix_config.hsv.v) * 3) >> 2;
+    const uint8_t pure_green_intensity = (((uint16_t)rgb_matrix_config.hsv.v) * 3) >> 2;
+    const uint8_t max_brightness_boost = (((uint16_t)rgb_matrix_config.hsv.v) * 3) >> 2;
     const uint8_t max_intensity        = rgb_matrix_config.hsv.v;
     const uint8_t decay_ticks          = 0xff / max_intensity;
 


### PR DESCRIPTION
RGB matrix digital rain animation did not follow the current set hsv value.
Due to this, it also ignored `RGB_MATRIX_MAXIMUM_BRIGHTNESS`, which might cause too much current to be drawn .

This pull request changes the algorithm to adapt to the currently set hsv value by both
 * scaling the brightness constants with the value
 * adjusting the speed of decay to keep time from full brightness to 0 roughly constant

- [ ] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

# Fixes 16705 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
