### PR TITLE
Port moonlander layout

### DIFF
--- a/keyboards/ferris/keymaps/kyleellman/config.h
+++ b/keyboards/ferris/keymaps/kyleellman/config.h
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 Pierre Chevalier <pierrechevalier83@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+// Set the mouse settings to a comfortable speed/accuracy trade-off,
+// assuming a screen refresh rate of 60 Htz or higher
+// The default is 50. This makes the mouse ~3 times faster and more accurate
+#define MOUSEKEY_INTERVAL 16
+// The default is 20. Since we made the mouse about 3 times faster with the previous setting,
+// give it more time to accelerate to max speed to retain precise control over short distances.
+#define MOUSEKEY_TIME_TO_MAX 40
+// The default is 300. Let's try and make this as low as possible while keeping the cursor responsive
+#define MOUSEKEY_DELAY 100
+// It makes sense to use the same delay for the mouseweel
+#define MOUSEKEY_WHEEL_DELAY 100
+// The default is 100
+#define MOUSEKEY_WHEEL_INTERVAL 50
+// The default is 40
+#define MOUSEKEY_WHEEL_TIME_TO_MAX 100
+
+// Pick good defaults for enabling homerow modifiers
+#define TAPPING_TERM 200
+#define PERMISSIVE_HOLD
+#define IGNORE_MOD_TAP_INTERRUPT
+#define TAPPING_FORCE_HOLD
+
+// Underglow configuration
+#ifdef RGBLIGHT_ENABLE
+  #define RGBLIGHT_ANIMATIONS
+  #define RGBLIGHT_HUE_STEP 8
+  #define RGBLIGHT_SAT_STEP 8
+  #define RGBLIGHT_VAL_STEP 8
+#endif

--- a/keyboards/ferris/keymaps/kyleellman/keymap.json
+++ b/keyboards/ferris/keymaps/kyleellman/keymap.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "notes": "ferris keymap",
+  "documentation": "\"This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK's source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`\"\n",
+  "keyboard": "ferris/0_2",
+  "keymap": "default",
+  "layout": "LAYOUT_split_3x5_2",
+  "layers": [
+    [
+      "KC_Q",         "KC_W",         "LT(5,KC_E)",   "KC_R",         "KC_T",                 "KC_Y",       "KC_U",           "LT(5,KC_I)",     "KC_O",           "KC_P",
+      "LSFT_T(KC_A)", "LCTL_T(KC_S)", "LALT_T(KC_D)", "LGUI_T(KC_F)", "KC_G",                 "KC_H",       "RGUI_T(KC_J)",   "RALT_T(KC_K)",   "RCTL_T(KC_L)",   "RSFT_T(KC_SCLN)",
+      "KC_Z",         "KC_X",         "KC_C",         "KC_V",         "KC_B",                 "KC_N",       "KC_M",           "KC_COMM",        "KC_DOT",         "KC_SLSH",
+                                                      "MO(1)",        "KC_SPC",               "KC_SPC",     "MO(2)"
+    ],
+    [
+      "KC_EXLM",      "KC_AT",        "KC_HASH",      "KC_DLR",       "KC_PERC",              "KC_RSFT",    "KC_AMPR",        "KC_ASTR",        "KC_SCLN",        "KC_COLN",
+      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",              "KC_LEFT",    "KC_DOWN",        "KC_UP",          "KC_RGHT",        "KC_QUOT",
+      "MO(4)",        "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",              "KC_HOME",    "KC_PGDN",        "KC_PGUP",        "KC_END",         "KC_DQUO",
+                                                      "KC_TRNS",      "KC_ENT",               "KC_ENT",     "MO(3)"
+    ],
+    [
+      "KC_ESC",       "KC_TRNS",      "KC_LPRN",      "KC_RPRN",      "KC_UNDS",              "KC_MINS",    "KC_7",           "KC_8",           "KC_9",           "KC_TRNS",
+      "KC_TAB",       "KC_PIPE",      "KC_LCBR",      "KC_RCBR",      "KC_PLUS",              "KC_EQL",     "RGUI_T(KC_4)",   "RALT_T(KC_5)",   "RCTL_T(KC_6)",   "KC_RSFT",
+      "KC_GRV",       "KC_TILD",      "KC_LBRC",      "KC_RBRC",      "KC_BSLS",              "KC_0",       "KC_1",           "KC_2",           "KC_3",           "KC_TRNS",
+                                                      "MO(3)",        "KC_TRNS",              "KC_TRNS",    "KC_TRNS"
+    ],
+    [
+      "RGB_TOG",      "KC_MUTE",      "KC_MS_U",      "KC_VOLD",      "KC_VOLU",              "KC_TRNS",    "KC_MRWD",        "KC_MFFD",        "KC_TRNS",        "KC_BRIU",
+      "KC_TRNS",      "KC_MS_L",      "KC_MS_D",      "KC_MS_R",      "KC_LGUI",              "KC_TRNS",    "KC_BTN1",        "KC_BTN2",        "KC_TRNS",        "KC_BRID",
+      "KC_TRNS",      "KC_MPLY",      "KC_WH_D",      "KC_WH_U",      "KC_LSFT",              "KC_TRNS",    "KC_ACL0",        "KC_ACL1",        "KC_ACL2",        "KC_TRNS",
+                                                      "KC_TRNS",      "KC_TRNS",              "KC_TRNS",    "KC_TRNS"
+    ],
+    [
+      "RESET",        "DEBUG",        "KC_TRNS",      "KC_TRNS",      "KC_TRNS",              "KC_F12",     "KC_F7",          "KC_F8",          "KC_F9",          "KC_TRNS",
+      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",              "KC_F11",     "KC_F4",          "KC_F5",          "KC_F6",          "KC_TRNS",
+      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",              "KC_F10",     "KC_F1",          "KC_F2",          "KC_F3",          "KC_TRNS",
+                                                      "KC_TRNS",      "KC_TRNS",              "KC_TRNS",    "KC_TRNS"
+    ],
+    [
+      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_ESC",       "KC_TRNS",              "KC_DEL",     "KC_BSPC",        "KC_TRNS",        "KC_TRNS",        "KC_TRNS",
+      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",              "KC_TRNS",    "KC_TRNS",        "KC_TRNS",        "KC_TRNS",        "KC_TRNS",
+      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",      "KC_TRNS",              "KC_TRNS",    "KC_TRNS",        "KC_TRNS",        "KC_TRNS",        "KC_TRNS",
+                                                      "KC_TRNS",      "KC_TRNS",              "KC_TRNS",    "KC_TRNS"
+    ]
+  ],
+  "author": "@kyleellman"
+}


### PR DESCRIPTION
This is a port of [the layout](https://configure.zsa.io/moonlander/layouts/4DMJd/WPMN3/0) I was using on the Moonlander (for additional use on a Planck), originally inspired by @benvallack.