### PR TITLE
[Core] Bug fix: Continue Caps Word when AltGr (right Alt) is held.

### DIFF
--- a/quantum/process_keycode/process_caps_word.c
+++ b/quantum/process_keycode/process_caps_word.c
@@ -87,7 +87,7 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
         return true;
     }
 
-    if (!(mods & ~MOD_MASK_SHIFT)) {
+    if (!(mods & ~(MOD_MASK_SHIFT | MOD_BIT(KC_RALT)))) {
         switch (keycode) {
             // Ignore MO, TO, TG, TT, and OSL layer switch keys.
             case QK_MOMENTARY ... QK_MOMENTARY_MAX:
@@ -95,6 +95,9 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
             case QK_TOGGLE_LAYER ... QK_TOGGLE_LAYER_MAX:
             case QK_LAYER_TAP_TOGGLE ... QK_LAYER_TAP_TOGGLE_MAX:
             case QK_ONE_SHOT_LAYER ... QK_ONE_SHOT_LAYER_MAX:
+            // Ignore AltGr.
+            case KC_RALT:
+            case OSM(MOD_RALT):
                 return true;
 
 #ifndef NO_ACTION_TAPPING

--- a/tests/caps_word/test_caps_word.cpp
+++ b/tests/caps_word/test_caps_word.cpp
@@ -212,6 +212,36 @@ TEST_F(CapsWord, SpaceTurnsOffCapsWord) {
     testing::Mock::VerifyAndClearExpectations(&driver);
 }
 
+// Tests that typing "AltGr + A" produces "Shift + AltGr + A".
+TEST_F(CapsWord, ShiftsAltGrSymbols) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_altgr(0, 1, 0, KC_RALT);
+    set_keymap({key_a, key_altgr});
+
+    // Allow any number of reports with no keys or only modifiers.
+    // clang-format off
+    EXPECT_CALL(driver, send_keyboard_mock(AnyOf(
+                KeyboardReport(),
+                KeyboardReport(KC_RALT),
+                KeyboardReport(KC_LSFT, KC_RALT))))
+        .Times(AnyNumber());
+    // Expect "Shift + AltGr + A, Space".
+    EXPECT_CALL(driver, send_keyboard_mock(KeyboardReport(KC_LSFT, KC_RALT, KC_A)));
+    // clang-format on
+
+    // Turn on Caps Word and type "AltGr + A".
+    caps_word_on();
+
+    key_altgr.press();
+    run_one_scan_loop();
+    TapKeys(key_a);
+    run_one_scan_loop();
+    key_altgr.release();
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
 struct CapsWordBothShiftsParams {
     std::string name;
     uint16_t    left_shift_keycode;


### PR DESCRIPTION
This is a bug fix so that Caps Word is allowed to continue when AltGr symbols are typed, such as accented letters.

## Description

Currently, Caps Word (added in PR #16588) turns off whenever a non-shift mod becomes active. This is done to avoid interfering with hotkeys. What I overlooked is that outside the US, the AltGr key is used to type additional symbols. Depending on the language, these AltGr symbols may include symbols used within words like accented letters where it would be desirable to continue Caps Word. Examples for several languages [are described on Wikipedia](https://en.wikipedia.org/wiki/AltGr_key). 

This commit makes an exception to allow Caps Word to continue when AltGr (right Alt) is held.

Fortunately, the fix is simple. I hope it can be merged before 2022-05-26 to make it in the 2022q2 release.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
