### PR TITLE
Make SPI Mode configurable for AW20216 and change default mode to 3

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -409,6 +409,7 @@ You can use up to 2 AW20216 IC's. Do not specify `DRIVER_<N>_xxx` defines for IC
 | `DRIVER_LED_TOTAL` | (Required) How many RGB lights are present across all drivers | |
 | `AW_SCALING_MAX` | (Optional) LED current scaling value (0-255, higher values mean LED is brighter at full PWM) | 150 |
 | `AW_GLOBAL_CURRENT_MAX` | (Optional) Driver global current limit (0-255, higher values means the driver may consume more power) | 150 |
+| `AW_SPI_MODE` | (Optional) Mode for SPI communication (0-3, defines polarity and phase of the clock) | 3 |
 | `AW_SPI_DIVISOR` | (Optional) Clock divisor for SPI communication (powers of 2, smaller numbers means faster communication, should not be less than 4) | 4 |
 
 Here is an example using 2 drivers.

--- a/drivers/led/aw20216.c
+++ b/drivers/led/aw20216.c
@@ -53,6 +53,10 @@
 #    define AW_GLOBAL_CURRENT_MAX 150
 #endif
 
+#ifndef AW_SPI_MODE
+#    define AW_SPI_MODE 3
+#endif
+
 #ifndef AW_SPI_DIVISOR
 #    define AW_SPI_DIVISOR 4
 #endif
@@ -63,7 +67,7 @@ bool    g_pwm_buffer_update_required[DRIVER_COUNT] = {false};
 bool AW20216_write(pin_t cs_pin, uint8_t page, uint8_t reg, uint8_t* data, uint8_t len) {
     static uint8_t s_spi_transfer_buffer[2] = {0};
 
-    if (!spi_start(cs_pin, false, 3, AW_SPI_DIVISOR)) {
+    if (!spi_start(cs_pin, false, AW_SPI_MODE, AW_SPI_DIVISOR)) {
         spi_stop();
         return false;
     }


### PR DESCRIPTION
## Description

Counterpart to #17262 but for `develop` branch instead of `master` branch

This PR makes the SPI Mode configurable for the AW20216. In  `master` branch, the bug was fixed by simply changing the mode from a hardcoded mode 0 to a hardcoded mode 3. Here in `develop` branch, we instead define a new variable `AW_SPI_MODE` which defaults to 3 but can more easily be changed/defined in `config.h` to be any value in 0, 1, 2, 3 without needing to touch the driver code at all.

Relevant Discord discussion: https://discord.com/channels/440868230475677696/473506116718952450/981056233152839690

```
Drashna — Yesterday at 11:47 PM
For making it configurable, look at the divider stuff.  Same idea.

triggerofsol — Today at 12:01 AM
Should I make the "configuration" PR against develop instead of master, then?

tzarc — Today at 12:01 AM
yeah that'd be great
basically identical to AW_SPI_DIVISOR yeah?

triggerofsol — Today at 12:02 AM
that is how i see it, yes

tzarc — Today at 12:02 AM
cool, just make sure you update docs/feature_rgb_matrix.md as well, it has the configurable options listed

triggerofsol — Today at 12:02 AM
#define AW_SPI_MODE 3

tzarc — Today at 12:02 AM
(for that driver)
perfect

triggerofsol — Today at 12:03 AM
yeah i was gonna say i saw the docs too

tzarc — Today at 12:03 AM
👍
good stuff

triggerofsol — Today at 12:09 AM
| `AW_SPI_MODE` | (Optional) Mode for SPI communication (0-3, defines polarity and phase of the clock) | 3 |

tzarc — Today at 12:10 AM
sounds good
ship it!
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fix #17250 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
