### PR TITLE
[Bug] Fix 3 speed mousekey mode

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -70,10 +70,6 @@ uint8_t mk_wheel_interval    = MOUSEKEY_WHEEL_INTERVAL;
 uint8_t mk_wheel_max_speed   = MOUSEKEY_WHEEL_MAX_SPEED;
 uint8_t mk_wheel_time_to_max = MOUSEKEY_WHEEL_TIME_TO_MAX;
 
-bool should_mousekey_report_send(report_mouse_t *mouse_report) {
-    return mouse_report->x || mouse_report->y || mouse_report->v || mouse_report->h;
-}
-
 #    ifndef MK_COMBINED
 
 static uint8_t move_unit(void) {
@@ -498,4 +494,8 @@ static void mousekey_debug(void) {
 
 report_mouse_t mousekey_get_report(void) {
     return mouse_report;
+}
+
+bool should_mousekey_report_send(report_mouse_t *mouse_report) {
+    return mouse_report->x || mouse_report->y || mouse_report->v || mouse_report->h;
 }

--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -174,6 +174,7 @@ void           mousekey_off(uint8_t code);
 void           mousekey_clear(void);
 void           mousekey_send(void);
 report_mouse_t mousekey_get_report(void);
+bool           should_mousekey_report_send(report_mouse_t *mouse_report);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description

I missed the mousekeys 3 speed define, and didn't put the function where it could be properly referenced. 

Fixed, and placed prototype in header to simplify. 

Confirmed compilng on all modes (3 speed, kinetic, constant and combined

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
