### PR TITLE
Allow for `keymaps` array to be implemented in a file other than `$(KEYMAP_C)`

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -400,6 +400,12 @@ endif
 
 OPT_DEFS += -DKEYMAP_C=\"$(KEYMAP_C)\"
 
+# If a keymap or userspace places their keymap array in another file instead, allow for it to be included
+# !!NOTE!! -- For this to work, the source file cannot be part of $(SRC), so users should not add it via `SRC += <file>`
+ifneq ($(strip $(INTROSPECTION_KEYMAP_C)),)
+OPT_DEFS += -DINTROSPECTION_KEYMAP_C=\"$(strip $(INTROSPECTION_KEYMAP_C))\"
+endif
+
 # project specific files
 SRC += \
     $(KEYBOARD_SRC) \

--- a/quantum/keymap_introspection.c
+++ b/quantum/keymap_introspection.c
@@ -4,6 +4,11 @@
 // Pull the actual keymap code so that we can inspect stuff from it
 #include KEYMAP_C
 
+// Allow for keymap or userspace rules.mk to specify an alternate location for the keymap array
+#ifdef INTROSPECTION_KEYMAP_C
+#    include INTROSPECTION_KEYMAP_C
+#endif // INTROSPECTION_KEYMAP_C
+
 #include "keymap_introspection.h"
 
 #define NUM_KEYMAP_LAYERS ((uint8_t)(sizeof(keymaps) / ((MATRIX_ROWS) * (MATRIX_COLS) * sizeof(uint16_t))))

--- a/users/manna-harbour_miryoku/post_rules.mk
+++ b/users/manna-harbour_miryoku/post_rules.mk
@@ -1,8 +1,6 @@
 # Copyright 2019 Manna Harbour
 # https://github.com/manna-harbour/miryoku
 
-SRC += manna-harbour_miryoku.c # keymaps
-
 # alternative layouts:
 
 # alphas

--- a/users/manna-harbour_miryoku/rules.mk
+++ b/users/manna-harbour_miryoku/rules.mk
@@ -5,7 +5,7 @@ MOUSEKEY_ENABLE = yes # Mouse keys
 EXTRAKEY_ENABLE = yes # Audio control and System control
 AUTO_SHIFT_ENABLE = yes # Auto Shift
 
-SRC += manna-harbour_miryoku.c # keymaps
+INTROSPECTION_KEYMAP_C = manna-harbour_miryoku.c # keymaps
 
 include users/manna-harbour_miryoku/custom_rules.mk
 


### PR DESCRIPTION
## Description

Some weird keymap generation going on with the miryoku keymaps -- they weren't _actually_ part of the normal `keymap.c` file, but rather specified elsewhere.

This adds the ability to specify a different file to include into the introspection code.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
