### PR TITLE
[Fix] Make ChibiOS `_wait.h` independent of `quantum.h`

### DIFF
--- a/platforms/chibios/_wait.h
+++ b/platforms/chibios/_wait.h
@@ -17,6 +17,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include "chibios_config.h"
 
 /* chThdSleepX of zero maps to infinite - so we map to a tiny delay to still yield */
 #define wait_ms(ms)                     \


### PR DESCRIPTION
## Description

...by including `chibios_config.h` directly. Otherwise drivers that don't include `quantum.h` directly will error out on `REALTIME_COUNTER_CLOCK` beeing undefined.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* e.g. the cirque trackpad driver only includes `wait.h`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
