### PR TITLE
Ensure that rgb+via compiles in all cases

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -461,6 +461,9 @@ void via_qmk_backlight_set_value(uint8_t *data) {
 #endif // #if defined(VIA_QMK_BACKLIGHT_ENABLE)
 
 #if defined(VIA_QMK_RGBLIGHT_ENABLE)
+#    ifndef RGBLIGHT_LIMIT_VAL
+#        define RGBLIGHT_LIMIT_VAL 255
+#    endif
 
 void via_qmk_rgblight_get_value(uint8_t *data) {
     uint8_t *value_id   = &(data[0]);
@@ -517,6 +520,11 @@ void via_qmk_rgblight_set_value(uint8_t *data) {
 #endif // #if defined(VIA_QMK_RGBLIGHT_ENABLE)
 
 #if defined(VIA_QMK_RGB_MATRIX_ENABLE)
+
+#    if !defined(RGB_MATRIX_MAXIMUM_BRIGHTNESS) || RGB_MATRIX_MAXIMUM_BRIGHTNESS > UINT8_MAX
+#        undef RGB_MATRIX_MAXIMUM_BRIGHTNESS
+#        define RGB_MATRIX_MAXIMUM_BRIGHTNESS UINT8_MAX
+#    endif
 
 // VIA supports only 4 discrete values for effect speed; map these to some
 // useful speed values for RGB Matrix.


### PR DESCRIPTION
## Description

Needs defines from rgb engines to work.  Added default/placeholders. 

Ran multibuild to ensure all of the keymaps compile. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
