### PR TITLE
[Keyboard] Fix kprepublic bm60hsrgb_ec rev2 compilation issues

### DIFF
--- a/keyboards/kprepublic/bm60hsrgb_ec/rev2/keymaps/default/keymap.c
+++ b/keyboards/kprepublic/bm60hsrgb_ec/rev2/keymaps/default/keymap.c
@@ -73,18 +73,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,  KC_GRV,  KC_PGUP, KC_PGDN,
         KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,
         KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
         KC_LSFT,          KC_Z,   KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_RSFT,        KC_UP,   KC_SLSH,
         KC_LCTL,   KC_LGUI,   KC_LALT,                       KC_SPC,                              KC_RALT, MO(1),   KC_LEFT, KC_DOWN, KC_RGHT
     ),
     [1] = LAYOUT(
-        _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  RESET,
+        _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  RESET,  _______, _______, _______,
         _______,     RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______, _______, _______, _______,
         _______,       RMT,  RMS,  RMIH,  RMDH,  RMIS,  RMDS,  RMIV,  RMDV, _______, _______, _______, _______,
         _______,            _______, _______, _______, _______, _______, NK_TOGG, _______, _______, _______, _______,        _______, _______,
         _______,   _______,   _______,                      _______,                              _______, _______, _______, _______, _______
-    ),
-
+    )
 };

--- a/keyboards/kprepublic/bm60hsrgb_ec/rev2/keymaps/via/rules.mk
+++ b/keyboards/kprepublic/bm60hsrgb_ec/rev2/keymaps/via/rules.mk
@@ -1,2 +1,1 @@
 VIA_ENABLE = yes
-LTO_ENABLE = yes

--- a/keyboards/kprepublic/bm60hsrgb_ec/rev2/rules.mk
+++ b/keyboards/kprepublic/bm60hsrgb_ec/rev2/rules.mk
@@ -19,3 +19,4 @@ AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
 RGB_MATRIX_DRIVER = IS31FL3733
 ENCODER_ENABLE = yes
+LTO_ENABLE = yes


### PR DESCRIPTION
## Description

Layout malformed in default keymap...

Size to large, LTO enabled for board in general, not just via keymap. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
