### PR TITLE
rgblight: Add functions to stop blinking one or all but one layer

### DIFF
--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -326,6 +326,19 @@ void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
 ```
 would turn the layer 0 (or 1) on and off again three times when `DEBUG` is pressed.
 
+Blinking accumulates layers so if multiple layers are set blinking at the same time they will all blink for the duration and repeat times of the last layer to be blinked.
+To stop these other layers from blinking use `rgblight_unblink_layer` or `rgblight_unblink_all_but_layer`:
+
+```c
+rgblight_blink_layer(1, 500);
+rgblight_unblink_all_but_layer(1);
+```
+
+```c
+rgblight_unblink_layer(3);
+rgblight_blink_layer(2, 500);
+```
+
 !> Lighting layers on split keyboards will require layer state synced to the slave half (e.g. `#define SPLIT_LAYER_STATE_ENABLE`). See [data sync options](feature_split_keyboard.md#data-sync-options) for more details.
 
 ### Overriding RGB Lighting on/off status

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -822,6 +822,21 @@ void rgblight_blink_layer_repeat(uint8_t layer, uint16_t duration_ms, uint8_t ti
     _repeat_timer = sync_timer_read() + duration_ms;
 }
 
+void rgblight_unblink_layer(uint8_t layer) {
+    rgblight_set_layer_state(layer, false);
+    _blinking_layer_mask &= ~((rgblight_layer_mask_t)1 << layer);
+}
+
+void rgblight_unblink_all_but_layer(uint8_t layer) {
+    for (uint8_t i = 0; i < RGBLIGHT_MAX_LAYERS; i++) {
+        if (i != layer) {
+            if ((_blinking_layer_mask & (rgblight_layer_mask_t)1 << i) != 0) {
+                rgblight_unblink_layer(i);
+            }
+        }
+    }
+}
+
 void rgblight_blink_layer_repeat_helper(void) {
     if (_blinking_layer_mask != 0 && timer_expired(sync_timer_read(), _repeat_timer)) {
         for (uint8_t layer = 0; layer < RGBLIGHT_MAX_LAYERS; layer++) {

--- a/quantum/rgblight/rgblight.h
+++ b/quantum/rgblight/rgblight.h
@@ -216,7 +216,25 @@ extern const rgblight_segment_t *const *rgblight_layers;
 #    ifdef RGBLIGHT_LAYER_BLINK
 #        define RGBLIGHT_USE_TIMER
 void rgblight_blink_layer(uint8_t layer, uint16_t duration_ms);
-void rgblight_blink_layer_repeat(uint8_t layer, uint16_t duration_ms, uint8_t times);
+void rgblight_blink_layer_repeat(uint8_t layer, uint16_ duration_ms, uint8_t times);
+/**
+ * \brief Stop blinking on one layer.
+ *
+ * Stop a layer that is blinking. If the layer is not blinking it will
+ * be unaffected.
+ *
+ * \param layer Layer number to stop blinking.
+ */
+void rgblight_unblink_layer(uint8_t layer);
+/**
+ * \brief Stop blinking all layers except one.
+ *
+ * Stop all layers that are blinking except for one specific layer.
+ * Layers that are not blinking are unaffected.
+ *
+ * \param layer Layer number to keep blinking.
+ */
+void rgblight_unblink_all_but_layer(uint8_t layer);
 #    endif
 
 #endif


### PR DESCRIPTION
## Description

Blinking RGB layers accumulate (as noted in #16824). Add functions to allow previously blinking layers to be stopped so that new layers can be made to blink instead.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
