### PR TITLE
Luna keyboard pet OLED timeout fix

### DIFF
--- a/keyboards/crkbd/keymaps/bermeo/keymap.c
+++ b/keyboards/crkbd/keymaps/bermeo/keymap.c
@@ -273,7 +273,6 @@ oled_rotation_t oled_init_user(oled_rotation_t rotation) {
 #    define ANIM_SIZE 96            // number of bytes in array. If you change sprites, minimize for adequate firmware size. max is 1024
 /* timers */
 uint32_t anim_timer = 0;
-uint32_t anim_sleep = 0;
 /* current frame */
 uint8_t current_frame = 0;
 /* status variables */
@@ -351,19 +350,19 @@ static void render_luna(int LUNA_X, int LUNA_Y) {
         current_frame = (current_frame + 1) % 2;
         /* draw */
         if (isBarking) {
-            oled_write_raw_P(bark[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(bark[current_frame], ANIM_SIZE);
 
         } else if (isSneaking) {
-            oled_write_raw_P(sneak[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sneak[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_WALK_SPEED) {
-            oled_write_raw_P(sit[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sit[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_RUN_SPEED) {
-            oled_write_raw_P(walk[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(walk[current_frame], ANIM_SIZE);
 
         } else {
-            oled_write_raw_P(run[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(run[current_frame], ANIM_SIZE);
         }
     }
     /* animation timer */

--- a/keyboards/kikoslab/ellora65/keymaps/default/keymap.c
+++ b/keyboards/kikoslab/ellora65/keymaps/default/keymap.c
@@ -68,7 +68,6 @@ oled_rotation_t oled_init_user(oled_rotation_t rotation) {
 
 /* timers */
 uint32_t anim_timer = 0;
-uint32_t anim_sleep = 0;
 
 /* current frame */
 uint8_t current_frame = 0;
@@ -160,34 +159,36 @@ static void render_luna(int LUNA_X, int LUNA_Y) {
 
         /* current status */
         if (led_usb_state.caps_lock) {
-            oled_write_raw_P(bark[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(bark[current_frame], ANIM_SIZE);
 
         } else if (isSneaking) {
-            oled_write_raw_P(sneak[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sneak[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_WALK_SPEED) {
-            oled_write_raw_P(sit[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sit[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_RUN_SPEED) {
-            oled_write_raw_P(walk[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(walk[current_frame], ANIM_SIZE);
 
         } else {
-            oled_write_raw_P(run[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(run[current_frame], ANIM_SIZE);
         }
     }
+
+#    if OLED_TIMEOUT > 0
+    /* the animation prevents the normal timeout from occuring */
+    if (last_input_activity_elapsed() > OLED_TIMEOUT && last_led_activity_elapsed() > OLED_TIMEOUT) {
+        oled_off();
+        return;
+    } else {
+        oled_on();
+    }
+#    endif
 
     /* animation timer */
     if (timer_elapsed32(anim_timer) > ANIM_FRAME_DURATION) {
         anim_timer = timer_read32();
         animate_luna();
-    }
-
-    /* this fixes the screen on and off bug */
-    if (current_wpm > 0) {
-        oled_on();
-        anim_sleep = timer_read32();
-    } else if (timer_elapsed32(anim_sleep) > OLED_TIMEOUT) {
-        oled_off();
     }
 }
 

--- a/keyboards/kikoslab/ellora65/keymaps/via/keymap.c
+++ b/keyboards/kikoslab/ellora65/keymaps/via/keymap.c
@@ -78,7 +78,6 @@ oled_rotation_t oled_init_user(oled_rotation_t rotation) {
 
 /* timers */
 uint32_t anim_timer = 0;
-uint32_t anim_sleep = 0;
 
 /* current frame */
 uint8_t current_frame = 0;
@@ -170,37 +169,38 @@ static void render_luna(int LUNA_X, int LUNA_Y) {
 
         /* current status */
         if (led_usb_state.caps_lock) {
-            oled_write_raw_P(bark[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(bark[current_frame], ANIM_SIZE);
 
         } else if (isSneaking) {
-            oled_write_raw_P(sneak[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sneak[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_WALK_SPEED) {
-            oled_write_raw_P(sit[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sit[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_RUN_SPEED) {
-            oled_write_raw_P(walk[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(walk[current_frame], ANIM_SIZE);
 
         } else {
-            oled_write_raw_P(run[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(run[current_frame], ANIM_SIZE);
         }
     }
+
+#    if OLED_TIMEOUT > 0
+    /* the animation prevents the normal timeout from occuring */
+    if (last_input_activity_elapsed() > OLED_TIMEOUT && last_led_activity_elapsed() > OLED_TIMEOUT) {
+        oled_off();
+        return;
+    } else {
+        oled_on();
+    }
+#    endif
 
     /* animation timer */
     if (timer_elapsed32(anim_timer) > ANIM_FRAME_DURATION) {
         anim_timer = timer_read32();
         animate_luna();
     }
-
-    /* this fixes the screen on and off bug */
-    if (current_wpm > 0) {
-        oled_on();
-        anim_sleep = timer_read32();
-    } else if (timer_elapsed32(anim_sleep) > OLED_TIMEOUT) {
-        oled_off();
-    }
 }
-
 
 /* KEYBOARD PET END */
 

--- a/keyboards/sofle/keymaps/flare576/graphics.c
+++ b/keyboards/sofle/keymaps/flare576/graphics.c
@@ -156,16 +156,16 @@ static void render_luna(int LUNA_X, int LUNA_Y) {
         current_frame = (current_frame + 1) % 2;
 
         if(isSneaking) {
-            oled_write_raw_P(sneak[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sneak[current_frame], ANIM_SIZE);
 
         } else if(current_wpm <= MIN_WALK_SPEED) {
-            oled_write_raw_P(sit[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sit[current_frame], ANIM_SIZE);
 
         } else if(current_wpm <= MIN_RUN_SPEED) {
-            oled_write_raw_P(walk[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(walk[current_frame], ANIM_SIZE);
 
         } else {
-            oled_write_raw_P(run[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(run[current_frame], ANIM_SIZE);
         }
     }
 

--- a/keyboards/sofle/keymaps/helltm/keymap.c
+++ b/keyboards/sofle/keymaps/helltm/keymap.c
@@ -188,7 +188,6 @@ static uint16_t held_shift = 0;
 
 /* timers */
 uint32_t anim_timer = 0;
-uint32_t anim_sleep = 0;
 
 /* current frame */
 uint8_t current_frame = 0;
@@ -280,34 +279,36 @@ static void render_luna(int LUNA_X, int LUNA_Y) {
 
         /* current status */
         if (led_usb_state.caps_lock) {
-            oled_write_raw_P(bark[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(bark[current_frame], ANIM_SIZE);
 
         } else if (isSneaking) {
-            oled_write_raw_P(sneak[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sneak[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_WALK_SPEED) {
-            oled_write_raw_P(sit[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(sit[current_frame], ANIM_SIZE);
 
         } else if (current_wpm <= MIN_RUN_SPEED) {
-            oled_write_raw_P(walk[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(walk[current_frame], ANIM_SIZE);
 
         } else {
-            oled_write_raw_P(run[abs(1 - current_frame)], ANIM_SIZE);
+            oled_write_raw_P(run[current_frame], ANIM_SIZE);
         }
     }
+
+#    if OLED_TIMEOUT > 0
+    /* the animation prevents the normal timeout from occuring */
+    if (last_input_activity_elapsed() > OLED_TIMEOUT && last_led_activity_elapsed() > OLED_TIMEOUT) {
+        oled_off();
+        return;
+    } else {
+        oled_on();
+    }
+#    endif
 
     /* animation timer */
     if (timer_elapsed32(anim_timer) > ANIM_FRAME_DURATION) {
         anim_timer = timer_read32();
         animate_luna();
-    }
-
-    /* this fixes the screen on and off bug */
-    if (current_wpm > 0) {
-        oled_on();
-        anim_sleep = timer_read32();
-    } else if (timer_elapsed32(anim_sleep) > OLED_TIMEOUT) {
-        oled_off();
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
The old keyboard pet code would cause the screen to flicker after timeout because the animation would keep on running and each new frame would turn the screen on, after which the timeout logic would turn it off (provided the screen was idle for `> OLED_TIMEOUT`). The same flicker would be triggered by other triggers that turn the screen on, for instance toggling Caps Lock.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The on/off bug is fixed by using the animation idle timer (`anim_sleep`) also to track whether the screen is off or not. If the screen turns on (for whatever reason), we restart the timer. Also, we only render the keyboard pet when the screen is on, to prevent causing it to turn on.
<!--- Describe your changes in detail here. -->

## Implications and Alternatives

The keyboard pet OLED timeout logic duplicates the timeout logic in the OLED driver. There are two more thorough solutions I can think of that make reimplementing the logic unnecessary.

1. If the wpm counter drops to 0, we could render a single frame image of a sleeping pet. As this image doesn't change, the screen doesn't update and the timeout isn't reset each time the pet is rendered.
2. Support for `OLED_IDLE_BLOCKS_MASK` is easy to implement. This macro would specify a `OLED_BLOCK_TYPE` value and blocks in the mask would not cause the screen to be turned on (and the timeout timer to be reset).

For (2), the `oled_on()` line in `drivers/oled/ssd1306_sh1106.c:oled_render` would change to
```c
    if ((OLED_BLOCK_TYPE)1 << update_start) & ~((OLED_BLOCK_TYPE) OLED_IDLE_BLOCKS_MASK) {
        oled_on();
    }
```
This second option would offer a generic solution for using the screen timeout when a long-running animation is being shown. The downside is that figuring out the correct blocks mask is not very ergonomic. It is also a bit of a misuse of the block-based rendering logic.

As a remnant of looking into this, I had the addition of an assertion in the OLED driver implementation laying around. I added it to this PR. The assertion is violated in [code](https://github.com/qmk/qmk_firmware/blob/0.16.9/keyboards/rate/pistachio_pro/config.h) by @7-rate, but indeed: that code is broken since support for fonts with lines of any height other than 8 pixels is not implemented.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Screen on/off bug with the Luna keyboard pet by @HellSingCoder.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
