### PR TITLE
Fix rgbkb/sol/rev2 build issues

### DIFF
--- a/lib/python/qmk/c_parse.py
+++ b/lib/python/qmk/c_parse.py
@@ -258,6 +258,9 @@ def _parse_led_config(file, matrix_cols, matrix_rows):
                         position_raw.append(_coerce_led_token(_type, value))
                     if section == 3 and bracket_count == 2:
                         flags.append(_coerce_led_token(_type, value))
+                elif _type in [Token.Comment.Preproc]:
+                    # TODO: Promote to error
+                    return None
 
     # Slightly better intrim format
     matrix = list(_get_chunks(matrix_raw, matrix_cols))

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -152,9 +152,14 @@ def generate_encoder_config(encoder_json, config_h_lines, postfix=''):
     config_h_lines.append(f'#   define ENCODERS_PAD_B{postfix} {{ { ", ".join(b_pads) } }}')
     config_h_lines.append(f'#endif // ENCODERS_PAD_B{postfix}')
 
-    config_h_lines.append(f'#ifndef ENCODER_RESOLUTIONS{postfix}')
-    config_h_lines.append(f'#   define ENCODER_RESOLUTIONS{postfix} {{ { ", ".join(resolutions) } }}')
-    config_h_lines.append(f'#endif // ENCODER_RESOLUTIONS{postfix}')
+    if len(set(resolutions)) == 1:
+        config_h_lines.append(f'#ifndef ENCODER_RESOLUTION{postfix}')
+        config_h_lines.append(f'#   define ENCODER_RESOLUTION{postfix} { resolutions[0] }')
+        config_h_lines.append(f'#endif // ENCODER_RESOLUTION{postfix}')
+    else:
+        config_h_lines.append(f'#ifndef ENCODER_RESOLUTIONS{postfix}')
+        config_h_lines.append(f'#   define ENCODER_RESOLUTIONS{postfix} {{ { ", ".join(resolutions) } }}')
+        config_h_lines.append(f'#endif // ENCODER_RESOLUTIONS{postfix}')
 
 
 def generate_split_config(kb_info_json, config_h_lines):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
* Ignore led config that contains preprocessor
* Generate `ENCODER_RESOLUTION` when all values are same value
  * avoids generating `ENCODER_RESOLUTIONS` which _might_ not match `len(ENCODERS_PAD_A)`
      * this is due to preprocessor use around encoders - last value wins

#17460 will continue efforts to gracefully handle preprocessor in `config.h` files 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
