### PR TITLE
Enhancement and fixes of "Secure" feature

### DIFF
--- a/quantum/process_keycode/process_secure.c
+++ b/quantum/process_keycode/process_secure.c
@@ -35,6 +35,10 @@ bool process_secure(uint16_t keycode, keyrecord_t *record) {
             secure_is_locked() ? secure_unlock() : secure_lock();
             return false;
         }
+        if (keycode == SECURE_REQUEST) {
+            secure_request_unlock();
+            return false;
+        }
     }
 #endif
     return true;

--- a/quantum/process_keycode/process_secure.c
+++ b/quantum/process_keycode/process_secure.c
@@ -7,7 +7,9 @@
 
 bool preprocess_secure(uint16_t keycode, keyrecord_t *record) {
     if (secure_is_unlocking()) {
-        if (!record->event.pressed) {
+        // !pressed will trigger on any already held keys (such as layer keys),
+        // and cause the request secure check to prematurely fail.
+        if (record->event.pressed) {
             secure_keypress_event(record->event.key.row, record->event.key.col);
         }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -561,8 +561,8 @@ void secure_hook_quantum(secure_status_t secure_status) {
     // clear these, when it is triggered.
 
     if (secure_status == SECURE_PENDING) {
-            clear_keyboard();
-            layer_clear();
+        clear_keyboard();
+        layer_clear();
     }
 }
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -553,3 +553,16 @@ const char *get_u16_str(uint16_t curr_num, char curr_pad) {
     last_pad = curr_pad;
     return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);
 }
+
+#if defined(SECURE_ENABLE)
+__attribute__((weak)) bool secure_hook_user(secure_status_t secure_status) {
+    return true;
+}
+__attribute__((weak)) bool secure_hook_kb(secure_status_t secure_status) {
+    return secure_hook_user(secure_status);
+}
+
+void secure_hook_quantum(secure_status_t secure_status) {
+    secure_hook_kb(secure_status);
+}
+#endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -564,7 +564,5 @@ void secure_hook_quantum(secure_status_t secure_status) {
             clear_keyboard();
             layer_clear();
     }
-
-    secure_hook_kb(secure_status);
 }
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -214,6 +214,11 @@ bool process_record_quantum(keyrecord_t *record) {
 
 #if defined(SECURE_ENABLE)
     if (!preprocess_secure(keycode, record)) {
+        // If keys are being held when this is triggered, they may not be released properly
+        // this can result in stuck keys, mods and layers.  To prevent that, manually
+        // clear these, when it is triggered.
+        clear_keyboard();
+        layer_clear();
         return false;
     }
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -217,8 +217,10 @@ bool process_record_quantum(keyrecord_t *record) {
         // If keys are being held when this is triggered, they may not be released properly
         // this can result in stuck keys, mods and layers.  To prevent that, manually
         // clear these, when it is triggered.
-        clear_keyboard();
-        layer_clear();
+        if (!record->event.pressed) {
+            clear_keyboard();
+            layer_clear();
+        }
         return false;
     }
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -553,16 +553,3 @@ const char *get_u16_str(uint16_t curr_num, char curr_pad) {
     last_pad = curr_pad;
     return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);
 }
-
-#if defined(SECURE_ENABLE)
-__attribute__((weak)) bool secure_hook_user(secure_status_t secure_status) {
-    return true;
-}
-__attribute__((weak)) bool secure_hook_kb(secure_status_t secure_status) {
-    return secure_hook_user(secure_status);
-}
-
-void secure_hook_quantum(secure_status_t secure_status) {
-    secure_hook_kb(secure_status);
-}
-#endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -214,13 +214,6 @@ bool process_record_quantum(keyrecord_t *record) {
 
 #if defined(SECURE_ENABLE)
     if (!preprocess_secure(keycode, record)) {
-        // If keys are being held when this is triggered, they may not be released properly
-        // this can result in stuck keys, mods and layers.  To prevent that, manually
-        // clear these, when it is triggered.
-        if (!record->event.pressed) {
-            clear_keyboard();
-            layer_clear();
-        }
         return false;
     }
 #endif
