### PR TITLE
[Core] Use polled waiting on ChibiOS platforms that support it

### DIFF
--- a/keyboards/handwired/onekey/elite_c/config.h
+++ b/keyboards/handwired/onekey/elite_c/config.h
@@ -30,3 +30,6 @@
 #define RGB_CI_PIN B1
 
 #define ADC_PIN F6
+
+#define QMK_WAITING_TEST_BUSY_PIN F6
+#define QMK_WAITING_TEST_YIELD_PIN F7

--- a/keyboards/handwired/onekey/keymaps/chibios_waiting_test/config.h
+++ b/keyboards/handwired/onekey/keymaps/chibios_waiting_test/config.h
@@ -1,0 +1,12 @@
+// Copyright 2022 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#if !defined(QMK_WAITING_TEST_BUSY_PIN)
+#    define QMK_WAITING_TEST_BUSY_PIN A8
+#endif
+
+#if !defined(QMK_WAITING_TEST_YIELD_PIN)
+#    define QMK_WAITING_TEST_YIELD_PIN A9
+#endif

--- a/keyboards/handwired/onekey/keymaps/chibios_waiting_test/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/chibios_waiting_test/keymap.c
@@ -1,0 +1,47 @@
+// Copyright 2022 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {LAYOUT_ortho_1x1(KC_A)};
+
+#if defined(__AVR__)
+#    pragma message "AVR uses polled waiting by default, running theses tests will not show any difference"
+static inline void chThdSleepMicroseconds(uint32_t us) {
+    wait_us(us);
+}
+#endif
+
+void keyboard_post_init_user(void) {
+    setPinOutput(QMK_WAITING_TEST_BUSY_PIN);
+    setPinOutput(QMK_WAITING_TEST_YIELD_PIN);
+}
+
+static inline void wait_us_polling_with_strobe(uint32_t us) {
+    writePinHigh(QMK_WAITING_TEST_BUSY_PIN);
+    wait_us(us);
+    writePinLow(QMK_WAITING_TEST_BUSY_PIN);
+}
+
+static inline void wait_us_yield_with_strobe(uint32_t us) {
+    writePinHigh(QMK_WAITING_TEST_YIELD_PIN);
+    chThdSleepMicroseconds(us);
+    writePinLow(QMK_WAITING_TEST_YIELD_PIN);
+}
+
+static const uint32_t waiting_values[] = {0, 1, 5, 10, 25, 50, 100, 150, 200, 500, 1000};
+
+void housekeeping_task_user(void) {
+    static uint32_t last_bench = 0;
+    if (timer_elapsed32(last_bench) > 500) {
+        for (int i = 0; i < (sizeof(waiting_values) / sizeof(waiting_values[0])); i++) {
+            wait_us_polling_with_strobe(waiting_values[i]);
+            wait_us(10);
+        }
+        for (int i = 0; i < (sizeof(waiting_values) / sizeof(waiting_values[0])); i++) {
+            wait_us_yield_with_strobe(waiting_values[i]);
+            wait_us(10);
+        }
+        last_bench = timer_read32();
+    }
+}

--- a/keyboards/handwired/onekey/promicro/config.h
+++ b/keyboards/handwired/onekey/promicro/config.h
@@ -30,3 +30,6 @@
 #define RGB_CI_PIN B1
 
 #define ADC_PIN F6
+
+#define QMK_WAITING_TEST_BUSY_PIN F6
+#define QMK_WAITING_TEST_YIELD_PIN F7

--- a/keyboards/handwired/onekey/rp2040/config.h
+++ b/keyboards/handwired/onekey/rp2040/config.h
@@ -6,9 +6,14 @@
 #include "config_common.h"
 
 #define PRODUCT Onekey Raspberry Pi RP2040
-#define MATRIX_COL_PINS { GP4 }
-#define MATRIX_ROW_PINS { GP5 }
+#define MATRIX_COL_PINS \
+    { GP4 }
+#define MATRIX_ROW_PINS \
+    { GP5 }
 #define DEBUG_MATRIX_SCAN_RATE
+
+#define QMK_WAITING_TEST_BUSY_PIN GP8
+#define QMK_WAITING_TEST_YIELD_PIN GP9
 
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP25

--- a/keyboards/handwired/onekey/teensy_2/config.h
+++ b/keyboards/handwired/onekey/teensy_2/config.h
@@ -29,3 +29,6 @@
 #define RGB_DI_PIN F6
 
 #define ADC_PIN F6
+
+#define QMK_WAITING_TEST_BUSY_PIN F6
+#define QMK_WAITING_TEST_YIELD_PIN F7

