### PR TITLE
Fixed NKRO issue caused by HID_SET_PROTOCOL on Chibios platform

### DIFF
--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -408,7 +408,7 @@ void qmkusbDataTransmitted(USBDriver *usbp, usbep_t ep) {
            size. Otherwise the recipient may expect more data coming soon and
            not return buffered data to app. See section 5.8.3 Bulk Transfer
            Packet Size Constraints of the USB Specification document.*/
-        if (!qmkusbp->config->fixed_size) {
+        if (!qmkusbp->config->fixed_size && (usbp->epc[ep]->ep_mode & USB_EP_MODE_TYPE) == USB_EP_MODE_TYPE_BULK) {
             usbStartTransmitI(usbp, ep, usbp->setup, 0);
         }
 

--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -408,7 +408,7 @@ void qmkusbDataTransmitted(USBDriver *usbp, usbep_t ep) {
            size. Otherwise the recipient may expect more data coming soon and
            not return buffered data to app. See section 5.8.3 Bulk Transfer
            Packet Size Constraints of the USB Specification document.*/
-        if (!qmkusbp->config->fixed_size && (usbp->epc[ep]->ep_mode & USB_EP_MODE_TYPE) == USB_EP_MODE_TYPE_BULK) {
+        if (!qmkusbp->config->fixed_size) {
             usbStartTransmitI(usbp, ep, usbp->setup, 0);
         }
 

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -641,8 +641,7 @@ static bool usb_request_hook_cb(USBDriver *usbp) {
                         if ((usbp->setup[4] == KEYBOARD_INTERFACE) && (usbp->setup[5] == 0)) { /* wIndex */
                             keyboard_protocol = ((usbp->setup[2]) != 0x00);                    /* LSB(wValue) */
 #ifdef NKRO_ENABLE
-                            keymap_config.nkro = !!keyboard_protocol;
-                            if (!keymap_config.nkro && keyboard_idle) {
+                            if (!keyboard_protocol && keyboard_idle) {
 #else  /* NKRO_ENABLE */
                             if (keyboard_idle) {
 #endif /* NKRO_ENABLE */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
NKRO is forced to turn on by mistake when receiving HID_SET_PROTOCOL.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
