### PR TITLE
Fix clean arg handling for compile/flash

### DIFF
--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -32,8 +32,9 @@ def compile(cli):
     If a keyboard and keymap are provided this command will build a firmware based on that.
     """
     if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
-        command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, 'clean')
-        cli.run(command, capture_output=False, stdin=DEVNULL)
+        if cli.config.compile.keyboard and cli.config.compile.keymap:
+            command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, 'clean')
+            cli.run(command, capture_output=False, stdin=DEVNULL)
 
     # Build the environment vars
     envs = {}

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -59,8 +59,9 @@ def flash(cli):
     If bootloader is omitted the make system will use the configured bootloader for that keyboard.
     """
     if cli.args.clean and not cli.args.filename and not cli.args.dry_run:
-        command = create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, 'clean')
-        cli.run(command, capture_output=False, stdin=DEVNULL)
+        if cli.config.flash.keyboard and cli.config.flash.keymap:
+            command = create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, 'clean')
+            cli.run(command, capture_output=False, stdin=DEVNULL)
 
     # Build the environment vars
     envs = {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

If you accidentally forget the `-km` arg, compile/flash currently barf out the following exception,
```
$ qmk compile -c -kb lets_split
<class 'TypeError'>
☒ sequence item 1: expected str instance, NoneType found
Traceback (most recent call last):
  File "/home/zvecr/qmk_firmware/.direnv/python-3.10.4/lib/python3.10/site-packages/milc/milc.py", line 528, in __call__
    return self.__call__()
  File "/home/zvecr/qmk_firmware/.direnv/python-3.10.4/lib/python3.10/site-packages/milc/milc.py", line 533, in __call__
    return self._subcommand(self)
  File "/home/zvecr/qmk_firmware/lib/python/qmk/decorators.py", line 27, in wrapper
    return func(*args, **kwargs)
  File "/home/zvecr/qmk_firmware/lib/python/qmk/decorators.py", line 47, in wrapper
    return func(*args, **kwargs)
  File "/home/zvecr/qmk_firmware/lib/python/qmk/cli/compile.py", line 35, in compile
    command = create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, 'clean')
  File "/home/zvecr/qmk_firmware/lib/python/qmk/commands.py", line 89, in create_make_command
    return create_make_target(':'.join(make_args), dry_run=dry_run, parallel=parallel, **env_vars)
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
