### PR TITLE
Pillow python dependency provided for NIX

### DIFF
--- a/util/nix/pyproject.toml
+++ b/util/nix/pyproject.toml
@@ -30,6 +30,7 @@ nose2 = "*"
 flake8 = "*"
 pep8-naming = "*"
 yapf = "*"
+pillow = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
QMK requires pillow python dependency, but NIX project definition lacks of it

## Description

Project requires python pillow and [requirements.txt](https://github.com/qmk/qmk_firmware/blob/master/requirements.txt) contains this dependency. But NIX project definition file doesn't.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
