### PR TITLE
Added emacs as an "operating system" for input mode. 

### DIFF
--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -127,7 +127,7 @@ The following input modes are available:
   By default, this mode uses Ctrl+Shift+U (`LCTL(LSFT(KC_U))`) to start Unicode input, but this can be changed by defining [`UNICODE_KEY_LNX`](#input-key-configuration) with a different keycode. This might be required for IBus versions ≥1.5.15, where Ctrl+Shift+U behavior is consolidated into Ctrl+Shift+E.
 
   Users who wish support in non-GTK apps without IBus may need to resort to a more indirect method, such as creating a custom keyboard layout ([more on this method](#custom-linux-layout)).
-  
+
 * **`UC_WIN`**: _(not recommended)_ Windows built-in hex numpad Unicode input. Supports code points up to `0xFFFF`.
 
   To enable, create a registry key under `HKEY_CURRENT_USER\Control Panel\Input Method` of type `REG_SZ` called `EnableHexNumpad` and set its value to `1`. This can be done from the Command Prompt by running `reg add "HKCU\Control Panel\Input Method" -v EnableHexNumpad -t REG_SZ -d 1` with administrator privileges. Reboot afterwards.
@@ -172,6 +172,7 @@ You can switch the input mode at any time by using the following keycodes. Addin
 |`UNICODE_MODE_WIN`    |`UC_M_WI`|`UC_WIN`    |Switch to Windows input                                                      |
 |`UNICODE_MODE_BSD`    |`UC_M_BS`|`UC_BSD`    |Switch to BSD input _(not implemented)_                                      |
 |`UNICODE_MODE_WINC`   |`UC_M_WC`|`UC_WINC`   |Switch to Windows input using WinCompose                                     |
+|`UNICODE_MODE_EMACS`  |`UC_M_EM`|`UC_EMACS`  |Switch to emacs (`C-x-8 RET`)                                               |
 
 You can also switch the input mode by calling `set_unicode_input_mode(x)` in your code, where _x_ is one of the above input mode constants (e.g. `UC_LNX`).
 

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -117,6 +117,12 @@ __attribute__((weak)) void unicode_input_start(void) {
             tap_code(UNICODE_KEY_WINC);
             tap_code(KC_U);
             break;
+        case UC_EMACS:
+	    // The usual way to type unicode in emacs is C-x-8 <RET> then the unicode number in hex
+	    tap_code16(LCTL(KC_X));
+            tap_code16(KC_8);
+            tap_code16(KC_ENTER);
+            break;
     }
 
     wait_ms(UNICODE_TYPE_DELAY);
@@ -142,7 +148,10 @@ __attribute__((weak)) void unicode_input_finish(void) {
         case UC_WINC:
             tap_code(KC_ENTER);
             break;
-    }
+        case UC_EMACS:
+		tap_code16(KC_ENTER);
+		break;
+        }
 
     set_mods(unicode_saved_mods); // Reregister previously set mods
 }

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -176,6 +176,9 @@ __attribute__((weak)) void unicode_input_cancel(void) {
                 tap_code(KC_NUM_LOCK);
             }
             break;
+        case UC_EMACS:
+	    tap_code16(LCTL(KC_G)); // C-g cancels
+	    break;
     }
 
     set_mods(unicode_saved_mods); // Reregister previously set mods
