### PR TITLE
Ensure eeconfig initialised before reading EEPROM handedness.

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -135,6 +135,10 @@ void split_pre_init(void) {
 #if defined(SPLIT_HAND_PIN)
     setPinInput(SPLIT_HAND_PIN);
     wait_us(100);
+#elif defined(EE_HANDS)
+    if (!eeconfig_is_enabled()) {
+        eeconfig_init();
+    }
 #endif
     isLeftHand = is_keyboard_left();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I noticed while using transient EEPROM and EE_HANDS that flashing using uf2-split-left, the left side matrix behaved as the right but the LEDs behaved correctly. This appears to be due to the eeconfig handedness being read before it's initialised returning 0.

I've added a check to split_pre_init to ensure eeconfig is enabled and initialise if not.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
