### PR TITLE
thomas miryoku skeletyl

### DIFF
--- a/layouts/community/split_3x5_3/manna-harbour_miryoku/config.h
+++ b/layouts/community/split_3x5_3/manna-harbour_miryoku/config.h
@@ -18,3 +18,5 @@ K10,   K11,   K12,   K13,   K14,          K15,   K16,   K17,   K18,   K19,\
 K20,   K21,   K22,   K23,   K24,          K25,   K26,   K27,   K28,   K29,\
               K32,   K33,   K34,          K35,   K36,   K37\
 )
+
+#define TAPPING_FORCE_HOLD_PER_KEY

--- a/users/manna-harbour_miryoku/manna-harbour_miryoku.c
+++ b/users/manna-harbour_miryoku/manna-harbour_miryoku.c
@@ -227,3 +227,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     U_NP,    U_NP,    KC_BTN2, KC_BTN3, KC_BTN1, KC_BTN1, KC_BTN3, KC_BTN2, U_NP,    U_NP
   )
 };
+
+bool get_tapping_force_hold(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case LT(1, KC_LSHIFT):
+        case LT(1, KC_LCTRL):
+        case LT(1, KC_LALT):
+        case LT(1, KC_LGUI):
+            return true;
+        default:
+            return false;
+    }
+}


### PR DESCRIPTION
changes to base miryoku for thomas' skeletyl:

tap force hold per key to allow double-tap and hold for continuous keypresses, useful for nav.

make w/:
`make bastardkb/skeletyl:manna-harbour_miryoku MIRYOKU_ALPHAS=QWERTY MIRYOKU_NAV=VI MIRYOKU_CLIBPOARD=MAC`

flash w/ qmk toolbox