### PR TITLE
Fix RGB heatmap to use XY positions and use correct led limits.

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -665,7 +665,22 @@ In order to change the delay of temperature decrease define `RGB_MATRIX_TYPING_H
 #define RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS 50
 ```
 
-Heatmap effect may not light up the correct adjacent LEDs for certain key matrix layout such as split keyboards. The following define will limit the effect to pressed keys only:
+As heatmap uses the physical position of the leds set in the g_led_config, you may need to tweak the following options to get the best effect for your keyboard. Note the size of this grid is `224x64`.
+
+Limit the distance the effect spreads to surrounding keys. 
+
+```c
+#define RGB_MATRIX_TYPING_HEATMAP_SPREAD 40
+```
+
+Limit how hot surrounding keys get from each press.
+
+```c
+#define RGB_MATRIX_TYPING_HEATMAP_AREA_LIMIT 16
+```
+
+Remove the spread effect entirely.
+
 ```c
 #define RGB_MATRIX_TYPING_HEATMAP_SLIM
 ```

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -23,11 +23,9 @@ void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
             if (i_row == row && i_col == col) {
                 g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
             } else {
-#            define CURRENT_LED_X g_led_config.point[g_led_config.matrix_co[row][col]].x
-#            define CURRENT_LED_Y g_led_config.point[g_led_config.matrix_co[row][col]].y
-#            define I_LED_X g_led_config.point[g_led_config.matrix_co[i_row][i_col]].x
-#            define I_LED_Y g_led_config.point[g_led_config.matrix_co[i_row][i_col]].y
-                uint8_t distance = sqrt16(((I_LED_X - CURRENT_LED_X) * (I_LED_X - CURRENT_LED_X)) + ((I_LED_Y - CURRENT_LED_Y) * (I_LED_Y - CURRENT_LED_Y)));
+#            define LED_DISTANCE(led_a, led_b) sqrt16(((int8_t)(led_a.x - led_b.x) * (int8_t)(led_a.x - led_b.x)) + ((int8_t)(led_a.y - led_b.y) * (int8_t)(led_a.y - led_b.y)))
+                uint8_t distance = LED_DISTANCE(g_led_config.point[g_led_config.matrix_co[row][col]], g_led_config.point[g_led_config.matrix_co[i_row][i_col]]);
+#            undef LED_DISTANCE
                 if (distance <= RGB_MATRIX_TYPING_HEATMAP_SPREAD) {
                     uint8_t amount = qsub8(RGB_MATRIX_TYPING_HEATMAP_SPREAD, distance);
                     if (amount > RGB_MATRIX_TYPING_HEATMAP_AREA_LIMIT) {

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -10,6 +10,9 @@ RGB_MATRIX_EFFECT(TYPING_HEATMAP)
 #            define RGB_MATRIX_TYPING_HEATMAP_SPREAD 40
 #        endif
 
+#        ifndef RGB_MATRIX_TYPING_HEATMAP_AREA_LIMIT
+#            define RGB_MATRIX_TYPING_HEATMAP_AREA_LIMIT 16
+#        endif
 void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
 #        ifdef RGB_MATRIX_TYPING_HEATMAP_SLIM
     // Limit effect to pressed keys
@@ -26,7 +29,10 @@ void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
 #            define I_LED_Y g_led_config.point[g_led_config.matrix_co[i_row][i_col]].y
                 uint8_t distance = sqrt16(((I_LED_X - CURRENT_LED_X) * (I_LED_X - CURRENT_LED_X)) + ((I_LED_Y - CURRENT_LED_Y) * (I_LED_Y - CURRENT_LED_Y)));
                 if (distance <= RGB_MATRIX_TYPING_HEATMAP_SPREAD) {
-                    uint8_t amount                   = RGB_MATRIX_TYPING_HEATMAP_SPREAD - distance > 24 ? 24 : RGB_MATRIX_TYPING_HEATMAP_SPREAD - distance;
+                    uint8_t amount = qsub8(RGB_MATRIX_TYPING_HEATMAP_SPREAD, distance);
+                    if (amount > RGB_MATRIX_TYPING_HEATMAP_AREA_LIMIT) {
+                        amount = RGB_MATRIX_TYPING_HEATMAP_AREA_LIMIT;
+                    }
                     g_rgb_frame_buffer[i_row][i_col] = qadd8(g_rgb_frame_buffer[i_row][i_col], amount);
                 }
             }

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -6,30 +6,31 @@ RGB_MATRIX_EFFECT(TYPING_HEATMAP)
 #            define RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS 25
 #        endif
 
+#        ifndef RGB_MATRIX_TYPING_HEATMAP_SPREAD
+#            define RGB_MATRIX_TYPING_HEATMAP_SPREAD 40
+#        endif
+
 void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
 #        ifdef RGB_MATRIX_TYPING_HEATMAP_SLIM
     // Limit effect to pressed keys
     g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
 #        else
-    uint8_t m_row = row - 1;
-    uint8_t p_row = row + 1;
-    uint8_t m_col = col - 1;
-    uint8_t p_col = col + 1;
-
-    if (m_col < col) g_rgb_frame_buffer[row][m_col] = qadd8(g_rgb_frame_buffer[row][m_col], 16);
-    g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
-    if (p_col < MATRIX_COLS) g_rgb_frame_buffer[row][p_col] = qadd8(g_rgb_frame_buffer[row][p_col], 16);
-
-    if (p_row < MATRIX_ROWS) {
-        if (m_col < col) g_rgb_frame_buffer[p_row][m_col] = qadd8(g_rgb_frame_buffer[p_row][m_col], 13);
-        g_rgb_frame_buffer[p_row][col] = qadd8(g_rgb_frame_buffer[p_row][col], 16);
-        if (p_col < MATRIX_COLS) g_rgb_frame_buffer[p_row][p_col] = qadd8(g_rgb_frame_buffer[p_row][p_col], 13);
-    }
-
-    if (m_row < row) {
-        if (m_col < col) g_rgb_frame_buffer[m_row][m_col] = qadd8(g_rgb_frame_buffer[m_row][m_col], 13);
-        g_rgb_frame_buffer[m_row][col] = qadd8(g_rgb_frame_buffer[m_row][col], 16);
-        if (p_col < MATRIX_COLS) g_rgb_frame_buffer[m_row][p_col] = qadd8(g_rgb_frame_buffer[m_row][p_col], 13);
+    for (uint8_t i_row = 0; i_row < MATRIX_ROWS; i_row++) {
+        for (uint8_t i_col = 0; i_col < MATRIX_COLS; i_col++) {
+            if (i_row == row && i_col == col) {
+                g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
+            } else {
+#            define CURRENT_LED_X g_led_config.point[g_led_config.matrix_co[row][col]].x
+#            define CURRENT_LED_Y g_led_config.point[g_led_config.matrix_co[row][col]].y
+#            define I_LED_X g_led_config.point[g_led_config.matrix_co[i_row][i_col]].x
+#            define I_LED_Y g_led_config.point[g_led_config.matrix_co[i_row][i_col]].y
+                uint8_t distance = sqrt16(((I_LED_X - CURRENT_LED_X) * (I_LED_X - CURRENT_LED_X)) + ((I_LED_Y - CURRENT_LED_Y) * (I_LED_Y - CURRENT_LED_Y)));
+                if (distance <= RGB_MATRIX_TYPING_HEATMAP_SPREAD) {
+                    uint8_t amount                   = RGB_MATRIX_TYPING_HEATMAP_SPREAD - distance > 24 ? 24 : RGB_MATRIX_TYPING_HEATMAP_SPREAD - distance;
+                    g_rgb_frame_buffer[i_row][i_col] = qadd8(g_rgb_frame_buffer[i_row][i_col], amount);
+                }
+            }
+        }
     }
 #        endif
 }
@@ -40,10 +41,7 @@ static uint16_t heatmap_decrease_timer;
 static bool decrease_heatmap_values;
 
 bool TYPING_HEATMAP(effect_params_t* params) {
-    // Modified version of RGB_MATRIX_USE_LIMITS to work off of matrix row / col size
-    uint8_t led_min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter;
-    uint8_t led_max = led_min + RGB_MATRIX_LED_PROCESS_LIMIT;
-    if (led_max > sizeof(g_rgb_frame_buffer)) led_max = sizeof(g_rgb_frame_buffer);
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
     if (params->init) {
         rgb_matrix_set_color_all(0, 0, 0);
@@ -63,28 +61,24 @@ bool TYPING_HEATMAP(effect_params_t* params) {
     }
 
     // Render heatmap & decrease
-    for (int i = led_min; i < led_max; i++) {
-        uint8_t row = i % MATRIX_ROWS;
-        uint8_t col = i / MATRIX_ROWS;
-        uint8_t val = g_rgb_frame_buffer[row][col];
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            if (g_led_config.matrix_co[row][col] >= led_min && g_led_config.matrix_co[row][col] <= led_max) {
+                uint8_t val = g_rgb_frame_buffer[row][col];
+                if (!HAS_ANY_FLAGS(g_led_config.flags[g_led_config.matrix_co[row][col]], params->flags)) continue;
 
-        // set the pixel colour
-        uint8_t led[LED_HITS_TO_REMEMBER];
-        uint8_t led_count = rgb_matrix_map_row_column_to_led(row, col, led);
-        for (uint8_t j = 0; j < led_count; ++j) {
-            if (!HAS_ANY_FLAGS(g_led_config.flags[led[j]], params->flags)) continue;
+                HSV hsv = {170 - qsub8(val, 85), rgb_matrix_config.hsv.s, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.hsv.v)};
+                RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+                rgb_matrix_set_color(g_led_config.matrix_co[row][col], rgb.r, rgb.g, rgb.b);
 
-            HSV hsv = {170 - qsub8(val, 85), rgb_matrix_config.hsv.s, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.hsv.v)};
-            RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
-            rgb_matrix_set_color(led[j], rgb.r, rgb.g, rgb.b);
-        }
-
-        if (decrease_heatmap_values) {
-            g_rgb_frame_buffer[row][col] = qsub8(val, 1);
+                if (decrease_heatmap_values) {
+                    g_rgb_frame_buffer[row][col] = qsub8(val, 1);
+                }
+            }
         }
     }
 
-    return led_max < sizeof(g_rgb_frame_buffer);
+    return rgb_matrix_check_finished_leds(led_max);
 }
 
 #    endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -67,7 +67,7 @@ bool TYPING_HEATMAP(effect_params_t* params) {
     // Render heatmap & decrease
     for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
         for (uint8_t col = 0; col < MATRIX_COLS; col++) {
-            if (g_led_config.matrix_co[row][col] >= led_min && g_led_config.matrix_co[row][col] <= led_max) {
+            if (g_led_config.matrix_co[row][col] >= led_min && g_led_config.matrix_co[row][col] < led_max) {
                 uint8_t val = g_rgb_frame_buffer[row][col];
                 if (!HAS_ANY_FLAGS(g_led_config.flags[g_led_config.matrix_co[row][col]], params->flags)) continue;
 

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -65,9 +65,11 @@ bool TYPING_HEATMAP(effect_params_t* params) {
     }
 
     // Render heatmap & decrease
-    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+    uint8_t count = 0;
+    for (uint8_t row = 0; row < MATRIX_ROWS && count < RGB_MATRIX_LED_PROCESS_LIMIT; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS && RGB_MATRIX_LED_PROCESS_LIMIT; col++) {
             if (g_led_config.matrix_co[row][col] >= led_min && g_led_config.matrix_co[row][col] < led_max) {
+                count++;
                 uint8_t val = g_rgb_frame_buffer[row][col];
                 if (!HAS_ANY_FLAGS(g_led_config.flags[g_led_config.matrix_co[row][col]], params->flags)) continue;
 

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -249,8 +249,15 @@ void process_rgb_matrix(uint8_t row, uint8_t col, bool pressed) {
 #endif // RGB_MATRIX_KEYREACTIVE_ENABLED
 
 #if defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && defined(ENABLE_RGB_MATRIX_TYPING_HEATMAP)
-    if (rgb_matrix_config.mode == RGB_MATRIX_TYPING_HEATMAP) {
-        process_rgb_matrix_typing_heatmap(row, col);
+#    if defined(RGB_MATRIX_KEYRELEASES)
+    if (!pressed)
+#    else
+    if (pressed)
+#    endif // defined(RGB_MATRIX_KEYRELEASES)
+    {
+        if (rgb_matrix_config.mode == RGB_MATRIX_TYPING_HEATMAP) {
+            process_rgb_matrix_typing_heatmap(row, col);
+        }
     }
 #endif // defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && defined(ENABLE_RGB_MATRIX_TYPING_HEATMAP)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Tested on a split keyboard and board with a duplex matrix and it behaves much better, no more trigger incorrect locations. The effect is slightly different visually compared with the old one. I've not tested on AVR, hopefully not too much impact.

There's a define `RGB_MATRIX_TYPING_HEATMAP_SPREAD` that can be changed to increase the area of effect.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes https://github.com/qmk/qmk_firmware/issues/14041

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
