### PR TITLE
Add Encoder Map Swap Hands config for boards that support both features

### DIFF
--- a/keyboards/keebio/iris/rev3/rev3.c
+++ b/keyboards/keebio/iris/rev3/rev3.c
@@ -17,6 +17,9 @@ const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
     {{0,3}, {1,3}, {2,3}, {3,3}, {4,3}, {5,3}},
     {{0,4}, {1,4}, {2,4}, {3,4}, {4,4}, {5,4}},
 };
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {1, 0};
+#    endif
 #endif
 
 void eeconfig_init_kb(void) {

--- a/keyboards/lime/lime.c
+++ b/keyboards/lime/lime.c
@@ -43,4 +43,7 @@ const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATRIX_COLS] =
  { {0, 5}, {1, 5}, {2, 5}, {3, 5}, {4, 5}, {5, 5} }, \
 };
 
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {0};
+#    endif
 #endif

--- a/keyboards/planck/planck.c
+++ b/keyboards/planck/planck.c
@@ -8,6 +8,9 @@ const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
   {{11, 2}, {10, 2}, {9, 2}, {8, 2}, {7, 2}, {6, 2}, {5, 2}, {4, 2}, {3, 2}, {2, 2}, {1, 2}, {0, 2}},
   {{11, 3}, {10, 3}, {9, 3}, {8, 3}, {7, 3}, {6, 3}, {5, 3}, {4, 3}, {3, 3}, {2, 3}, {1, 3}, {0, 3}},
 };
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {0};
+#    endif
 #endif
 
 __attribute__ ((weak))

--- a/keyboards/preonic/rev3/rev3.c
+++ b/keyboards/preonic/rev3/rev3.c
@@ -58,4 +58,7 @@ const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
     {{5, 8}, {4, 8}, {3, 8}, {2, 8}, {1, 8}, {0, 8}},
     {{5, 9}, {4, 9}, {3, 9}, {2, 9}, {1, 9}, {0, 9}},
 };
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {0};
+#    endif
 #endif

--- a/keyboards/preonic/rev3_drop/rev3_drop.c
+++ b/keyboards/preonic/rev3_drop/rev3_drop.c
@@ -58,4 +58,7 @@ const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
     {{5, 8}, {4, 8}, {3, 8}, {2, 8}, {1, 8}, {0, 8}},
     {{5, 9}, {4, 9}, {3, 9}, {2, 9}, {1, 9}, {0, 9}},
 };
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {0};
+#    endif
 #endif

--- a/keyboards/sofle/sofle.c
+++ b/keyboards/sofle/sofle.c
@@ -39,4 +39,8 @@ const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATRIX_COLS] =
  { {0, 4}, {1, 4}, {2, 4}, {3, 4}, {4, 4}, {5, 4} }, \
 };
 
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {1, 0};
+#    endif
+
 #endif

--- a/keyboards/splitkb/kyria/rev1/rev1.c
+++ b/keyboards/splitkb/kyria/rev1/rev1.c
@@ -28,6 +28,9 @@ __attribute__ ((weak)) const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATR
     {{0, 3}, {1, 3}, {2, 3}, {3, 3}, {4, 3}, {5, 3}, {6, 3}, {7, 3}}
 };
 // clang-format on
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {1, 0};
+#    endif
 #endif
 
 #ifdef RGB_MATRIX_ENABLE

--- a/keyboards/splitkb/kyria/rev2/rev2.c
+++ b/keyboards/splitkb/kyria/rev2/rev2.c
@@ -43,6 +43,9 @@ __attribute__ ((weak)) const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATR
     {{0, 3}, {1, 3}, {2, 3}, {3, 3}, {4, 3}, {5, 3}, {6, 3}, {7, 3}}
 };
 // clang-format on
+#    ifdef ENCODER_MAP_ENABLE
+const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS] = {1, 0};
+#    endif
 #endif
 
 #ifdef RGB_MATRIX_ENABLE


### PR DESCRIPTION
## Description

Adds missing configs for the boards that support both Encoders and Swap Hands features, so that encoder map will compile properly, if enabled. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
