### PR TITLE
KBD67 Rev1 Caps Lock LED Fix

### DIFF
--- a/keyboards/kbdfans/kbd67/rev1/config.h
+++ b/keyboards/kbdfans/kbd67/rev1/config.h
@@ -48,6 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DIODE_DIRECTION COL2ROW
 
 #define LED_CAPS_LOCK_PIN B2
+#define LED_PIN_ON_STATE 0
 
 #define BACKLIGHT_PIN B6
 #ifdef BACKLIGHT_PIN


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This change properly aligns caps lock with its LED.

## Description

Current bug: When caps lock is set to off, the caps lock LED indicator is on. When caps lock is set to on, the caps lock LED indicator is off. This used to be handled by KBDFans who had their own QMK configurator at  http://qmkeyboard.cn/ but it now appears to be offline.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
