### PR TITLE
Fix kinetic mouse mode

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -66,11 +66,16 @@ uint8_t mk_time_to_max = MOUSEKEY_TIME_TO_MAX;
 /* milliseconds between the initial key press and first repeated motion event (0-2550) */
 uint8_t mk_wheel_delay = MOUSEKEY_WHEEL_DELAY / 10;
 /* milliseconds between repeated motion events (0-255) */
-uint8_t mk_wheel_interval    = MOUSEKEY_WHEEL_INTERVAL;
+#    ifndef MK_KINETIC_SPEED
+uint8_t mk_wheel_interval = MOUSEKEY_WHEEL_INTERVAL;
+#    else  /* #ifndef MK_KINETIC_SPEED */
+float mk_wheel_interval = 1000.0f / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
+#    endif /* #ifndef MK_KINETIC_SPEED */
 uint8_t mk_wheel_max_speed   = MOUSEKEY_WHEEL_MAX_SPEED;
 uint8_t mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
 
 #    ifndef MK_COMBINED
+#        ifndef MK_KINETIC_SPEED
 
 static uint8_t move_unit(void) {
     uint16_t unit;
@@ -108,8 +113,7 @@ static uint8_t wheel_unit(void) {
     return (unit > MOUSEKEY_WHEEL_MAX ? MOUSEKEY_WHEEL_MAX : (unit == 0 ? 1 : unit));
 }
 
-#    else /* #ifndef MK_COMBINED */
-#        ifdef MK_KINETIC_SPEED
+#        else /* #ifndef MK_KINETIC_SPEED */
 
 /*
  * Kinetic movement  acceleration algorithm
@@ -129,7 +133,7 @@ const uint16_t mk_decelerated_speed = MOUSEKEY_DECELERATED_SPEED;
 const uint16_t mk_initial_speed     = MOUSEKEY_INITIAL_SPEED;
 
 static uint8_t move_unit(void) {
-    float speed = mk_initial_speed;
+    float speed = (float)mk_initial_speed;
 
     if (mousekey_accel & ((1 << 0) | (1 << 2))) {
         speed = mousekey_accel & (1 << 2) ? mk_accelerated_speed : mk_decelerated_speed;
@@ -146,8 +150,6 @@ static uint8_t move_unit(void) {
 
     return speed > MOUSEKEY_MOVE_MAX ? MOUSEKEY_MOVE_MAX : speed;
 }
-
-float mk_wheel_interval = 1000.0f / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
 
 static uint8_t wheel_unit(void) {
     float speed = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
@@ -167,7 +169,8 @@ static uint8_t wheel_unit(void) {
     return 1;
 }
 
-#        else /* #ifndef MK_KINETIC_SPEED */
+#        endif /* #ifndef MK_KINETIC_SPEED */
+#    else      /* #ifndef MK_COMBINED */
 
 static uint8_t move_unit(void) {
     uint16_t unit;
@@ -205,8 +208,7 @@ static uint8_t wheel_unit(void) {
     return (unit > MOUSEKEY_WHEEL_MAX ? MOUSEKEY_WHEEL_MAX : (unit == 0 ? 1 : unit));
 }
 
-#        endif /* #ifndef MK_KINETIC_SPEED */
-#    endif     /* #ifndef MK_COMBINED */
+#    endif /* #ifndef MK_COMBINED */
 
 void mousekey_task(void) {
     // report cursor and scroll movement independently


### PR DESCRIPTION
## Description

Kinetic mouse mode is currently broken, as described in https://github.com/qmk/qmk_firmware/issues/12082 and https://github.com/qmk/qmk_firmware/issues/13711.

The PR https://github.com/qmk/qmk_firmware/pull/11766 introduced a set of fixes in early 2021. This PR was closed in favour of ongoing refactoring of QMK's mouse code (see https://github.com/qmk/qmk_firmware/pull/11766#issuecomment-776931052 and https://github.com/qmk/qmk_firmware/issues/12082#issuecomment-790809864).

Since the mentioned comments, it appears nothing has been merged in order to fix kinetic mode, meaning kinetic mode is still broken. This commit adopts the changes from the pull request that was originally supposed to fix the problem, and updates the changes to handle recent changes to the mousekey.c file.

These changes have been tested with my personal keyboard, and result in kinetic mode working as advertised.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fixes https://github.com/qmk/qmk_firmware/issues/12082
Fixes https://github.com/qmk/qmk_firmware/issues/13711

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).