### PR TITLE
Handle timeout on UART for Redox Wireless receiver-to-keyboard communication.

### DIFF
--- a/keyboards/redox_w/matrix.c
+++ b/keyboards/redox_w/matrix.c
@@ -18,6 +18,8 @@
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -39,11 +41,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = (uint8_t) 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/redox_w/matrix.c
+++ b/keyboards/redox_w/matrix.c
@@ -49,7 +49,7 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
             uart_data[i] = uart_read();
         } else {
-            uart_data[i] = (uint8_t) 0x00;
+            uart_data[i] = 0x00;
         }
     }
 


### PR DESCRIPTION
- This fixes the issue of keyboard deadlocking on the first matrix
  scan with Redox Wireless keyboards

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Resolves #16553. Closes #17071 

This brings back handling time-out in matrix scanning code. Versions `0.15.x` and before handled timeout implicitly, by using a non-blocking `UDR` register read.

The timeout variable is shared across each matrix scan — happy to change it to be individual to each UART byte read instead on a clear recommendation from someone more knowledgeable in UART comms.

The current `HEAD` uses a blocking read, disregarding the timeout code.

From my testing, it looks like it's only ever the first write/receive loop that fails. Debug messages never occured later in the short space I've tested this.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #16553 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