@@ -308,14 +311,30 @@ bool process_unicode_common(uint16_t keycode, keyrecord_t *record) {
                 cycle_unicode_input_mode(shifted ? +1 : -1);
                 audio_helper();
                 break;
-
-            case UNICODE_MODE_MAC ... UNICODE_MODE_WINC: {
-                // Keycodes and input modes follow the same ordering
-                uint8_t delta = keycode - UNICODE_MODE_MAC;
-                set_unicode_input_mode(UC_MAC + delta);
-                audio_helper();
+	    case UNICODE_MODE_MAC:
+		set_unicode_input_mode(UC_MAC);
+		audio_helper();
                 break;
-            }
+	    case UNICODE_MODE_LNX:
+		set_unicode_input_mode(UC_LNX);
+		audio_helper();
+                break;
+	    case UNICODE_MODE_WIN:
+		set_unicode_input_mode(UC_WIN);
+		audio_helper();
+                break;
+	    case UNICODE_MODE_BSD:
+		set_unicode_input_mode(UC_BSD);
+		audio_helper();
+                break;
+	    case UNICODE_MODE_WINC:
+		set_unicode_input_mode(UC_WINC);
+		audio_helper();
+                break;
+	    case UNICODE_MODE_EMACS:
+		set_unicode_input_mode(UC_EMACS);
+		audio_helper();
+                break;
         }
     }
 

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -149,9 +149,9 @@ __attribute__((weak)) void unicode_input_finish(void) {
             tap_code(KC_ENTER);
             break;
         case UC_EMACS:
-		tap_code16(KC_ENTER);
-		break;
-        }
+            tap_code16(KC_ENTER);
+            break;
+    }
 
     set_mods(unicode_saved_mods); // Reregister previously set mods
 }

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -177,8 +177,8 @@ __attribute__((weak)) void unicode_input_cancel(void) {
             }
             break;
         case UC_EMACS:
-	    tap_code16(LCTL(KC_G)); // C-g cancels
-	    break;
+            tap_code16(LCTL(KC_G)); // C-g cancels
+            break;
     }
 
     set_mods(unicode_saved_mods); // Reregister previously set mods
