### PR TITLE
Fix up Djinn fuse handling.

### DIFF
--- a/keyboards/tzarc/djinn/keymaps/default/config.h
+++ b/keyboards/tzarc/djinn/keymaps/default/config.h
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #pragma once
 
+// Uncomment the following if your board uses 1.5A and 3.0A hold current fuses.
+//#define DJINN_SUPPORTS_3A_FUSE
+
 // Encoder settings
 #define ENCODER_RESOLUTION 2
 


### PR DESCRIPTION
## Description

The old BOM on the Djinn had fuses spec'ed wrongly -- this adds a preprocessor definition `DJINN_SUPPORTS_3A_FUSE` that can be added to config.h in order to enable the full 3A fuses on the newer BOM.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
