### PR TITLE
Revert UART setup for redox_w keyboard to 0.15 version, fixes #16553

### DIFF
--- a/keyboards/redox_w/config.h
+++ b/keyboards/redox_w/config.h
@@ -53,3 +53,13 @@
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING
 //#define NO_ACTION_ONESHOT
+
+/* Legacy UART setup from 0.15 QMK firmware version */
+//UART settings for communication with the RF microcontroller
+#define SERIAL_UART_BAUD 1000000
+#define SERIAL_UART_RXD_PRESENT (UCSR1A & _BV(RXC1))
+#define SERIAL_UART_INIT_CUSTOM       \
+    /* enable TX and RX */            \
+    UCSR1B = _BV(TXEN1) | _BV(RXEN1); \
+    /* 8-bit data */                  \
+    UCSR1C = _BV(UCSZ11) | _BV(UCSZ10);

--- a/keyboards/redox_w/matrix.c
+++ b/keyboards/redox_w/matrix.c
@@ -16,10 +16,11 @@
 
 #include "quantum.h"
 #include "matrix.h"
-#include "uart.h"
+#include "protocol/serial.h"
 
 void matrix_init_custom(void) {
-    uart_init(1000000);
+    //legacy approach from version 0.15
+    serial_init();
 }
 
 bool matrix_scan_custom(matrix_row_t current_matrix[]) {
@@ -27,7 +28,8 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     bool changed = false;
 
     //the s character requests the RF slave to send the matrix
-    uart_write('s');
+    //legacy approach from version 0.15
+    SERIAL_UART_DATA = 's';
 
     //trust the external keystates entirely, erase the last data
     uint8_t uart_data[11] = {0};
@@ -37,13 +39,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //wait for the serial data, timeout if it's been too long
         //this only happened in testing with a loose wire, but does no
         //harm to leave it in here
-        while (!uart_available()) {
+        //
+        //legacy approach from version 0.15
+        while (!SERIAL_UART_RXD_PRESENT) {
             timeout++;
             if (timeout > 10000) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+        //legacy approach from version 0.15
+        uart_data[i] = SERIAL_UART_DATA;
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/redox_w/rules.mk
+++ b/keyboards/redox_w/rules.mk
@@ -19,5 +19,4 @@ AUDIO_ENABLE = no           # Audio output
 CUSTOM_MATRIX = lite
 
 # project specific files
-SRC += matrix.c
-QUANTUM_LIB_SRC += uart.c
+SRC += matrix.c serial_uart.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This reverts the UART setup for `redox_w` keyboard back to its state in versions `0.15.x`. The main rationale is to resolve issue #16553 — ensure that `redox_w` users with USB-C receivers (myself included) can have a stable, working firmware whether using `0.16.x` version of `qmk` or the online `QMK Configurator`.

I realise this change reverts some of the good changes applied and I will be happy to explore how to later re-work `0.16` changes to work. At this point, however, my priority is to bring back `redox_w` to a working state, especially as people non-coders are currently affected. Looking forward to seeing guidance from experienced contributors.

The change has been tested on a recent Redox Wireless made by Falba Tech.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #16553 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
