### PR TITLE
Add Zsh note for tab complete

### DIFF
--- a/docs/cli_tab_complete.md
+++ b/docs/cli_tab_complete.md
@@ -14,7 +14,7 @@ Add this to the end of your `.profile` or `.bashrc`:
 
 If you put `qmk_firmware` into another location you will need to adjust this path.
 
-Zsh users may need to add the following to their `~/.zshrc` file:
+Zsh users will need to load `bashcompinit`. The following can be added to `~/.zshrc` file:
 
     autoload -Uz bashcompinit && bashcompinit
 

--- a/docs/cli_tab_complete.md
+++ b/docs/cli_tab_complete.md
@@ -14,6 +14,10 @@ Add this to the end of your `.profile` or `.bashrc`:
 
 If you put `qmk_firmware` into another location you will need to adjust this path.
 
+Zsh users may need to add the following to their `~/.zshrc` file:
+
+    autoload -Uz bashcompinit && bashcompinit
+
 ### System Wide Symlink
 
 If you want the tab completion available to all users of the system you can add a symlink to the `qmk_tab_complete.sh` script:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

[argcomplete](https://github.com/kislyuk/argcomplete) requires `bashcompinit` to be loaded. Without this, sourcing the tab completion script returns `(eval):46: command not found: complete` on shell startup and does not work. 

## Types of Changes

- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
