### PR TITLE
Add WB32 evaluation board onekey targets.

### DIFF
--- a/keyboards/handwired/onekey/evb_wb32f3g71/config.h
+++ b/keyboards/handwired/onekey/evb_wb32f3g71/config.h
@@ -1,0 +1,11 @@
+// Copyright 2021 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include "config_common.h"
+
+#define PRODUCT Onekey WB32F3G71
+
+#define MATRIX_COL_PINS { B12 }
+#define MATRIX_ROW_PINS { B13 }
+#define UNUSED_PINS

--- a/keyboards/handwired/onekey/evb_wb32f3g71/readme.md
+++ b/keyboards/handwired/onekey/evb_wb32f3g71/readme.md
@@ -1,0 +1,3 @@
+# Westberry Tech WB32F3G71 Evaluation Board Onekey
+
+To trigger keypress, short together pins *B12* and *B13*.

--- a/keyboards/handwired/onekey/evb_wb32f3g71/rules.mk
+++ b/keyboards/handwired/onekey/evb_wb32f3g71/rules.mk
@@ -1,0 +1,9 @@
+# MCU name
+MCU = WB32F3G71
+
+# Bootloader selection
+BOOTLOADER = wb32-dfu
+
+MOUSEKEY_ENABLE = no       # Mouse keys
+EXTRAKEY_ENABLE = no       # Audio control and System control
+NKRO_ENABLE = no           # Enable N-Key Rollover

--- a/keyboards/handwired/onekey/evb_wb32fq95/config.h
+++ b/keyboards/handwired/onekey/evb_wb32fq95/config.h
@@ -1,0 +1,11 @@
+// Copyright 2021 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include "config_common.h"
+
+#define PRODUCT Onekey WB32FQ95
+
+#define MATRIX_COL_PINS { B12 }
+#define MATRIX_ROW_PINS { B13 }
+#define UNUSED_PINS

--- a/keyboards/handwired/onekey/evb_wb32fq95/readme.md
+++ b/keyboards/handwired/onekey/evb_wb32fq95/readme.md
@@ -1,0 +1,3 @@
+# Westberry Tech WB32FQ95 Evaluation Board Onekey
+
+To trigger keypress, short together pins *B12* and *B13*.

--- a/keyboards/handwired/onekey/evb_wb32fq95/rules.mk
+++ b/keyboards/handwired/onekey/evb_wb32fq95/rules.mk
@@ -1,0 +1,9 @@
+# MCU name
+MCU = WB32FQ95
+
+# Bootloader selection
+BOOTLOADER = wb32-dfu
+
+MOUSEKEY_ENABLE = no       # Mouse keys
+EXTRAKEY_ENABLE = no       # Audio control and System control
+NKRO_ENABLE = no           # Enable N-Key Rollover


### PR DESCRIPTION
## Description

So Tz CI has something that exercises these boards.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
