### PR TITLE
[QP] Explicit buffer alignment.

### DIFF
--- a/quantum/painter/qp_draw_core.c
+++ b/quantum/painter/qp_draw_core.c
@@ -20,17 +20,17 @@ _Static_assert((QUANTUM_PAINTER_PIXDATA_BUFFER_SIZE > 0) && (QUANTUM_PAINTER_PIX
 //
 
 // Buffer used for transmitting native pixel data to the downstream device.
-uint8_t qp_internal_global_pixdata_buffer[QUANTUM_PAINTER_PIXDATA_BUFFER_SIZE];
+__attribute__((__aligned__(4))) uint8_t qp_internal_global_pixdata_buffer[QUANTUM_PAINTER_PIXDATA_BUFFER_SIZE];
 
 // Static buffer to contain a generated color palette
-static bool       generated_palette = false;
-static int16_t    generated_steps   = -1;
-static qp_pixel_t interpolated_fg_hsv888;
-static qp_pixel_t interpolated_bg_hsv888;
+static bool                                       generated_palette = false;
+static int16_t                                    generated_steps   = -1;
+__attribute__((__aligned__(4))) static qp_pixel_t interpolated_fg_hsv888;
+__attribute__((__aligned__(4))) static qp_pixel_t interpolated_bg_hsv888;
 #if QUANTUM_PAINTER_SUPPORTS_256_PALETTE
-qp_pixel_t qp_internal_global_pixel_lookup_table[256];
+__attribute__((__aligned__(4))) qp_pixel_t qp_internal_global_pixel_lookup_table[256];
 #else
-qp_pixel_t qp_internal_global_pixel_lookup_table[16];
+__attribute__((__aligned__(4))) qp_pixel_t qp_internal_global_pixel_lookup_table[16];
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

RP2040 was throwing exceptions when these buffers are placed at an odd-numbered memory address.
Forces 4-byte alignment.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
