### PR TITLE
[Fix] printf update aftermath

### DIFF
--- a/keyboards/cannonkeys/satisfaction75/satisfaction_oled.c
+++ b/keyboards/cannonkeys/satisfaction75/satisfaction_oled.c
@@ -145,7 +145,7 @@ static char* get_time(void) {
         hour = 12;
     }
 
-    static char time_str[8] = "";
+    static char time_str[11] = "";
     sprintf(time_str, "%02d:%02d%s", hour, minute, is_pm ? "pm" : "am");
 
     return time_str;
@@ -162,7 +162,7 @@ static char* get_date(void) {
         day   = day_config;
     }
 
-    static char date_str[11] = "";
+    static char date_str[15] = "";
     sprintf(date_str, "%04d-%02d-%02d", year, month, day);
 
     return date_str;

--- a/keyboards/handwired/tractyl_manuform/tractyl_manuform.c
+++ b/keyboards/handwired/tractyl_manuform/tractyl_manuform.c
@@ -247,17 +247,17 @@ static bool has_shift_mod(void) {
  */
 __attribute__((unused)) static void debug_charybdis_config_to_console(charybdis_config_t* config) {
 #    ifdef CONSOLE_ENABLE
-    dprintf("(charybdis) process_record_kb: config = {\n"
-            "\traw = 0x%04X,\n"
-            "\t{\n"
-            "\t\tis_dragscroll_enabled=%b\n"
-            "\t\tis_sniping_enabled=%b\n"
-            "\t\tdefault_dpi=0x%02X (%ld)\n"
-            "\t\tsniping_dpi=0x%01X (%ld)\n"
-            "\t}\n"
-            "}\n",
-            config->raw, config->is_dragscroll_enabled, config->is_sniping_enabled, config->pointer_default_dpi, get_pointer_default_dpi(config), config->pointer_sniping_dpi, get_pointer_sniping_dpi(config));
-#    endif  // CONSOLE_ENABLE
+    IGNORE_FORMAT_WARNING(dprintf("(charybdis) process_record_kb: config = {\n"
+                                  "\traw = 0x%04X,\n"
+                                  "\t{\n"
+                                  "\t\tis_dragscroll_enabled=%b\n"
+                                  "\t\tis_sniping_enabled=%b\n"
+                                  "\t\tdefault_dpi=0x%02X (%ld)\n"
+                                  "\t\tsniping_dpi=0x%01X (%ld)\n"
+                                  "\t}\n"
+                                  "}\n",
+                                  config->raw, config->is_dragscroll_enabled, config->is_sniping_enabled, config->pointer_default_dpi, get_pointer_default_dpi(config), config->pointer_sniping_dpi, get_pointer_sniping_dpi(config)));
+#    endif // CONSOLE_ENABLE
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t* record) {

--- a/keyboards/rocketboard_16/keymaps/default/keymap.c
+++ b/keyboards/rocketboard_16/keymaps/default/keymap.c
@@ -107,10 +107,10 @@ static void oled_write_ln_centered(const char * data, bool inverted)
     char line_buf[21];
 
     // Amount to offset string from left side
-    uint8_t offset = (21 - strlen(data))/2;
+    uint8_t offset = (22 - strlen(data)) / 2;
 
     // Formatted string centering... look, it works, don't ask how...
-    snprintf(line_buf, 21, "%*s%s%*s\0", offset, "", data, offset, ""); // Centers data within 21 character buffer with null termination
+    snprintf(line_buf, 21, "%*s%s%*s", offset, "", data, offset, ""); // Centers data within 21 character buffer
 
     oled_write_ln(line_buf, inverted);
 }

--- a/keyboards/rocketboard_16/keymaps/via/keymap.c
+++ b/keyboards/rocketboard_16/keymaps/via/keymap.c
@@ -107,10 +107,10 @@ static void oled_write_ln_centered(const char * data, bool inverted)
     char line_buf[21];
 
     // Amount to offset string from left side
-    uint8_t offset = (21 - strlen(data))/2;
+    uint8_t offset = (22 - strlen(data))/2;
 
     // Formatted string centering... look, it works, don't ask how...
-    snprintf(line_buf, 21, "%*s%s%*s\0", offset, "", data, offset, ""); // Centers data within 21 character buffer with null termination
+    snprintf(line_buf, 21, "%*s%s%*s", offset, "", data, offset, ""); // Centers data within 21 character buffer
 
     oled_write_ln(line_buf, inverted);
 }

