### PR TITLE
[Fix] Fix compilation warning for non-split keebs after #17423

### DIFF
--- a/platforms/synchronization_util.h
+++ b/platforms/synchronization_util.h
@@ -9,8 +9,10 @@ void split_shared_memory_lock(void);
 void split_shared_memory_unlock(void);
 #    endif
 #else
+#    if defined(SPLIT_KEYBOARD)
 inline void split_shared_memory_lock(void){};
 inline void split_shared_memory_unlock(void){};
+#    endif
 #endif
 
 /* GCCs cleanup attribute expects a function with one parameter, which is a
@@ -31,6 +33,7 @@ inline void split_shared_memory_unlock(void){};
  * lock_autounlock function macro */
 #define QMK_DECLARE_AUTOUNLOCK_CALL(prefix) unsigned prefix##_guard __attribute__((unused, cleanup(prefix##_autounlock_unlock_helper))) = prefix##_autounlock_lock_helper
 
+#if defined(SPLIT_KEYBOARD)
 QMK_DECLARE_AUTOUNLOCK_HELPERS(split_shared_memory)
 
 /**
@@ -41,4 +44,5 @@ QMK_DECLARE_AUTOUNLOCK_HELPERS(split_shared_memory)
  * `split_shared_memory_lock_autounlock()` is called in goes out of scope i.e.
  * when the enclosing function returns.
  */
-#define split_shared_memory_lock_autounlock QMK_DECLARE_AUTOUNLOCK_CALL(split_shared_memory)
+#    define split_shared_memory_lock_autounlock QMK_DECLARE_AUTOUNLOCK_CALL(split_shared_memory)
+#endif


### PR DESCRIPTION
## Description

I forgot to add a `#ifdef` guard for the non-split keyboard case. That resulted in build errors on `develop`.

## Successful builds again

**AVR non-split**

```
make adelheid:default
QMK Firmware breakpoint_2022_05_28
Making adelheid with keymap default

avr-gcc (GCC) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   16270       0   16270    3f8e adelheid_default.hex

Copying adelheid_default.hex to qmk_firmware folder                                                 [OK]
Checking file size of adelheid_default.hex                                                          [OK]
 * The firmware size is fine - 16270/28672 (56%, 12402 bytes free)
```

**AVR split**

```
make crkbd:snowe
QMK Firmware breakpoint_2022_05_28
Making crkbd/rev1 with keymap snowe

Size before:
avr-gcc (GCC) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

   text    data     bss     dec     hex filename
      0   23784       0   23784    5ce8 crkbd_rev1_snowe.hex

Copying crkbd_rev1_snowe.hex to qmk_firmware folder                                                 [OK]
Checking file size of crkbd_rev1_snowe.hex                                                          [OK]
 * The firmware size is fine - 23784/28672 (82%, 4888 bytes free)
```

**ARM non-split**

```
make acheron/austin:default
QMK Firmware breakpoint_2022_05_28
Making acheron/austin with keymap default

arm-none-eabi-gcc (15:10.3-2021.07-4) 10.3.1 20210621 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   35040       0   35040    88e0 acheron_austin_default.bin

Compiling: platforms/chibios/synchronization_util.c                                                 [OK]
Linking: .build/acheron_austin_default.elf                                                          [OK]
Creating binary load file for flashing: .build/acheron_austin_default.bin                           [OK]
Creating load file for flashing: .build/acheron_austin_default.hex                                  [OK]

Size after:
   text    data     bss     dec     hex filename
      0   35040       0   35040    88e0 acheron_austin_default.bin

Copying acheron_austin_default.bin to qmk_firmware folder                                           [OK]
(Firmware size check does not yet support STM32F072; skipping)
```

**ARM split**

```
make zvecr/zv48/f401:default
QMK Firmware breakpoint_2022_05_28
Making zvecr/zv48/f401 with keymap default

arm-none-eabi-gcc (15:10.3-2021.07-4) 10.3.1 20210621 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   35532       0   35532    8acc zvecr_zv48_f401_default.bin


Size after:
   text    data     bss     dec     hex filename
      0   35532       0   35532    8acc zvecr_zv48_f401_default.bin

Copying zvecr_zv48_f401_default.bin to qmk_firmware folder                                          [OK]
(Firmware size check does not yet support STM32F401; skipping)
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
