### PR TITLE
Improve PS/2 mouse performance

### DIFF
--- a/drivers/ps2/ps2.h
+++ b/drivers/ps2/ps2.h
@@ -89,6 +89,7 @@ uint8_t ps2_host_send(uint8_t data);
 uint8_t ps2_host_recv_response(void);
 uint8_t ps2_host_recv(void);
 void    ps2_host_set_led(uint8_t usb_led);
+bool    pbuf_has_data(void);
 
 /*--------------------------------------------------------------------
  * static functions

--- a/drivers/ps2/ps2_interrupt.c
+++ b/drivers/ps2/ps2_interrupt.c
@@ -66,8 +66,8 @@ uint8_t ps2_error = PS2_ERR_NONE;
 
 static inline uint8_t pbuf_dequeue(void);
 static inline void    pbuf_enqueue(uint8_t data);
-static inline bool    pbuf_has_data(void);
 static inline void    pbuf_clear(void);
+bool                  pbuf_has_data(void);
 
 #if defined(PROTOCOL_CHIBIOS)
 void ps2_interrupt_service_routine(void);
@@ -309,7 +309,7 @@ static inline uint8_t pbuf_dequeue(void) {
 
     return val;
 }
-static inline bool pbuf_has_data(void) {
+bool pbuf_has_data(void) {
 #if defined(__AVR__)
     uint8_t sreg = SREG;
     cli();

--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -75,19 +75,33 @@ void ps2_mouse_task(void) {
     extern int     tp_buttons;
 
     /* receives packet from mouse */
+#ifdef PS2_MOUSE_USE_REMOTE_MODE
     uint8_t rcv;
     rcv = ps2_host_send(PS2_MOUSE_READ_DATA);
     if (rcv == PS2_ACK) {
         mouse_report.buttons = ps2_host_recv_response() | tp_buttons;
         mouse_report.x       = ps2_host_recv_response() * PS2_MOUSE_X_MULTIPLIER;
         mouse_report.y       = ps2_host_recv_response() * PS2_MOUSE_Y_MULTIPLIER;
-#ifdef PS2_MOUSE_ENABLE_SCROLLING
+#    ifdef PS2_MOUSE_ENABLE_SCROLLING
         mouse_report.v = -(ps2_host_recv_response() & PS2_MOUSE_SCROLL_MASK) * PS2_MOUSE_V_MULTIPLIER;
-#endif
+#    endif
     } else {
         if (debug_mouse) print("ps2_mouse: fail to get mouse packet\n");
         return;
     }
