### PR TITLE
Scale brigthness for VIA

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -64,7 +64,7 @@ void via_qmk_rgblight_get_value(uint8_t *data);
 #endif
 
 #if defined(VIA_QMK_RGB_MATRIX_ENABLE)
-#include <lib/lib8tion/lib8tion.h>
+#    include <lib/lib8tion/lib8tion.h>
 void via_qmk_rgb_matrix_set_value(uint8_t *data);
 void via_qmk_rgb_matrix_get_value(uint8_t *data);
 void eeconfig_update_rgb_matrix(void);

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -422,7 +422,7 @@ void via_qmk_backlight_get_value(uint8_t *data) {
     switch (*value_id) {
         case id_qmk_backlight_brightness: {
             // level / BACKLIGHT_LEVELS * 255
-            value_data[0] = ((uint16_t)get_backlight_level()) * 255 / BACKLIGHT_LEVELS;
+            value_data[0] = ((uint16_t)get_backlight_level() * UINT8_MAX) / BACKLIGHT_LEVELS;
             break;
         }
         case id_qmk_backlight_effect: {
@@ -442,7 +442,7 @@ void via_qmk_backlight_set_value(uint8_t *data) {
     switch (*value_id) {
         case id_qmk_backlight_brightness: {
             // level / 255 * BACKLIGHT_LEVELS
-            backlight_level_noeeprom(((uint16_t)value_data[0]) * BACKLIGHT_LEVELS / 255);
+            backlight_level_noeeprom(((uint16_t)value_data[0] * BACKLIGHT_LEVELS) / UINT8_MAX);
             break;
         }
         case id_qmk_backlight_effect: {
@@ -467,7 +467,7 @@ void via_qmk_rgblight_get_value(uint8_t *data) {
     uint8_t *value_data = &(data[1]);
     switch (*value_id) {
         case id_qmk_rgblight_brightness: {
-            value_data[0] = rgblight_get_val();
+            value_data[0] = ((uint16_t)rgblight_get_val() * UINT8_MAX) / RGBLIGHT_LIMIT_VAL;
             break;
         }
         case id_qmk_rgblight_effect: {
@@ -491,7 +491,7 @@ void via_qmk_rgblight_set_value(uint8_t *data) {
     uint8_t *value_data = &(data[1]);
     switch (*value_id) {
         case id_qmk_rgblight_brightness: {
-            rgblight_sethsv_noeeprom(rgblight_get_hue(), rgblight_get_sat(), value_data[0]);
+            rgblight_sethsv_noeeprom(rgblight_get_hue(), rgblight_get_sat(), ((uint16_t)value_data[0] * RGBLIGHT_LIMIT_VAL) / UINT8_MAX;
             break;
         }
         case id_qmk_rgblight_effect: {
@@ -558,7 +558,7 @@ void via_qmk_rgb_matrix_get_value(uint8_t *data) {
     uint8_t *value_data = &(data[1]);
     switch (*value_id) {
         case id_qmk_rgblight_brightness:
-            value_data[0] = ((uint16_t)rgb_matrix_get_val() * 255) / RGB_MATRIX_MAXIMUM_BRIGHTNESS;
+            value_data[0] = ((uint16_t)rgb_matrix_get_val() * UINT8_MAX) / RGB_MATRIX_MAXIMUM_BRIGHTNESS;
             break;
         case id_qmk_rgblight_effect:
             value_data[0] = rgb_matrix_get_mode();

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -64,6 +64,7 @@ void via_qmk_rgblight_get_value(uint8_t *data);
 #endif
 
 #if defined(VIA_QMK_RGB_MATRIX_ENABLE)
+#include <lib/lib8tion/lib8tion.h>
 void via_qmk_rgb_matrix_set_value(uint8_t *data);
 void via_qmk_rgb_matrix_get_value(uint8_t *data);
 void eeconfig_update_rgb_matrix(void);
@@ -557,7 +558,7 @@ void via_qmk_rgb_matrix_get_value(uint8_t *data) {
     uint8_t *value_data = &(data[1]);
     switch (*value_id) {
         case id_qmk_rgblight_brightness:
-            value_data[0] = rgb_matrix_get_val();
+            value_data[0] = ((uint16_t)rgb_matrix_get_val() * 255) / RGB_MATRIX_MAXIMUM_BRIGHTNESS;
             break;
         case id_qmk_rgblight_effect:
             value_data[0] = rgb_matrix_get_mode();
@@ -577,7 +578,7 @@ void via_qmk_rgb_matrix_set_value(uint8_t *data) {
     uint8_t *value_data = &(data[1]);
     switch (*value_id) {
         case id_qmk_rgblight_brightness:
-            rgb_matrix_sethsv_noeeprom(rgb_matrix_get_hue(), rgb_matrix_get_sat(), value_data[0]);
+            rgb_matrix_sethsv_noeeprom(rgb_matrix_get_hue(), rgb_matrix_get_sat(), scale8(value_data[0], RGB_MATRIX_MAXIMUM_BRIGHTNESS));
             break;
         case id_qmk_rgblight_effect:
             rgb_matrix_mode_noeeprom(value_data[0]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This fix is to scale the rgb_matrix brightness from and to VIA in case the max brightness set in firmware is not 255.

We have had confusion from users in an upcoming keyboard testing round about this.

VIA expects a value from 0 to 255. If the max brigthness in the firmware is set to below 255, any value send from VIA to the keyboard above the max firmware brightness will clip to the max firmware brightness. This results in the VIA slider to feel unresponsive.

As we are already doing something similar for Effect Speed I think this is appropriate.

EDIT:
This is also already done for backlight, so I cleaned it up a bit and did the same for rgblight

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
