### PR TITLE
SPI Bugfix for ChibiOS `21.11.1` => `21.11.2`

### DIFF
--- a/drivers/led/aw20216.c
+++ b/drivers/led/aw20216.c
@@ -54,7 +54,7 @@
 #endif
 
 #ifndef AW_SPI_MODE
-#    define AW_SPI_MODE 3
+#    define AW_SPI_MODE 0
 #endif
 
 #ifndef AW_SPI_DIVISOR

--- a/util/update_chibios_mirror.sh
+++ b/util/update_chibios_mirror.sh
@@ -7,7 +7,7 @@
 chibios_branches="trunk stable_20.3.x stable_21.11.x"
 
 # The ChibiOS tags to mirror
-chibios_tags="ver20.3.1 ver20.3.2 ver20.3.3 ver20.3.4 ver21.11.1"
+chibios_tags="ver20.3.1 ver20.3.2 ver20.3.3 ver20.3.4 ver21.11.1 ver21.11.2"
 
 # The ChibiOS-Contrib branches to mirror
 contrib_branches="chibios-20.3.x chibios-21.11.x"


### PR DESCRIPTION
## Description

Also rolls back the Mode0=>Mode3 "hack" for the AW20216 driver caused by the SPI bug.

Refer #17262, #17263, @trwnh it would be great if you could verify this fix.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
