### PR TITLE
Swap F4x1 default board files away from blackpill

### DIFF
--- a/builddefs/mcu_selection.mk
+++ b/builddefs/mcu_selection.mk
@@ -359,7 +359,7 @@ ifneq ($(findstring STM32F401, $(MCU)),)
 
   # Board: it should exist either in <chibios>/os/hal/boards/,
   # <keyboard_dir>/boards/, or drivers/boards/
-  BOARD ?= BLACKPILL_STM32_F401
+  BOARD ?= GENERIC_STM32_F401XC
 
   USE_FPU ?= yes
 
@@ -475,7 +475,7 @@ ifneq ($(findstring STM32F411, $(MCU)),)
 
   # Board: it should exist either in <chibios>/os/hal/boards/,
   # <keyboard_dir>/boards/, or drivers/boards/
-  BOARD ?= BLACKPILL_STM32_F411
+  BOARD ?= GENERIC_STM32_F411XE
 
   USE_FPU ?= yes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Going forward this aligns the defaults with other STM32 variants. Blackpill users should take advantage of the DD info.json config:

```json
{
  "development_board": "blackpill_f401"
}
```
or
```json
{
  "development_board": "blackpill_f411"
}
```

Which will correctly set up the mcu / bootlaoder / board files.

```sh
# Find keyboards to migrate
rg -l "MCU = STM32F4.1" keyboards/ | xargs grep -L "^BOARD"
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
