### PR TITLE
add via support for creatkeebs/thera

### DIFF
--- a/keyboards/creatkeebs/thera/info.json
+++ b/keyboards/creatkeebs/thera/info.json
@@ -1,5 +1,5 @@
 {
-    "keyboard_name": "jelly epoch",
+    "keyboard_name": "thera",
     "url": "https://eschit.com/collections/thera75",
     "maintainer": "https://github.com/Timliuzhaolu",
     "layouts": {

--- a/keyboards/creatkeebs/thera/keymaps/via/keymap.c
+++ b/keyboards/creatkeebs/thera/keymaps/via/keymap.c
@@ -1,0 +1,1 @@
+#include "../default/keymap.c"

--- a/keyboards/creatkeebs/thera/keymaps/via/rules.mk
+++ b/keyboards/creatkeebs/thera/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
Thera missing VIA support

## Description

Added creatkeebs/thera/keymaps/via and friends
fix keyboard_name in info.json

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
