### PR TITLE
Fix Caps Word not working with Auto Shift and Combo feature

### DIFF
--- a/quantum/process_keycode/process_caps_word.c
+++ b/quantum/process_keycode/process_caps_word.c
@@ -83,7 +83,13 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
 #endif // CAPS_WORD_IDLE_TIMEOUT > 0
 
     // From here on, we only take action on press events.
-    if (!record->event.pressed) {
+    // The exceptions are the combo results and the chord keys,
+    // which send keypress with a release event.
+    if (!record->event.pressed
+#ifdef COMBO_ENABLE
+        && !caps_word_press_user(keycode)
+#endif // COMBO_ENABLE
+    ) {
         return true;
     }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -298,6 +298,9 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef PRINTING_ENABLE
             process_printer(keycode, record) &&
 #endif
+#ifdef CAPS_WORD_ENABLE
+            process_caps_word(keycode, record) &&
+#endif
 #ifdef AUTO_SHIFT_ENABLE
             process_auto_shift(keycode, record) &&
 #endif
@@ -306,9 +309,6 @@ bool process_record_quantum(keyrecord_t *record) {
 #endif
 #ifdef TERMINAL_ENABLE
             process_terminal(keycode, record) &&
-#endif
-#ifdef CAPS_WORD_ENABLE
-            process_caps_word(keycode, record) &&
 #endif
 #ifdef SPACE_CADET_ENABLE
             process_space_cadet(keycode, record) &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Currently Caps Word feature doesn't work with Auto Shifted keys, result keys and chord keys (which are the part of Combo feature).

This PR fixes the bug by reordering event processing order, and allowing Caps Word process for user Caps Word keys' release event when Combo feature is enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Core
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
