### PR TITLE
[keyboard] annepro2 Add and use functions to directly control led colors

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -106,6 +106,7 @@ void keyboard_post_init_kb(void) {
 
     #ifdef RGB_MATRIX_ENABLE
     ap2_led_enable();
+    ap2_led_set_manual_control(1);
     #endif
 
     keyboard_post_init_user();
@@ -129,7 +130,7 @@ void matrix_scan_kb() {
     if(rgb_row_changed[current_rgb_row])
     {
         rgb_row_changed[current_rgb_row] = 0;
-        ap2_led_mask_set_row(current_rgb_row);
+        ap2_led_colors_set_row(current_rgb_row);
     }
     current_rgb_row = (current_rgb_row + 1) % NUM_ROW;
     #endif

--- a/keyboards/annepro2/ap2_led.c
+++ b/keyboards/annepro2/ap2_led.c
@@ -22,6 +22,7 @@
 #include "protocol.h"
 
 ap2_led_t       led_mask[KEY_COUNT];
+ap2_led_t       led_colors[KEY_COUNT];
 ap2_led_status_t ap2_led_status;
 uint8_t rgb_row_changed[NUM_ROW];
 
@@ -90,6 +91,32 @@ void ap2_led_mask_set_all(void) {
 
 /* Set all keys to a given color */
 void ap2_led_mask_set_mono(const ap2_led_t color) { proto_tx(CMD_LED_MASK_SET_MONO, (uint8_t *)&color, sizeof(color), 1); }
+
+void ap2_led_colors_set_key(uint8_t row, uint8_t col, ap2_led_t color) {
+    uint8_t payload[] = {row, col, color.p.blue, color.p.green, color.p.red, color.p.alpha};
+    proto_tx(CMD_LED_COLOR_SET_KEY, payload, sizeof(payload), 1);
+}
+
+/* Push a whole local row to the shine */
+void ap2_led_colors_set_row(uint8_t row) {
+    uint8_t payload[NUM_COLUMN * sizeof(ap2_led_t) + 1];
+    payload[0] = row;
+    memcpy(payload + 1, &led_colors[ROWCOL2IDX(row, 0)], sizeof(*led_colors) * NUM_COLUMN);
+    proto_tx(CMD_LED_COLOR_SET_ROW, payload, sizeof(payload), 1);
+}
+
+/* Synchronize all rows */
+void ap2_led_colors_set_all(void) {
+    for (int row = 0; row < 5; row++) ap2_led_colors_set_row(row);
+}
+
+/* Set all keys to a given color */
+void ap2_led_colors_set_mono(const ap2_led_t color) { proto_tx(CMD_LED_COLOR_SET_MONO, (uint8_t *)&color, sizeof(color), 1); }
+
+void ap2_led_set_manual_control(uint8_t manual) {
+    uint8_t payload[] = {manual};
+    proto_tx(CMD_LED_SET_MANUAL, payload, sizeof(payload), 1);
+}
 
 void ap2_led_blink(uint8_t row, uint8_t col, ap2_led_t color, uint8_t count, uint8_t hundredths) {
     uint8_t payload[] = {row, col, color.p.blue, color.p.green, color.p.red, color.p.alpha, count, hundredths};

--- a/keyboards/annepro2/ap2_led.h
+++ b/keyboards/annepro2/ap2_led.h
@@ -40,6 +40,7 @@ typedef union {
 
 /* Local copy of led_mask, used to override colors on the board */
 extern ap2_led_t led_mask[KEY_COUNT];
+extern ap2_led_t led_colors[KEY_COUNT];
 extern uint8_t rgb_row_changed[NUM_ROW];
 
 /* Handle incoming messages */
@@ -65,6 +66,18 @@ void ap2_led_mask_set_all(void);
 
 /* Set all keys to a given color */
 void ap2_led_mask_set_mono(ap2_led_t color);
+
+/* Set single key to a given color; alpha controls which is displayed */
+void ap2_led_colors_set_key(uint8_t row, uint8_t col, ap2_led_t color);
+/* Push a whole local row to the shine */
+void ap2_led_colors_set_row(uint8_t row);
+/* Synchronize all rows */
+void ap2_led_colors_set_all(void);
+
+/* Set all keys to a given color */
+void ap2_led_colors_set_mono(ap2_led_t color);
+
+void ap2_led_set_manual_control(uint8_t manual);
 
 /* Blink given key `count` times by masking it with a `color`. Blink takes `hundredths` of a second */
 void ap2_led_blink(uint8_t row, uint8_t col, ap2_led_t color, uint8_t count, uint8_t hundredths);

--- a/keyboards/annepro2/protocol.h
+++ b/keyboards/annepro2/protocol.h
@@ -42,6 +42,12 @@ enum {
     CMD_LED_KEY_UP     = 0x23, /* TODO */
     CMD_LED_IAP        = 0x24,
 
+    /* Manual color control */
+    CMD_LED_SET_MANUAL = 0x30,
+    CMD_LED_COLOR_SET_KEY = 0x31,
+    CMD_LED_COLOR_SET_ROW = 0x32,
+    CMD_LED_COLOR_SET_MONO = 0x33,
+
     /* LED -> Main */
     /* Payload with data to send over HID */
     CMD_LED_DEBUG = 0x40,

--- a/keyboards/annepro2/rgb_driver.c
+++ b/keyboards/annepro2/rgb_driver.c
@@ -36,11 +36,11 @@ void init(void) {
 void flush(void) {}
 
 void set_color(int index, uint8_t r, uint8_t g, uint8_t b) {
-    if (r != led_mask[led_pos[index]].p.red   ||
-        g != led_mask[led_pos[index]].p.green ||
-        b != led_mask[led_pos[index]].p.blue)
+    if (r != led_colors[led_pos[index]].p.red   ||
+        g != led_colors[led_pos[index]].p.green ||
+        b != led_colors[led_pos[index]].p.blue)
         {
-            led_mask[led_pos[index]] = (ap2_led_t){
+            led_colors[led_pos[index]] = (ap2_led_t){
                 .p.blue  = b,
                 .p.red   = r,
                 .p.green = g,


### PR DESCRIPTION
This change utilizes new AnnePro2-Shine functionality and allows users to utilize the led_mask layer to set e.g. caps lock indicator while using the QMK rgb animations.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I have added functions that utilize new AnnePro2-Shine functionality (added [here](https://github.com/OpenAnnePro/AnnePro2-Shine/commit/a0878587e8220d6688e334332613503c246b911d)) to set led color directly rather than through mask. I have also made it so these functions are used for setting animation of the keyboard in `matrix_scan_kb`.

`ap2_led.c` now contains 2 led arrays, one for base layer and one for mask layer. The base layer is used to handle rgb animations, the mask layer can be used by users in their keymap for indicator lights.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
