### PR TITLE
Data driven `g_led_config`

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -322,10 +322,16 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_5)/info.json)","")
 endif
 
 CONFIG_H += $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/layouts.h
+KEYBOARD_SRC += $(KEYBOARD_OUTPUT)/src/default_keyboard.c
 
 $(KEYBOARD_OUTPUT)/src/info_config.h: $(INFO_JSON_FILES)
 	@$(SILENT) || printf "$(MSG_GENERATING) $@" | $(AWK_CMD)
 	$(eval CMD=$(QMK_BIN) generate-config-h --quiet --keyboard $(KEYBOARD) --output $(KEYBOARD_OUTPUT)/src/info_config.h)
+	@$(BUILD_CMD)
+
+$(KEYBOARD_OUTPUT)/src/default_keyboard.c: $(INFO_JSON_FILES)
+	@$(SILENT) || printf "$(MSG_GENERATING) $@" | $(AWK_CMD)
+	$(eval CMD=$(QMK_BIN) generate-keyboard-c --quiet --keyboard $(KEYBOARD) --output $(KEYBOARD_OUTPUT)/src/default_keyboard.c)
 	@$(BUILD_CMD)
 
 $(KEYBOARD_OUTPUT)/src/default_keyboard.h: $(INFO_JSON_FILES)
@@ -338,7 +344,7 @@ $(KEYBOARD_OUTPUT)/src/layouts.h: $(INFO_JSON_FILES)
 	$(eval CMD=$(QMK_BIN) generate-layouts --quiet --keyboard $(KEYBOARD) --output $(KEYBOARD_OUTPUT)/src/layouts.h)
 	@$(BUILD_CMD)
 
-generated-files: $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/default_keyboard.h $(KEYBOARD_OUTPUT)/src/layouts.h
+generated-files: $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/default_keyboard.c $(KEYBOARD_OUTPUT)/src/default_keyboard.h $(KEYBOARD_OUTPUT)/src/layouts.h
 
 .INTERMEDIATE : generated-files
 

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -212,6 +212,62 @@
                 "timeout": {"$ref": "qmk.definitions.v1#/unsigned_int"}
             }
         },
+        "led_matrix": {
+            "type": "object",
+            "properties": {
+                "driver": {"type": "string"},
+                "layout": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "matrix": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": {
+                                    "type": "number",
+                                    "min": 0,
+                                    "multipleOf": 1
+                                }
+                            },
+                            "x": {"$ref": "qmk.definitions.v1#/key_unit"},
+                            "y": {"$ref": "qmk.definitions.v1#/key_unit"},
+                            "flags": {"$ref": "qmk.definitions.v1#/unsigned_decimal"}
+                        }
+                    }
+                }
+            }
+        },
+        "rgb_matrix": {
+            "type": "object",
+            "properties": {
+                "driver": {"type": "string"},
+                "layout": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "matrix": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": {
+                                    "type": "number",
+                                    "min": 0,
+                                    "multipleOf": 1
+                                }
+                            },
+                            "x": {"$ref": "qmk.definitions.v1#/key_unit"},
+                            "y": {"$ref": "qmk.definitions.v1#/key_unit"},
+                            "flags": {"$ref": "qmk.definitions.v1#/unsigned_decimal"}
+                        }
+                    }
+                }
+            }
+        },
         "rgblight": {
             "type": "object",
             "additionalProperties": false,

--- a/lib/python/qmk/c_parse.py
+++ b/lib/python/qmk/c_parse.py
@@ -197,6 +197,8 @@ def _coerce_led_token(_type, value):
     }
     if _type is Token.Literal.Number.Integer:
         return int(value)
+    if _type is Token.Literal.Number.Float:
+        return float(value)
     if _type is Token.Literal.Number.Hex:
         return int(value, 0)
     if _type is Token.Name and value in value_map.keys():
@@ -233,7 +235,7 @@ def _parse_led_config(file, matrix_cols, matrix_rows):
                 bracket_count -= 1
             else:
                 # Assume any non whitespace value here is important enough to stash
-                if _type in [Token.Literal.Number.Integer, Token.Literal.Number.Hex, Token.Name]:
+                if _type in [Token.Literal.Number.Integer, Token.Literal.Number.Float, Token.Literal.Number.Hex, Token.Name]:
                     if section == 1 and bracket_count == 3:
                         matrix_raw.append(_coerce_led_token(_type, value))
                     if section == 2 and bracket_count == 3:

--- a/lib/python/qmk/c_parse.py
+++ b/lib/python/qmk/c_parse.py
@@ -1,5 +1,9 @@
 """Functions for working with config.h files.
 """
