### PR TITLE
[Core][Bugfix] Joystick: Ignore axis-related code when axes count=0

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -764,12 +764,14 @@ ifeq ($(strip $(JOYSTICK_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_joystick.c
     SRC += $(QUANTUM_DIR)/joystick.c
 
-    ifeq ($(strip $(JOYSTICK_DRIVER)), analog)
-        OPT_DEFS += -DANALOG_JOYSTICK_ENABLE
-        SRC += analog.c
-    endif
-    ifeq ($(strip $(JOYSTICK_DRIVER)), digital)
-        OPT_DEFS += -DDIGITAL_JOYSTICK_ENABLE
+    ifeq ($(shell expr $(JOYSTICK_AXES_COUNT) \> 0), 1)
+        ifeq ($(strip $(JOYSTICK_DRIVER)), analog)
+            OPT_DEFS += -DANALOG_JOYSTICK_ENABLE
+            SRC += analog.c
+        endif
+        ifeq ($(strip $(JOYSTICK_DRIVER)), digital)
+            OPT_DEFS += -DDIGITAL_JOYSTICK_ENABLE
+        endif
     endif
 endif
 

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -764,14 +764,12 @@ ifeq ($(strip $(JOYSTICK_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_joystick.c
     SRC += $(QUANTUM_DIR)/joystick.c
 
-    ifeq ($(shell expr $(JOYSTICK_AXES_COUNT) \> 0), 1)
-        ifeq ($(strip $(JOYSTICK_DRIVER)), analog)
-            OPT_DEFS += -DANALOG_JOYSTICK_ENABLE
-            SRC += analog.c
-        endif
-        ifeq ($(strip $(JOYSTICK_DRIVER)), digital)
-            OPT_DEFS += -DDIGITAL_JOYSTICK_ENABLE
-        endif
+    ifeq ($(strip $(JOYSTICK_DRIVER)), analog)
+        OPT_DEFS += -DANALOG_JOYSTICK_ENABLE
+        SRC += analog.c
+    endif
+    ifeq ($(strip $(JOYSTICK_DRIVER)), digital)
+        OPT_DEFS += -DDIGITAL_JOYSTICK_ENABLE
     endif
 endif
 

--- a/quantum/process_keycode/process_joystick.c
+++ b/quantum/process_keycode/process_joystick.c
@@ -1,10 +1,8 @@
 #include "joystick.h"
 #include "process_joystick.h"
 
-#if JOYSTICK_AXES_COUNT > 0
-#   ifdef ANALOG_JOYSTICK_ENABLE
-#       include "analog.h"
-#   endif
+#if JOYSTICK_AXES_COUNT > 0 && defined(ANALOG_JOYSTICK_ENABLE)
+#   include "analog.h"
 #endif
 
 #include <string.h>

--- a/quantum/process_keycode/process_joystick.c
+++ b/quantum/process_keycode/process_joystick.c
@@ -41,6 +41,8 @@ uint16_t savePinState(pin_t pin) {
         |unused|ODR|IDR|PUPDR|OSPEEDR|OTYPER|MODER|
         */
         return ((PAL_PORT(pin)->MODER >> (2 * PAL_PAD(pin))) & 0x3) | (((PAL_PORT(pin)->OTYPER >> (1 * PAL_PAD(pin))) & 0x1) << 2) | (((PAL_PORT(pin)->OSPEEDR >> (2 * PAL_PAD(pin))) & 0x3) << 3) | (((PAL_PORT(pin)->PUPDR >> (2 * PAL_PAD(pin))) & 0x3) << 5) | (((PAL_PORT(pin)->IDR >> (1 * PAL_PAD(pin))) & 0x1) << 7) | (((PAL_PORT(pin)->ODR >> (1 * PAL_PAD(pin))) & 0x1) << 8);
+#   else
+        return 0;
 #   endif
 #else
     return 0;
@@ -60,6 +62,8 @@ void restorePinState(pin_t pin, uint16_t restoreState) {
         PAL_PORT(pin)->PUPDR   = (PAL_PORT(pin)->PUPDR & ~(0x3 << (2 * PAL_PAD(pin)))) | ((restoreState >> 5) & 0x3) << (2 * PAL_PAD(pin));
         PAL_PORT(pin)->IDR     = (PAL_PORT(pin)->IDR & ~(0x1 << (1 * PAL_PAD(pin)))) | ((restoreState >> 7) & 0x1) << (1 * PAL_PAD(pin));
         PAL_PORT(pin)->ODR     = (PAL_PORT(pin)->ODR & ~(0x1 << (1 * PAL_PAD(pin)))) | ((restoreState >> 8) & 0x1) << (1 * PAL_PAD(pin));
+#   else
+        return;
 #   endif
 #else
     return;


### PR DESCRIPTION
The analog joystick feature does not compile accross all platforms (see https://github.com/qmk/qmk_firmware/pull/4226#pullrequestreview-460275628)

All joystick related code is put between `#if JOYSTICK_AXES_COUNT > 0`

This also reduces the size of the compiled code when you only want to use joystick buttons.

### How to reproduce bug:

1. `qmk new-keyboard`
2. select the MCU `GD32VF103` (other options don't matter)
3. `rules.mk` Add `JOYSTICK_ENABLE = yes`
4. `config.h` : Add
    ```c
    #define JOYSTICK_BUTTON_COUNT 1
    #define JOYSTICK_AXES_COUNT 0
    ```
5. (optional) Change a key to `JS_BUTTON0` in keymap
6. run `qmk compile` against new keyboard

Errors will show related to the ADC.

### Disclaimer

1. I do not have the proper HW to debug on all keyboards, but it does work from the RP2040 branch which has a similar problem
   TBH, I'm mostly submitting this PR because it allows me to :see_no_evil: on the bug I described in  https://github.com/qmk/qmk_firmware/pull/14877#issuecomment-1114032488
2. I guess `ifeq ($(shell expr $(JOYSTICK_AXES_COUNT) \> 0), 1)` ain't so pretty,
   but it didn't work with `#ifneq ($(JOYSTICK_AXES_COUNT), 0)` ??
3. I have not been able to test if it actually broke the joystick (axis) feature, but I really can't see how it would.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
