### PR TITLE
Fix compilation issue with Cirque Guestures file

### DIFF
--- a/drivers/sensors/cirque_pinnacle_gestures.c
+++ b/drivers/sensors/cirque_pinnacle_gestures.c
@@ -19,6 +19,7 @@
 #include "cirque_pinnacle_gestures.h"
 #include "pointing_device.h"
 #include "timer.h"
+#include "wait.h"
 
 #if defined(CIRQUE_PINNACLE_TAP_ENABLE) || defined(CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE)
 static cirque_pinnacle_features_t features = {.tap_enable = true, .circular_scroll_enable = true};


### PR DESCRIPTION
## Description

Compliation of cirque guestures errors out on wait_ms(x).  Adds include for wait.h to fix.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* reported on discord by freznel

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
