### PR TITLE
CLI: Lint non-data driven macros in info.json

### DIFF
--- a/lib/python/qmk/c_parse.py
+++ b/lib/python/qmk/c_parse.py
@@ -10,6 +10,7 @@ from qmk.comment_remover import comment_remover
 default_key_entry = {'x': -1, 'y': 0, 'w': 1}
 single_comment_regex = re.compile(r'\s+/[/*].*$')
 multi_comment_regex = re.compile(r'/\*(.|\n)*?\*/', re.MULTILINE)
+layout_macro_define_regex = re.compile(r'^#\s*define')
 
 
 def strip_line_comment(string):
@@ -51,7 +52,7 @@ def find_layouts(file):
     file_contents = file_contents.replace('\\\n', '')
 
     for line in file_contents.split('\n'):
-        if line.startswith('#define') and '(' in line and 'LAYOUT' in line:
+        if layout_macro_define_regex.match(line.lstrip()) and '(' in line and 'LAYOUT' in line:
             # We've found a LAYOUT macro
             macro_name, layout, matrix = _parse_layout_macro(line.strip())
 

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -118,7 +118,8 @@ def lint(cli):
 
         # Check if all non-data driven macros exist in <keyboard.h>
         for layout, data in keyboard_info['layouts'].items():
-            if not data['c_macro'] and not all('matrix' in key_data.keys() for key_data in data['layout']):
+            # Matrix data should be a list with exactly two integers: [0, 1]
+            if not data['c_macro'] and not all('matrix' in key_data.keys() or len(key_data) == 2 or all(isinstance(n, int) for n in key_data) for key_data in data['layout']):
                 cli.log.error(f'"{layout}" has no "matrix" definition in either "info.json" or "{kb}.h"!')
                 ok = False
 

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -116,6 +116,12 @@ def lint(cli):
             if not keymap_check(kb, cli.config.lint.keymap):
                 ok = False
 
+        # Check if all non-data driven macros exist in <keyboard.h>
+        for layout, data in keyboard_info['layouts'].items():
+            if not data['c_macro'] and not all('matrix' in key_data.keys() for key_data in data['layout']):
+                cli.log.error(f'"{layout}" has no "matrix" definition in either "info.json" or "{kb}.h"!')
+                ok = False
+
         # Report status
         if not ok:
             failed.append(kb)

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -120,7 +120,7 @@ def lint(cli):
         for layout, data in keyboard_info['layouts'].items():
             # Matrix data should be a list with exactly two integers: [0, 1]
             if not data['c_macro'] and not all('matrix' in key_data.keys() or len(key_data) == 2 or all(isinstance(n, int) for n in key_data) for key_data in data['layout']):
-                cli.log.error(f'"{layout}" has no "matrix" definition in either "info.json" or "{kb}.h"!')
+                cli.log.error(f'"{layout}" has no "matrix" definition in either "info.json" or "<keyboard>.h"!')
                 ok = False
 
         # Report status

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -120,7 +120,7 @@ def lint(cli):
         for layout, data in keyboard_info['layouts'].items():
             # Matrix data should be a list with exactly two integers: [0, 1]
             if not data['c_macro'] and not all('matrix' in key_data.keys() or len(key_data) == 2 or all(isinstance(n, int) for n in key_data) for key_data in data['layout']):
-                cli.log.error(f'"{layout}" has no "matrix" definition in either "info.json" or "<keyboard>.h"!')
+                cli.log.error(f'{kb}: "{layout}" has no "matrix" definition in either "info.json" or "<keyboard>.h"!')
                 ok = False
 
         # Report status


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Macros in `info.json` should either have the "matrix" key with the matrix
data or should should be also present in `<keyboard>.h`

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
