### PR TITLE
Expose the time of the last change to the LED state

### DIFF
--- a/quantum/led.c
+++ b/quantum/led.c
@@ -15,6 +15,7 @@
  */
 #include "led.h"
 #include "host.h"
+#include "timer.h"
 #include "debug.h"
 #include "gpio.h"
 
@@ -53,6 +54,14 @@ static void handle_backlight_caps_lock(led_t led_state) {
     backlight_set(bl_toggle_lvl);
 }
 #endif
+
+static uint32_t last_led_modification_time = 0;
+uint32_t        last_led_activity_time(void) {
+    return last_led_modification_time;
+}
+uint32_t last_led_activity_elapsed(void) {
+    return timer_elapsed32(last_led_modification_time);
+}
 
 /** \brief Lock LED set callback - keymap/user level
  *
@@ -174,7 +183,8 @@ void led_task(void) {
     // update LED
     uint8_t led_status = host_keyboard_leds();
     if (last_led_status != led_status) {
-        last_led_status = led_status;
+        last_led_status            = led_status;
+        last_led_modification_time = timer_read32();
 
         if (debug_keyboard) {
             debug("led_task: ");

--- a/quantum/led.h
+++ b/quantum/led.h
@@ -61,6 +61,9 @@ void led_set_kb(uint8_t usb_led);
 bool led_update_user(led_t led_state);
 bool led_update_kb(led_t led_state);
 
+uint32_t last_led_activity_time(void);    // Timestamp of the LED activity
+uint32_t last_led_activity_elapsed(void); // Number of milliseconds since the last LED activity
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR is in part a question: would the proposed change make sense? It extends #11552 and  #11595.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This introduces two new functions that mimic
```c
uint32_t last_input_activity_time(void);    // Timestamp of the last matrix or encoder activity
uint32_t last_input_activity_elapsed(void); // Number of milliseconds since the last matrix or encoder activity
```
from `keyboard.h`.

Keyboard activity can come from inside (key and/or encoder activity), or from outside. Outside activity happens in the form of USB 'set' reports that can change the LED state.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Some keyboards use a screen to show the LED state. If such keyboards have a need to implement custom screen timeout logic (e.g. when they show an animation that breaks the normal timeout logic), it would be real easy if they could just do:
```c
    if (timer_elapsed32(MAX(last_input_activity_time(), last_led_activity_time())) > CUSTOM_TIMEOUT) screen_off();
```

I found user code by @bcat and @snowe2010 that wold benefit from this.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