@@ -560,3 +553,18 @@ const char *get_u16_str(uint16_t curr_num, char curr_pad) {
     last_pad = curr_pad;
     return get_numeric_str(buf, sizeof(buf), curr_num, curr_pad);
 }
+
+#if defined(SECURE_ENABLE)
+void secure_hook_quantum(secure_status_t secure_status) {
+    // If keys are being held when this is triggered, they may not be released properly
+    // this can result in stuck keys, mods and layers.  To prevent that, manually
+    // clear these, when it is triggered.
+
+    if (secure_status == SECURE_PENDING) {
+            clear_keyboard();
+            layer_clear();
+    }
+
+    secure_hook_kb(secure_status);
+}
+#endif

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -600,6 +600,7 @@ enum quantum_keycodes {
     SECURE_LOCK,
     SECURE_UNLOCK,
     SECURE_TOGGLE,
+    SECURE_REQUEST,
 
     // Start of custom keycode range for keyboards and keymaps - always leave at the end
     SAFE_RANGE

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -39,18 +39,10 @@ void secure_unlock(void) {
     secure_hook_quantum(secure_status);
 }
 
-void clear_keyboard(void);
-void layer_clear(void);
-
 void secure_request_unlock(void) {
     if (secure_status == SECURE_LOCKED) {
         secure_status = SECURE_PENDING;
         unlock_time   = timer_read32();
-        // If keys are being held when this is triggered, they may not be released properly
-        // this can result in stuck keys, mods and layers.  To prevent that, manually
-        // clear these, when it is triggered.
-        clear_keyboard();
-        layer_clear();
     }
     secure_hook_quantum(secure_status);
 }

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -89,7 +89,6 @@ void secure_task(void) {
 #endif
 }
 
-#if defined(SECURE_ENABLE)
 __attribute__((weak)) bool secure_hook_user(secure_status_t secure_status) {
     return true;
 }
@@ -100,4 +99,3 @@ __attribute__((weak)) bool secure_hook_kb(secure_status_t secure_status) {
 __attribute__((weak)) void secure_hook_quantum(secure_status_t secure_status) {
     secure_hook_kb(secure_status);
 }
-#endif

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -4,7 +4,6 @@
 #include "secure.h"
 #include "timer.h"
 
-
 #ifndef SECURE_UNLOCK_TIMEOUT
 #    define SECURE_UNLOCK_TIMEOUT 5000
 #endif

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -3,7 +3,7 @@
 
 #include "secure.h"
 #include "timer.h"
-#include "action_layer.h"
+
 
 #ifndef SECURE_UNLOCK_TIMEOUT
 #    define SECURE_UNLOCK_TIMEOUT 5000
@@ -38,6 +38,9 @@ void secure_unlock(void) {
     idle_time     = timer_read32();
     secure_hook_quantum(secure_status);
 }
+
+void clear_keyboard(void);
+void layer_clear(void);
 
 void secure_request_unlock(void) {
     if (secure_status == SECURE_LOCKED) {
@@ -94,3 +97,16 @@ void secure_task(void) {
     }
 #endif
 }
+
+#if defined(SECURE_ENABLE)
+__attribute__((weak)) bool secure_hook_user(secure_status_t secure_status) {
+    return true;
+}
+__attribute__((weak)) bool secure_hook_kb(secure_status_t secure_status) {
+    return secure_hook_user(secure_status);
+}
+
+__attribute__((weak)) void secure_hook_quantum(secure_status_t secure_status) {
+    secure_hook_kb(secure_status);
+}
+#endif

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -23,19 +23,24 @@ static secure_status_t secure_status = SECURE_LOCKED;
 static uint32_t        unlock_time   = 0;
 static uint32_t        idle_time     = 0;
 
+static void secure_hook(secure_status_t secure_status) {
+    secure_hook_quantum(secure_status);
+    secure_hook_kb(secure_status);
+}
+
 secure_status_t secure_get_status(void) {
     return secure_status;
 }
 
 void secure_lock(void) {
     secure_status = SECURE_LOCKED;
-    secure_hook_quantum(secure_status);
+    secure_hook(secure_status);
 }
 
 void secure_unlock(void) {
     secure_status = SECURE_UNLOCKED;
     idle_time     = timer_read32();
-    secure_hook_quantum(secure_status);
+    secure_hook(secure_status);
 }
 
 void secure_request_unlock(void) {
@@ -43,7 +48,7 @@ void secure_request_unlock(void) {
         secure_status = SECURE_PENDING;
         unlock_time   = timer_read32();
     }
-    secure_hook_quantum(secure_status);
+    secure_hook(secure_status);
 }
 
 void secure_activity_event(void) {
@@ -94,8 +99,4 @@ __attribute__((weak)) bool secure_hook_user(secure_status_t secure_status) {
 }
 __attribute__((weak)) bool secure_hook_kb(secure_status_t secure_status) {
     return secure_hook_user(secure_status);
-}
-
-__attribute__((weak)) void secure_hook_quantum(secure_status_t secure_status) {
-    secure_hook_kb(secure_status);
 }

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -3,6 +3,7 @@
 
 #include "secure.h"
 #include "timer.h"
+#include "action_layer.h"
 
 #ifndef SECURE_UNLOCK_TIMEOUT
 #    define SECURE_UNLOCK_TIMEOUT 5000
@@ -42,6 +43,11 @@ void secure_request_unlock(void) {
     if (secure_status == SECURE_LOCKED) {
         secure_status = SECURE_PENDING;
         unlock_time   = timer_read32();
+        // If keys are being held when this is triggered, they may not be released properly
+        // this can result in stuck keys, mods and layers.  To prevent that, manually
+        // clear these, when it is triggered.
+        clear_keyboard();
+        layer_clear();
     }
     secure_hook_quantum(secure_status);
 }

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -29,11 +29,13 @@ secure_status_t secure_get_status(void) {
 
 void secure_lock(void) {
     secure_status = SECURE_LOCKED;
+    secure_hook_quantum(secure_status);
 }
 
 void secure_unlock(void) {
     secure_status = SECURE_UNLOCKED;
     idle_time     = timer_read32();
+    secure_hook_quantum(secure_status);
 }
 
 void secure_request_unlock(void) {
@@ -41,6 +43,7 @@ void secure_request_unlock(void) {
         secure_status = SECURE_PENDING;
         unlock_time   = timer_read32();
     }
+    secure_hook_quantum(secure_status);
 }
 
 void secure_activity_event(void) {

--- a/quantum/secure.h
+++ b/quantum/secure.h
@@ -65,3 +65,15 @@ void secure_keypress_event(uint8_t row, uint8_t col);
 /** \brief Handle various secure subsystem background tasks
  */
 void secure_task(void);
+
+/** \brief quantum hook called when changing secure status device
+ */
+void secure_hook_quantum(secure_status_t secure_status);
+
+/** \brief user hook called when changing secure status device
+ */
+bool secure_hook_user(secure_status_t secure_status);
+
+/** \brief keyboard hook called when changing secure status device
+ */
+bool secure_hook_kb(secure_status_t secure_status);

--- a/tests/secure/config.h
+++ b/tests/secure/config.h
@@ -1,0 +1,24 @@
+/* Copyright 2021 Stefan Kerkmann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "test_common.h"
+
+#define SECURE_UNLOCK_SEQUENCE \
+    {                          \
+        { 0, 1 }, { 0, 2 }, { 0, 3 }, { 0, 4 } \
+    }

--- a/tests/secure/config.h
+++ b/tests/secure/config.h
@@ -24,3 +24,6 @@
             0, 4                  \
         }                         \
     }
+
+#define SECURE_UNLOCK_TIMEOUT 20
+#define SECURE_IDLE_TIMEOUT 50

--- a/tests/secure/config.h
+++ b/tests/secure/config.h
@@ -18,12 +18,15 @@
 
 #include "test_common.h"
 
-#define SECURE_UNLOCK_SEQUENCE    \
-    {                             \
-        {0, 1}, {0, 2}, {0, 3}, { \
-            0, 4                  \
-        }                         \
+// clang-format off
+#define SECURE_UNLOCK_SEQUENCE \
+    {                          \
+        {0, 1},                \
+        {0, 2},                \
+        {0, 3},                \
+        {0, 4}                 \
     }
+// clang-format on
 
 #define SECURE_UNLOCK_TIMEOUT 20
 #define SECURE_IDLE_TIMEOUT 50

--- a/tests/secure/config.h
+++ b/tests/secure/config.h
@@ -18,7 +18,9 @@
 
 #include "test_common.h"
 
-#define SECURE_UNLOCK_SEQUENCE \
-    {                          \
-        { 0, 1 }, { 0, 2 }, { 0, 3 }, { 0, 4 } \
+#define SECURE_UNLOCK_SEQUENCE    \
+    {                             \
+        {0, 1}, {0, 2}, {0, 3}, { \
+            0, 4                  \
+        }                         \
     }

--- a/tests/secure/test.mk
+++ b/tests/secure/test.mk
@@ -1,0 +1,20 @@
+# Copyright 2021 Stefan Kerkmann
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# --------------------------------------------------------------------------------
+# Keep this file, even if it is empty, as a marker that this folder contains tests
+# --------------------------------------------------------------------------------
+
+SECURE_ENABLE = yes

--- a/tests/secure/test_secure.cpp
+++ b/tests/secure/test_secure.cpp
@@ -70,7 +70,7 @@ TEST_F(Secure, test_unlock_timeout) {
     EXPECT_FALSE(secure_is_unlocked());
     secure_unlock();
     EXPECT_TRUE(secure_is_unlocked());
-    idle_for(SECURE_UNLOCK_TIMEOUT+1);
+    idle_for(SECURE_IDLE_TIMEOUT+1);
     EXPECT_FALSE(secure_is_unlocked());
 
     testing::Mock::VerifyAndClearExpectations(&driver);
@@ -135,7 +135,7 @@ TEST_F(Secure, test_unlock_request_timeout) {
     EXPECT_FALSE(secure_is_unlocked());
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
-    idle_for(SECURE_IDLE_TIMEOUT+1);
+    idle_for(SECURE_UNLOCK_TIMEOUT+1);
     EXPECT_FALSE(secure_is_unlocking());
     EXPECT_FALSE(secure_is_unlocked());
 

--- a/tests/secure/test_secure.cpp
+++ b/tests/secure/test_secure.cpp
@@ -44,29 +44,19 @@ class Secure : public TestFixture {
     }
 };
 
-TEST_F(Secure, test_unlock) {
-    TestDriver driver;
-
-    // Allow any number of empty reports.
-    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
-
-    secure_unlock();
-    EXPECT_TRUE(secure_is_unlocked());
-
-    testing::Mock::VerifyAndClearExpectations(&driver);
-}
-
 TEST_F(Secure, test_lock) {
     TestDriver driver;
 
     // Allow any number of empty reports.
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
 
+    EXPECT_FALSE(secure_is_unlocked());
     secure_unlock();
     EXPECT_TRUE(secure_is_unlocked());
     run_one_scan_loop();
+    EXPECT_TRUE(secure_is_unlocked());
     secure_lock();
-    EXPECT_TRUE(secure_is_locked());
+    EXPECT_FALSE(secure_is_unlocked());
 
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
@@ -77,9 +67,11 @@ TEST_F(Secure, test_unlock_timeout) {
     // Allow any number of empty reports.
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
 
+    EXPECT_FALSE(secure_is_unlocked());
     secure_unlock();
+    EXPECT_TRUE(secure_is_unlocked());
     idle_for(SECURE_UNLOCK_TIMEOUT+1);
-    EXPECT_FALSE(secure_is_locked());
+    EXPECT_FALSE(secure_is_unlocked());
 
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
@@ -97,6 +89,7 @@ TEST_F(Secure, test_unlock_request) {
     // Allow any number of empty reports.
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
 
+    EXPECT_TRUE(secure_is_locked());
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     TapKeys(key_a, key_b, key_c, key_d);
@@ -124,6 +117,7 @@ TEST_F(Secure, test_unlock_request_fail) {
         EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_C)));
         EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_D)));
     }
+    EXPECT_TRUE(secure_is_locked());
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     TapKeys(key_e, key_a, key_b, key_c, key_d);
@@ -138,6 +132,7 @@ TEST_F(Secure, test_unlock_request_timeout) {
     // Allow any number of empty reports.
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
 
+    EXPECT_FALSE(secure_is_unlocked());
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     idle_for(SECURE_IDLE_TIMEOUT+1);
@@ -165,6 +160,7 @@ TEST_F(Secure, test_unlock_request_fail_mid) {
         EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_C)));
         EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_D)));
     }
+    EXPECT_FALSE(secure_is_unlocked());
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     TapKeys(key_a, key_b, key_e, key_c, key_d);
@@ -191,9 +187,11 @@ TEST_F(Secure, test_unlock_request_fail_out_of_order) {
         EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_B)));
         EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_C)));
     }
+    EXPECT_FALSE(secure_is_unlocked());
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     TapKeys(key_a, key_d, key_b, key_c);
+    EXPECT_TRUE(secure_is_locked());
     EXPECT_FALSE(secure_is_unlocking());
     EXPECT_FALSE(secure_is_unlocked());
 
@@ -213,6 +211,7 @@ TEST_F(Secure, test_unlock_request_on_layer) {
     // Allow any number of empty reports.
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
 
+    EXPECT_TRUE(secure_is_locked());
     key_mo.press();
     run_one_scan_loop();
     secure_request_unlock();
@@ -239,6 +238,7 @@ TEST_F(Secure, test_unlock_request_mid_stroke) {
     // Allow any number of empty reports.
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_E)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    EXPECT_TRUE(secure_is_locked());
     key_e.press();
     run_one_scan_loop();
     secure_request_unlock();
@@ -264,6 +264,7 @@ TEST_F(Secure, test_unlock_request_mods) {
     // Allow any number of empty reports.
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(key_lsft.report_code)));
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    EXPECT_TRUE(secure_is_locked());
     key_lsft.press();
     run_one_scan_loop();
     secure_request_unlock();

--- a/tests/secure/test_secure.cpp
+++ b/tests/secure/test_secure.cpp
@@ -140,7 +140,8 @@ TEST_F(Secure, test_unlock_request_timeout) {
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     idle_for(SECURE_IDLE_TIMEOUT+1);
-    EXPECT_FALSE(secure_is_locked() && secure_is_unlocking());
+    EXPECT_FALSE(secure_is_locked());
+    EXPECT_FALSE(secure_is_unlocking());
 
     testing::Mock::VerifyAndClearExpectations(&driver);
 }

--- a/tests/secure/test_secure.cpp
+++ b/tests/secure/test_secure.cpp
@@ -63,6 +63,7 @@ TEST_F(Secure, test_lock) {
     EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
 
     secure_unlock();
+    EXPECT_TRUE(secure_is_unlocked());
     run_one_scan_loop();
     secure_lock();
     EXPECT_TRUE(secure_is_locked());
@@ -140,8 +141,8 @@ TEST_F(Secure, test_unlock_request_timeout) {
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     idle_for(SECURE_IDLE_TIMEOUT+1);
-    EXPECT_FALSE(secure_is_locked());
     EXPECT_FALSE(secure_is_unlocking());
+    EXPECT_FALSE(secure_is_unlocked());
 
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
@@ -167,6 +168,7 @@ TEST_F(Secure, test_unlock_request_fail_mid) {
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     TapKeys(key_a, key_b, key_e, key_c, key_d);
+    EXPECT_FALSE(secure_is_unlocking());
     EXPECT_FALSE(secure_is_unlocked());
 
     testing::Mock::VerifyAndClearExpectations(&driver);
@@ -192,6 +194,7 @@ TEST_F(Secure, test_unlock_request_fail_out_of_order) {
     secure_request_unlock();
     EXPECT_TRUE(secure_is_unlocking());
     TapKeys(key_a, key_d, key_b, key_c);
+    EXPECT_FALSE(secure_is_unlocking());
     EXPECT_FALSE(secure_is_unlocked());
 
     testing::Mock::VerifyAndClearExpectations(&driver);

--- a/tests/secure/test_secure.cpp
+++ b/tests/secure/test_secure.cpp
@@ -70,6 +70,19 @@ TEST_F(Secure, test_lock) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
 
+TEST_F(Secure, test_unlock_timeout) {
+    TestDriver driver;
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
+
+    secure_unlock();
+    idle_for(SECURE_UNLOCK_TIMEOUT+1);
+    EXPECT_FALSE(secure_is_locked());
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
 TEST_F(Secure, test_unlock_request) {
     TestDriver driver;
     auto       key_mo = KeymapKey(0, 0, 0, MO(1));
@@ -117,6 +130,21 @@ TEST_F(Secure, test_unlock_request_fail) {
 
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
+
+TEST_F(Secure, test_unlock_request_timeout) {
+    TestDriver driver;
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
+
+    secure_request_unlock();
+    EXPECT_TRUE(secure_is_unlocking());
+    idle_for(SECURE_IDLE_TIMEOUT+1);
+    EXPECT_FALSE(secure_is_locked() && secure_is_unlocking());
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
 
 TEST_F(Secure, test_unlock_request_fail_mid) {
     TestDriver driver;

--- a/tests/secure/test_secure.cpp
+++ b/tests/secure/test_secure.cpp
@@ -1,0 +1,170 @@
+/* Copyright 2021 Stefan Kerkmann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "gtest/gtest.h"
+#include "keyboard_report_util.hpp"
+#include "test_common.hpp"
+
+using testing::_;
+using testing::AnyNumber;
+using testing::InSequence;
+
+class Secure : public TestFixture {
+   public:
+    void SetUp() override {
+        secure_lock();
+    }
+    // Convenience function to tap `key`.
+    void TapKey(KeymapKey key) {
+        key.press();
+        run_one_scan_loop();
+        key.release();
+        run_one_scan_loop();
+    }
+
+    // Taps in order each key in `keys`.
+    template <typename... Ts>
+    void TapKeys(Ts... keys) {
+        for (KeymapKey key : {keys...}) {
+            TapKey(key);
+        }
+    }
+};
+
+TEST_F(Secure, test_unlock) {
+    TestDriver driver;
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
+
+    secure_unlock();
+    EXPECT_TRUE(secure_is_unlocked());
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(Secure, test_lock) {
+    TestDriver driver;
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
+
+    secure_unlock();
+    run_one_scan_loop();
+    secure_lock();
+    EXPECT_TRUE(secure_is_locked());
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(Secure, test_unlock_request) {
+    TestDriver driver;
+    auto       key_mo = KeymapKey(0, 0, 0, MO(1));
+    auto       key_a  = KeymapKey(0, 1, 0, KC_A);
+    auto       key_b  = KeymapKey(0, 2, 0, KC_B);
+    auto       key_c  = KeymapKey(0, 3, 0, KC_C);
+    auto       key_d  = KeymapKey(0, 4, 0, KC_D);
+
+    set_keymap({key_mo, key_a, key_b, key_c, key_d});
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
+
+    secure_request_unlock();
+    EXPECT_TRUE(secure_is_unlocking());
+    TapKeys(key_a, key_b, key_c, key_d);
+    EXPECT_TRUE(secure_is_unlocked());
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(Secure, test_unlock_request_on_layer) {
+    TestDriver driver;
+    auto       key_mo = KeymapKey(0, 0, 0, MO(1));
+    auto       key_a  = KeymapKey(0, 1, 0, KC_A);
+    auto       key_b  = KeymapKey(0, 2, 0, KC_B);
+    auto       key_c  = KeymapKey(0, 3, 0, KC_C);
+    auto       key_d  = KeymapKey(0, 4, 0, KC_D);
+
+    set_keymap({key_mo, key_a, key_b, key_c, key_d});
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport())).Times(0);
+
+    key_mo.press();
+    run_one_scan_loop();
+    secure_request_unlock();
+    key_mo.release();
+    run_one_scan_loop();
+    EXPECT_TRUE(secure_is_unlocking());
+    TapKeys(key_a, key_b, key_c, key_d);
+    EXPECT_TRUE(secure_is_unlocked());
+    EXPECT_FALSE(layer_state_is(1));
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(Secure, test_unlock_request_mid_stroke) {
+    TestDriver driver;
+    auto       key_e = KeymapKey(0, 0, 0, KC_E);
+    auto       key_a = KeymapKey(0, 1, 0, KC_A);
+    auto       key_b = KeymapKey(0, 2, 0, KC_B);
+    auto       key_c = KeymapKey(0, 3, 0, KC_C);
+    auto       key_d = KeymapKey(0, 4, 0, KC_D);
+
+    set_keymap({key_e, key_a, key_b, key_c, key_d});
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_E)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    key_e.press();
+    run_one_scan_loop();
+    secure_request_unlock();
+    key_e.release();
+    run_one_scan_loop();
+    EXPECT_TRUE(secure_is_unlocking());
+    TapKeys(key_a, key_b, key_c, key_d);
+    EXPECT_TRUE(secure_is_unlocked());
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+
+TEST_F(Secure, test_unlock_request_mods) {
+    TestDriver driver;
+    auto       key_lsft = KeymapKey(0, 0, 0, KC_LSFT);
+    auto       key_a = KeymapKey(0, 1, 0, KC_A);
+    auto       key_b = KeymapKey(0, 2, 0, KC_B);
+    auto       key_c = KeymapKey(0, 3, 0, KC_C);
+    auto       key_d = KeymapKey(0, 4, 0, KC_D);
+
+    set_keymap({key_lsft, key_a, key_b, key_c, key_d});
+
+    // Allow any number of empty reports.
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(key_lsft.report_code)));
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport()));
+    key_lsft.press();
+    run_one_scan_loop();
+    secure_request_unlock();
+    key_lsft.release();
+    run_one_scan_loop();
+    EXPECT_TRUE(secure_is_unlocking());
+    TapKeys(key_a, key_b, key_c, key_d);
+    EXPECT_TRUE(secure_is_unlocked());
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}


### PR DESCRIPTION
## Description

* Add hook for secure feature, for locking related events
* fix issue with stuck keys when unlocking request is sent
  * Since the pending request blocks all keystrokes, this can/will cause keys to get stuck if they were being held when the request function was called.  To prevent this, clear all pressed keys and clear layers to ensure that no keys get stuck
* Better handle unlocking request keystrokes
  * Can add a preprocessor for this instead, but found that !pressed causes problems, in general wit

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Issues Fixed or Closed by This PR

* Issues found when testing out the feature

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
