### PR TITLE
[Split] Ensure SOFT_SERIAL_PIN is defined if USE_I2C isn't defined

### DIFF
--- a/platforms/avr/drivers/serial.c
+++ b/platforms/avr/drivers/serial.c
@@ -498,6 +498,10 @@ bool soft_serial_transaction(int sstd_index) {
     sei();
     return true;
 }
+#else
+#    ifndef USE_I2C
+#        error SOFT_SERIAL_PIN is required but has not been defined.
+#     endif
 #endif
 
 // Helix serial.c history

--- a/platforms/avr/drivers/serial.c
+++ b/platforms/avr/drivers/serial.c
@@ -500,7 +500,7 @@ bool soft_serial_transaction(int sstd_index) {
 }
 #else
 #    ifndef USE_I2C
-#        error SOFT_SERIAL_PIN is required but has not been defined.
+#        error SOFT_SERIAL_PIN or USE_I2C is required but has not been defined.
 #    endif
 #endif
 

--- a/platforms/avr/drivers/serial.c
+++ b/platforms/avr/drivers/serial.c
@@ -501,7 +501,7 @@ bool soft_serial_transaction(int sstd_index) {
 #else
 #    ifndef USE_I2C
 #        error SOFT_SERIAL_PIN is required but has not been defined.
-#     endif
+#    endif
 #endif
 
 // Helix serial.c history


### PR DESCRIPTION
## Description

If a serial pin isn't defined, and i2c isn't enabled, it gives some esoteric errors. 

This makes sure it errors out in a more obvious way.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Troubleshooting on discord

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  - `qmk multibuild -f SPLIT_KEYBOARD=yes` came back with no errors
