### PR TITLE
[Keymap] Improve Pain27 default keymap readability

### DIFF
--- a/keyboards/wsk/pain27/keymaps/default/keymap.c
+++ b/keyboards/wsk/pain27/keymaps/default/keymap.c
@@ -1,18 +1,41 @@
+// Copyright 2020 Worldspawn (@worldspawn00)
+// Copyright 2022 Hunter Haugen (@hunner)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #include QMK_KEYBOARD_H
 
+#define LCTL_Z   MT(MOD_LCTL, KC_Z)
+#define LALT_X   MT(MOD_LALT, KC_X)
+#define ONE_C    LT(1, KC_C)
+#define TWO_V    LT(2, KC_V)
+#define RGUI_B   MT(MOD_RGUI, KC_B)
+#define RALT_N   MT(MOD_RALT, KC_N)
+#define RCTL_M   MT(MOD_RCTL, KC_M)
+#define LSFT_SPC MT(MOD_LSFT, KC_SPC)
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P,
-        KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L,
-        MT(MOD_LCTL, KC_Z), MT(MOD_LALT, KC_X), LT(1, KC_C), LT(2, KC_V), MT(MOD_RGUI,KC_B), MT(MOD_RALT, KC_N), MT(MOD_RCTL, KC_M), MT(MOD_LSFT, KC_SPC)),
-    [1] = LAYOUT(KC_ESC, KC_MUTE, KC_VOLD, KC_VOLU, KC_MPLY, KC_HOME, KC_PGDN, KC_PGUP, KC_END, KC_BSPC,
-        KC_TAB, RGB_TOG, RGB_VAD, RGB_VAI, RGB_MOD, KC_LEFT, KC_DOWN, KC_UP, KC_RGHT,
-        KC_LCTL, KC_LALT, KC_TRNS, MO(3), KC_RGUI, KC_RALT, KC_RCTL, KC_NO),
-    [2] = LAYOUT(KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0,
-        KC_GRV, KC_BSLS, KC_MINS, KC_EQL, KC_LBRC, KC_RBRC, KC_SCLN, KC_QUOT, KC_ENT,
-        KC_LCTL, KC_LALT, MO(3), KC_TRNS, KC_COMM, KC_DOT, KC_SLSH, KC_NO),
-    [3] = LAYOUT(KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10,
-        KC_F11, KC_F12, RGB_SPD, RGB_SPI, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, KC_DEL,
-        KC_LCTL, KC_LALT, KC_TRNS, KC_TRNS, KC_RGUI, KC_RALT, KC_RCTL, KC_NO)
-
+    [0] = LAYOUT(
+        KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   ,
+        KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   ,
+        LCTL_Z , LALT_X , ONE_C  , TWO_V  , RGUI_B , RALT_N , RCTL_M ,
+        LSFT_SPC
+    ),
+    [1] = LAYOUT(
+        KC_ESC , KC_MUTE, KC_VOLD, KC_VOLU, KC_MPLY, KC_HOME, KC_PGDN, KC_PGUP, KC_END , KC_BSPC,
+        KC_TAB , RGB_TOG, RGB_VAD, RGB_VAI, RGB_MOD, KC_LEFT, KC_DOWN, KC_UP  , KC_RGHT,
+        KC_LCTL, KC_LALT, _______, MO(3)  , KC_RGUI, KC_RALT, KC_RCTL,
+        XXXXXXX
+    ),
+    [2] = LAYOUT(
+        KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   ,
+        KC_GRV , KC_BSLS, KC_MINS, KC_EQL , KC_LBRC, KC_RBRC, KC_SCLN, KC_QUOT, KC_ENT ,
+        KC_LCTL, KC_LALT, MO(3)  , _______, KC_COMM, KC_DOT , KC_SLSH,
+        XXXXXXX
+    ),
+    [3] = LAYOUT(
+        KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_F7  , KC_F8  , KC_F9  , KC_F10  ,
+        KC_F11 , KC_F12 , RGB_SPD, RGB_SPI, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, KC_DEL,
+        KC_LCTL, KC_LALT, _______, _______, KC_RGUI, KC_RALT, KC_RCTL,
+        XXXXXXX
+    )
 };
-


### PR DESCRIPTION
## Description
This is the same layout, just with keys aligned and separated by rows
for better readability.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
