### PR TITLE
Allow module check to error out when piped to /dev/null

### DIFF
--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -156,6 +156,18 @@ def _broken_module_imports(requirements):
     return False
 
 
+def _yesno(*args):
+    """Wrapper to only prompt if interactive
+    """
+    return sys.stdout.isatty() and yesno(*args)
+
+
+def _eprint(errmsg):
+    """Wrapper to print to stderr
+    """
+    print(errmsg, file=sys.stderr)
+
+
 # Make sure our python is new enough
 #
 # Supported version information
@@ -177,7 +189,7 @@ def _broken_module_imports(requirements):
 # void: 3.9
 
 if sys.version_info[0] != 3 or sys.version_info[1] < 7:
-    print('Error: Your Python is too old! Please upgrade to Python 3.7 or later.')
+    _eprint('Error: Your Python is too old! Please upgrade to Python 3.7 or later.')
     exit(127)
 
 milc_version = __VERSION__.split('.')
@@ -185,7 +197,7 @@ milc_version = __VERSION__.split('.')
 if int(milc_version[0]) < 2 and int(milc_version[1]) < 4:
     requirements = Path('requirements.txt').resolve()
 
-    print(f'Your MILC library is too old! Please upgrade: python3 -m pip install -U -r {str(requirements)}')
+    _eprint(f'Your MILC library is too old! Please upgrade: python3 -m pip install -U -r {str(requirements)}')
     exit(127)
 
 # Make sure we can run binaries in the same directory as our Python interpreter
@@ -195,7 +207,7 @@ if python_dir not in os.environ['PATH'].split(':'):
     os.environ['PATH'] = ":".join((python_dir, os.environ['PATH']))
 
 # Check to make sure we have all our dependencies
-msg_install = f'Please run `{sys.executable} -m pip install -r %s` to install required python dependencies.'
+msg_install = f'\nPlease run `{sys.executable} -m pip install -r %s` to install required python dependencies.'
 args = sys.argv[1:]
 while args and args[0][0] == '-':
     del args[0]
@@ -204,24 +216,20 @@ safe_command = args and args[0] in safe_commands
 
 if not safe_command:
     if _broken_module_imports('requirements.txt'):
-        if yesno('Would you like to install the required Python modules?'):
+        if _yesno('Would you like to install the required Python modules?'):
             _install_deps('requirements.txt')
         else:
-            print()
-            print(msg_install % (str(Path('requirements.txt').resolve()),))
-            print()
+            _eprint(msg_install % (str(Path('requirements.txt').resolve()),))
             exit(1)
 
     if cli.config.user.developer and _broken_module_imports('requirements-dev.txt'):
-        if yesno('Would you like to install the required developer Python modules?'):
+        if _yesno('Would you like to install the required developer Python modules?'):
             _install_deps('requirements-dev.txt')
-        elif yesno('Would you like to disable developer mode?'):
+        elif _yesno('Would you like to disable developer mode?'):
             _run_cmd(sys.argv[0], 'config', 'user.developer=None')
         else:
-            print()
-            print(msg_install % (str(Path('requirements-dev.txt').resolve()),))
-            print('You can also turn off developer mode: qmk config user.developer=None')
-            print()
+            _eprint(msg_install % (str(Path('requirements-dev.txt').resolve()),))
+            _eprint('You can also turn off developer mode: qmk config user.developer=None')
             exit(1)
 
 # Import our subcommands
@@ -231,6 +239,6 @@ for subcommand in subcommands:
 
     except (ImportError, ModuleNotFoundError) as e:
         if safe_command:
-            print(f'Warning: Could not import {subcommand}: {e.__class__.__name__}, {e}')
+            _eprint(f'Warning: Could not import {subcommand}: {e.__class__.__name__}, {e}')
         else:
             raise


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently if you run `make` when python modules are missing, it will block indefinitely. 

This is due the "install modules?" being piped to `/dev/null`,  ctrl+c produces the following:

```
^CTraceback (most recent call last):
  File "/home/zvecr/qmk_firmware/.direnv/python-3.10.5/bin/qmk", line 8, in <module>
    sys.exit(main())
  File "/home/zvecr/qmk_firmware/.direnv/python-3.10.5/lib/python3.10/site-packages/qmk_cli/script_qmk.py", line 76, in main
    import qmk.cli  # noqa
  File "/home/zvecr/qmk_firmware/lib/python/qmk/cli/__init__.py", line 213, in <module>

    if yesno('Would you like to install the required Python modules?'):
  File "/home/zvecr/qmk_firmware/.direnv/python-3.10.5/lib/python3.10/site-packages/milc/questions.py", line 46, in yesno
    answer = input(format_ansi(prompt % args))
KeyboardInterrupt
```

#### Testing
```bash
echo "rq" >> requirements.txt
qmk hello # should prompt for module install per previous behaviour
qmk hello | grep asdf # should now error out
make handwired/onekey:default # should also now error out
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
