### PR TITLE
Cirque circular scroll: Support POINTING_DEVICE_COMBINED

### DIFF
--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -412,7 +412,7 @@ report_mouse_t pointing_device_combine_reports(report_mouse_t left_report, repor
  */
 report_mouse_t pointing_device_adjust_by_defines_right(report_mouse_t mouse_report) {
     // Support rotation of the sensor data
-#    if defined(POINTING_DEVICE_ROTATION_90_RIGHT) || defined(POINTING_DEVICE_ROTATION_RIGHT) || defined(POINTING_DEVICE_ROTATION_RIGHT)
+#    if defined(POINTING_DEVICE_ROTATION_90_RIGHT) || defined(POINTING_DEVICE_ROTATION_180_RIGHT) || defined(POINTING_DEVICE_ROTATION_270_RIGHT)
     mouse_xy_report_t x = mouse_report.x;
     mouse_xy_report_t y = mouse_report.y;
 #        if defined(POINTING_DEVICE_ROTATION_90_RIGHT)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Adjust coordinates for circular scroll, handle `POINTING_DEVICE_ROTATION_*_RIGHT` appropriately.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Reuse `pointing_device_adjust_by_defines*()` instead of using an incomplete custom implementation of the same logic.
Fix `pointing_device_adjust_by_defines_right()` for 180 & 270 degrees.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
