### PR TITLE
Add warning for CTPC/CONVERT_TO_PROTON_C.

### DIFF
--- a/builddefs/converters.mk
+++ b/builddefs/converters.mk
@@ -1,8 +1,19 @@
+# Note for new boards -- CTPC and CONVERT_TO_PROTON_C are deprecated terms
+# and should not be replicated for new boards. These will be removed from
+# documentation as well as existing keymaps in due course.
 ifeq ($(strip $(CTPC)), yes)
     CONVERT_TO_PROTON_C=yes
 endif
 ifeq ($(strip $(CONVERT_TO_PROTON_C)), yes)
     CONVERT_TO=proton_c
+
+cpfirmware: ctpc_warning
+.INTERMEDIATE: ctpc_warning
+ctpc_warning: elf
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
+	$(info The `CONVERT_TO_PROTON_C` and `CTPC` options are soon to be deprecated.)
+	$(info Boards should be changed to use `CONVERT_TO=proton_c` instead.)
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 endif
 
 # TODO: opt in rather than assume everything uses a pro micro


### PR DESCRIPTION
## Description

Adds a build-time warning for CTCP/CONVERT_TO_PROTON_C -- stating the new syntax.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
