### PR TITLE
Use Pro Micro SDA/SCL pinout for PM2040

### DIFF
--- a/platforms/chibios/boards/QMK_PM2040/configs/config.h
+++ b/platforms/chibios/boards/QMK_PM2040/configs/config.h
@@ -7,10 +7,10 @@
 #    define I2C_DRIVER I2CD2
 #endif
 #ifndef I2C1_SDA_PIN
-#    define I2C1_SDA_PIN 2U
+#    define I2C1_SDA_PIN D1
 #endif
 #ifndef I2C1_SCL_PIN
-#    define I2C1_SCL_PIN 3U
+#    define I2C1_SCL_PIN D0
 #endif
 
 #ifndef RP2040_BOOTLOADER_DOUBLE_TAP_RESET


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Refactor #17578 to use Pro Micro pinout instead. This will allow wider converter support for RP2040 boards such as Blok that uses different GPIO pins for SDA and SCL.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
