### PR TITLE
Revert USB_POLLING_INTERVAL_MS back to 10

### DIFF
--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -445,7 +445,7 @@ const USB_Descriptor_Device_t PROGMEM DeviceDescriptor = {
 #endif
 
 #ifndef USB_POLLING_INTERVAL_MS
-#    define USB_POLLING_INTERVAL_MS 1
+#    define USB_POLLING_INTERVAL_MS 10
 #endif
 
 /*


### PR DESCRIPTION
`USB_POLLING_INTERVAL_MS` was changed from 10 to 1 in commit tag 1.6.0

This caused devices to not work through some USB hubs, specifically the one built into my Acer monitor. The device connects and does show up in "Bluetooth and other devices" before reporting "Driver error" and not working as a keyboard.

Reverting `USB_POLLING_INTERVAL_MS` back to 10 will cause firmware built from master to work through this USB hub, without this change, firmware does not work.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
