### PR TITLE
[Layout/Keymap] kbdfans kbd67 rev 2 : add new LAYOUT_65_iso_split_bs

### DIFF
--- a/keyboards/kbdfans/kbd67/rev2/keymaps/naphtaline/keymap.c
+++ b/keyboards/kbdfans/kbd67/rev2/keymaps/naphtaline/keymap.c
@@ -1,0 +1,86 @@
+/* Copyright 2018 'mechmerlin'
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+// Defines the keycodes used by our macros in process_record_user
+enum custom_keycodes {
+  QMKBEST = SAFE_RANGE,
+  QMKURL
+}; 
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap (Base Layer) Default Layer
+   * ,----------------------------------------------------------------.
+   * |GESC|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp| Del|
+   * |----------------------------------------------------------------|
+   * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]| Ent |PgUp|
+   * |-------------------------------------------------------.   |----|
+   * |Caps   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;| '|   |    |PgDn|
+   * |----------------------------------------------------------------|
+   * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift | Up|End |
+   * |----------------------------------------------------------------|
+   * |Ctrl|Win |Alt |  Space  |MS3|  Space  |Alt |MO1|Ctrl|Lef|Dow|Rig|
+   * `----------------------------------------------------------------'
+   */
+[0] = LAYOUT_65_iso_split_bs(
+  QK_GESC, KC_1,    KC_2,   KC_3,   KC_4,   KC_5,   KC_6,   KC_7,   KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DELETE,
+  KC_TAB,  KC_Q,    KC_W,   KC_E,   KC_R,   KC_T,   KC_Y,   KC_U,   KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,         KC_PGUP,
+  KC_CAPS, KC_A,    KC_S,   KC_D,   KC_F,   KC_G,   KC_H,   KC_J,   KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT, KC_PGDN,
+  KC_LSFT, KC_NUBS, KC_Z,    KC_X,   KC_C,   KC_V,   KC_B,   KC_N,   KC_M,   KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,   KC_END,
+  KC_LCTL, KC_LGUI, KC_LALT,      KC_SPC,      KC_MS_BTN3,      KC_SPC,          KC_RALT, MO(1), KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT),
+
+  /* Keymap Fn Layer
+   * ,----------------------------------------------------------------.
+   * |~ `|F1 |F2 |F3 |F4 |F5 |F6 |F7 |F8 |F9 |F10|F11|F12|Del    |Mute|
+   * |----------------------------------------------------------------|
+   * |     |   |Up |   |   |   |   |   |   |   |   |   |   |     |Vol+|
+   * |----------------------------------------------------------------|
+   * |      |Lef|Dow|Rig|   |   |   |   |   |   |   |   |        |Vol-|
+   * |----------------------------------------------------------------|
+   * |        |   |   |   |   |   |   |   |   |   |   |      |   |    |
+   * |----------------------------------------------------------------|
+   * |    |    |    |  Space |Space|  Space |   |   |    |   |   |    |
+   * `----------------------------------------------------------------'
+   */
+[1] = LAYOUT_65_iso_split_bs(
+        QK_GESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  KC_MUTE,
+        _______, _______, KC_UP, _______, _______, _______, _______, _______, _______, _______, _______,  _______,  _______,          KC_VOLU,
+        _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_VOLD,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______,      KC_SPC,      KC_SPC,      KC_SPC,          _______, _______, _______, _______, _______, _______),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QMKBEST:
+      if (record->event.pressed) {
+        // when keycode QMKBEST is pressed
+        SEND_STRING("QMK is the best thing ever!");
+      } else {
+        // when keycode QMKBEST is released
+      }
+      break;
+    case QMKURL:
+      if (record->event.pressed) {
+        // when keycode QMKURL is pressed
+        SEND_STRING("https://qmk.fm/" SS_TAP(X_ENTER));
+      } else {
+        // when keycode QMKURL is released
+      }
+      break;
+  }
+  return true;
+}

--- a/keyboards/kbdfans/kbd67/rev2/keymaps/naphtaline/readme.md
+++ b/keyboards/kbdfans/kbd67/rev2/keymaps/naphtaline/readme.md
@@ -1,0 +1,4 @@
+# Not the default keymap for kbd67
+
+ -  this is my personnal layout, but is meant to be used as a base for the new layout LAYOUT_65_iso_split_bs
+ -  3 splitted space bar. (Space - Mouse click 3 - Space)

--- a/keyboards/kbdfans/kbd67/rev2/rev2.h
+++ b/keyboards/kbdfans/kbd67/rev2/rev2.h
@@ -130,6 +130,22 @@
     { K40, K41,   KC_NO, K43, KC_NO, KC_NO, K46, KC_NO, KC_NO, KC_NO, K4A, K4B, K4C,   K4D,   K4E,   K4F }, \
 }
 
+#define LAYOUT_65_iso_split_bs( \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C,      K0E, K0F, \
+    K10,      K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D,      K1F, \
+    K20,      K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, K2C, K1E, K2D, K2F, \
+    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B,      K3D, K3E, K3F, \
+    K40, K41,      K43, K44,      K46,      K48,      K4A, K4B, K4C, K4D, K4E, K4F  \
+) \
+{ \
+    { K00, K01,   K02,   K03, K04,   K05,   K06, K07,   K08,   K09,   K0A, K0B, K0C,   KC_NO, K0E,   K0F }, \
+    { K10, KC_NO, K12,   K13, K14,   K15,   K16, K17,   K18,   K19,   K1A, K1B, K1C,   K1D,   K1E,   K1F }, \
+    { K20, KC_NO, K22,   K23, K24,   K25,   K26, K27,   K28,   K29,   K2A, K2B, K2C,   K2D,   KC_NO, K2F }, \
+    { K30, K31,   K32,   K33, K34,   K35,   K36, K37,   K38,   K39,   K3A, K3B, KC_NO, K3D,   K3E,   K3F }, \
+    { K40, K41,   KC_NO, K43, K44, KC_NO,   K46, KC_NO, K48, KC_NO,   K4A, K4B, K4C,   K4D,   K4E,   K4F }, \
+}
+
+
 #define LAYOUT_65_ansi_split_space( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C,      K0E, K0F, \
     K10,      K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, K1E, K1F, \


### PR DESCRIPTION
kbdfans kbd67 rev 2 : add new LAYOUT_65_iso_split_bs
and add keymap naphtaline as a working example 

## Description

<!--- everything is in the title :) -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
