### PR TITLE
[QP] Check BPP capabilities before loading the palette

### DIFF
--- a/quantum/painter/qp_draw_image.c
+++ b/quantum/painter/qp_draw_image.c
@@ -131,6 +131,12 @@ static bool qp_drawimage_prepare_frame_for_stream_read(painter_device_t device, 
     // Ensure we aren't reusing any palette
     qp_internal_invalidate_palette();
 
+    if (!qp_internal_bpp_capable(info->bpp)) {
+        qp_dprintf("qp_drawimage_recolor: fail (image bpp too high (%d), check QUANTUM_PAINTER_SUPPORTS_256_PALETTE)\n", (int)info->bpp);
+        qp_comms_stop(device);
+        return false;
+    }
+
     // Handle palette if needed
     const uint16_t palette_entries  = 1u << info->bpp;
     bool           needs_pixconvert = false;
@@ -144,12 +150,6 @@ static bool qp_drawimage_prepare_frame_for_stream_read(painter_device_t device, 
     } else {
         // Interpolate from fg/bg
         needs_pixconvert = qp_internal_interpolate_palette(fg_hsv888, bg_hsv888, palette_entries);
-    }
-
-    if (!qp_internal_bpp_capable(info->bpp)) {
-        qp_dprintf("qp_drawimage_recolor: fail (image bpp too high (%d), check QUANTUM_PAINTER_SUPPORTS_256_PALETTE)\n", (int)info->bpp);
-        qp_comms_stop(device);
-        return false;
     }
 
     if (needs_pixconvert) {


### PR DESCRIPTION
## Description

Loading and drawing an image with 256 colors on a firmware with 16 colors maximum enabled, leads to memory corruption because the palette is loaded before checking if it this is even possible. This overwrites unrelated memory in https://github.com/qmk/qmk_firmware/blob/develop/quantum/painter/qp_draw_core.c#L124-L141. Without the change the firmware hard-faults at runtime.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
