### PR TITLE
Don't omit keyboards whose name contains "keymaps" in `qmk list-keyboards`

### DIFF
--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -103,7 +103,7 @@ def list_keyboards():
     """
     # We avoid pathlib here because this is performance critical code.
     kb_wildcard = os.path.join(base_path, "**", "rules.mk")
-    paths = [path for path in glob(kb_wildcard, recursive=True) if 'keymaps' not in path]
+    paths = [path for path in glob(kb_wildcard, recursive=True) if os.path.sep + 'keymaps' + os.path.sep not in path]
 
     return sorted(set(map(resolve_keyboard, map(_find_name, paths))))
 


### PR DESCRIPTION
## Description

In `lib/python/qmk/keyboard.py`, we can see that `list-keyboards` omits any path containing the word "keymaps":
```py
def list_keyboards():
    """Returns a list of all keyboards.
    """
    # We avoid pathlib here because this is performance critical code.
    kb_wildcard = os.path.join(base_path, "**", "rules.mk")
    paths = [path for path in glob(kb_wildcard, recursive=True) if 'keymaps' not in path]
```

However, the [keyboard naming guidelines](https://docs.qmk.fm/#/hardware_keyboard_guidelines?id=naming-your-keyboardproject) do not mention that "keymaps" is somehow a reserved keyword or something.
<!-- A clear and concise description of what the bug is. -->

## Demo

```sh
~/qmk_firmware/keyboards on develop *3 ⨤6                                                                                                                                                             
❯ mkdir agogo
mkdir: created directory 'agogo'

~/qmk_firmware/keyboards on develop *3 ⨤6                                                                                                                                                             
❯ touch agogo/rules.mk  

~/qmk_firmware/keyboards on develop *3 ⨤7                                                                                                                                                             
❯ qmk list-keyboards | grep agogo
agogo

~/qmk_firmware/keyboards on develop *3 ⨤7                                                                                                                                                             
❯ mv agogo/ keymapsagogo

~/qmk_firmware/keyboards on develop *3 ⨤7                                                                                                                                                             
❯ qmk list-keyboards | grep agogo

~/qmk_firmware/keyboards on develop *3 ⨤7                                                                                                                                                       
❯ mv keymapsagogo keyagogo

~/qmk_firmware/keyboards on develop *3 ⨤6                                                                                                                                                             
❯ qmk list-keyboards | grep agogo
keyagogo

~/qmk_firmware/keyboards on develop *3 ⨤6                                                                                                                                                             
❯ git checkout list-keyboards-with-keymaps-in-name

~/qmk_firmware/keyboards on list-keyboar…maps-in-name *3 ⨤7
❯ mv keyagogo keymapsagogo

~/qmk_firmware/keyboards on list-keyboar…maps-in-name *3 ⨤7                                                                                                                                   
❯ qmk list-keyboards | grep agogo                 
keymapsagogo
```

<!-- Add any other relevant information about the problem here. -->

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  #17467

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
