### PR TITLE
Add mechanism to limit available converters

### DIFF
--- a/data/mappings/defaults.json
+++ b/data/mappings/defaults.json
@@ -2,16 +2,19 @@
     "development_board": {
         "promicro": {
             "processor": "atmega32u4",
-            "bootloader": "caterina"
+            "bootloader": "caterina",
+            "pin_compatible": "promicro"
         },
         "elite_c": {
             "processor": "atmega32u4",
-            "bootloader": "atmel-dfu"
+            "bootloader": "atmel-dfu",
+            "pin_compatible": "promicro"
         },
         "proton_c": {
             "processor": "STM32F303",
             "bootloader": "stm32-dfu",
-            "board": "QMK_PROTON_C"
+            "board": "QMK_PROTON_C",
+            "pin_compatible": "promicro"
         }
     }
 }

--- a/data/mappings/info_rules.json
+++ b/data/mappings/info_rules.json
@@ -19,6 +19,7 @@
     "MCU": {"info_key": "processor", "warn_duplicate": false},
     "MOUSEKEY_ENABLE": {"info_key": "mouse_key.enabled", "value_type": "bool"},
     "NO_USB_STARTUP_CHECK": {"info_key": "usb.no_startup_check", "value_type": "bool"},
+    "PIN_COMPATIBLE": {"info_key": "pin_compatible"},
     "SPLIT_KEYBOARD": {"info_key": "split.enabled", "value_type": "bool"},
     "SPLIT_TRANSPORT": {"info_key": "split.transport.protocol", "to_c": false},
     "WAIT_FOR_USB": {"info_key": "usb.wait_for", "value_type": "bool"}

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -16,6 +16,10 @@
             "type": "string",
             "enum": ["promicro", "elite_c", "proton_c"]
         },
+        "pin_compatible": {
+            "type": "string",
+            "enum": ["promicro"]
+        },
         "processor": {
             "type": "string",
             "enum": ["cortex-m0", "cortex-m0plus", "cortex-m3", "cortex-m4", "MKL26Z64", "MK20DX128", "MK20DX256", "MK66FX1M0", "STM32F042", "STM32F072", "STM32F103", "STM32F303", "STM32F401", "STM32F405", "STM32F407", "STM32F411", "STM32F446", "STM32G431", "STM32G474", "STM32L412", "STM32L422", "STM32L432", "STM32L433", "STM32L442", "STM32L443", "GD32VF103", "WB32F3G71", "atmega16u2", "atmega32u2", "atmega16u4", "atmega32u4", "at90usb162", "at90usb646", "at90usb647", "at90usb1286", "at90usb1287", "atmega32a", "atmega328p", "atmega328", "attiny85", "unknown"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Cherry picked whats ready to go from https://github.com/qmk/qmk_firmware/pull/16598.

This PR aims to help link `development_board` presets to converters.

In a future develop cycle, this will block invalid conversion attempts, such as make xd48pro CTPC=yes.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