@@ -311,29 +311,29 @@ bool process_unicode_common(uint16_t keycode, keyrecord_t *record) {
                 cycle_unicode_input_mode(shifted ? +1 : -1);
                 audio_helper();
                 break;
-	    case UNICODE_MODE_MAC:
-		set_unicode_input_mode(UC_MAC);
-		audio_helper();
+            case UNICODE_MODE_MAC:
+                set_unicode_input_mode(UC_MAC);
+                audio_helper();
                 break;
-	    case UNICODE_MODE_LNX:
-		set_unicode_input_mode(UC_LNX);
-		audio_helper();
+            case UNICODE_MODE_LNX:
+                set_unicode_input_mode(UC_LNX);
+                audio_helper();
                 break;
-	    case UNICODE_MODE_WIN:
-		set_unicode_input_mode(UC_WIN);
-		audio_helper();
+            case UNICODE_MODE_WIN:
+                set_unicode_input_mode(UC_WIN);
+                audio_helper();
                 break;
-	    case UNICODE_MODE_BSD:
-		set_unicode_input_mode(UC_BSD);
-		audio_helper();
+            case UNICODE_MODE_BSD:
+                set_unicode_input_mode(UC_BSD);
+                audio_helper();
                 break;
-	    case UNICODE_MODE_WINC:
-		set_unicode_input_mode(UC_WINC);
-		audio_helper();
+            case UNICODE_MODE_WINC:
+                set_unicode_input_mode(UC_WINC);
+                audio_helper();
                 break;
-	    case UNICODE_MODE_EMACS:
-		set_unicode_input_mode(UC_EMACS);
-		audio_helper();
+            case UNICODE_MODE_EMACS:
+                set_unicode_input_mode(UC_EMACS);
+                audio_helper();
                 break;
         }
     }

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -118,8 +118,8 @@ __attribute__((weak)) void unicode_input_start(void) {
             tap_code(KC_U);
             break;
         case UC_EMACS:
-	    // The usual way to type unicode in emacs is C-x-8 <RET> then the unicode number in hex
-	    tap_code16(LCTL(KC_X));
+            // The usual way to type unicode in emacs is C-x-8 <RET> then the unicode number in hex
+            tap_code16(LCTL(KC_X));
             tap_code16(KC_8);
             tap_code16(KC_ENTER);
             break;

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -64,6 +64,7 @@ enum unicode_input_modes {
     UC_WIN,   // Windows using EnableHexNumpad
     UC_BSD,   // BSD (not implemented)
     UC_WINC,  // Windows using WinCompose (https://github.com/samhocevar/wincompose)
+    UC_EMACS, // Emacs is an operating system in search of a good text editor
     UC__COUNT // Number of available input modes (always leave at the end)
 };
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -473,9 +473,9 @@ enum quantum_keycodes {
     // Lock Key
     KC_LOCK, // 5D2B
 
-    // Terminal
-    TERM_ON,  // 5D2C
-    TERM_OFF, // 5D2D
+    // Unused slots
+    UNUSED_000, // 5D2C
+    UNUSED_001, // 5D2D
 
     // Sequencer
     SQ_ON,  // 5D2E

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -610,6 +610,8 @@ enum quantum_keycodes {
     MAGIC_UNSWAP_ESCAPE_CAPSLOCK,
     MAGIC_TOGGLE_ESCAPE_CAPSLOCK,
 
+    UNICODE_MODE_EMACS,
+
     // Start of custom keycode range for keyboards and keymaps - always leave at the end
     SAFE_RANGE
 };

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -895,6 +895,7 @@ enum quantum_keycodes {
 #define UC_M_WI UNICODE_MODE_WIN
 #define UC_M_BS UNICODE_MODE_BSD
 #define UC_M_WC UNICODE_MODE_WINC
+#define UC_M_EM UNICODE_MODE_EMACS
 
 // Swap Hands
 #define SH_T(kc) (QK_SWAP_HANDS | (kc))

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -385,114 +385,113 @@ enum quantum_keycodes {
     UNICODE_MODE_WIN,     // 5CE4
     UNICODE_MODE_BSD,     // 5CE5
     UNICODE_MODE_WINC,    // 5CE6
-    UNICODE_MODE_EMACS,   // SCE7
 
     // Haptic
-    HPT_ON,   // 5CE8
-    HPT_OFF,  // 5CE9
-    HPT_TOG,  // 5CEA
-    HPT_RST,  // 5CEB
-    HPT_FBK,  // 5CEC
-    HPT_BUZ,  // 5CED
-    HPT_MODI, // 5CEE
-    HPT_MODD, // 5CEF
-    HPT_CONT, // 5CF0
-    HPT_CONI, // 5CF1
-    HPT_COND, // 5CF2
-    HPT_DWLI, // 5CF3
-    HPT_DWLD, // 5CF4
+    HPT_ON,   // 5CE7
+    HPT_OFF,  // 5CE8
+    HPT_TOG,  // 5CE9
+    HPT_RST,  // 5CEA
+    HPT_FBK,  // 5CEB
+    HPT_BUZ,  // 5CEC
+    HPT_MODI, // 5CED
+    HPT_MODD, // 5CEE
+    HPT_CONT, // 5CEF
+    HPT_CONI, // 5CF0
+    HPT_COND, // 5CF1
+    HPT_DWLI, // 5CF2
+    HPT_DWLD, // 5CF3
 
     // Space Cadet (continued)
-    KC_LCPO, // 5CF5
-    KC_RCPC, // 5CF6
-    KC_LAPO, // 5CF7
-    KC_RAPC, // 5CF8
+    KC_LCPO, // 5CF4
+    KC_RCPC, // 5CF5
+    KC_LAPO, // 5CF6
+    KC_RAPC, // 5CF7
 
     // Combos
-    CMB_ON,  // 5CF9
-    CMB_OFF, // 5CFA
-    CMB_TOG, // 5CFB
+    CMB_ON,  // 5CF8
+    CMB_OFF, // 5CF9
+    CMB_TOG, // 5CFA
 
     // Magic (continued)
-    MAGIC_SWAP_LCTL_LGUI,   // 5CFC
-    MAGIC_SWAP_RCTL_RGUI,   // 5CFD
-    MAGIC_UNSWAP_LCTL_LGUI, // 5CFE
-    MAGIC_UNSWAP_RCTL_RGUI, // 5CFF
-    MAGIC_SWAP_CTL_GUI,     // 5D00
-    MAGIC_UNSWAP_CTL_GUI,   // 5D01
-    MAGIC_TOGGLE_CTL_GUI,   // 5D02
-    MAGIC_EE_HANDS_LEFT,    // 5D03
-    MAGIC_EE_HANDS_RIGHT,   // 5D04
+    MAGIC_SWAP_LCTL_LGUI,   // 5CFB
+    MAGIC_SWAP_RCTL_RGUI,   // 5CFC
+    MAGIC_UNSWAP_LCTL_LGUI, // 5CFD
+    MAGIC_UNSWAP_RCTL_RGUI, // 5CFE
+    MAGIC_SWAP_CTL_GUI,     // 5CFF
+    MAGIC_UNSWAP_CTL_GUI,   // 5D00
+    MAGIC_TOGGLE_CTL_GUI,   // 5D01
+    MAGIC_EE_HANDS_LEFT,    // 5D02
+    MAGIC_EE_HANDS_RIGHT,   // 5D03
 
     // Dynamic Macros
-    DYN_REC_START1,  // 5D05
-    DYN_REC_START2,  // 5D06
-    DYN_REC_STOP,    // 5D07
-    DYN_MACRO_PLAY1, // 5D08
-    DYN_MACRO_PLAY2, // 5D09
+    DYN_REC_START1,  // 5D04
+    DYN_REC_START2,  // 5D05
+    DYN_REC_STOP,    // 5D06
+    DYN_MACRO_PLAY1, // 5D07
+    DYN_MACRO_PLAY2, // 5D08
 
     // Joystick
-    JS_BUTTON0,  // 5D0A
-    JS_BUTTON1,  // 5D0B
-    JS_BUTTON2,  // 5D0C
-    JS_BUTTON3,  // 5D0D
-    JS_BUTTON4,  // 5D0E
-    JS_BUTTON5,  // 5D0F
-    JS_BUTTON6,  // 5D10
-    JS_BUTTON7,  // 5D11
-    JS_BUTTON8,  // 5D12
-    JS_BUTTON9,  // 5D13
-    JS_BUTTON10, // 5D14
-    JS_BUTTON11, // 5D15
-    JS_BUTTON12, // 5D16
-    JS_BUTTON13, // 5D17
-    JS_BUTTON14, // 5D18
-    JS_BUTTON15, // 5D19
-    JS_BUTTON16, // 5D1A
-    JS_BUTTON17, // 5D1B
-    JS_BUTTON18, // 5D1C
-    JS_BUTTON19, // 5D1D
-    JS_BUTTON20, // 5D1E
-    JS_BUTTON21, // 5D1F
-    JS_BUTTON22, // 5D20
-    JS_BUTTON23, // 5D21
-    JS_BUTTON24, // 5D22
-    JS_BUTTON25, // 5D23
-    JS_BUTTON26, // 5D24
-    JS_BUTTON27, // 5D25
-    JS_BUTTON28, // 5D26
-    JS_BUTTON29, // 5D27
-    JS_BUTTON30, // 5D28
-    JS_BUTTON31, // 5D29
+    JS_BUTTON0,  // 5D09
+    JS_BUTTON1,  // 5D0A
+    JS_BUTTON2,  // 5D0B
+    JS_BUTTON3,  // 5D0C
+    JS_BUTTON4,  // 5D0D
+    JS_BUTTON5,  // 5D0E
+    JS_BUTTON6,  // 5D0F
+    JS_BUTTON7,  // 5D10
+    JS_BUTTON8,  // 5D11
+    JS_BUTTON9,  // 5D12
+    JS_BUTTON10, // 5D13
+    JS_BUTTON11, // 5D14
+    JS_BUTTON12, // 5D15
+    JS_BUTTON13, // 5D16
+    JS_BUTTON14, // 5D17
+    JS_BUTTON15, // 5D18
+    JS_BUTTON16, // 5D19
+    JS_BUTTON17, // 5D1A
+    JS_BUTTON18, // 5D1B
+    JS_BUTTON19, // 5D1C
+    JS_BUTTON20, // 5D1D
+    JS_BUTTON21, // 5D1E
+    JS_BUTTON22, // 5D1F
+    JS_BUTTON23, // 5D20
+    JS_BUTTON24, // 5D21
+    JS_BUTTON25, // 5D22
+    JS_BUTTON26, // 5D23
+    JS_BUTTON27, // 5D24
+    JS_BUTTON28, // 5D25
+    JS_BUTTON29, // 5D26
+    JS_BUTTON30, // 5D27
+    JS_BUTTON31, // 5D28
 
     // Leader Key
-    KC_LEAD, // 5D2A
+    KC_LEAD, // 5D29
 
     // Bluetooth: output selection (continued)
-    OUT_BT, // 5D2B
+    OUT_BT, // 5D2A
 
     // Lock Key
-    KC_LOCK, // 5D2C
+    KC_LOCK, // 5D2B
 
     // Terminal
-    TERM_ON,  // 5D2D
-    TERM_OFF, // 5D2E
+    TERM_ON,  // 5D2C
+    TERM_OFF, // 5D2D
 
     // Sequencer
-    SQ_ON,  // 5D2F
-    SQ_OFF, // 5D30
-    SQ_TOG, // 5D31
+    SQ_ON,  // 5D2E
+    SQ_OFF, // 5D2F
+    SQ_TOG, // 5D30
 
-    SQ_TMPD, // 5D32
-    SQ_TMPU, // 5D33
+    SQ_TMPD, // 5D31
+    SQ_TMPU, // 5D32
 
-    SQ_RESD, // 5D34
-    SQ_RESU, // 5D35
+    SQ_RESD, // 5D33
+    SQ_RESU, // 5D34
 
-    SQ_SALL, // 5D36
-    SQ_SCLR, // 5D37
+    SQ_SALL, // 5D35
+    SQ_SCLR, // 5D36
 
-    SEQUENCER_STEP_MIN, // 5D38
+    SEQUENCER_STEP_MIN, // 5D37
     SEQUENCER_STEP_MAX = SEQUENCER_STEP_MIN + SEQUENCER_STEPS,
 
     SEQUENCER_RESOLUTION_MIN,

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -385,113 +385,114 @@ enum quantum_keycodes {
     UNICODE_MODE_WIN,     // 5CE4
     UNICODE_MODE_BSD,     // 5CE5
     UNICODE_MODE_WINC,    // 5CE6
+    UNICODE_MODE_EMACS,   // SCE7
 
     // Haptic
-    HPT_ON,   // 5CE7
-    HPT_OFF,  // 5CE8
-    HPT_TOG,  // 5CE9
-    HPT_RST,  // 5CEA
-    HPT_FBK,  // 5CEB
-    HPT_BUZ,  // 5CEC
-    HPT_MODI, // 5CED
-    HPT_MODD, // 5CEE
-    HPT_CONT, // 5CEF
-    HPT_CONI, // 5CF0
-    HPT_COND, // 5CF1
-    HPT_DWLI, // 5CF2
-    HPT_DWLD, // 5CF3
+    HPT_ON,   // 5CE8
+    HPT_OFF,  // 5CE9
+    HPT_TOG,  // 5CEA
+    HPT_RST,  // 5CEB
+    HPT_FBK,  // 5CEC
+    HPT_BUZ,  // 5CED
+    HPT_MODI, // 5CEE
+    HPT_MODD, // 5CEF
+    HPT_CONT, // 5CF0
+    HPT_CONI, // 5CF1
+    HPT_COND, // 5CF2
+    HPT_DWLI, // 5CF3
+    HPT_DWLD, // 5CF4
 
     // Space Cadet (continued)
-    KC_LCPO, // 5CF4
-    KC_RCPC, // 5CF5
-    KC_LAPO, // 5CF6
-    KC_RAPC, // 5CF7
+    KC_LCPO, // 5CF5
+    KC_RCPC, // 5CF6
+    KC_LAPO, // 5CF7
+    KC_RAPC, // 5CF8
 
     // Combos
-    CMB_ON,  // 5CF8
-    CMB_OFF, // 5CF9
-    CMB_TOG, // 5CFA
+    CMB_ON,  // 5CF9
+    CMB_OFF, // 5CFA
+    CMB_TOG, // 5CFB
 
     // Magic (continued)
-    MAGIC_SWAP_LCTL_LGUI,   // 5CFB
-    MAGIC_SWAP_RCTL_RGUI,   // 5CFC
-    MAGIC_UNSWAP_LCTL_LGUI, // 5CFD
-    MAGIC_UNSWAP_RCTL_RGUI, // 5CFE
-    MAGIC_SWAP_CTL_GUI,     // 5CFF
-    MAGIC_UNSWAP_CTL_GUI,   // 5D00
-    MAGIC_TOGGLE_CTL_GUI,   // 5D01
-    MAGIC_EE_HANDS_LEFT,    // 5D02
-    MAGIC_EE_HANDS_RIGHT,   // 5D03
+    MAGIC_SWAP_LCTL_LGUI,   // 5CFC
+    MAGIC_SWAP_RCTL_RGUI,   // 5CFD
+    MAGIC_UNSWAP_LCTL_LGUI, // 5CFE
+    MAGIC_UNSWAP_RCTL_RGUI, // 5CFF
+    MAGIC_SWAP_CTL_GUI,     // 5D00
+    MAGIC_UNSWAP_CTL_GUI,   // 5D01
+    MAGIC_TOGGLE_CTL_GUI,   // 5D02
+    MAGIC_EE_HANDS_LEFT,    // 5D03
+    MAGIC_EE_HANDS_RIGHT,   // 5D04
 
     // Dynamic Macros
-    DYN_REC_START1,  // 5D04
-    DYN_REC_START2,  // 5D05
-    DYN_REC_STOP,    // 5D06
-    DYN_MACRO_PLAY1, // 5D07
-    DYN_MACRO_PLAY2, // 5D08
+    DYN_REC_START1,  // 5D05
+    DYN_REC_START2,  // 5D06
+    DYN_REC_STOP,    // 5D07
+    DYN_MACRO_PLAY1, // 5D08
+    DYN_MACRO_PLAY2, // 5D09
 
     // Joystick
-    JS_BUTTON0,  // 5D09
-    JS_BUTTON1,  // 5D0A
-    JS_BUTTON2,  // 5D0B
-    JS_BUTTON3,  // 5D0C
-    JS_BUTTON4,  // 5D0D
-    JS_BUTTON5,  // 5D0E
-    JS_BUTTON6,  // 5D0F
-    JS_BUTTON7,  // 5D10
-    JS_BUTTON8,  // 5D11
-    JS_BUTTON9,  // 5D12
-    JS_BUTTON10, // 5D13
-    JS_BUTTON11, // 5D14
-    JS_BUTTON12, // 5D15
-    JS_BUTTON13, // 5D16
-    JS_BUTTON14, // 5D17
-    JS_BUTTON15, // 5D18
-    JS_BUTTON16, // 5D19
-    JS_BUTTON17, // 5D1A
-    JS_BUTTON18, // 5D1B
-    JS_BUTTON19, // 5D1C
-    JS_BUTTON20, // 5D1D
-    JS_BUTTON21, // 5D1E
-    JS_BUTTON22, // 5D1F
-    JS_BUTTON23, // 5D20
-    JS_BUTTON24, // 5D21
-    JS_BUTTON25, // 5D22
-    JS_BUTTON26, // 5D23
-    JS_BUTTON27, // 5D24
-    JS_BUTTON28, // 5D25
-    JS_BUTTON29, // 5D26
-    JS_BUTTON30, // 5D27
-    JS_BUTTON31, // 5D28
+    JS_BUTTON0,  // 5D0A
+    JS_BUTTON1,  // 5D0B
+    JS_BUTTON2,  // 5D0C
+    JS_BUTTON3,  // 5D0D
+    JS_BUTTON4,  // 5D0E
+    JS_BUTTON5,  // 5D0F
+    JS_BUTTON6,  // 5D10
+    JS_BUTTON7,  // 5D11
+    JS_BUTTON8,  // 5D12
+    JS_BUTTON9,  // 5D13
+    JS_BUTTON10, // 5D14
+    JS_BUTTON11, // 5D15
+    JS_BUTTON12, // 5D16
+    JS_BUTTON13, // 5D17
+    JS_BUTTON14, // 5D18
+    JS_BUTTON15, // 5D19
+    JS_BUTTON16, // 5D1A
+    JS_BUTTON17, // 5D1B
+    JS_BUTTON18, // 5D1C
+    JS_BUTTON19, // 5D1D
+    JS_BUTTON20, // 5D1E
+    JS_BUTTON21, // 5D1F
+    JS_BUTTON22, // 5D20
+    JS_BUTTON23, // 5D21
+    JS_BUTTON24, // 5D22
+    JS_BUTTON25, // 5D23
+    JS_BUTTON26, // 5D24
+    JS_BUTTON27, // 5D25
+    JS_BUTTON28, // 5D26
+    JS_BUTTON29, // 5D27
+    JS_BUTTON30, // 5D28
+    JS_BUTTON31, // 5D29
 
     // Leader Key
-    KC_LEAD, // 5D29
+    KC_LEAD, // 5D2A
 
     // Bluetooth: output selection (continued)
-    OUT_BT, // 5D2A
+    OUT_BT, // 5D2B
 
     // Lock Key
-    KC_LOCK, // 5D2B
+    KC_LOCK, // 5D2C
 
-    // Unused slots
-    UNUSED_000, // 5D2C
-    UNUSED_001, // 5D2D
+    // Terminal
+    TERM_ON,  // 5D2D
+    TERM_OFF, // 5D2E
 
     // Sequencer
-    SQ_ON,  // 5D2E
-    SQ_OFF, // 5D2F
-    SQ_TOG, // 5D30
+    SQ_ON,  // 5D2F
+    SQ_OFF, // 5D30
+    SQ_TOG, // 5D31
 
-    SQ_TMPD, // 5D31
-    SQ_TMPU, // 5D32
+    SQ_TMPD, // 5D32
+    SQ_TMPU, // 5D33
 
-    SQ_RESD, // 5D33
-    SQ_RESU, // 5D34
+    SQ_RESD, // 5D34
+    SQ_RESU, // 5D35
 
-    SQ_SALL, // 5D35
-    SQ_SCLR, // 5D36
+    SQ_SALL, // 5D36
+    SQ_SCLR, // 5D37
 
-    SEQUENCER_STEP_MIN, // 5D37
+    SEQUENCER_STEP_MIN, // 5D38
     SEQUENCER_STEP_MAX = SEQUENCER_STEP_MIN + SEQUENCER_STEPS,
 
     SEQUENCER_RESOLUTION_MIN,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
I added a new unicode input mode: emacs. 

While strictly not an operating system, inserting unicode characters in emacs has its own keybinding. The most usual way is `C-x-8 RET` followed by the unicode in hex. As a person who works across different OSes but with the constant being emacs, this was the most straightforward way forwards. 

Of course, the main credit goes to TrentinQuarantino in this [emacs stack exchange post](https://emacs.stackexchange.com/a/56027).
 
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I added a new unicode input mode in `quantum/process_unicode_common.(c|h)`. Then I updated all the programmer friendly numbers of the enums, and added documentation too.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Additional notes

I'm unfamiliar with the testing protocols of this project. If I could get some help that'd be great. I'm reasonably familiar with C. However, what I have done is I have flashed two ergodox-EZs with this and tested it on emacs on both linux and macos. My Windows computer isn't quite available right now, so I'm unable to test on Windows. 