### PR TITLE
Fix 1U space in Keebio/sinc/rev2 layout macros

### DIFF
--- a/keyboards/keebio/sinc/rev2/rev2.h
+++ b/keyboards/keebio/sinc/rev2/rev2.h
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { KC_NO, KC_NO, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { KC_NO, KC_NO, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { KC_NO, KC_NO, LD3, KC_NO, LD5, LD6, LD7, LD8, LD9 }, \
-    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { KC_NO, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, KC_NO }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, KC_NO }, \
@@ -63,7 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { KC_NO, KC_NO, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { KC_NO, KC_NO, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { KC_NO, KC_NO, LD3, KC_NO, LD5, LD6, LD7, LD8, LD9 }, \
-    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { KC_NO, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, RA9 }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, RB9 }, \
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { LB1, LB2, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { LC1, LC2, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { LD1, LD2, LD3, KC_NO, LD5, LD6, LD7, LD8, LD9 }, \
-    { LE1, LE2, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { LE1, LE2, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { LF1, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, KC_NO }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, KC_NO }, \
@@ -109,7 +109,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { LB1, LB2, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { LC1, LC2, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { LD1, LD2, LD3, KC_NO, LD5, LD6, LD7, LD8, LD9 }, \
-    { LE1, LE2, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { LE1, LE2, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { LF1, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, RA9 }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, RB9 }, \
@@ -132,7 +132,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { KC_NO, KC_NO, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { KC_NO, KC_NO, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { KC_NO, KC_NO, LD3, LD4, LD5, LD6, LD7, LD8, LD9 }, \
-    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { KC_NO, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, KC_NO }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, KC_NO, KC_NO }, \
@@ -155,7 +155,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { KC_NO, KC_NO, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { KC_NO, KC_NO, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { KC_NO, KC_NO, LD3, LD4, LD5, LD6, LD7, LD8, LD9 }, \
-    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { KC_NO, KC_NO, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { KC_NO, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, RA9 }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, KC_NO, RB9 }, \
@@ -178,7 +178,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { LB1, LB2, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { LC1, LC2, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { LD1, LD2, LD3, LD4, LD5, LD6, LD7, LD8, LD9 }, \
-    { LE1, LE2, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { LE1, LE2, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { LF1, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, KC_NO }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, KC_NO, KC_NO }, \
@@ -201,7 +201,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { LB1, LB2, LB3, LB4, LB5, LB6, LB7, LB8, KC_NO }, \
     { LC1, LC2, LC3, LC4, LC5, LC6, LC7, LC8, KC_NO }, \
     { LD1, LD2, LD3, LD4, LD5, LD6, LD7, LD8, LD9 }, \
-    { LE1, LE2, LE3, LE4, LE5, LE6, KC_NO, LE8, KC_NO }, \
+    { LE1, LE2, LE3, LE4, LE5, LE6, LE7, LE8, KC_NO }, \
     { LF1, KC_NO, LF3, LF4, LF5, LF6, LF7, LF8, LF9 }, \
     { RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, RA9 }, \
     { RB1, RB2, RB3, RB4, RB5, RB6, RB7, KC_NO, RB9 }, \


### PR DESCRIPTION
## Description

Each of the layouts for the keebio sinc include a 1u  space on the left.  This is also the spot on pcb which you use for a 3u spacebar.   In the header file, the key in the layout was left as KC_NO.  This failed to to compile and provide a working key despite the keymapping file matching the layout correctly.

I tested this change with LAYOUT_80_with_macro.

I cross referenced keyboards/keebio/sinc/info.json to ensure the key was there in all layouts, but did not test flashing my keyboard with those layouts.

Reach out if this is incomplete.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #16900

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
