### PR TITLE
[BUG] Fix deadlocks on disconnected secondary half

### DIFF
--- a/platforms/synchronization_util.h
+++ b/platforms/synchronization_util.h
@@ -12,3 +12,33 @@ void split_shared_memory_unlock(void);
 inline void split_shared_memory_lock(void){};
 inline void split_shared_memory_unlock(void){};
 #endif
+
+/* GCCs cleanup attribute expects a function with one parameter, which is a
+ * pointer to a type compatible with the variable. As we don't want to expose
+ * the platforms internal mutex type this workaround with auto generated adapter
+ * function is defined */
+#define QMK_DECLARE_AUTOUNLOCK_HELPERS(prefix)                              \
+    inline unsigned prefix##_autounlock_lock_helper(void) {                 \
+        prefix##_lock();                                                    \
+        return 0;                                                           \
+    }                                                                       \
+                                                                            \
+    inline void prefix##_autounlock_unlock_helper(unsigned* unused_guard) { \
+        prefix##_unlock();                                                  \
+    }
+
+/* Convinience macro the automatically generate the correct RAII-style
+ * lock_autounlock function macro */
+#define QMK_DECLARE_AUTOUNLOCK_CALL(prefix) unsigned prefix##_guard __attribute__((unused, cleanup(prefix##_autounlock_unlock_helper))) = prefix##_autounlock_lock_helper
+
+QMK_DECLARE_AUTOUNLOCK_HELPERS(split_shared_memory)
+
+/**
+ * @brief Acquire exclusive access to the split keyboard shared memory, by
+ * calling the platforms `split_shared_memory_lock()` function. The lock is
+ * automatically released by calling the platforms `split_shared_memory_unlock()`
+ * function. This happens when the block where
+ * `split_shared_memory_lock_autounlock()` is called in goes out of scope i.e.
+ * when the enclosing function returns.
+ */
+#define split_shared_memory_lock_autounlock QMK_DECLARE_AUTOUNLOCK_CALL(split_shared_memory)


### PR DESCRIPTION
## Description

This fixes a deadlock bug that sneaked in with #16669. It can only be triggered on a secondary half that is not connected to the main usb connected half, thus not receiving any handshake packets. Which should be a edge-case e.g. when updating one half but still...

**The problematic code that could trigger the deadlock**

```c
static THD_FUNCTION(SlaveThread, arg) {
    (void)arg;
    chRegSetThreadName("split_protocol_tx_rx");

    while (true) {
        split_shared_memory_lock(); // <-- (1.) Acquire Mutex in rx/tx thread which runs concurrent with main thread
        if (unlikely(!react_to_transaction())) {
            serial_transport_driver_clear();
        }
        split_shared_memory_unlock();
    }
}

static inline bool react_to_transaction(void) {
    uint8_t transaction_id = 0;
    if (unlikely(!serial_transport_receive_blocking(&transaction_id, sizeof(transaction_id)))) { // <-- (2.) Potentially wait forever if disconnected and no handshake packet is received.
        return false;
    }
    // SNIP
}
```
And now in `transactions_slave()` the Mutex is acquired again.

```c
#define TRANSACTION_HANDLER_SLAVE(prefix)                     \
    do {                                                      \
        split_shared_memory_lock(); // <-- (3.) Deadlock in main thread because Mutex is already held by tx/rx thread and never released.                          \
        prefix##_handlers_slave(master_matrix, slave_matrix); \
        split_shared_memory_unlock();                         \
    } while (0)
```
Because manually locking and unlocking can be quite error prone, I added support for RAII-style mutex guards `split_shared_memory_lock_autounlock` that can be used in addition to the already existing `lock` / `unlock` functions. Unfortunately [GCC `cleanup` attribute](https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html) always wants a cleanup function with a pointer variable, so some *unsexy* function wrapping was necessary.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None ATM

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
