### PR TITLE
keep gcc11 happy, -Werror=array-bounds will trip the compilation

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -72,10 +72,10 @@ void eeconfig_update_rgb_matrix(void);
 // Can be called in an overriding via_init_kb() to test if keyboard level code usage of
 // EEPROM is invalid and use/save defaults.
 bool via_eeprom_is_valid(void) {
-    char *  p      = QMK_BUILDDATE; // e.g. "2019-11-05-11:29:54"
-    uint8_t magic0 = ((p[2] & 0x0F) << 4) | (p[3] & 0x0F);
-    uint8_t magic1 = ((p[5] & 0x0F) << 4) | (p[6] & 0x0F);
-    uint8_t magic2 = ((p[8] & 0x0F) << 4) | (p[9] & 0x0F);
+    static const char p[20]  = QMK_BUILDDATE; // e.g. "2019-11-05-11:29:54"
+    uint8_t           magic0 = ((p[2] & 0x0F) << 4) | (p[3] & 0x0F);
+    uint8_t           magic1 = ((p[5] & 0x0F) << 4) | (p[6] & 0x0F);
+    uint8_t           magic2 = ((p[8] & 0x0F) << 4) | (p[9] & 0x0F);
 
     return (eeprom_read_byte((void *)VIA_EEPROM_MAGIC_ADDR + 0) == magic0 && eeprom_read_byte((void *)VIA_EEPROM_MAGIC_ADDR + 1) == magic1 && eeprom_read_byte((void *)VIA_EEPROM_MAGIC_ADDR + 2) == magic2);
 }
@@ -83,10 +83,10 @@ bool via_eeprom_is_valid(void) {
 // Sets VIA/keyboard level usage of EEPROM to valid/invalid
 // Keyboard level code (eg. via_init_kb()) should not call this
 void via_eeprom_set_valid(bool valid) {
-    char *  p      = QMK_BUILDDATE; // e.g. "2019-11-05-11:29:54"
-    uint8_t magic0 = ((p[2] & 0x0F) << 4) | (p[3] & 0x0F);
-    uint8_t magic1 = ((p[5] & 0x0F) << 4) | (p[6] & 0x0F);
-    uint8_t magic2 = ((p[8] & 0x0F) << 4) | (p[9] & 0x0F);
+    static const char p[20]  = QMK_BUILDDATE; // e.g. "2019-11-05-11:29:54"
+    uint8_t           magic0 = ((p[2] & 0x0F) << 4) | (p[3] & 0x0F);
+    uint8_t           magic1 = ((p[5] & 0x0F) << 4) | (p[6] & 0x0F);
+    uint8_t           magic2 = ((p[8] & 0x0F) << 4) | (p[9] & 0x0F);
 
     eeprom_update_byte((void *)VIA_EEPROM_MAGIC_ADDR + 0, valid ? magic0 : 0xFF);
     eeprom_update_byte((void *)VIA_EEPROM_MAGIC_ADDR + 1, valid ? magic1 : 0xFF);


### PR DESCRIPTION
gcc11 makes construct like 
```
char *p='text'
```

as errors replaced with a static array in this case since is possible.