### PR TITLE
Add Dip Switch split support

### DIFF
--- a/quantum/dip_switch.c
+++ b/quantum/dip_switch.c
@@ -16,20 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <string.h> // for memcpy
-
 #include "dip_switch.h"
 #include "gpio.h"
 #include "util.h"
-
 #ifdef SPLIT_KEYBOARD
 #    include "split_common/split_util.h"
 #endif
 
-// for memcpy
-#include <string.h>
+#include <string.h> // for memcpy
 
-extern volatile bool isLeftHand;
 
 #if !defined(DIP_SWITCH_PINS) && !defined(DIP_SWITCH_MATRIX_GRID)
 #    error "Either DIP_SWITCH_PINS or DIP_SWITCH_MATRIX_GRID must be defined."
@@ -40,12 +35,12 @@ extern volatile bool isLeftHand;
 #endif
 
 #ifdef DIP_SWITCH_PINS
-#    define NUMBER_OF_DIP_SWITCHES (ARRAY_SIZE(dip_switch_pad))
 static pin_t dip_switch_pad[NUM_DIP_SWITCHES_MAX_PER_SIDE] = DIP_SWITCH_PINS;
 #endif
 
+extern volatile bool isLeftHand;
+
 #ifdef DIP_SWITCH_MATRIX_GRID
-#    define NUMBER_OF_DIP_SWITCHES (ARRAY_SIZE(dip_switch_pad))
 static matrix_index_t dip_switch_pad[NUM_DIP_SWITCHES_MAX_PER_SIDE] = DIP_SWITCH_MATRIX_GRID;
 extern bool           peek_matrix(uint8_t row_index, uint8_t col_index, bool read_raw);
 static uint16_t       scan_count;
@@ -75,6 +70,11 @@ __attribute__((weak)) bool dip_switch_update_mask_kb(uint32_t state) {
     return dip_switch_update_mask_user(state);
 }
 