--- a/keyboards/tzarc/djinn/graphics/theme_djinn_default.c
+++ b/keyboards/tzarc/djinn/graphics/theme_djinn_default.c
@@ -158,7 +158,7 @@ void draw_ui_user(void) {
         if (hue_redraw || rgb_effect_redraw) {
             static int max_rgb_xpos = 0;
             xpos                    = 16;
-            snprintf_(buf, sizeof(buf), "rgb: %s", rgb_matrix_name(curr_effect));
+            snprintf(buf, sizeof(buf), "rgb: %s", rgb_matrix_name(curr_effect));
 
             for (int i = 5; i < sizeof(buf); ++i) {
                 if (buf[i] == 0)
@@ -187,7 +187,7 @@ void draw_ui_user(void) {
 
             static int max_layer_xpos = 0;
             xpos                      = 16;
-            snprintf_(buf, sizeof(buf), "layer: %s", layer_name);
+            snprintf(buf, sizeof(buf), "layer: %s", layer_name);
             xpos += qp_drawtext_recolor(lcd, xpos, ypos, thintel, buf, curr_hue, 255, 255, curr_hue, 255, 0);
             if (max_layer_xpos < xpos) {
                 max_layer_xpos = xpos;
@@ -200,7 +200,7 @@ void draw_ui_user(void) {
         if (hue_redraw || power_state_redraw) {
             static int max_power_xpos = 0;
             xpos                      = 16;
-            snprintf_(buf, sizeof(buf), "power: %s", usbpd_str(kb_state.current_setting));
+            snprintf(buf, sizeof(buf), "power: %s", usbpd_str(kb_state.current_setting));
             xpos += qp_drawtext_recolor(lcd, xpos, ypos, thintel, buf, curr_hue, 255, 255, curr_hue, 255, 0);
             if (max_power_xpos < xpos) {
                 max_power_xpos = xpos;
@@ -213,7 +213,7 @@ void draw_ui_user(void) {
         if (hue_redraw || scan_redraw) {
             static int max_scans_xpos = 0;
             xpos                      = 16;
-            snprintf_(buf, sizeof(buf), "scans: %d", (int)theme_state.scan_rate);
+            snprintf(buf, sizeof(buf), "scans: %d", (int)theme_state.scan_rate);
             xpos += qp_drawtext_recolor(lcd, xpos, ypos, thintel, buf, curr_hue, 255, 255, curr_hue, 255, 0);
             if (max_scans_xpos < xpos) {
                 max_scans_xpos = xpos;
@@ -226,7 +226,7 @@ void draw_ui_user(void) {
         if (hue_redraw || wpm_redraw) {
             static int max_wpm_xpos = 0;
             xpos                    = 16;
-            snprintf_(buf, sizeof(buf), "wpm: %d", (int)get_current_wpm());
+            snprintf(buf, sizeof(buf), "wpm: %d", (int)get_current_wpm());
             xpos += qp_drawtext_recolor(lcd, xpos, ypos, thintel, buf, curr_hue, 255, 255, curr_hue, 255, 0);
             if (max_wpm_xpos < xpos) {
                 max_wpm_xpos = xpos;

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -161,7 +161,7 @@ static void command_common_help(void) {
 }
 
 static void print_version(void) {
-    print(/* clang-format off */
+    xprintf("%s", /* clang-format off */
         "\n\t- Version -\n"
         "VID: " STR(VENDOR_ID) "(" STR(MANUFACTURER) ") "
         "PID: " STR(PRODUCT_ID) "(" STR(PRODUCT) ") "

--- a/quantum/logging/print.h
+++ b/quantum/logging/print.h
@@ -100,7 +100,7 @@ void print_set_sendchar(sendchar_func_t func);
 #define print_bin32(i) IGNORE_FORMAT_WARNING(xprintf("%032lb", i))
 #define print_bin_reverse8(i) IGNORE_FORMAT_WARNING(xprintf("%08b", bitrev(i)))
 #define print_bin_reverse16(i) IGNORE_FORMAT_WARNING(xprintf("%016b", bitrev16(i)))
-#define print_bin_reverse32(i) IGNORE_FORMAT_WARNINGxprintf("%032lb", bitrev32(i)))
+#define print_bin_reverse32(i) IGNORE_FORMAT_WARNING(xprintf("%032lb", bitrev32(i)))
 /* print value utility */
 #define print_val_dec(v) xprintf(#v ": %u\n", v)
 #define print_val_decs(v) xprintf(#v ": %d\n", v)


### PR DESCRIPTION
## Description

* Add missing '(' to `print_bin_reverse32` declaration
* Fix insufficient character buffers on satisfaction75
* Remove `\0` character in format string and use corrected offset math
  instead on rocketboard 16
* Replace `snprintf_` with `snprintf` for djinn
* Explicitly ignore format checks for tracktyl manuform that uses `%b`
  specifier
* Print properly escaped version string in command.c, as `PRODUCT` or
  other defines can contain constructs like 'Vendor keyboard 66%' which
  will be interpreted as a format specifier

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Build errors after #16163 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
