### PR TITLE
Remove ARM pgm_read_word workaround in rgblight

### DIFF
--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -559,12 +559,8 @@ void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool w
                 // static gradient
                 uint8_t delta     = rgblight_config.mode - rgblight_status.base_mode;
                 bool    direction = (delta % 2) == 0;
-#    ifdef __AVR__
-                // probably due to how pgm_read_word is defined for ARM, but the ARM compiler really hates this line
+
                 uint8_t range = pgm_read_word(&RGBLED_GRADIENT_RANGES[delta / 2]);
-#    else
-                uint8_t range = RGBLED_GRADIENT_RANGES[delta / 2];
-#    endif
                 for (uint8_t i = 0; i < rgblight_ranges.effect_num_leds; i++) {
                     uint8_t _hue = ((uint16_t)i * (uint16_t)range) / rgblight_ranges.effect_num_leds;
                     if (direction) {

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -560,7 +560,7 @@ void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool w
                 uint8_t delta     = rgblight_config.mode - rgblight_status.base_mode;
                 bool    direction = (delta % 2) == 0;
 
-                uint8_t range = pgm_read_word(&RGBLED_GRADIENT_RANGES[delta / 2]);
+                uint8_t range = pgm_read_byte(&RGBLED_GRADIENT_RANGES[delta / 2]);
                 for (uint8_t i = 0; i < rgblight_ranges.effect_num_leds; i++) {
                     uint8_t _hue = ((uint16_t)i * (uint16_t)range) / rgblight_ranges.effect_num_leds;
                     if (direction) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Reproduced in deb10 + arm gcc 6.3.1. Error was
```
Compiling: quantum/rgblight/rgblight.c                                                             quantum/rgblight/rgblight.c: In function 'rgblight_sethsv_eeprom_helper':
quantum/rgblight/rgblight.c:563:17: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
                 uint8_t range = pgm_read_word(&RGBLED_GRADIENT_RANGES[delta / 2]);
                 ^~~~~~~
cc1: all warnings being treated as errors
```

This was due to the wrong progmem api being used, trying to read a u8 with th u16 version.
 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
