### PR TITLE
Add .orig to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Merge files
 *.orig
+*.rej
 
 # Build artifacts
 .clang_complete

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .DS_Store
 ._*
 
+# Merge files
+*.orig
+
 # Build artifacts
 .clang_complete
 .build/


### PR DESCRIPTION
Just a suggestion that we add this, since git merges seem to create these by default on my machine regardless of the mergetool I use. I figure we might as well just add this ignore line to master.