--- a/keyboards/handwired/onekey/teensy_2pp/config.h
+++ b/keyboards/handwired/onekey/teensy_2pp/config.h
@@ -29,3 +29,6 @@
 #define RGB_DI_PIN F6
 
 #define ADC_PIN F6
+
+#define QMK_WAITING_TEST_BUSY_PIN F6
+#define QMK_WAITING_TEST_YIELD_PIN F7

--- a/keyboards/planck/rev6_drop/matrix.c
+++ b/keyboards/planck/rev6_drop/matrix.c
@@ -15,14 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "hal.h"
-#include "timer.h"
-#include "wait.h"
-#include "debug.h"
-#include "matrix.h"
+#include "quantum.h"
 
 /*
  *     col: { B11, B10, B2, B1, A7, B0 }
@@ -38,9 +31,13 @@ __attribute__((weak)) void matrix_init_user(void) {}
 
 __attribute__((weak)) void matrix_scan_user(void) {}
 
-__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+__attribute__((weak)) void matrix_init_kb(void) {
+    matrix_init_user();
+}
 
-__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+__attribute__((weak)) void matrix_scan_kb(void) {
+    matrix_scan_user();
+}
 
 void matrix_init(void) {
     dprintf("matrix init\n");
@@ -146,9 +143,13 @@ uint8_t matrix_scan(void) {
     return 1;
 }
 
-bool matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & (1 << col)); }
+bool matrix_is_on(uint8_t row, uint8_t col) {
+    return (matrix[row] & (1 << col));
+}
 
-matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }
+matrix_row_t matrix_get_row(uint8_t row) {
+    return matrix[row];
+}
 
 void matrix_print(void) {
     dprintf("\nr/c 01234567\n");

--- a/keyboards/preonic/rev3_drop/matrix.c
+++ b/keyboards/preonic/rev3_drop/matrix.c
@@ -15,14 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "hal.h"
-#include "timer.h"
-#include "wait.h"
-#include "debug.h"
-#include "matrix.h"
+#include "quantum.h"
 
 typedef uint16_t matrix_col_t;
 
@@ -40,9 +33,13 @@ __attribute__((weak)) void matrix_init_user(void) {}
 
 __attribute__((weak)) void matrix_scan_user(void) {}
 
-__attribute__((weak)) void matrix_init_kb(void) { matrix_init_user(); }
+__attribute__((weak)) void matrix_init_kb(void) {
+    matrix_init_user();
+}
 
-__attribute__((weak)) void matrix_scan_kb(void) { matrix_scan_user(); }
+__attribute__((weak)) void matrix_scan_kb(void) {
+    matrix_scan_user();
+}
 
 void matrix_init(void) {
     dprintf("matrix init\n");
@@ -150,9 +147,13 @@ uint8_t matrix_scan(void) {
     return 1;
 }
 
-bool matrix_is_on(uint8_t row, uint8_t col) { return (matrix[row] & (1 << col)); }
+bool matrix_is_on(uint8_t row, uint8_t col) {
+    return (matrix[row] & (1 << col));
+}
 
-matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }
+matrix_row_t matrix_get_row(uint8_t row) {
+    return matrix[row];
+}
 
 void matrix_print(void) {
     dprintf("\nr/c 01234567\n");

--- a/platforms/chibios/_wait.h
+++ b/platforms/chibios/_wait.h
@@ -30,6 +30,11 @@
 
 #ifdef WAIT_US_TIMER
 void wait_us(uint16_t duration);
+#elif PORT_SUPPORTS_RT == TRUE
+#    define wait_us(us)                                            \
+        do {                                                       \
+            chSysPolledDelayX(US2RTC(REALTIME_COUNTER_CLOCK, us)); \
+        } while (0)
 #else
 #    define wait_us(us)                     \
         do {                                \

--- a/platforms/chibios/bootloaders/rp2040.c
+++ b/platforms/chibios/bootloaders/rp2040.c
@@ -43,9 +43,8 @@ void __late_init(void) {
     if (magic_location != magic_token) {
         magic_location = magic_token;
         // ChibiOS is not initialized at this point, so sleeping is only
-        // possible via busy waiting. The internal timer peripheral is running
-        // at this point with a precision of 1us.
-        chSysPolledDelayX(MS2RTC(1 * MHZ, RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT));
+        // possible via busy waiting.
+        wait_us(RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT * 1000U);
         magic_location = 0;
         return;
     }

--- a/platforms/chibios/chibios_config.h
+++ b/platforms/chibios/chibios_config.h
@@ -21,6 +21,9 @@
 
 #if defined(MCU_RP)
 #    define CPU_CLOCK RP_CORE_CLK
+// ChibiOS uses the RP2040 timer peripheral as its real time counter, this timer
+// is monotonic and running at 1MHz.
+#    define REALTIME_COUNTER_CLOCK 1000000
 
 #    define USE_GPIOV1
 #    define PAL_OUTPUT_TYPE_OPENDRAIN _Static_assert(0, "RP2040 has no Open Drain GPIO configuration, setting this is not possible");
@@ -102,10 +105,19 @@
 #    endif
 #endif
 
+#if defined(MCU_MIMXRT1062)
+#    include "clock_config.h"
+#    define CPU_CLOCK BOARD_BOOTCLOCKRUN_CORE_CLOCK
+#endif
+
 #if defined(HT32)
 #    define CPU_CLOCK HT32_CK_SYS_FREQUENCY
 #    define PAL_MODE_ALTERNATE PAL_HT32_MODE_AF
 #    define PAL_OUTPUT_TYPE_OPENDRAIN (PAL_HT32_MODE_OD | PAL_HT32_MODE_DIR)
 #    define PAL_OUTPUT_TYPE_PUSHPULL PAL_HT32_MODE_DIR
 #    define PAL_OUTPUT_SPEED_HIGHEST 0
+#endif
+
+#if !defined(REALTIME_COUNTER_CLOCK)
+#    define REALTIME_COUNTER_CLOCK CPU_CLOCK
 #endif

--- a/platforms/chibios/drivers/serial.c
+++ b/platforms/chibios/drivers/serial.c
@@ -20,7 +20,8 @@
 #    error "chSysPolledDelayX method not supported on this platform"
 #else
 #    undef wait_us
-#    define wait_us(x) chSysPolledDelayX(US2RTC(CPU_CLOCK, x))
+// Force usage of polled waiting - in case WAIT_US_TIMER is activated
+#    define wait_us(us) chSysPolledDelayX(US2RTC(REALTIME_COUNTER_CLOCK, us))
 #endif
 
 #ifndef SELECT_SOFT_SERIAL_SPEED

--- a/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
@@ -152,7 +152,7 @@ static inline void enter_rx_state(void) {
     }
     // Wait for ~11 bits, 1 start bit + 8 data bits + 1 stop bit + 1 bit
     // headroom.
-    chSysPolledDelayX(US2RTC(1 * MHZ, (1000000U * 11 / SERIAL_USART_SPEED)));
+    wait_us(1000000U * 11U / SERIAL_USART_SPEED);
     // Disable tx state machine to not interfere with our tx pin manipulation
     pio_sm_set_enabled(pio, tx_state_machine, false);
     gpio_set_drive_strength(SERIAL_USART_TX_PIN, GPIO_DRIVE_STRENGTH_2MA);


### PR DESCRIPTION
## Description

Due to context switching overhead waiting a very short amount of time on a sleeping thread is often not accurate and in fact not usable for timing critical usage i.e. in a driver. Thus we use polled waiting for ranges in the us range on platforms that support it instead. The fallback is the thread sleeping mechanism.

This includes:

* ARM platforms with CYCCNT register (ARMv7, ARMv8) this is incremented at CPU clock frequency
* GD32VF103 RISC-V port with CSR_MCYCLE register this is incremented at CPU clock frequency
* RP2040 ARMv6 port which uses the integrated timer peripheral which is incremented with a fixed 1MHz frequency

## Comparison busy waiting vs sleeping

Waiting values are 0, 1, 5, 10, 25, 50, 100, 150, 200, 500 and 1000 microseconds with 10us spacing. Pink is busy waiting, green is sleeping by yielding the thread.

### STM32F411

![stm32f411](https://user-images.githubusercontent.com/13887561/178106537-edd94a7b-af09-4b3e-a10b-e719a6570c40.png)

<span style="color:pink">busy waiting</span>

* minimal busy waiting: **1us**
* minimal sleeping time: **111us**

### RP2040

![rp2040](https://user-images.githubusercontent.com/13887561/178106536-af821e3f-91be-437e-ac58-0a5d674f9a18.png)

* minimal busy waiting: **1us**
* minimal sleeping time: **28us**

### GD32VF103

![gd32vf103](https://user-images.githubusercontent.com/13887561/178106532-a93e8024-23f0-427b-beb5-98849b5ceaab.png)

* minimal busy waiting: **1us**
* minimal sleeping time: **189us**

Matrix scanning frequency on DZZY keypad with 5x6 matrix:

* busy waiting: **4.6k** (575%!)
* thread sleeping: **800**

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Overhead in pointing device drivers and matrix scanning

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
