### PR TITLE
Update LED/RGB Matrix flag function behavior

### DIFF
--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -621,7 +621,7 @@ void led_matrix_decrease_speed(void) {
 void led_matrix_set_flags_eeprom_helper(led_flags_t flags, bool write_to_eeprom) {
     led_matrix_config.flags = flags;
     eeconfig_flag_led_matrix(write_to_eeprom);
-    dprintf("led matrix set speed [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.flags);
+    dprintf("led matrix set speed [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", led_matrix_config.flags);
 }
 
 led_flags_t led_matrix_get_flags(void) {

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -618,10 +618,20 @@ void led_matrix_decrease_speed(void) {
     led_matrix_decrease_speed_helper(true);
 }
 
+void led_matrix_set_flags_eeprom_helper(led_flags_t flags, bool write_to_eeprom) {
+    led_matrix_config.flags = flags;
+    eeconfig_flag_led_matrix(write_to_eeprom);
+    dprintf("led matrix set speed [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.flags);
+}
+
 led_flags_t led_matrix_get_flags(void) {
-    return led_matrix_eeconfig.flags;
+    return led_matrix_config.flags;
 }
 
 void led_matrix_set_flags(led_flags_t flags) {
-    led_matrix_eeconfig.flags = flags;
+    led_matrix_set_flags_eeprom_helper(flags, true);
+}
+
+void led_matrix_set_flags_noeeprom(led_flags_t flags) {
+    led_matrix_set_flags_eeprom_helper(flags, false);
 }

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -158,6 +158,7 @@ void        led_matrix_decrease_speed(void);
 void        led_matrix_decrease_speed_noeeprom(void);
 led_flags_t led_matrix_get_flags(void);
 void        led_matrix_set_flags(led_flags_t flags);
+void        led_matrix_set_flags_noeeprom(led_flags_t flags);
 
 typedef struct {
     /* Perform any initialisation required for the other driver functions to work. */

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -724,10 +724,20 @@ void rgb_matrix_decrease_speed(void) {
     rgb_matrix_decrease_speed_helper(true);
 }
 
+void rgb_matrix_set_flags_eeprom_helper(led_flags_t flags, bool write_to_eeprom) {
+    rgb_matrix_config.flags = flags;
+    eeconfig_flag_rgb_matrix(write_to_eeprom);
+    dprintf("rgb matrix set speed [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.flags);
+}
+
 led_flags_t rgb_matrix_get_flags(void) {
     return rgb_matrix_config.flags;
 }
 
 void rgb_matrix_set_flags(led_flags_t flags) {
-    rgb_matrix_config.flags = flags;
+    rgb_matrix_set_flags_eeprom_helper(flags, true);
+}
+
+void rgb_matrix_set_flags_noeeprom(led_flags_t flags) {
+    rgb_matrix_set_flags_eeprom_helper(flags, false);
 }

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -182,6 +182,7 @@ void        rgb_matrix_increase_speed_noeeprom(void);
 void        rgb_matrix_decrease_speed(void);
 void        rgb_matrix_decrease_speed_noeeprom(void);
 led_flags_t rgb_matrix_get_flags(void);
+led_flags_t rgb_matrix_get_flags_noeeprom(void);
 void        rgb_matrix_set_flags(led_flags_t flags);
 
 #ifndef RGBLIGHT_ENABLE


### PR DESCRIPTION
## Description

LED/RGB Matrix config was updated so all of it is in EEPROM, including flags.  However, the flag functions were not updated to properly write to eeprom. 

This ensures that it does, and that adds a "noeeprom" version, as well. 

Wasn't sure if to target develop or master here.  Based on master, targets develop. Should be able to be switched without issue, if needed.

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
