### PR TITLE
(develop)Keychron Q2: Enable support for WL EEPROM Driver

### DIFF
--- a/keyboards/keychron/q2/config.h
+++ b/keyboards/keychron/q2/config.h
@@ -64,7 +64,8 @@
 #define DYNAMIC_KEYMAP_EEPROM_MAX_ADDR 2047
 
 /* EEPROM Driver Configuration */
-#define EXTERNAL_EEPROM_I2C_BASE_ADDRESS 0b10100010
+#define WEAR_LEVELING_LOGICAL_SIZE 2048
+#define WEAR_LEVELING_BACKING_SIZE (WEAR_LEVELING_LOGICAL_SIZE * 2)
 
 // RGB Matrix Animation modes. Explicitly enabled
 // For full list of effects, see:

--- a/keyboards/keychron/q2/rev_0110/rules.mk
+++ b/keyboards/keychron/q2/rev_0110/rules.mk
@@ -20,7 +20,8 @@ ENCODER_ENABLE = no         # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = CKLED2001
-EEPROM_DRIVER = i2c
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = embedded_flash
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/keychron/q2/rev_0111/rules.mk
+++ b/keyboards/keychron/q2/rev_0111/rules.mk
@@ -20,7 +20,8 @@ ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = CKLED2001
-EEPROM_DRIVER = i2c
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = embedded_flash
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/keychron/q2/rev_0112/rules.mk
+++ b/keyboards/keychron/q2/rev_0112/rules.mk
@@ -20,7 +20,8 @@ ENCODER_ENABLE = no         # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = CKLED2001
-EEPROM_DRIVER = i2c
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = embedded_flash
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/keychron/q2/rev_0113/rules.mk
+++ b/keyboards/keychron/q2/rev_0113/rules.mk
@@ -20,7 +20,8 @@ ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_DRIVER = CKLED2001
-EEPROM_DRIVER = i2c
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = embedded_flash
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Enable WL EEPROM driver support for all the Keychron Q2 variants.

This PR removes the support for the (probably unused) I2c EEPROM but given that the _famous playground_ branch doesn't have support for I2C EEPROM, I can make a safe assumption that there's no user with a board with an I2C EEPROM

All variants compile successfully (Test builds using the VIA keymap):

rev_0110:
```
Ψ Compiling keymap with make --jobs=1 keychron/q2/rev_0110:via


QMK Firmware 0.17.2
Making keychron/q2/rev_0110 with keymap via

arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.10) 10.3.1 20210824 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   40642       0   40642    9ec2 keychron_q2_rev_0110_via.bin


Size after:
   text    data     bss     dec     hex filename
      0   40642       0   40642    9ec2 keychron_q2_rev_0110_via.bin

Copying keychron_q2_rev_0110_via.bin to qmk_firmware folder                                         [OK]
(Firmware size check does not yet support STM32L433; skipping)
```

rev_0111:
```
Ψ Compiling keymap with make --jobs=1 keychron/q2/rev_0111:via


QMK Firmware 0.17.2
Making keychron/q2/rev_0111 with keymap via

arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.10) 10.3.1 20210824 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   41206       0   41206    a0f6 keychron_q2_rev_0111_via.bin


Size after:
   text    data     bss     dec     hex filename
      0   41206       0   41206    a0f6 keychron_q2_rev_0111_via.bin

Copying keychron_q2_rev_0111_via.bin to qmk_firmware folder                                         [OK]
(Firmware size check does not yet support STM32L433; skipping)
```

rev_0112:
```
Ψ Compiling keymap with make --jobs=1 keychron/q2/rev_0112:via


QMK Firmware 0.17.2
Making keychron/q2/rev_0112 with keymap via

arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.10) 10.3.1 20210824 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   40650       0   40650    9eca keychron_q2_rev_0112_via.bin


Size after:
   text    data     bss     dec     hex filename
      0   40650       0   40650    9eca keychron_q2_rev_0112_via.bin

Copying keychron_q2_rev_0112_via.bin to qmk_firmware folder                                         [OK]
(Firmware size check does not yet support STM32L433; skipping)
```

rev_0113:
```
Ψ Compiling keymap with make --jobs=1 keychron/q2/rev_0113:via


QMK Firmware 0.17.2
Making keychron/q2/rev_0113 with keymap via

arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.10) 10.3.1 20210824 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   41214       0   41214    a0fe keychron_q2_rev_0113_via.bin


Size after:
   text    data     bss     dec     hex filename
      0   41214       0   41214    a0fe keychron_q2_rev_0113_via.bin

Copying keychron_q2_rev_0113_via.bin to qmk_firmware folder                                         [OK]
(Firmware size check does not yet support STM32L433; skipping)
```

Tested all the compiled binaries with my rev_0111 board.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
