### PR TITLE
Better handle device init for Pointing Devices

### DIFF
--- a/drivers/sensors/adns5050.h
+++ b/drivers/sensors/adns5050.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 
 // CPI values
 // clang-format off

--- a/drivers/sensors/cirque_pinnacle.c
+++ b/drivers/sensors/cirque_pinnacle.c
@@ -198,7 +198,7 @@ void cirque_pinnacle_cursor_smoothing(bool enable) {
 }
 
 /*  Pinnacle-based TM040040/TM035035/TM023023 Functions  */
-void cirque_pinnacle_init(void) {
+bool cirque_pinnacle_init(void) {
 #if defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_spi)
     spi_init();
 #elif defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_i2c)
@@ -233,6 +233,8 @@ void cirque_pinnacle_init(void) {
     cirque_pinnacle_calibrate();
 
     cirque_pinnacle_enable_feed(true);
+
+    return touchpad_init;
 }
 
 pinnacle_data_t cirque_pinnacle_read_data(void) {

--- a/drivers/sensors/cirque_pinnacle.h
+++ b/drivers/sensors/cirque_pinnacle.h
@@ -6,6 +6,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// Convenient way to store and access measurements
+typedef struct {
+    uint16_t xValue;
+    uint16_t yValue;
+    uint16_t zValue;
+    uint8_t  buttonFlags;
+    bool     touchDown;
+} pinnacle_data_t;
+
 #ifndef CIRQUE_PINNACLE_TIMEOUT
 #    define CIRQUE_PINNACLE_TIMEOUT 20 // I2C timeout in milliseconds
 #endif
@@ -93,7 +102,7 @@ typedef struct {
 #endif
 } pinnacle_data_t;
 
-void            cirque_pinnacle_init(void);
+bool            cirque_pinnacle_init(void);
 void            cirque_pinnacle_calibrate(void);
 void            cirque_pinnacle_cursor_smoothing(bool enable);
 pinnacle_data_t cirque_pinnacle_read_data(void);

--- a/drivers/sensors/pimoroni_trackball.c
+++ b/drivers/sensors/pimoroni_trackball.c
@@ -31,6 +31,8 @@
 #define PIMORONI_TRACKBALL_REG_DOWN    0x07
 // clang-format on
 
+bool pimoroni_trackball_initialized = true;
+
 static uint16_t precision = 128;
 
 uint16_t pimoroni_trackball_get_cpi(void) {
@@ -56,8 +58,11 @@ void pimoroni_trackball_set_cpi(uint16_t cpi) {
 
 void pimoroni_trackball_set_rgbw(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
     uint8_t                              data[4] = {r, g, b, w};
-    __attribute__((unused)) i2c_status_t status  = i2c_writeReg(PIMORONI_TRACKBALL_ADDRESS << 1, PIMORONI_TRACKBALL_REG_LED_RED, data, sizeof(data), PIMORONI_TRACKBALL_TIMEOUT);
+   i2c_status_t status  = i2c_writeReg(PIMORONI_TRACKBALL_ADDRESS << 1, PIMORONI_TRACKBALL_REG_LED_RED, data, sizeof(data), PIMORONI_TRACKBALL_TIMEOUT);
 
+    if (status != I2C_STATUS_SUCCESS) {
+        pimoroni_trackball_initialized = false;
+    }
 #ifdef CONSOLE_ENABLE
     if (debug_mouse) dprintf("Trackball RGBW i2c_status_t: %d\n", status);
 #endif
@@ -78,9 +83,10 @@ i2c_status_t read_pimoroni_trackball(pimoroni_data_t* data) {
     return status;
 }
 
-__attribute__((weak)) void pimoroni_trackball_device_init(void) {
+__attribute__((weak)) bool pimoroni_trackball_device_init(void) {
     i2c_init();
     pimoroni_trackball_set_rgbw(0x00, 0x00, 0x00, 0x00);
+    return pimoroni_trackball_initialized;
 }
 
 int16_t pimoroni_trackball_get_offsets(uint8_t negative_dir, uint8_t positive_dir, uint8_t scale) {

--- a/drivers/sensors/pimoroni_trackball.c
+++ b/drivers/sensors/pimoroni_trackball.c
@@ -57,8 +57,8 @@ void pimoroni_trackball_set_cpi(uint16_t cpi) {
 }
 
 void pimoroni_trackball_set_rgbw(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
-    uint8_t                              data[4] = {r, g, b, w};
-   i2c_status_t status  = i2c_writeReg(PIMORONI_TRACKBALL_ADDRESS << 1, PIMORONI_TRACKBALL_REG_LED_RED, data, sizeof(data), PIMORONI_TRACKBALL_TIMEOUT);
+    uint8_t      data[4] = {r, g, b, w};
+    i2c_status_t status  = i2c_writeReg(PIMORONI_TRACKBALL_ADDRESS << 1, PIMORONI_TRACKBALL_REG_LED_RED, data, sizeof(data), PIMORONI_TRACKBALL_TIMEOUT);
 
     if (status != I2C_STATUS_SUCCESS) {
         pimoroni_trackball_initialized = false;

--- a/drivers/sensors/pimoroni_trackball.h
+++ b/drivers/sensors/pimoroni_trackball.h
@@ -49,7 +49,7 @@ typedef struct {
     uint8_t click;
 } pimoroni_data_t;
 
-void         pimoroni_trackball_device_init(void);
+bool         pimoroni_trackball_device_init(void);
 void         pimoroni_trackball_set_rgbw(uint8_t red, uint8_t green, uint8_t blue, uint8_t white);
 int16_t      pimoroni_trackball_get_offsets(uint8_t negative_dir, uint8_t positive_dir, uint8_t scale);
 uint16_t     pimoroni_trackball_get_cpi(void);

--- a/quantum/pointing_device.c
+++ b/quantum/pointing_device.c
@@ -247,13 +247,13 @@ __attribute__((weak)) void pointing_device_task(void) {
         static uint8_t old_buttons = 0;
     local_mouse_report.buttons = old_buttons;
     if (pointing_device_initialized) {
-        local_mouse_report         = pointing_device_driver.get_report(local_mouse_report);
+        local_mouse_report = pointing_device_driver.get_report(local_mouse_report);
     }
-    old_buttons                = local_mouse_report.buttons;
+    old_buttons = local_mouse_report.buttons;
 #    elif defined(POINTING_DEVICE_LEFT) || defined(POINTING_DEVICE_RIGHT)
-    if (pointing_device_initialized) {
-        local_mouse_report = POINTING_DEVICE_THIS_SIDE ? pointing_device_driver.get_report(local_mouse_report) : shared_mouse_report;
-    }
+        if (pointing_device_initialized) {
+            local_mouse_report = POINTING_DEVICE_THIS_SIDE ? pointing_device_driver.get_report(local_mouse_report) : shared_mouse_report;
+        }
 #    else
 #        error "You need to define the side(s) the pointing device is on. POINTING_DEVICE_COMBINED / POINTING_DEVICE_LEFT / POINTING_DEVICE_RIGHT"
 #    endif

--- a/quantum/pointing_device.h
+++ b/quantum/pointing_device.h
@@ -57,7 +57,7 @@ void           pointing_device_driver_set_cpi(uint16_t cpi);
 #endif
 
 typedef struct {
-    void (*init)(void);
+    bool (*init)(void);
     report_mouse_t (*get_report)(report_mouse_t mouse_report);
     void (*set_cpi)(uint16_t);
     uint16_t (*get_cpi)(void);

--- a/quantum/pointing_device_drivers.c
+++ b/quantum/pointing_device_drivers.c
@@ -27,6 +27,11 @@
 
 // get_report functions should probably be moved to their respective drivers.
 #if defined(POINTING_DEVICE_DRIVER_adns5050)
+static bool init(void) {
+    adns5050_init();
+    return true;
+}
+
 report_mouse_t adns5050_get_report(report_mouse_t mouse_report) {
     report_adns5050_t data = adns5050_read_burst();
 
@@ -44,7 +49,7 @@ report_mouse_t adns5050_get_report(report_mouse_t mouse_report) {
 
 // clang-format off
 const pointing_device_driver_t pointing_device_driver = {
-    .init         = adns5050_init,
+    .init         = init,
     .get_report   = adns5050_get_report,
     .set_cpi      = adns5050_set_cpi,
     .get_cpi      = adns5050_get_cpi,
@@ -52,6 +57,10 @@ const pointing_device_driver_t pointing_device_driver = {
 // clang-format on
 
 #elif defined(POINTING_DEVICE_DRIVER_adns9800)
+static bool init(void) {
+    adns9800_init();
+    return true;
+}
 
 report_mouse_t adns9800_get_report_driver(report_mouse_t mouse_report) {
     report_adns9800_t sensor_report = adns9800_get_report();
@@ -64,7 +73,7 @@ report_mouse_t adns9800_get_report_driver(report_mouse_t mouse_report) {
 
 // clang-format off
 const pointing_device_driver_t pointing_device_driver = {
-    .init       = adns9800_init,
+    .init       = init,
     .get_report = adns9800_get_report_driver,
     .set_cpi    = adns9800_set_cpi,
     .get_cpi    = adns9800_get_cpi
@@ -72,6 +81,11 @@ const pointing_device_driver_t pointing_device_driver = {
 // clang-format on
 
 #elif defined(POINTING_DEVICE_DRIVER_analog_joystick)
+static bool init(void) {
+    analog_joystick_init();
+    return true;
+}
+
 report_mouse_t analog_joystick_get_report(report_mouse_t mouse_report) {
     report_analog_joystick_t data = analog_joystick_read();
 
@@ -89,7 +103,7 @@ report_mouse_t analog_joystick_get_report(report_mouse_t mouse_report) {
 
 // clang-format off
 const pointing_device_driver_t pointing_device_driver = {
-    .init       = analog_joystick_init,
+    .init       = init,
     .get_report = analog_joystick_get_report,
     .set_cpi    = NULL,
     .get_cpi    = NULL
@@ -258,8 +272,8 @@ const pointing_device_driver_t pointing_device_driver = {
 // clang-format on
 
 #elif defined(POINTING_DEVICE_DRIVER_pmw3360) || defined(POINTING_DEVICE_DRIVER_pmw3389)
-static void pmw33xx_init_wrapper(void) {
-    pmw33xx_init(0);
+static bool pmw33xx_init_wrapper(void) {
+    return pmw33xx_init(0);
 }
 
 static void pmw33xx_set_cpi_wrapper(uint16_t cpi) {
@@ -301,9 +315,8 @@ const pointing_device_driver_t pointing_device_driver = {
     .get_cpi    = pmw33xx_get_cpi_wrapper
 };
 // clang-format on
-
 #else
-__attribute__((weak)) void           pointing_device_driver_init(void) {}
+__attribute__((weak)) bool           pointing_device_driver_init(void) {}
 __attribute__((weak)) report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report) {
     return mouse_report;
 }


### PR DESCRIPTION
## Description

Noticed when messing with the code, that bad/poor initialization of pointing device sensors wasn't really handled gracefully. 

Changes and adds some logic to disable querying a device if it doesn't init properly.

Unfortunately, not all devices have a way to check if it's been initialized properly, and some could use an overhaul for the logic.  But for now, just allow for basic logic to be used. 

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] Enhancement/optimization


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  - Code compiles for all sensors (and includes some additional fixes to do so), and pmw3360 sensor works on ploopy mouse.