### PR TITLE
Fix Caps Word and Unicode Map

### DIFF
--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -95,6 +95,7 @@ __attribute__((weak)) void unicode_input_start(void) {
 
     unicode_saved_mods = get_mods(); // Save current mods
     clear_mods();                    // Unregister mods to start from a clean state
+    clear_weak_mods();
 
     switch (unicode_config.input_mode) {
         case UC_MAC:

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -289,6 +289,9 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef TAP_DANCE_ENABLE
             process_tap_dance(keycode, record) &&
 #endif
+#ifdef CAPS_WORD_ENABLE
+            process_caps_word(keycode, record) &&
+#endif
 #if defined(UNICODE_COMMON_ENABLE)
             process_unicode_common(keycode, record) &&
 #endif
@@ -306,9 +309,6 @@ bool process_record_quantum(keyrecord_t *record) {
 #endif
 #ifdef TERMINAL_ENABLE
             process_terminal(keycode, record) &&
-#endif
-#ifdef CAPS_WORD_ENABLE
-            process_caps_word(keycode, record) &&
 #endif
 #ifdef SPACE_CADET_ENABLE
             process_space_cadet(keycode, record) &&


### PR DESCRIPTION
## Description

Caps Word doesn't work with Unicode Map pairs `XP(a, A)`.

I changed order of calling `process_caps_word` in `process_record_quantum`. Moved it before `process_unicode_common`.

In `unicode_input_start` I just clear `weak_mods`. I don't know if it breaks anything else. I'm still a little bit confused with weak mods and how they work. Maybe save and restore `weak_mods` after sending unicode keys, just like `mods`? Or is it unnecessary?

User function `caps_word_press_user` can look like this:

    bool caps_word_press_user(uint16_t keycode) {
        switch (keycode) {
            case KC_A ... KC_Z:
            case QK_UNICODEMAP_PAIR ... QK_UNICODEMAP_PAIR_MAX: // use whole range or filter only required pairs
                add_weak_mods(MOD_BIT(KC_LSFT));
                return true;
    
            default:
                return false;
        }
    }

Btw I just noticed that there is also another bug fix (#17240) that changes the order of calling `process_caps_word`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
