### PR TITLE
Fix matrix scan reporting interval

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -149,7 +149,7 @@ void matrix_scan_perf_task(void) {
     matrix_scan_count++;
 
     uint32_t timer_now = timer_read32();
-    if (TIMER_DIFF_32(timer_now, matrix_timer) > 1000) {
+    if (TIMER_DIFF_32(timer_now, matrix_timer) >= 1000) {
 #    if defined(CONSOLE_ENABLE)
         dprintf("matrix scan frequency: %lu\n", matrix_scan_count);
 #    endif


### PR DESCRIPTION
## Description

The number of matrix scans per second should be counted using a 1000ms interval, not 1001ms which will result in a slightly higher number.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
