### PR TITLE
(develop)AP2: Enable support for WL EEPROM Driver

### DIFF
--- a/keyboards/annepro2/c15/config.h
+++ b/keyboards/annepro2/c15/config.h
@@ -49,3 +49,21 @@
 
 // Obins stock firmware has something similar to this already enabled, but disabled by default in QMK
 #define PERMISSIVE_HOLD
+
+// SPI configuration
+#define SPI_DRIVER SPID1
+#define SPI_SCK_PIN A0
+#define SPI_MOSI_PIN A1
+#define SPI_MISO_PIN A2
+
+// Flash configuration
+#define EXTERNAL_FLASH_SPI_SLAVE_SELECT_PIN B6
+#define EXTERNAL_FLASH_SPI_CLOCK_DIVISOR 16
+#define EXTERNAL_FLASH_PAGE_SIZE 256
+#define EXTERNAL_FLASH_SECTOR_SIZE 4096
+#define EXTERNAL_FLASH_BLOCK_SIZE 4096
+#define EXTERNAL_FLASH_SIZE (256 * 1024) // 2M-bit flash size
+
+// Wear-leveling driver configuration
+#define WEAR_LEVELING_LOGICAL_SIZE 1024
+#define WEAR_LEVELING_BACKING_SIZE (WEAR_LEVELING_LOGICAL_SIZE * 2)

--- a/keyboards/annepro2/c15/rules.mk
+++ b/keyboards/annepro2/c15/rules.mk
@@ -26,6 +26,10 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 
+# Wear-levelling driver
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = spi_flash
+
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = custom

--- a/keyboards/annepro2/c18/config.h
+++ b/keyboards/annepro2/c18/config.h
@@ -47,3 +47,21 @@
 
 // Obins stock firmware has something similar to this already enabled, but disabled by default in QMK
 #define PERMISSIVE_HOLD
+
+// SPI configuration
+#define SPI_DRIVER SPID1
+#define SPI_SCK_PIN A0
+#define SPI_MOSI_PIN A1
+#define SPI_MISO_PIN A2
+
+// Flash configuration
+#define EXTERNAL_FLASH_SPI_SLAVE_SELECT_PIN A3
+#define EXTERNAL_FLASH_SPI_CLOCK_DIVISOR 16
+#define EXTERNAL_FLASH_PAGE_SIZE 256
+#define EXTERNAL_FLASH_SECTOR_SIZE 4096
+#define EXTERNAL_FLASH_BLOCK_SIZE 4096
+#define EXTERNAL_FLASH_SIZE (256 * 1024) // 2M-bit flash size
+
+// Wear-leveling driver configuration
+#define WEAR_LEVELING_LOGICAL_SIZE 1024
+#define WEAR_LEVELING_BACKING_SIZE (WEAR_LEVELING_LOGICAL_SIZE * 2)

--- a/keyboards/annepro2/c18/rules.mk
+++ b/keyboards/annepro2/c18/rules.mk
@@ -26,6 +26,10 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 
+# Wear-levelling driver
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = spi_flash
+
 # Custom RGB matrix handling
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = custom

--- a/keyboards/annepro2/halconf.h
+++ b/keyboards/annepro2/halconf.h
@@ -25,4 +25,8 @@
 
 #define SERIAL_USB_BUFFERS_SIZE 256
 
+#define HAL_USE_SPI TRUE
+#define SPI_USE_WAIT TRUE
+#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
+
 #include_next <halconf.h>

--- a/keyboards/annepro2/mcuconf.h
+++ b/keyboards/annepro2/mcuconf.h
@@ -60,3 +60,11 @@
 
 #define HT32_USB_USE_USB0 TRUE
 #define HT32_USB_USB0_IRQ_PRIORITY 5
+
+/*
+ * SPI driver setting
+ */
+
+#define HT32_SPI_USE_SPI1 TRUE
+#define HT32_SPI1_IRQ_PRIORITY 9
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Enable WL EEPROM driver support for both variant of the AnnePro2(C15/C18) 

Tested only with the C18 variant but the C!5 uses the same NOR Flash with the exception of a different pin for the `EXTERNAL_FLASH_SPI_SLAVE_SELECT_PIN`

Nonetheless both variants compile:

C15 default keymap:
```
Ψ Compiling keymap with make --jobs=1 annepro2/c15:default


QMK Firmware 0.17.2
Making annepro2/c15 with keymap default

arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.10) 10.3.1 20210824 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   40476       0   40476    9e1c annepro2_c15_default.bin


Size after:
   text    data     bss     dec     hex filename
      0   40476       0   40476    9e1c annepro2_c15_default.bin

Copying annepro2_c15_default.bin to qmk_firmware folder                                             [OK]
(Firmware size check does not yet support cortex-m0plus; skipping)
```

C18 default keymap:
```
Ψ Compiling keymap with make --jobs=1 annepro2/c18:default


QMK Firmware 0.17.2
Making annepro2/c18 with keymap default

arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.10) 10.3.1 20210824 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   40552       0   40552    9e68 annepro2_c18_default.bin


Size after:
   text    data     bss     dec     hex filename
      0   40552       0   40552    9e68 annepro2_c18_default.bin

Copying annepro2_c18_default.bin to qmk_firmware folder                                             [OK]
(Firmware size check does not yet support cortex-m0plus; skipping)
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
