### PR TITLE
Fix external flash on AVR

### DIFF
--- a/drivers/flash/flash_spi.c
+++ b/drivers/flash/flash_spi.c
@@ -57,7 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* Mode setting comands */
 #define FLASH_CMD_DP 0xB9  /* DP (Deep Power Down) */
-#define FLASH_CMD_RDP 0xAB /* RDP (Release form Deep Power Down) */
+#define FLASH_CMD_RDP 0xAB /* RDP (Release from Deep Power Down) */
 
 /* Status register */
 #define FLASH_FLAG_WIP 0x01 /* Write in progress bit */

--- a/drivers/flash/flash_spi.h
+++ b/drivers/flash/flash_spi.h
@@ -74,21 +74,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     The sector size of the FLASH in bytes, as specified in the datasheet.
 */
 #ifndef EXTERNAL_FLASH_SECTOR_SIZE
-#    define EXTERNAL_FLASH_SECTOR_SIZE (4 * 1024)
+#    define EXTERNAL_FLASH_SECTOR_SIZE (4 * 1024L)
 #endif
 
 /*
     The block size of the FLASH in bytes, as specified in the datasheet.
 */
 #ifndef EXTERNAL_FLASH_BLOCK_SIZE
-#    define EXTERNAL_FLASH_BLOCK_SIZE (64 * 1024)
+#    define EXTERNAL_FLASH_BLOCK_SIZE (64 * 1024L)
 #endif
 
 /*
     The total size of the FLASH in bytes, as specified in the datasheet.
 */
 #ifndef EXTERNAL_FLASH_SIZE
-#    define EXTERNAL_FLASH_SIZE (512 * 1024)
+#    define EXTERNAL_FLASH_SIZE (512 * 1024L)
 #endif
 
 /*


### PR DESCRIPTION
Integers are 16-bit on AVR. 512*1024 does not fit in 16 bits, which caused a compile error. So let's make sure they are 32-bit.

I also threw in a spelling fix for good luck.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
