### PR TITLE
Fix AVR I2C master 1ms timeout

### DIFF
--- a/platforms/avr/drivers/i2c_master.c
+++ b/platforms/avr/drivers/i2c_master.c
@@ -64,7 +64,7 @@ static i2c_status_t i2c_start_impl(uint8_t address, uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) >= timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -81,7 +81,7 @@ static i2c_status_t i2c_start_impl(uint8_t address, uint16_t timeout) {
 
     timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) >= timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -102,7 +102,7 @@ i2c_status_t i2c_start(uint8_t address, uint16_t timeout) {
     i2c_status_t status;
     do {
         status = i2c_start_impl(address, time_slice);
-    } while ((status < 0) && ((timeout == I2C_TIMEOUT_INFINITE) || (timer_elapsed(timeout_timer) < timeout)));
+    } while ((status < 0) && ((timeout == I2C_TIMEOUT_INFINITE) || (timer_elapsed(timeout_timer) <= timeout)));
     return status;
 }
 
@@ -114,7 +114,7 @@ i2c_status_t i2c_write(uint8_t data, uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) >= timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -132,7 +132,7 @@ int16_t i2c_read_ack(uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) >= timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -147,7 +147,7 @@ int16_t i2c_read_nack(uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) >= timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }

--- a/platforms/avr/drivers/i2c_master.c
+++ b/platforms/avr/drivers/i2c_master.c
@@ -64,7 +64,7 @@ static i2c_status_t i2c_start_impl(uint8_t address, uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && (timer_elapsed(timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -81,7 +81,7 @@ static i2c_status_t i2c_start_impl(uint8_t address, uint16_t timeout) {
 
     timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && (timer_elapsed(timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -114,7 +114,7 @@ i2c_status_t i2c_write(uint8_t data, uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && (timer_elapsed(timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -132,7 +132,7 @@ int16_t i2c_read_ack(uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && (timer_elapsed(timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }
@@ -147,7 +147,7 @@ int16_t i2c_read_nack(uint16_t timeout) {
 
     uint16_t timeout_timer = timer_read();
     while (!(TWCR & (1 << TWINT))) {
-        if ((timeout != I2C_TIMEOUT_INFINITE) && ((timer_read() - timeout_timer) > timeout)) {
+        if ((timeout != I2C_TIMEOUT_INFINITE) && (timer_elapsed(timeout_timer) > timeout)) {
             return I2C_STATUS_TIMEOUT;
         }
     }


### PR DESCRIPTION
`i2c_start()` produces a minimum `time_slice` of 1ms for use as timeout value.
The timer granularity is 1ms, it is entirely possible for `timer_count` to tick up immediately after the last timer read and falsely trigger timeout with a `>= 1` comparison.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
