### PR TITLE
[Core] Refactor writePin to work with statements

### DIFF
--- a/platforms/chibios/gpio.h
+++ b/platforms/chibios/gpio.h
@@ -31,7 +31,14 @@ typedef ioline_t pin_t;
 
 #define writePinHigh(pin) palSetLine(pin)
 #define writePinLow(pin) palClearLine(pin)
-#define writePin(pin, level) ((level) ? (writePinHigh(pin)) : (writePinLow(pin)))
+#define writePin(pin, level)   \
+    do {                       \
+        if (level) {           \
+            writePinHigh(pin); \
+        } else {               \
+            writePinLow(pin);  \
+        }                      \
+    } while (0)
 
 #define readPin(pin) palReadLine(pin)
 


### PR DESCRIPTION
## Description

The ternary operator expects expressions as its arguments, this works for most gpio implementations but not for the RP2040 port as the gpio macros are implemented as statements. Using `writePin` would error on Macro expansion during compilation.  See https://github.com/qmk/qmk_firmware/pull/14877#issuecomment-1075645743

Therefore the ternary operator is replaced with a wrapped if-else statement which does accept simple statements.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Part of #14877 which throws compilation errors when using `writePin`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
