### PR TITLE
[keyboard] annepro2 Add support for sticky keys

### DIFF
--- a/keyboards/annepro2/ap2_led.c
+++ b/keyboards/annepro2/ap2_led.c
@@ -138,6 +138,24 @@ void ap2_led_reset_foreground_color() {
     ap2_led_mask_set_mono(color);
 }
 
+void ap2_led_sticky_set_key(uint8_t row, uint8_t col, ap2_led_t color) {
+    uint8_t payload[] = {row, col, color.p.blue, color.p.green, color.p.red, color.p.alpha};
+    proto_tx(CMD_LED_STICKY_SET_KEY, payload, sizeof(payload), 1);
+}
+
+void ap2_led_unset_sticky_key(uint8_t row, uint8_t col) {
+    uint8_t payload[] = {row, col};
+    proto_tx(CMD_LED_STICKY_UNSET_KEY, payload, sizeof(payload), 1);
+}
+
+void ap2_led_unset_sticky_row(uint8_t row) {
+    uint8_t payload[] = {row};
+    proto_tx(CMD_LED_STICKY_UNSET_ROW, payload, sizeof(payload), 1);
+}
+void ap2_led_unset_sticky_all(void) {
+    proto_tx(CMD_LED_STICKY_UNSET_ALL, NULL, 0, 1);
+}
+
 /*
  * Currently keypresses are unified with other messages, still with single 1
  * byte payload. Transfer is normally fast enough for that to not be a problem -

--- a/keyboards/annepro2/ap2_led.h
+++ b/keyboards/annepro2/ap2_led.h
@@ -86,6 +86,11 @@ void ap2_led_blink(uint8_t row, uint8_t col, ap2_led_t color, uint8_t count, uin
 void ap2_led_set_foreground_color(uint8_t red, uint8_t green, uint8_t blue);
 void ap2_led_reset_foreground_color(void);
 
+void ap2_led_sticky_set_key(uint8_t row, uint8_t col, ap2_led_t color);
+void ap2_led_unset_sticky_key(uint8_t row, uint8_t col);
+void ap2_led_unset_sticky_row(uint8_t row);
+void ap2_led_unset_sticky_all(void);
+
 typedef struct {
     uint8_t amount_of_profiles;
     uint8_t current_profile;

--- a/keyboards/annepro2/keymaps/default-full-caps/keymap.c
+++ b/keyboards/annepro2/keymaps/default-full-caps/keymap.c
@@ -96,7 +96,7 @@ enum anne_pro_layers {
   *
   */
  [FN2] = LAYOUT_60_ansi( /* FN2 */
-    _______, KC_AP2_BT1, KC_AP2_BT2, KC_AP2_BT3, KC_AP2_BT4, _______, _______, _______, KC_AP_LED_OFF, KC_AP_LED_ON, _______, _______, _______, _______,
+    _______, KC_AP2_BT1, KC_AP2_BT2, KC_AP2_BT3, KC_AP2_BT4, _______, _______, _______, _______, KC_AP_RGB_MOD, KC_AP_RGB_TOG, KC_AP_RGB_VAD, KC_AP_RGB_VAI, _______,
     MO(FN2), _______,    KC_UP,      _______,    _______,    _______, _______, _______, _______,       _______,      KC_PSCR, KC_HOME, KC_END,  _______,
     _______, KC_LEFT,    KC_DOWN,    KC_RGHT,    _______,    _______, _______, _______, _______,       _______,      KC_PGUP, KC_PGDN, _______,
     _______,             _______,    _______,    _______,    _______, _______, _______, _______,       _______,      KC_INS,  KC_DEL,  _______,
@@ -109,9 +109,11 @@ enum anne_pro_layers {
 bool led_update_user(led_t leds) {
     if (leds.caps_lock) {
         // Set the leds to red
-        ap2_led_set_foreground_color(0xFF, 0x00, 0x00);
+        const ap2_led_t color = {.p.red = 0xff, .p.green = 0x00, .p.blue = 0x00, .p.alpha = 0xff};
+        ap2_led_mask_set_mono(color);
     } else {
-        ap2_led_reset_foreground_color();
+        const ap2_led_t color = {.p.red = 0x00, .p.green = 0x00, .p.blue = 0x00, .p.alpha = 0x00};
+        ap2_led_mask_set_mono(color);
     }
 
     return true;

--- a/keyboards/annepro2/keymaps/default-layer-indicators/keymap.c
+++ b/keyboards/annepro2/keymaps/default-layer-indicators/keymap.c
@@ -96,7 +96,7 @@ enum anne_pro_layers {
   *
   */
  [FN2] = LAYOUT_60_ansi( /* FN2 */
-    _______, KC_AP2_BT1, KC_AP2_BT2, KC_AP2_BT3, KC_AP2_BT4, _______, _______, _______, _______, KC_AP_LED_TOG, KC_AP_LED_NEXT_INTENSITY, KC_AP_LED_PREV_PROFILE, KC_AP_LED_NEXT_PROFILE, _______,
+    _______, KC_AP2_BT1, KC_AP2_BT2, KC_AP2_BT3, KC_AP2_BT4, _______, _______, _______, _______, KC_AP_RGB_MOD, KC_AP_RGB_TOG, KC_AP_RGB_VAD, KC_AP_RGB_VAI, _______,
     MO(FN2), _______,    KC_UP,      _______,    _______,    _______, _______, _______, _______, _______, KC_PSCR, KC_HOME, KC_END,  _______,
     _______, KC_LEFT,    KC_DOWN,    KC_RGHT,    _______,    _______, _______, _______, _______, _______, KC_PGUP, KC_PGDN, _______,
     _______,             _______,    _______,    _______,    _______, _______, _______, _______, _______, KC_INS,  KC_DEL,  _______,
@@ -134,16 +134,12 @@ bool led_update_user(led_t leds) {
     if (leds.caps_lock) {
         // Set the caps-lock to red
         const ap2_led_t color = {.p.red = 0xff, .p.green = 0x00, .p.blue = 0x00, .p.alpha = 0xff};
-
-        ap2_led_mask_set_key(2, 0, color);
+        ap2_led_sticky_set_key(2, 0, color);
         /* NOTE: Instead of colouring the capslock only, you can change the whole
-           keyboard with ap2_led_set_foreground_color */
+           keyboard with ap2_led_mask_set_mono */
     } else {
         // Reset the capslock if there is no layer active
-        if (!layer_state_is(FN1) && !layer_state_is(FN2)) {
-            const ap2_led_t color = {.p.red = 0xff, .p.green = 0x00, .p.blue = 0x00, .p.alpha = 0x00};
-            ap2_led_mask_set_key(2, 0, color);
-        }
+        ap2_led_unset_sticky_key(2, 0);
     }
 
     return true;

--- a/keyboards/annepro2/protocol.h
+++ b/keyboards/annepro2/protocol.h
@@ -55,6 +55,14 @@ enum {
     /* Number of profiles, current profile, on/off state,
        reactive flag, brightness, errors */
     CMD_LED_STATUS = 0x41,
+
+    /* Set sticky key, meaning the key will light up even when LEDs are turned off */
+    CMD_LED_STICKY_SET_KEY = 0x50,
+    CMD_LED_STICKY_SET_ROW = 0x51,
+    CMD_LED_STICKY_SET_MONO = 0x52,
+    CMD_LED_STICKY_UNSET_KEY = 0x53,
+    CMD_LED_STICKY_UNSET_ROW = 0x54,
+    CMD_LED_STICKY_UNSET_ALL = 0x55,
 };
 
 /* 1 ROW * 14 COLS * 4B (RGBX) = 56 + header prefix. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This change utilizes new AnnePro2-Shine functionality and allows users to set sticky keys, which shine even after led backlight is turned off, this is useful e.g. for caps lock indicator.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

I have added functions that utilize new AnnePro2-Shine functionality (added [here](https://github.com/OpenAnnePro/AnnePro2-Shine/commit/058af8537df266d8c539fdb10ae320f74c195e01)) to set sticky keys that remain shining even after backlight is turned off.

I have also edited the default-layer-indicator keymap to utilize the sticky keys function. (I've also updated default-full-caps as I've forgotten to do so in the last merge request)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
