### PR TITLE
65_iso_split_bs Community Layout Keymap Bugfix

### DIFF
--- a/layouts/default/65_iso_split_bs/default_65_iso_split_bs/keymap.c
+++ b/layouts/default/65_iso_split_bs/default_65_iso_split_bs/keymap.c
@@ -14,7 +14,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * │Ctrl│GUI │Alt │                        │Alt│GUI│Ctl│ ← │ ↓ │ → │
      * └────┴────┴────┴────────────────────────┴───┴───┴───┴───┴───┴───┘
      */
-    [0] = LAYOUT_65_iso(
+    [0] = LAYOUT_65_iso_split_bs(
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_BSPC, KC_HOME,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_PGUP,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_ENT,  KC_PGDN,


### PR DESCRIPTION
## Description

Fix the layout macro reference in the `keymap.c` file, which caused this keymap to not be able to be compiled.

## Types of Changes

- [x] Bugfix
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