+from pygments.lexers.c_cpp import CLexer
+from pygments.token import Token
+from pygments import lex
+from itertools import islice
 from pathlib import Path
 import re
 
@@ -11,6 +15,13 @@ default_key_entry = {'x': -1, 'y': 0, 'w': 1}
 single_comment_regex = re.compile(r'\s+/[/*].*$')
 multi_comment_regex = re.compile(r'/\*(.|\n)*?\*/', re.MULTILINE)
 layout_macro_define_regex = re.compile(r'^#\s*define')
+
+
+def _get_chunks(it, size):
+    """Break down a collection into smaller parts
+    """
+    it = iter(it)
+    return iter(lambda: tuple(islice(it, size)), ())
 
 
 def strip_line_comment(string):
@@ -170,3 +181,108 @@ def _parse_matrix_locations(matrix, file, macro_name):
                 matrix_locations[identifier] = [row_num, col_num]
 
     return matrix_locations
+
+
+def _coerce_led_token(_type, value):
+    """ Convert token to valid info.json content
+    """
+    value_map = {
+        'NO_LED': None,
+        'LED_FLAG_ALL': 0xFF,
+        'LED_FLAG_NONE': 0x00,
+        'LED_FLAG_MODIFIER': 0x01,
+        'LED_FLAG_UNDERGLOW': 0x02,
+        'LED_FLAG_KEYLIGHT': 0x04,
+        'LED_FLAG_INDICATOR': 0x08,
+    }
+    if _type is Token.Literal.Number.Integer:
+        return int(value)
+    if _type is Token.Literal.Number.Hex:
+        return int(value, 0)
+    if _type is Token.Name and value in value_map.keys():
+        return value_map[value]
+
+
+def _parse_led_config(file, matrix_cols, matrix_rows):
+    """Return any 'raw' led/rgb matrix config
+    """
+    file_contents = file.read_text(encoding='utf-8')
+    file_contents = comment_remover(file_contents)
+    file_contents = file_contents.replace('\\\n', '')
+
+    matrix_raw = []
+    position_raw = []
+    flags = []
+
+    found_led_config = False
+    bracket_count = 0
+    section = 0
+    for _type, value in lex(file_contents, CLexer()):
+        # Assume g_led_config..stuff..;
+        if value == 'g_led_config':
+            found_led_config = True
+        elif value == ';':
+            found_led_config = False
+        elif found_led_config:
+            # Assume bracket count hints to section of config we are within
+            if value == '{':
+                bracket_count += 1
+                if bracket_count == 2:
+                    section += 1
+            elif value == '}':
+                bracket_count -= 1
+            else:
+                # Assume any non whitespace value here is important enough to stash
+                if _type in [Token.Literal.Number.Integer, Token.Literal.Number.Hex, Token.Name]:
+                    if section == 1 and bracket_count == 3:
+                        matrix_raw.append(_coerce_led_token(_type, value))
+                    if section == 2 and bracket_count == 3:
+                        position_raw.append(_coerce_led_token(_type, value))
+                    if section == 3 and bracket_count == 2:
+                        flags.append(_coerce_led_token(_type, value))
+
+    # Slightly better intrim format
+    matrix = list(_get_chunks(matrix_raw, matrix_cols))
+    position = list(_get_chunks(position_raw, 2))
+    matrix_indexes = list(filter(lambda x: x is not None, matrix_raw))
+
+    # If we have not found anything - bail
+    if not section:
+        return None
+
+    # TODO: Improve crude parsing/validation
+    if len(matrix) != matrix_rows and len(matrix) != (matrix_rows / 2):
+        raise ValueError("Unable to parse g_led_config matrix data")
+    if len(position) != len(flags):
+        raise ValueError("Unable to parse g_led_config position data")
+    if len(matrix_indexes) and (max(matrix_indexes) >= len(flags)):
+        raise ValueError("OOB within g_led_config matrix data")
+
+    return (matrix, position, flags)
+
+
+def find_led_config(file, matrix_cols, matrix_rows):
+    """Search file for led/rgb matrix config
+    """
+    found = _parse_led_config(file, matrix_cols, matrix_rows)
+    if not found:
+        return None
+
+    # Expand collected content
+    (matrix, position, flags) = found
+
+    # Align to output format
+    led_config = []
+    for index, item in enumerate(position, start=0):
+        led_config.append({
+            'x': item[0],
+            'y': item[1],
+            'flags': flags[index],
+        })
+    for r in range(len(matrix)):
+        for c in range(len(matrix[r])):
+            index = matrix[r][c]
+            if index is not None:
+                led_config[index]['matrix'] = [r, c]
+
+    return led_config

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -52,6 +52,7 @@ subcommands = [
     'qmk.cli.generate.dfu_header',
     'qmk.cli.generate.docs',
     'qmk.cli.generate.info_json',
+    'qmk.cli.generate.keyboard_c',
     'qmk.cli.generate.keyboard_h',
     'qmk.cli.generate.layouts',
     'qmk.cli.generate.rgb_breathe_table',

--- a/lib/python/qmk/cli/generate/keyboard_c.py
+++ b/lib/python/qmk/cli/generate/keyboard_c.py
@@ -15,6 +15,7 @@ def _gen_led_config(info_data):
     cols = info_data['matrix_size']['cols']
     rows = info_data['matrix_size']['rows']
 
+    led_config = None
     if 'layout' in info_data.get('rgb_matrix', {}):
         led_config = info_data['rgb_matrix']['layout']
     elif 'layout' in info_data.get('led_matrix', {}):

--- a/lib/python/qmk/cli/generate/keyboard_c.py
+++ b/lib/python/qmk/cli/generate/keyboard_c.py
@@ -1,0 +1,65 @@
+"""Used by the make system to generate keyboard.c from info.json.
+"""
+from milc import cli
+
+from qmk.info import info_json
+from qmk.commands import dump_lines
+from qmk.keyboard import keyboard_completer, keyboard_folder
+from qmk.path import normpath
+from qmk.constants import GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE
+
+
+def _gen_led_config(info_data):
+    """Convert info.json content to g_led_config
+    """
+    cols = info_data['matrix_size']['cols']
+    rows = info_data['matrix_size']['rows']
+
+    if 'layout' in info_data.get('rgb_matrix', {}):
+        led_config = info_data['rgb_matrix']['layout']
+    elif 'layout' in info_data.get('led_matrix', {}):
+        led_config = info_data['led_matrix']['layout']
+
+    lines = []
+    if not led_config:
+        return lines
+
+    matrix = [['NO_PIN'] * cols for i in range(rows)]
+    pos = []
+    flags = []
+
+    for index, item in enumerate(led_config, start=0):
+        if 'matrix' in item:
+            (x, y) = item['matrix']
+            matrix[x][y] = str(index)
+        pos.append(f'{{ {item.get("x", 0)},{item.get("y", 0)} }}')
+        flags.append(str(item.get('flags', 0)))
+
+    lines.append('__attribute__ ((weak)) led_config_t g_led_config = {')
+    lines.append('  {')
+    for line in matrix:
+        lines.append(f'    {{ {",".join(line)} }},')
+    lines.append('  },')
+    lines.append(f'  {{ {",".join(pos)} }},')
+    lines.append(f'  {{ {",".join(flags)} }},')
+    lines.append('};')
+
+    return lines
+
+
+@cli.argument('-o', '--output', arg_only=True, type=normpath, help='File to write to')
+@cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
+@cli.argument('-kb', '--keyboard', arg_only=True, type=keyboard_folder, completer=keyboard_completer, required=True, help='Keyboard to generate keyboard.c for.')
+@cli.subcommand('Used by the make system to generate keyboard.c from info.json', hidden=True)
+def generate_keyboard_c(cli):
+    """Generates the keyboard.h file.
+    """
+    kb_info_json = info_json(cli.args.keyboard)
+
+    # Build the layouts.h file.
+    keyboard_h_lines = [GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE, '#include QMK_KEYBOARD_H', '']
+
+    keyboard_h_lines.extend(_gen_led_config(kb_info_json))
+
+    # Show the results
+    dump_lines(cli.args.output, keyboard_h_lines, cli.args.quiet)

--- a/lib/python/qmk/cli/generate/keyboard_c.py
+++ b/lib/python/qmk/cli/generate/keyboard_c.py
@@ -25,7 +25,7 @@ def _gen_led_config(info_data):
     if not led_config:
         return lines
 
-    matrix = [['NO_PIN'] * cols for i in range(rows)]
+    matrix = [['NO_LED'] * cols for i in range(rows)]
     pos = []
     flags = []
 

--- a/lib/python/qmk/cli/generate/keyboard_c.py
+++ b/lib/python/qmk/cli/generate/keyboard_c.py
@@ -15,26 +15,34 @@ def _gen_led_config(info_data):
     cols = info_data['matrix_size']['cols']
     rows = info_data['matrix_size']['rows']
 
-    led_config = None
+    config_type = None
     if 'layout' in info_data.get('rgb_matrix', {}):
-        led_config = info_data['rgb_matrix']['layout']
+        config_type = 'rgb_matrix'
     elif 'layout' in info_data.get('led_matrix', {}):
-        led_config = info_data['led_matrix']['layout']
+        config_type = 'led_matrix'
 
     lines = []
-    if not led_config:
+    if not config_type:
         return lines
 
     matrix = [['NO_LED'] * cols for i in range(rows)]
     pos = []
     flags = []
 
+    led_config = info_data[config_type]['layout']
     for index, item in enumerate(led_config, start=0):
         if 'matrix' in item:
             (x, y) = item['matrix']
             matrix[x][y] = str(index)
         pos.append(f'{{ {item.get("x", 0)},{item.get("y", 0)} }}')
         flags.append(str(item.get('flags', 0)))
+
+    if config_type == 'rgb_matrix':
+        lines.append('#ifdef RGB_MATRIX_ENABLE')
+        lines.append('#include "rgb_matrix.h"')
+    elif config_type == 'led_matrix':
+        lines.append('#ifdef LED_MATRIX_ENABLE')
+        lines.append('#include "led_matrix.h"')
 
     lines.append('__attribute__ ((weak)) led_config_t g_led_config = {')
     lines.append('  {')
@@ -44,6 +52,7 @@ def _gen_led_config(info_data):
     lines.append(f'  {{ {",".join(pos)} }},')
     lines.append(f'  {{ {",".join(flags)} }},')
     lines.append('};')
+    lines.append('#endif')
 
     return lines
 

--- a/lib/python/qmk/json_encoders.py
+++ b/lib/python/qmk/json_encoders.py
@@ -75,8 +75,8 @@ class InfoJSONEncoder(QMKJSONEncoder):
         """Encode info.json dictionaries.
         """
         if obj:
-            if self.indentation_level == 4:
-                # These are part of a layout, put them on a single line.
+            if set(("x", "y")).issubset(obj.keys()):
+                # These are part of a layout/led_config, put them on a single line.
                 return "{ " + ", ".join(f"{self.encode(key)}: {self.encode(element)}" for key, element in sorted(obj.items())) + " }"
 
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
<!--- Describe your changes in detail here. -->

## Description
Building blocks for #15631.

`info.json` providing context on LED location and key binding, will facilitate client UI presentation and `set led <index> to <colour>` style API.

It also allows better validation of the contents, and scope for future tooling.

### Future
- [ ] fix parsing warnings due to:
    * inconsistent config for splits
    * fake padding for encoders
    * config incorrect - not correctly defaulted to NO_LED but led 0?

```
qmk info -f json -kb splitkb/kyria/rev1
{
    "manufacturer": "splitkb",
    "keyboard_name": "Kyria rev1",
    "maintainer": "splitkb.com",
    "bootloader": "atmel-dfu",
...
    "keyboard_folder": "splitkb/kyria/rev1",
    "rgb_matrix": {
        "layout": [
            { "flags": 255, "matrix": [2, 1], "x": 91, "y": 40 },
            { "flags": 255, "matrix": [3, 2], "x": 77, "y": 56 },
            { "flags": 255, "matrix": [3, 3], "x": 63, "y": 56 },
            { "flags": 255, "matrix": [1, 2], "x": 77, "y": 24 },
            { "flags": 255, "matrix": [0, 3], "x": 63, "y": 8 },
            { "flags": 255, "matrix": [0, 6], "x": 21, "y": 8 },
            { "flags": 255, "matrix": [2, 6], "x": 21, "y": 40 },
            { "flags": 255, "matrix": [2, 5], "x": 35, "y": 40 },
            { "flags": 255, "matrix": [2, 7], "x": 7, "y": 40 },
            { "flags": 255, "matrix": [0, 7], "x": 7, "y": 8 },
            { "flags": 255, "matrix": [6, 1], "x": 133, "y": 40 },
            { "flags": 255, "matrix": [7, 2], "x": 147, "y": 56 },
            { "flags": 255, "matrix": [7, 3], "x": 161, "y": 56 },
            { "flags": 255, "matrix": [5, 2], "x": 147, "y": 24 },
            { "flags": 255, "matrix": [4, 3], "x": 161, "y": 8 },
            { "flags": 255, "matrix": [4, 6], "x": 203, "y": 8 },
            { "flags": 255, "matrix": [6, 6], "x": 203, "y": 40 },
            { "flags": 255, "matrix": [6, 5], "x": 189, "y": 40 },
            { "flags": 255, "matrix": [6, 7], "x": 217, "y": 40 },
            { "flags": 255, "matrix": [4, 7], "x": 217, "y": 8 }
        ]
    },
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
