### PR TITLE
Move more UART-based keyboards to use timeout correctly.

### DIFF
--- a/keyboards/centromere/matrix.c
+++ b/keyboards/centromere/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(500000);
 }
@@ -39,11 +41,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //wait for the serial data, timeout if it's been too long
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/dichotomy/matrix.c
+++ b/keyboards/dichotomy/matrix.c
@@ -48,6 +48,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MAIN_ROWMASK 0xFFF0;
 #define LOWER_ROWMASK 0x3FC0;
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
 
@@ -96,8 +98,6 @@ void matrix_init(void) {
 
 uint8_t matrix_scan(void)
 {
-    //xprintf("\r\nTRYING TO SCAN");
-
     uint32_t timeout = 0;
 
     //the s character requests the RF slave to send the matrix
@@ -113,18 +113,22 @@ uint8_t matrix_scan(void)
         //harm to leave it in here
         while(!uart_available()){
             timeout++;
-            if (timeout > 10000){
-		xprintf("\r\nTime out in keyboard.");
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0
     //will only show up here if the correct bytes were recieved
             uint8_t checksum = 0x00;
-            for (uint8_t z=0; z<10; z++){
+            for (uint8_t z = 0; z < 10; z++){
                 checksum = checksum^uart_data[z];
             }
             checksum = checksum ^ (uart_data[10] & 0xF0);

--- a/keyboards/glenpickle/chimera_ergo/matrix.c
+++ b/keyboards/glenpickle/chimera_ergo/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/glenpickle/chimera_ls/matrix.c
+++ b/keyboards/glenpickle/chimera_ls/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/glenpickle/chimera_ortho/matrix.c
+++ b/keyboards/glenpickle/chimera_ortho/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/glenpickle/chimera_ortho_plus/matrix.c
+++ b/keyboards/glenpickle/chimera_ortho_plus/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/keyhive/honeycomb/matrix.c
+++ b/keyboards/keyhive/honeycomb/matrix.c
@@ -46,6 +46,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # define ROW_SHIFTER  ((uint32_t)1)
 #endif
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 /* matrix state(1:on, 0:off) */
 static matrix_row_t matrix[MATRIX_ROWS];
 //extern int8_t encoderValue;
@@ -112,12 +114,16 @@ uint8_t matrix_scan(void)
         // harm to leave it in here
         while(!uart_available()){
             timeout++;
-            if (timeout > 10000){
-                xprintf("\r\nTime out in keyboard.");
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     // Check for the end packet, it's our checksum.

--- a/keyboards/mitosis/matrix.c
+++ b/keyboards/mitosis/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -34,18 +36,23 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     //trust the external keystates entirely, erase the last data
     uint8_t uart_data[11] = {0};
 
-    //there are 10 bytes corresponding to 10 columns, and an end byte
+    //there are 10 bytes corresponding to 10 columns, and then an end byte
     for (uint8_t i = 0; i < 11; i++) {
         //wait for the serial data, timeout if it's been too long
         //this only happened in testing with a loose wire, but does no
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/redox_w/matrix.c
+++ b/keyboards/redox_w/matrix.c
@@ -34,7 +34,7 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     //trust the external keystates entirely, erase the last data
     uint8_t uart_data[11] = {0};
 
-    //there are 14 bytes corresponding to 14 columns, and an end byte
+    //there are 10 bytes corresponding to 10 columns, and then an end byte
     for (uint8_t i = 0; i < 11; i++) {
         //wait for the serial data, timeout if it's been too long
         //this only happened in testing with a loose wire, but does no

--- a/keyboards/satt/comet46/matrix.c
+++ b/keyboards/satt/comet46/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/sirius/uni660/rev1/matrix.c
+++ b/keyboards/sirius/uni660/rev1/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/sirius/uni660/rev2/matrix.c
+++ b/keyboards/sirius/uni660/rev2/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0

--- a/keyboards/telophase/matrix.c
+++ b/keyboards/telophase/matrix.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "uart.h"
 
+#define UART_MATRIX_RESPONSE_TIMEOUT 10000
+
 void matrix_init_custom(void) {
     uart_init(1000000);
 }
@@ -41,11 +43,16 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         //harm to leave it in here
         while (!uart_available()) {
             timeout++;
-            if (timeout > 10000) {
+            if (timeout > UART_MATRIX_RESPONSE_TIMEOUT) {
                 break;
             }
         }
-        uart_data[i] = uart_read();
+
+        if (timeout < UART_MATRIX_RESPONSE_TIMEOUT) {
+            uart_data[i] = uart_read();
+        } else {
+            uart_data[i] = 0x00;
+        }
     }
 
     //check for the end packet, the key state bytes use the LSBs, so 0xE0


### PR DESCRIPTION
- this uses the approach used recently in Redox Wireless to fix the
  blocking UART read issue

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This follows-up on the fix implemented for `redox_w` keyboard (issue: #16553, PR: #17203), replicating the timeout mechanism to similarly working keyboards.

Includes tiny comment updates for consistency.

The following keyboards could be impacted:

- [ ] centromere
- [ ] dichotomy
- [ ] glenpickle/chimera_ergo
- [ ] glenpickle/chimera_ls
- [ ] glenpickle/chimera_ortho
- [ ] glenpickle/chimera_ortho_plus
- [ ] keyhive/honeycomb
- [ ] mitosis
- [ ] satt/comet46
- [ ] sirius/uni660/rev1
- [ ] sirius/uni660/rev2
- [ ] telophase

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

For the last point, a test from owners of keyboards listed in Description section would be great.