### PR TITLE
Keymap: sinc/lickel: Use backlight keys in Fn Row

### DIFF
--- a/keyboards/keebio/bdn9/keymaps/lickel/readme.md
+++ b/keyboards/keebio/bdn9/keymaps/lickel/readme.md
@@ -12,6 +12,6 @@
 
 ## Changelog
 
-### 1/17/2022 - 1.0
+### 2022-01-17 - 1.0
 
 - Initial release

--- a/keyboards/keebio/sinc/keymaps/lickel/keymap.c
+++ b/keyboards/keebio/sinc/keymaps/lickel/keymap.c
@@ -32,7 +32,7 @@ enum custom_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT_80_with_macro(
-    KC_MUTE,          KC_ESC,  KC_BRID, KC_BRIU, KC_MCTL, KC_LPAD, RGB_VAD, RGB_VAI, KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_VOLD, KC_VOLU, KC_DEL,  KC_MPLY,
+    KC_MUTE,          KC_ESC,  KC_BRID, KC_BRIU, KC_MCTL, KC_LPAD, BL_DEC,  BL_INC,  KC_MPRV, KC_MPLY, KC_MNXT, KC_MUTE, KC_VOLD, KC_VOLU, KC_DEL,  KC_MPLY,
     KC_F1,   KC_F2,   KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_BSPC, KC_HOME,
     KC_F3,   KC_F4,   KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_PGUP,
     KC_F5,   KC_F6,   KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGDN,

--- a/keyboards/keebio/sinc/keymaps/lickel/readme.md
+++ b/keyboards/keebio/sinc/keymaps/lickel/readme.md
@@ -7,12 +7,16 @@
 - Left macros are: F1->F10
 - Right macros are: Play, Home, Pg Up, Pg Dn, End, Right
 
-![Layout](https://i.imgur.com/uQnzMSe.png)
+![Layout](https://i.imgur.com/0uXXrJY.png)
 
 ([KLE](http://www.keyboard-layout-editor.com/#/gists/e0350d8914cac3166abcca6abfd093b7))
 
 ## Changelog
 
-### 11/27/2021 - 1.0
+### 2022-03-04 - 1.1
+
+- Correct function row to change LED backlights, not underglow
+
+### 2021-11-27 - 1.0
 
 - Initial release


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The intent was for these keys to behave like macOS. 
At the time, my board didn't have backlight LEDs, so I didn't realize my mistake.

When I went to update my readme, I realized I was using a bad date format, so I changed both of my keymaps in the repo to use ISO8601 format.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
