### PR TITLE
Use --exclude-from=.gitignore in place of --exclude-standard

### DIFF
--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -111,9 +111,9 @@ def git_check_deviation(active_branch):
 
 
 def git_get_ignored_files(check_dir='.'):
-    """Return a list of files that would be captured by the current .gitingore
+    """Return a list of files that would be captured by the current .gitignore
     """
-    invalid = cli.run(['git', 'ls-files', '-c', '-o', '-i', '--exclude-standard', check_dir])
+    invalid = cli.run(['git', 'ls-files', '-c', '-o', '-i', '--exclude-from=.gitignore', check_dir])
     if invalid.returncode != 0:
         return []
     return invalid.stdout.strip().splitlines()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The lint check spews an error anytime it encounters a file that's listed in the output of `git_get_ignored_files`. However, the use of `--exclude-standard` in the git shell command ran by the aforementioned python function also ignores files in `.git/info/exclude` and the user's global `.gitignore`.

```
$ man git ls-files
[snip]
       -X <file>, --exclude-from=<file>
           Read exclude patterns from <file>; 1 per line.

       --exclude-per-directory=<file>
           Read additional exclude patterns that apply only to the directory and
           its subdirectories in <file>.

       --exclude-standard
           Add the standard Git exclusions: .git/info/exclude, .gitignore in
           each directory, and the user’s global exclusion file.
[snip]
```

This has the undesirable consequence of always failing the lint check if the user added some of his keyboard or keymap folders in a personal git ignore file like `.git/info/exclude` or his global `.gitignore`.

As explained in the docstring of the function, the intent of the function is only to "return a list of files that would be captured by the **current .gitignore**". To actually achieve that and avoid false negatives, using the option `exclude-from=.gitignore` is more appropriate.

Note: `exclude-from=.gitignore` works even when the `check_dir` is not the root directory


```
~/qmk_firmware on stricter_git_ignored_files *3 ⨤3                                
❯ cat .git/info/exclude
# git ls-files --others --exclude-from=.git/info/exclude
# Lines that start with '#' are comments.
# For a project mostly in C, the following would be a good set of
# exclude patterns (uncomment them if you want to use them):
# *.[oa]
# *~
keyboards/handwired/dactyl_manuform/5x6/keymaps/precondition
keyboards/polilla/rev1/keymaps/precondition
keyboards/splitography

~/qmk_firmware on stricter_git_ignored_files *3 ⨤3
❯ cd keyboards/handwired/dactyl_manuform/5x6

~/qmk_firmware/k/handw/dactyl_manuform/5x6 on stricter_git_ignored_files *3 ⨤3 
❯ touch via.json

~/qmk_firmware/k/handw/dactyl_manuform/5x6 on stricter_git_ignored_files *3 ⨤3    
❯ git ls-files -c -o -i --exclude-standard  
keymaps/precondition
via.json

~/qmk_firmware/k/handw/dactyl_manuform/5x6 on stricter_git_ignored_files *3 ⨤3    
❯ git ls-files -c -o -i --exclude-from=.gitignore
via.json
```
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
