### PR TITLE
Turn off keyboard lights after inactivity or device sleep

### DIFF
--- a/keyboards/gmmk/pro/ansi/config.h
+++ b/keyboards/gmmk/pro/ansi/config.h
@@ -25,4 +25,4 @@
 // Timeout lights after 5m or sleep/usb suspended
 #define RGBLIGHT_SLEEP
 #define RGB_DISABLE_TIMEOUT 300000
-#define RGB_DISABLE_WHEN_USB_SUSPENDED true
+#define RGB_DISABLE_WHEN_USB_SUSPENDED

--- a/keyboards/gmmk/pro/ansi/config.h
+++ b/keyboards/gmmk/pro/ansi/config.h
@@ -21,3 +21,8 @@
 #define DRIVER_1_LED_TOTAL 66
 #define DRIVER_2_LED_TOTAL 32
 #define DRIVER_LED_TOTAL (DRIVER_1_LED_TOTAL + DRIVER_2_LED_TOTAL)
+
+// Timeout lights after 5m or sleep/usb suspended
+#define RGBLIGHT_SLEEP
+#define RGB_DISABLE_TIMEOUT 300000
+#define RGB_DISABLE_WHEN_USB_SUSPENDED true


### PR DESCRIPTION
As implemented the RGB lights stay on forever especially since computers keep their USB ports on even when the computer sleeps. This ensures lights shut off after 5m. 

## Description

Adds 5 minute RGB light time out. Also turns off lights when USB enters a suspended mode or if the main device sleeps.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