+#else
+    if (pbuf_has_data()) {
+        mouse_report.buttons = ps2_host_recv_response() | tp_buttons;
+        mouse_report.x       = ps2_host_recv_response() * PS2_MOUSE_X_MULTIPLIER;
+        mouse_report.y       = ps2_host_recv_response() * PS2_MOUSE_Y_MULTIPLIER;
+#    ifdef PS2_MOUSE_ENABLE_SCROLLING
+        mouse_report.v       = -(ps2_host_recv_response() & PS2_MOUSE_SCROLL_MASK) * PS2_MOUSE_V_MULTIPLIER;
+#    endif
+    } else {
+        if (debug_mouse) print("ps2_mouse: fail to get mouse packet\n");
+        return;
+    }
+#endif
 
     /* if mouse moves or buttons state changes */
     if (mouse_report.x || mouse_report.y || mouse_report.v || ((mouse_report.buttons ^ buttons_prev) & PS2_MOUSE_BTN_MASK)) {

--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -53,6 +53,7 @@ void ps2_mouse_init(void) {
     ps2_mouse_set_remote_mode();
 #else
     ps2_mouse_enable_data_reporting();
+    ps2_mouse_set_stream_mode();
 #endif
 
 #ifdef PS2_MOUSE_ENABLE_SCROLLING

--- a/platforms/avr/drivers/ps2/ps2_usart.c
+++ b/platforms/avr/drivers/ps2/ps2_usart.c
@@ -72,8 +72,8 @@ uint8_t ps2_error = PS2_ERR_NONE;
 
 static inline uint8_t pbuf_dequeue(void);
 static inline void    pbuf_enqueue(uint8_t data);
-static inline bool    pbuf_has_data(void);
 static inline void    pbuf_clear(void);
+bool                  pbuf_has_data(void);
 
 void ps2_host_init(void) {
     idle(); // without this many USART errors occur when cable is disconnected
@@ -212,7 +212,7 @@ static inline uint8_t pbuf_dequeue(void) {
 
     return val;
 }
-static inline bool pbuf_has_data(void) {
+bool pbuf_has_data(void) {
     uint8_t sreg = SREG;
     cli();
     bool has_data = (pbuf_head != pbuf_tail);


### PR DESCRIPTION
Source PR: #5408

Credits to @tomykaira for doing the actual work!

## Description

This PR improves performance of PS/2 mouse in both **interrupt mode** and **USART mode**. On my keyboard, it reduces matrix scan delay from 11ms to 1ms. This makes it possible to use encoder AND trackpoint at the same time without any lags!

Additional changes introduced are:
  - Compatibility with USART mode: [platforms/avr/drivers/ps2/ps2_usart.c:76](https://github.com/qmk/qmk_firmware/pull/17111/files#diff-16b236943697980f2e8cb8e73e308a87e3a061e663eda599bec8ee1776c2b087R76)
  - Call `ps2_mouse_set_stream_mode` during initialization if stream mode is selected - not sure why that wasn't done already: [drivers/ps2/ps2_mouse.c:56](https://github.com/qmk/qmk_firmware/pull/17111/files#diff-a254e860ff8244ed2cd1622be056ef47b05d65b60d04269d359b10947fee3f8dR56). This makes USART mode work properly when booting the keyboard.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5357
* #5408

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Test case

**Wiring & trackpoint images (source: https://github.com/joric/jorne/wiki/Trackpoint)**

<details>

![Wiring](https://camo.githubusercontent.com/18e9eab725752aa9a4c2e15d039a7bd05b5010c2c17c555d29092e60e69e6a96/68747470733a2f2f692e696d6775722e636f6d2f536f4643644d722e6a7067)

![R61 Trackpoint](https://camo.githubusercontent.com/61e43f79cda100a2fa7112e4df43aa537a61260fd23bf0556ee8157c246065de/68747470733a2f2f692e696d6775722e636f6d2f584833555541352e6a7067)
</details>

**Config (tested with both INT & USARG modes)**

<details>

```c
#define PS2_MOUSE_INIT_DELAY 200

#ifdef PS2_USE_USART
#define PS2_CLOCK_PIN   D5
#define PS2_DATA_PIN    D2

/* #define PS2_MOUSE_USE_REMOTE_MODE */

/* synchronous, odd parity, 1-bit stop, 8-bit data, sample at falling edge */
/* set DDR of CLOCK as input to be slave */
#define PS2_USART_INIT() do {   \
    PS2_CLOCK_DDR &= ~(1<<PS2_CLOCK_BIT);   \
    PS2_DATA_DDR &= ~(1<<PS2_DATA_BIT);     \
    UCSR1C = ((1 << UMSEL10) |  \
              (3 << UPM10)   |  \
              (0 << USBS1)   |  \
              (3 << UCSZ10)  |  \
              (0 << UCPOL1));   \
    UCSR1A = 0;                 \
    UBRR1H = 0;                 \
    UBRR1L = 0;                 \
} while (0)
#define PS2_USART_RX_INT_ON() do {  \
    UCSR1B = ((1 << RXCIE1) |       \
              (1 << RXEN1));        \
} while (0)
#define PS2_USART_RX_POLL_ON() do { \
    UCSR1B = (1 << RXEN1);          \
} while (0)
#define PS2_USART_OFF() do {    \
    UCSR1C = 0;                 \
    UCSR1B &= ~((1 << RXEN1) |  \
                (1 << TXEN1));  \
} while (0)
#define PS2_USART_RX_READY      (UCSR1A & (1<<RXC1))
#define PS2_USART_RX_DATA       UDR1
#define PS2_USART_ERROR         (UCSR1A & ((1<<FE1) | (1<<DOR1) | (1<<UPE1)))
#define PS2_USART_RX_VECT       USART1_RX_vect
#endif

#ifdef PS2_USE_INT
// Note: pins are swapped, so re-soldering is needed to test both modes
#define PS2_CLOCK_PIN   D2
#define PS2_DATA_PIN    D5

/* #define PS2_MOUSE_USE_REMOTE_MODE */

#define PS2_INT_INIT()  do {    \
    EICRA |= ((1<<ISC21) |      \
              (0<<ISC20));      \
} while (0)
#define PS2_INT_ON()  do {      \
    EIMSK |= (1<<INT2);         \
} while (0)
#define PS2_INT_OFF() do {      \
    EIMSK &= ~(1<<INT2);        \
} while (0)
#define PS2_INT_VECT   INT2_vect
#endif
#endif

```
</details>

Demo of me using trackpoint & encoder simultaneously: https://imgur.com/a/cqL8j1x