### PR TITLE
Fix rgblight_blink_layer when multiple layers are active

### DIFF
--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -825,18 +825,19 @@ void rgblight_blink_layer_repeat(uint8_t layer, uint16_t duration_ms, uint8_t ti
 void rgblight_blink_layer_repeat_helper(void) {
     if (_blinking_layer_mask != 0 && timer_expired(sync_timer_read(), _repeat_timer)) {
         for (uint8_t layer = 0; layer < RGBLIGHT_MAX_LAYERS; layer++) {
-            if ((_blinking_layer_mask & (rgblight_layer_mask_t)1 << layer) != 0 && _times_remaining > 0) {
+            if ((_blinking_layer_mask & (rgblight_layer_mask_t)1 << layer) != 0) {
                 if (_times_remaining % 2 == 1) {
                     rgblight_set_layer_state(layer, false);
                 } else {
                     rgblight_set_layer_state(layer, true);
                 }
-                _times_remaining--;
-                _repeat_timer = sync_timer_read() + _dur;
             }
         }
+        _times_remaining--;
         if (_times_remaining <= 0) {
             _blinking_layer_mask = 0;
+        } else {
+            _repeat_timer = sync_timer_read() + _dur;
         }
     }
 }


### PR DESCRIPTION
<!--- Describe your changes in detail here. -->
The change to support repeated blinking (#12237) does not work correctly when there are multiple blinking layers active at the same time.
    
It is decrementing the number of times remaining for every active layer which will cause it to reach 0 prematurely and ignore some of the layers.
    
Decrement times remaining only once for each timer event.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
