### PR TITLE
Post-bootloader EFL/SPI fixes.

### DIFF
--- a/platforms/chibios/drivers/spi_master.c
+++ b/platforms/chibios/drivers/spi_master.c
@@ -46,7 +46,6 @@ __attribute__((weak)) void spi_init(void) {
         palSetPadMode(PAL_PORT(SPI_MOSI_PIN), PAL_PAD(SPI_MOSI_PIN), SPI_MOSI_FLAGS);
         palSetPadMode(PAL_PORT(SPI_MISO_PIN), PAL_PAD(SPI_MISO_PIN), SPI_MISO_FLAGS);
 #endif
-        spiUnselect(&SPI_DRIVER);
         spiStop(&SPI_DRIVER);
         currentSlavePin = NO_PIN;
     }

--- a/platforms/chibios/drivers/wear_leveling/wear_leveling_efl.c
+++ b/platforms/chibios/drivers/wear_leveling/wear_leveling_efl.c
@@ -43,6 +43,9 @@ bool backing_store_init(void) {
     bs_dprintf("Init\n");
     flash = (BaseFlash *)&EFLD1;
 
+    // Need to re-lock the EFL, as if we've just had the bootloader executing it'll already be unlocked.
+    backing_store_lock();
+
     const flash_descriptor_t *desc    = flashGetDescriptor(flash);
     uint32_t                  counter = 0;
 

--- a/platforms/chibios/drivers/wear_leveling/wear_leveling_efl.c
+++ b/platforms/chibios/drivers/wear_leveling/wear_leveling_efl.c
@@ -132,7 +132,7 @@ bool backing_store_lock(void) {
 
 bool backing_store_read(uint32_t address, backing_store_int_t *value) {
     uint32_t             offset = (base_offset + address);
-    backing_store_int_t *loc    = (backing_store_int_t *)offset;
+    backing_store_int_t *loc    = (backing_store_int_t *)flashGetOffsetAddress(flash, offset);
     *value                      = ~(*loc);
     bs_dprintf("Read  ");
     wl_dump(offset, value, sizeof(backing_store_int_t));


### PR DESCRIPTION
## Description

EFL and SPI post-bootloader startup bugs, detected through assertions.

Under normal circumstances program code is mapped to `0x00000000` as well as `0x08000000`.
Post-bootloader, only the latter address is correct, so EFL is swapped to using the other location.

Also noted after bootloader is that the flash is already unlocked -- re-unlocking causes a fault and necessitates a restart.
Added explicit invocation of `backing_store_lock()` during `backing_store_init()` to force it to be in the correct state.
Invoking it even when locked is fine.

Also noted with debugging enabled that `spiUnselect()` requires the peripheral to be in the stopped state - with assertions disabled this is ignored, but is obviously "wrong" as far as ChibiOS is concerned. Have removed the call.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
