### PR TITLE
Improve ENCODER_DEFAULT_POS to recognize lost ticks

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -163,7 +163,14 @@ static bool encoder_update(uint8_t index, uint8_t state) {
     index += thisHand;
 #endif
     encoder_pulses[i] += encoder_LUT[state & 0xF];
+
+#ifdef ENCODER_DEFAULT_POS
+    if ( (encoder_pulses[i] >= resolution) || (encoder_pulses[i] <= -resolution)|| ((state & 0x3) == ENCODER_DEFAULT_POS) ) {
+        if (encoder_pulses[i] >= 1) {
+#else
     if (encoder_pulses[i] >= resolution) {
+#endif
+
         encoder_value[index]++;
         changed = true;
 #ifdef ENCODER_MAP_ENABLE
@@ -172,7 +179,12 @@ static bool encoder_update(uint8_t index, uint8_t state) {
         encoder_update_kb(index, ENCODER_COUNTER_CLOCKWISE);
 #endif // ENCODER_MAP_ENABLE
     }
+
+#ifdef ENCODER_DEFAULT_POS
+    if (encoder_pulses[i] <= -1) {
+#else
     if (encoder_pulses[i] <= -resolution) { // direction is arbitrary here, but this clockwise
+#endif
         encoder_value[index]--;
         changed = true;
 #ifdef ENCODER_MAP_ENABLE
@@ -183,8 +195,7 @@ static bool encoder_update(uint8_t index, uint8_t state) {
     }
     encoder_pulses[i] %= resolution;
 #ifdef ENCODER_DEFAULT_POS
-    if ((state & 0x3) == ENCODER_DEFAULT_POS) {
-        encoder_pulses[i] = 0;
+    encoder_pulses[i] = 0;
     }
 #endif
     return changed;

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -165,37 +165,37 @@ static bool encoder_update(uint8_t index, uint8_t state) {
     encoder_pulses[i] += encoder_LUT[state & 0xF];
 
 #ifdef ENCODER_DEFAULT_POS
-    if ( (encoder_pulses[i] >= resolution) || (encoder_pulses[i] <= -resolution)|| ((state & 0x3) == ENCODER_DEFAULT_POS) ) {
+    if ((encoder_pulses[i] >= resolution) || (encoder_pulses[i] <= -resolution) || ((state & 0x3) == ENCODER_DEFAULT_POS)) {
         if (encoder_pulses[i] >= 1) {
 #else
     if (encoder_pulses[i] >= resolution) {
 #endif
 
-        encoder_value[index]++;
-        changed = true;
+            encoder_value[index]++;
+            changed = true;
 #ifdef ENCODER_MAP_ENABLE
-        encoder_exec_mapping(index, ENCODER_COUNTER_CLOCKWISE);
+            encoder_exec_mapping(index, ENCODER_COUNTER_CLOCKWISE);
 #else  // ENCODER_MAP_ENABLE
         encoder_update_kb(index, ENCODER_COUNTER_CLOCKWISE);
 #endif // ENCODER_MAP_ENABLE
-    }
+        }
 
 #ifdef ENCODER_DEFAULT_POS
-    if (encoder_pulses[i] <= -1) {
+        if (encoder_pulses[i] <= -1) {
 #else
     if (encoder_pulses[i] <= -resolution) { // direction is arbitrary here, but this clockwise
 #endif
-        encoder_value[index]--;
-        changed = true;
+            encoder_value[index]--;
+            changed = true;
 #ifdef ENCODER_MAP_ENABLE
-        encoder_exec_mapping(index, ENCODER_CLOCKWISE);
+            encoder_exec_mapping(index, ENCODER_CLOCKWISE);
 #else  // ENCODER_MAP_ENABLE
         encoder_update_kb(index, ENCODER_CLOCKWISE);
 #endif // ENCODER_MAP_ENABLE
-    }
-    encoder_pulses[i] %= resolution;
+        }
+        encoder_pulses[i] %= resolution;
 #ifdef ENCODER_DEFAULT_POS
-    encoder_pulses[i] = 0;
+        encoder_pulses[i] = 0;
     }
 #endif
     return changed;


### PR DESCRIPTION
Modified encoder_update to be more permissive about lost pulses when returning to the ENCODER_DEFAULT_POS  to detect if a tick has happened. E.g. on resolution 4 rotary encoder all ticks with only 1, 2 or 3 detected pulses have been discarded in the original code, but when the rotary encoder returns ENCODER_DEFAULT_POS  and pulses are present, we can be sure, that a tick has happened. This modification catches all these lost ticks with only 1,2 or 3 pulses, which results in a more reliable performance of the rotary encoder.


## Description

Modified the encoder_update method to emit ticks even when not all pulses have been detected but direction is clear and the rotary encoder returned to its ENCODER_DEFAULT_POS.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
