### PR TITLE
Change AW20216 SPI Mode from 0 to 3, to fix RGB LEDs on GMMK Pro

### DIFF
--- a/drivers/led/aw20216.c
+++ b/drivers/led/aw20216.c
@@ -63,7 +63,7 @@ bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 bool AW20216_write(pin_t cs_pin, uint8_t page, uint8_t reg, uint8_t* data, uint8_t len) {
     static uint8_t s_spi_transfer_buffer[2] = {0};
 
-    if (!spi_start(cs_pin, false, 0, AW_SPI_DIVISOR)) {
+    if (!spi_start(cs_pin, false, 3, AW_SPI_DIVISOR)) {
         spi_stop();
         return false;
     }


### PR DESCRIPTION
## Description

As observed in #17250, SPI Mode 0 currently causes issues on 0.17.0 and changing to SPI Mode 3 fixes the issue. This is considered a quick fix, and can be improved upon later by making a configurable mode.

Relevant discord discussion: https://discord.com/channels/440868230475677696/473506116718952450/981047895031705680

```
tzarc — Today at 11:14 PM
kinda smells like the SPI issues I had with the displays on the Djinn
I 'fixed" it my swapping to SPI mode 3
https://github.com/qmk/qmk_firmware/blob/master/drivers/led/aw20216.c#L66
try swapping the 0 to 3

triggerofsol — Today at 11:17 PM
oh, that worked!

tzarc — Today at 11:18 PM
bugger
that means ChibiOS bug

Drashna — Today at 11:19 PM
I'm probably using mode 3 already 😅
Yup

triggerofsol — Today at 11:21 PM
so do i send a pr to change the 0 to a 3, or is there some other better fix

Drashna — Today at 11:21 PM
For now, that's probably the best solution
And as a bugfix PR to master, rather than develop
Longer term, would probably be best to have a configurable mode for it

tzarc — Today at 11:22 PM
make it configurable now, as part of the bugfix
if/when there's a ChibiOS fix then it'll need to go back

triggerofsol — Today at 11:23 PM
how would i make it configurable ^_^;
i was literally just about to send a PR that does nothing except change the 0 to a 3

tzarc — Today at 11:25 PM
just do that, then
can handle it "properly" on develop later
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix #17250

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
