### PR TITLE
Add missing dependency for qmk setup on Fedora

### DIFF
--- a/util/install/fedora.sh
+++ b/util/install/fedora.sh
@@ -8,7 +8,7 @@ _qmk_install() {
         clang diffutils git gcc glibc-headers kernel-devel kernel-headers \
         make unzip wget zip python3 avr-binutils avr-gcc avr-libc \
         arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs arm-none-eabi-newlib \
-        avrdude dfu-programmer dfu-util hidapi
+        avrdude dfu-programmer dfu-util hidapi libusb1-devel
 
     python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }


### PR DESCRIPTION
## Description


When building qmk on Fedora it fails due to missing include usb.h
Added libusb1-devel package that contains the required header file.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or closed by this PR

## Checklist

- [x ] My code follows the code style of this project: [C](https://docs.qmk.fm/#/coding_conventions_c), Python
- [x ] I have read the PR Checklist document and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).