### PR TITLE
Add workaround to allow Sesame to work without atomic interactions

### DIFF
--- a/keyboards/kb_elmo/sesame/config.h
+++ b/keyboards/kb_elmo/sesame/config.h
@@ -46,3 +46,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Bootmagic Lite key configuration */
 #define BOOTMAGIC_LITE_ROW 0
 #define BOOTMAGIC_LITE_COLUMN 1
+
+/* Workaround for https://github.com/qmk/qmk_firmware/issues/11389 */
+#define IGNORE_ATOMIC_BLOCK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is a small workaround for https://github.com/qmk/qmk_firmware/issues/11389. While I don't love it (as this ultimately just works around the root cause), the original PR that caused this bug seems to be a fix for RGB (https://github.com/qmk/qmk_firmware/pull/10491), which this board does not have. ~~It also seems that some other keyboards (namely `massdrop/alt` and `massdrop/ctrl`) seem to have done similar, citing "matrix delay", which I can only assume is this same issue.~~

cc: @kb-elmo 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* I don't know if I'd call it "fixed", but https://github.com/qmk/qmk_firmware/issues/11389 is certainly relevant

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