+
+__attribute__((weak)) void dip_switch_wait_pullup_charge(void) {
+    wait_us(100);
+}
+
 void dip_switch_init(void) {
 #ifdef SPLIT_KEYBOARD
     thisHand  = isLeftHand ? 0 : NUM_DIP_SWITCHES_LEFT;
@@ -97,6 +97,7 @@ void dip_switch_init(void) {
     for (uint8_t i = 0; i < thisCount; i++) {
         setPinInputHigh(dip_switch_pad[i]);
     }
+    dip_switch_wait_pullup_charge();
     dip_switch_read(true);
 #endif
 #ifdef DIP_SWITCH_MATRIX_GRID

--- a/quantum/dip_switch.c
+++ b/quantum/dip_switch.c
@@ -56,7 +56,7 @@ static uint8_t thisCount;
 static uint8_t thisHand, thatHand;
 static uint8_t thatCount;
 #endif
-static bool dip_switch_state[NUM_DIP_SWITCHES]         = {0};
+static bool dip_switch_state[NUM_DIP_SWITCHES]      = {0};
 static bool last_dip_switch_state[NUM_DIP_SWITCHES] = {0};
 
 __attribute__((weak)) bool dip_switch_update_user(uint8_t index, bool active) {
@@ -82,7 +82,7 @@ void dip_switch_init(void) {
     thisCount = isLeftHand ? NUM_DIP_SWITCHES_LEFT : NUM_DIP_SWITCHES_RIGHT;
     thatCount = isLeftHand ? NUM_DIP_SWITCHES_RIGHT : NUM_DIP_SWITCHES_LEFT;
 #else // SPLIT_KEYBOARD
-    thisCount                = NUM_DIP_SWITCHES;
+    thisCount = NUM_DIP_SWITCHES;
 #endif
 
 #ifdef DIP_SWITCH_PINS

--- a/quantum/dip_switch.c
+++ b/quantum/dip_switch.c
@@ -51,8 +51,15 @@ extern bool           peek_matrix(uint8_t row_index, uint8_t col_index, bool rea
 static uint16_t       scan_count;
 #endif /* DIP_SWITCH_MATRIX_GRID */
 
+#ifdef SPLIT_KEYBOARD
+static uint8_t thisHand, thatHand;
+// slave half comes over
+static bool dip_switch_state[NUMBER_OF_DIP_SWITCHES * 2]      = {0};
+static bool last_dip_switch_state[NUMBER_OF_DIP_SWITCHES * 2] = {0};
+#else
 static bool dip_switch_state[NUMBER_OF_DIP_SWITCHES]      = {0};
 static bool last_dip_switch_state[NUMBER_OF_DIP_SWITCHES] = {0};
+#endif
 
 __attribute__((weak)) bool dip_switch_update_user(uint8_t index, bool active) {
     return true;
@@ -88,11 +95,16 @@ void dip_switch_init(void) {
 #ifdef DIP_SWITCH_MATRIX_GRID
     scan_count = 0;
 #endif
+#ifdef SPLIT_KEYBOARD
+    thisHand = isLeftHand ? 0 : NUMBER_OF_DIP_SWITCHES;
+    thatHand = NUMBER_OF_DIP_SWITCHES - thisHand;
+#endif
 }
 
 void dip_switch_read(bool forced) {
     bool     has_dip_state_changed = false;
     uint32_t dip_switch_mask       = 0;
+    uint8_t  index                 = 0;
 
 #ifdef DIP_SWITCH_MATRIX_GRID
     bool read_raw = false;
@@ -109,16 +121,21 @@ void dip_switch_read(bool forced) {
 #endif
 
     for (uint8_t i = 0; i < NUMBER_OF_DIP_SWITCHES; i++) {
+        index = i;
+
+#ifdef SPLIT_KEYBOARD
+        index += thisHand;
+#endif
 #ifdef DIP_SWITCH_PINS
-        dip_switch_state[i] = !readPin(dip_switch_pad[i]);
+        dip_switch_state[index] = !readPin(dip_switch_pad[i]);
 #endif
 #ifdef DIP_SWITCH_MATRIX_GRID
-        dip_switch_state[i] = peek_matrix(dip_switch_pad[i].row, dip_switch_pad[i].col, read_raw);
+        dip_switch_state[index] = peek_matrix(dip_switch_pad[i].row, dip_switch_pad[i].col, read_raw);
 #endif
-        dip_switch_mask |= dip_switch_state[i] << i;
-        if (last_dip_switch_state[i] != dip_switch_state[i] || forced) {
+        dip_switch_mask |= dip_switch_state[i] << index;
+        if (last_dip_switch_state[index] != dip_switch_state[index] || forced) {
             has_dip_state_changed = true;
-            dip_switch_update_kb(i, dip_switch_state[i]);
+            dip_switch_update_kb(index, dip_switch_state[index]);
         }
     }
     if (has_dip_state_changed) {
@@ -126,3 +143,41 @@ void dip_switch_read(bool forced) {
         memcpy(last_dip_switch_state, dip_switch_state, sizeof(dip_switch_state));
     }
 }
+
+#ifdef SPLIT_KEYBOARD
+void dip_switch_state_raw(bool *slave_state) {
+    memcpy(slave_state, &dip_switch_state[thisHand], sizeof(bool) * NUMBER_OF_DIP_SWITCHES);
+}
+
+void dip_switch_update_raw(bool *slave_state) {
+    uint8_t  index_that_hand       = 0;
+    uint8_t  index_this_hand       = 0;
+    uint32_t dip_switch_mask       = 0;
+    bool     has_dip_state_changed = false;
+
+    for (int i = 0; i < NUMBER_OF_DIP_SWITCHES; ++i) {
+        index_that_hand = i + thatHand;
+        index_this_hand = i + thisHand;
+
+        // copy slave state to master state
+        dip_switch_state[index_that_hand] = slave_state[i];
+
+        // update mask for both sides
+        dip_switch_mask |= dip_switch_state[index_that_hand] << index_that_hand;
+        dip_switch_mask |= dip_switch_state[index_this_hand] << index_this_hand;
+
+        // if there is a change do update
+        if (last_dip_switch_state[index_that_hand] != dip_switch_state[index_that_hand]) {
+            has_dip_state_changed = true;
+            dip_switch_update_kb(index_that_hand, dip_switch_state[index_that_hand]);
+        }
+    }
+
+    // if mask has changed do update
+    if (has_dip_state_changed) {
+        dip_switch_update_mask_kb(dip_switch_mask);
+        memcpy(last_dip_switch_state, dip_switch_state, sizeof(dip_switch_state));
+    }
+}
+
+#endif

--- a/quantum/dip_switch.h
+++ b/quantum/dip_switch.h
@@ -43,27 +43,27 @@ void dip_switch_state_raw(bool *slave_state);
 void dip_switch_update_raw(bool *slave_state);
 #    if defined(DIP_SWITCH_PINS)
 #        if defined(DIP_SWITCH_PINS_RIGHT)
-#            define NUM_DIP_SWITCHES_LEFT (sizeof(((pin_t[])DIP_SWITCH_PINS)) / sizeof(pin_t))
-#            define NUM_DIP_SWITCHES_RIGHT (sizeof(((pin_t[])DIP_SWITCH_PINS_RIGHT)) / sizeof(pin_t))
+#            define NUM_DIP_SWITCHES_LEFT (ARRAY_SIZE((pin_t[])DIP_SWITCH_PINS))
+#            define NUM_DIP_SWITCHES_RIGHT (ARRAY_SIZE((pin_t[])DIP_SWITCH_PINS_RIGHT))
 #        else
-#            define NUM_DIP_SWITCHES_LEFT (sizeof(((pin_t[])DIP_SWITCH_PINS)) / sizeof(pin_t))
+#            define NUM_DIP_SWITCHES_LEFT (ARRAY_SIZE((pin_t[])DIP_SWITCH_PINS))
 #            define NUM_DIP_SWITCHES_RIGHT NUM_DIP_SWITCHES_LEFT
 #        endif
 #    elif defined(DIP_SWITCH_MATRIX_GRID)
 #        if defined(DIP_SWITCH_MATRIX_GRID_RIGHT)
-#            define NUM_DIP_SWITCHES_LEFT (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID)) / sizeof(matrix_index_t))
-#            define NUM_DIP_SWITCHES_RIGHT (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID_RIGHT)) / sizeof(matrix_index_t))
+#            define NUM_DIP_SWITCHES_LEFT (ARRAY_SIZE((pin_t[])DIP_SWITCH_MATRIX_GRID))
+#            define NUM_DIP_SWITCHES_RIGHT (ARRAY_SIZE((pin_t[])DIP_SWITCH_MATRIX_GRID_RIGHT)))
 #        else
-#            define NUM_DIP_SWITCHES_LEFT (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID)) / sizeof(matrix_index_t))
+#            define NUM_DIP_SWITCHES_LEFT (ARRAY_SIZE((pin_t[])DIP_SWITCH_MATRIX_GRID))
 #            define NUM_DIP_SWITCHES_RIGHT NUM_DIP_SWITCHES_LEFT
 #        endif
 #    endif
 #    define NUM_DIP_SWITCHES (NUM_DIP_SWITCHES_LEFT + NUM_DIP_SWITCHES_RIGHT)
 #else // SPLIT_KEYBOARD
 #    if defined(DIP_SWITCH_PINS)
-#        define NUM_DIP_SWITCHES (sizeof(((pin_t[])DIP_SWITCH_PINS)) / sizeof(pin_t))
+#        define NUM_DIP_SWITCHES (ARRAY_SIZE((pin_t[])DIP_SWITCH_PINS))
 #    elif defined(DIP_SWITCH_MATRIX_GRID)
-#        define NUM_DIP_SWITCHES (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID)) / sizeof(matrix_index_t))
+#        define NUM_DIP_SWITCHES (ARRAY_SIZE((pin_t[])DIP_SWITCH_MATRIX_GRID))
 #    endif
 #    define NUM_DIP_SWITCHES_LEFT NUM_DIP_SWITCHES
 #    define NUM_DIP_SWITCHES_RIGHT 0

--- a/quantum/dip_switch.h
+++ b/quantum/dip_switch.h
@@ -20,6 +20,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "quantum.h"
+#include "util.h"
 
 bool dip_switch_update_kb(uint8_t index, bool active);
 bool dip_switch_update_user(uint8_t index, bool active);
@@ -29,7 +31,48 @@ bool dip_switch_update_mask_kb(uint32_t state);
 void dip_switch_init(void);
 void dip_switch_read(bool forced);
 
+#ifdef DIP_SWITCH_MATRIX_GRID
+typedef struct matrix_index_t {
+    uint8_t row;
+    uint8_t col;
+} matrix_index_t;
+#endif
+
 #ifdef SPLIT_KEYBOARD
 void dip_switch_state_raw(bool *slave_state);
 void dip_switch_update_raw(bool *slave_state);
-#endif
+#    if defined(DIP_SWITCH_PINS)
+#        if defined(DIP_SWITCH_PINS_RIGHT)
+#            define NUM_DIP_SWITCHES_LEFT (sizeof(((pin_t[])DIP_SWITCH_PINS)) / sizeof(pin_t))
+#            define NUM_DIP_SWITCHES_RIGHT (sizeof(((pin_t[])DIP_SWITCH_PINS_RIGHT)) / sizeof(pin_t))
+#        else
+#            define NUM_DIP_SWITCHES_LEFT (sizeof(((pin_t[])DIP_SWITCH_PINS)) / sizeof(pin_t))
+#            define NUM_DIP_SWITCHES_RIGHT NUM_DIP_SWITCHES_LEFT
+#        endif
+#    elif defined(DIP_SWITCH_MATRIX_GRID)
+#        if defined(DIP_SWITCH_MATRIX_GRID_RIGHT)
+#            define NUM_DIP_SWITCHES_LEFT (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID)) / sizeof(matrix_index_t))
+#            define NUM_DIP_SWITCHES_RIGHT (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID_RIGHT)) / sizeof(matrix_index_t))
+#        else
+#            define NUM_DIP_SWITCHES_LEFT (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID)) / sizeof(matrix_index_t))
+#            define NUM_DIP_SWITCHES_RIGHT NUM_DIP_SWITCHES_LEFT
+#        endif
+#    endif
+#    define NUM_DIP_SWITCHES (NUM_DIP_SWITCHES_LEFT + NUM_DIP_SWITCHES_RIGHT)
+#else // SPLIT_KEYBOARD
+#    if defined(DIP_SWITCH_PINS)
+#        define NUM_DIP_SWITCHES (sizeof(((pin_t[])DIP_SWITCH_PINS)) / sizeof(pin_t))
+#    elif defined(DIP_SWITCH_MATRIX_GRID)
+#        define NUM_DIP_SWITCHES (sizeof(((matrix_index_t[])DIP_SWITCH_MATRIX_GRID)) / sizeof(matrix_index_t))
+#    endif
+#    define NUM_DIP_SWITCHES_LEFT NUM_DIP_SWITCHES
+#    define NUM_DIP_SWITCHES_RIGHT 0
+#endif // SPLIT_KEYBOARD
+
+#ifndef NUM_DIP_SWITCHES
+#    define NUM_DIP_SWITCHES 0
+#    define NUM_DIP_SWITCHES_LEFT 0
+#    define NUM_DIP_SWITCHES_RIGHT 0
+#endif // NUM_ENCODERS
+
+#define NUM_DIP_SWITCHES_MAX_PER_SIDE MAX(NUM_DIP_SWITCHES_LEFT, NUM_DIP_SWITCHES_RIGHT)

--- a/quantum/dip_switch.h
+++ b/quantum/dip_switch.h
@@ -28,3 +28,8 @@ bool dip_switch_update_mask_kb(uint32_t state);
 
 void dip_switch_init(void);
 void dip_switch_read(bool forced);
+
+#ifdef SPLIT_KEYBOARD
+void dip_switch_state_raw(bool *slave_state);
+void dip_switch_update_raw(bool *slave_state);
+#endif

--- a/quantum/split_common/transaction_id_define.h
+++ b/quantum/split_common/transaction_id_define.h
@@ -33,6 +33,11 @@ enum serial_transaction_id {
     GET_ENCODERS_DATA,
 #endif // ENCODER_ENABLE
 
+#ifdef DIP_SWITCH_ENABLE
+    GET_DIP_SWITCH_CHECKSUM,
+    GET_DIP_SWITCH_DATA,
+#endif  // DIP_SWITCH_ENABLE
+
 #ifndef DISABLE_SYNC_TIMER
     PUT_SYNC_TIMER,
 #endif // DISABLE_SYNC_TIMER

--- a/quantum/split_common/transaction_id_define.h
+++ b/quantum/split_common/transaction_id_define.h
@@ -36,7 +36,7 @@ enum serial_transaction_id {
 #ifdef DIP_SWITCH_ENABLE
     GET_DIP_SWITCH_CHECKSUM,
     GET_DIP_SWITCH_DATA,
-#endif  // DIP_SWITCH_ENABLE
+#endif // DIP_SWITCH_ENABLE
 
 #ifndef DISABLE_SYNC_TIMER
     PUT_SYNC_TIMER,

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -718,12 +718,11 @@ static void pointing_handlers_slave(matrix_row_t master_matrix[], matrix_row_t s
 
 #endif // defined(POINTING_DEVICE_ENABLE) && defined(SPLIT_POINTING_ENABLE)
 
-
 #if defined(DIP_SWITCH_ENABLE)
 
 static bool dip_switch_handlers_master(matrix_row_t master_matrix[], matrix_row_t slave_matrix[]) {
     static uint32_t last_update = 0;
-    bool         temp_state[NUM_DIP_SWITCHES_MAX_PER_SIDE];
+    bool            temp_state[NUM_DIP_SWITCHES_MAX_PER_SIDE];
 
     bool okay = read_if_checksum_mismatch(GET_DIP_SWITCH_CHECKSUM, GET_DIP_SWITCH_DATA, &last_update, temp_state, split_shmem->dip_switch.state, sizeof(temp_state));
     if (okay) dip_switch_update_raw(temp_state);

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -77,7 +77,7 @@ typedef struct _split_slave_encoder_sync_t {
 #ifdef DIP_SWITCH_ENABLE
 typedef struct _split_slave_dip_switch_sync_t {
     uint8_t checksum;
-    bool    state[NUM_ENCODERS_MAX_PER_SIDE];
+    bool    state[NUM_DIP_SWITCHES_MAX_PER_SIDE];
 } split_slave_dip_switch_sync_t;
 #endif // DIP_SWITCH_ENABLE
 

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -46,7 +46,6 @@ bool transport_execute_transaction(int8_t id, const void *initiator2target_buf, 
 
 #ifdef DIP_SWITCH_ENABLE
 #    include "dip_switch.h"
-#    define NUMBER_OF_DIP_SWITCHES (sizeof((pin_t[])DIP_SWITCH_PINS) / sizeof(pin_t))
 #endif // DIP_SWITCH_ENABLE
 
 #ifdef BACKLIGHT_ENABLE
@@ -78,9 +77,9 @@ typedef struct _split_slave_encoder_sync_t {
 #ifdef DIP_SWITCH_ENABLE
 typedef struct _split_slave_dip_switch_sync_t {
     uint8_t checksum;
-    bool state[NUMBER_OF_DIP_SWITCHES];
+    bool    state[NUM_ENCODERS_MAX_PER_SIDE];
 } split_slave_dip_switch_sync_t;
-#endif  // DIP_SWITCH_ENABLE
+#endif // DIP_SWITCH_ENABLE
 
 #if !defined(NO_ACTION_LAYER) && defined(SPLIT_LAYER_STATE_ENABLE)
 typedef struct _split_layers_sync_t {
@@ -175,7 +174,7 @@ typedef struct _split_shared_memory_t {
 
 #ifdef DIP_SWITCH_ENABLE
     split_slave_dip_switch_sync_t dip_switches;
-#endif  // DIP_SWITCH_ENABLE
+#endif // DIP_SWITCH_ENABLE
 
 #ifndef DISABLE_SYNC_TIMER
     uint32_t sync_timer;

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -44,6 +44,11 @@ bool transport_execute_transaction(int8_t id, const void *initiator2target_buf, 
 #    include "encoder.h"
 #endif // ENCODER_ENABLE
 
+#ifdef DIP_SWITCH_ENABLE
+#    include "dip_switch.h"
+#    define NUMBER_OF_DIP_SWITCHES (sizeof((pin_t[])DIP_SWITCH_PINS) / sizeof(pin_t))
+#endif // DIP_SWITCH_ENABLE
+
 #ifdef BACKLIGHT_ENABLE
 #    include "backlight.h"
 #endif // BACKLIGHT_ENABLE
@@ -69,6 +74,13 @@ typedef struct _split_slave_encoder_sync_t {
     uint8_t state[NUM_ENCODERS_MAX_PER_SIDE];
 } split_slave_encoder_sync_t;
 #endif // ENCODER_ENABLE
+
+#ifdef DIP_SWITCH_ENABLE
+typedef struct _split_slave_dip_switch_sync_t {
+    uint8_t checksum;
+    bool state[NUMBER_OF_DIP_SWITCHES];
+} split_slave_dip_switch_sync_t;
+#endif  // DIP_SWITCH_ENABLE
 
 #if !defined(NO_ACTION_LAYER) && defined(SPLIT_LAYER_STATE_ENABLE)
 typedef struct _split_layers_sync_t {
@@ -160,6 +172,10 @@ typedef struct _split_shared_memory_t {
 #ifdef ENCODER_ENABLE
     split_slave_encoder_sync_t encoders;
 #endif // ENCODER_ENABLE
+
+#ifdef DIP_SWITCH_ENABLE
+    split_slave_dip_switch_sync_t dip_switches;
+#endif  // DIP_SWITCH_ENABLE
 
 #ifndef DISABLE_SYNC_TIMER
     uint32_t sync_timer;

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -173,7 +173,7 @@ typedef struct _split_shared_memory_t {
 #endif // ENCODER_ENABLE
 
 #ifdef DIP_SWITCH_ENABLE
-    split_slave_dip_switch_sync_t dip_switches;
+    split_slave_dip_switch_sync_t dip_switch;
 #endif // DIP_SWITCH_ENABLE
 
 #ifndef DISABLE_SYNC_TIMER


### PR DESCRIPTION
## Description

Add support for syncing Dip Switch states over split

## Types of Changes

- [x] Core
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
