### PR TITLE
Add emulated eeprom support for STM32F303xE

### DIFF
--- a/platforms/chibios/eeprom_stm32_defs.h
+++ b/platforms/chibios/eeprom_stm32_defs.h
@@ -25,7 +25,7 @@
 #        ifndef FEE_PAGE_COUNT
 #            define FEE_PAGE_COUNT 2 // How many pages are used
 #        endif
-#    elif defined(STM32F103xE) || defined(STM32F303xC) || defined(STM32F072xB) || defined(STM32F070xB)
+#    elif defined(STM32F103xE) || defined(STM32F303xC) || defined(STM32F303xE) || defined(STM32F072xB) || defined(STM32F070xB)
 #        ifndef FEE_PAGE_SIZE
 #            define FEE_PAGE_SIZE 0x800 // Page size = 2KByte
 #        endif
@@ -51,7 +51,7 @@
 #        define FEE_MCU_FLASH_SIZE 128 // Size in Kb
 #    elif defined(STM32F303xC) || defined(STM32F401xC)
 #        define FEE_MCU_FLASH_SIZE 256 // Size in Kb
-#    elif defined(STM32F103xE) || defined(STM32F401xE) || defined(STM32F411xE)
+#    elif defined(STM32F103xE) || defined(STM32F303xE) || defined(STM32F401xE) || defined(STM32F411xE)
 #        define FEE_MCU_FLASH_SIZE 512 // Size in Kb
 #    elif defined(STM32F405xG)
 #        define FEE_MCU_FLASH_SIZE 1024 // Size in Kb


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Added STM32F303xE to `FEE_PAGE_SIZE` and `FEE_MCU_FLASH_SIZE` defines in `platforms/ChibiOS/eeprom_stm32_defs.h`<br/>
QMK currently assumes mcus to be STM32F303xC for `MCU = STM32F303`. In order to compile for STM32F303xE, it was necessary to include a board.h as explained in https://github.com/qmk/qmk_firmware/pull/8179#issuecomment-819868686. However, that solution no longer works so this PR fixes it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
