### PR TITLE
[Core] Introduce pointing device specific debug messages

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -487,3 +487,13 @@ report_mouse_t pointing_device_task_combined_user(report_mouse_t left_report, re
     return pointing_device_combine_reports(left_report, right_report);
 }
 ```
+
+# Troubleshooting
+
+If you are having issues with pointing device drivers debug messages can be enabled that will give you insights in the inner workings. To enable these add to your keyboards `config.h` file:
+
+```c
+#define POINTING_DEVICE_DEBUG
+```
+ 
+?> The messages will be printed out to the `CONSOLE` output. For additional information, refer to [Debugging/Troubleshooting QMK](faq_debug.md).

--- a/drivers/sensors/cirque_pinnacle.c
+++ b/drivers/sensors/cirque_pinnacle.c
@@ -4,8 +4,6 @@
 // refer to documentation: Gen2 and Gen3 (Pinnacle ASIC) at https://www.cirque.com/documentation
 
 #include "cirque_pinnacle.h"
-#include "print.h"
-#include "debug.h"
 #include "wait.h"
 #include "timer.h"
 
@@ -26,12 +24,6 @@ void cirque_pinnacle_clear_flags(void);
 void cirque_pinnacle_enable_feed(bool feedEnable);
 void RAP_ReadBytes(uint8_t address, uint8_t* data, uint8_t count);
 void RAP_Write(uint8_t address, uint8_t data);
-
-#ifdef CONSOLE_ENABLE
-void print_byte(uint8_t byte) {
-    xprintf("%c%c%c%c%c%c%c%c|", (byte & 0x80 ? '1' : '0'), (byte & 0x40 ? '1' : '0'), (byte & 0x20 ? '1' : '0'), (byte & 0x10 ? '1' : '0'), (byte & 0x08 ? '1' : '0'), (byte & 0x04 ? '1' : '0'), (byte & 0x02 ? '1' : '0'), (byte & 0x01 ? '1' : '0'));
-}
-#endif
 
 #if CIRQUE_PINNACLE_POSITION_MODE
 /*  Logical Scaling Functions */

--- a/drivers/sensors/cirque_pinnacle.h
+++ b/drivers/sensors/cirque_pinnacle.h
@@ -5,6 +5,7 @@
 #include "cirque_pinnacle_regdefs.h"
 #include <stdint.h>
 #include <stdbool.h>
+#include "pointing_device_internal.h"
 
 #ifndef CIRQUE_PINNACLE_TIMEOUT
 #    define CIRQUE_PINNACLE_TIMEOUT 20 // I2C timeout in milliseconds

--- a/drivers/sensors/cirque_pinnacle_i2c.c
+++ b/drivers/sensors/cirque_pinnacle_i2c.c
@@ -1,8 +1,6 @@
 // Copyright (c) 2018 Cirque Corp. Restrictions apply. See: www.cirque.com/sw-license
 #include "cirque_pinnacle.h"
 #include "i2c_master.h"
-#include "print.h"
-#include "debug.h"
 #include "stdio.h"
 
 // Masks for Cirque Register Access Protocol (RAP)
@@ -18,9 +16,7 @@ void RAP_ReadBytes(uint8_t address, uint8_t* data, uint8_t count) {
     if (touchpad_init) {
         i2c_writeReg(CIRQUE_PINNACLE_ADDR << 1, cmdByte, NULL, 0, CIRQUE_PINNACLE_TIMEOUT);
         if (i2c_readReg(CIRQUE_PINNACLE_ADDR << 1, cmdByte, data, count, CIRQUE_PINNACLE_TIMEOUT) != I2C_STATUS_SUCCESS) {
-#ifdef CONSOLE_ENABLE
-            dprintf("error cirque_pinnacle i2c_readReg\n");
-#endif
+            pd_dprintf("error cirque_pinnacle i2c_readReg\n");
             touchpad_init = false;
         }
         i2c_stop();
@@ -33,9 +29,7 @@ void RAP_Write(uint8_t address, uint8_t data) {
 
     if (touchpad_init) {
         if (i2c_writeReg(CIRQUE_PINNACLE_ADDR << 1, cmdByte, &data, sizeof(data), CIRQUE_PINNACLE_TIMEOUT) != I2C_STATUS_SUCCESS) {
-#ifdef CONSOLE_ENABLE
-            dprintf("error cirque_pinnacle i2c_writeReg\n");
-#endif
+            pd_dprintf("error cirque_pinnacle i2c_writeReg\n");
             touchpad_init = false;
         }
         i2c_stop();

--- a/drivers/sensors/cirque_pinnacle_spi.c
+++ b/drivers/sensors/cirque_pinnacle_spi.c
@@ -1,8 +1,6 @@
 // Copyright (c) 2018 Cirque Corp. Restrictions apply. See: www.cirque.com/sw-license
 #include "cirque_pinnacle.h"
 #include "spi_master.h"
-#include "print.h"
-#include "debug.h"
 
 // Masks for Cirque Register Access Protocol (RAP)
 #define WRITE_MASK 0x80
@@ -24,9 +22,7 @@ void RAP_ReadBytes(uint8_t address, uint8_t* data, uint8_t count) {
                 data[i] = spi_write(FILLER_BYTE); // write filler, receive data on the third filler send
             }
         } else {
-#ifdef CONSOLE_ENABLE
-            dprintf("error cirque_pinnacle spi_start read\n");
-#endif
+            pd_dprintf("error cirque_pinnacle spi_start read\n");
             touchpad_init = false;
         }
         spi_stop();
@@ -42,9 +38,7 @@ void RAP_Write(uint8_t address, uint8_t data) {
             spi_write(cmdByte);
             spi_write(data);
         } else {
-#ifdef CONSOLE_ENABLE
-            dprintf("error cirque_pinnacle spi_start write\n");
-#endif
+            pd_dprintf("error cirque_pinnacle spi_start write\n");
             touchpad_init = false;
         }
         spi_stop();

--- a/drivers/sensors/pimoroni_trackball.c
+++ b/drivers/sensors/pimoroni_trackball.c
@@ -14,10 +14,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include "pointing_device_internal.h"
 #include "pimoroni_trackball.h"
 #include "i2c_master.h"
-#include "print.h"
-#include "debug.h"
 #include "timer.h"
 
 // clang-format off
@@ -58,20 +58,17 @@ void pimoroni_trackball_set_rgbw(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
     uint8_t                              data[4] = {r, g, b, w};
     __attribute__((unused)) i2c_status_t status  = i2c_writeReg(PIMORONI_TRACKBALL_ADDRESS << 1, PIMORONI_TRACKBALL_REG_LED_RED, data, sizeof(data), PIMORONI_TRACKBALL_TIMEOUT);
 
-#ifdef CONSOLE_ENABLE
-    if (debug_mouse) dprintf("Trackball RGBW i2c_status_t: %d\n", status);
-#endif
+    pd_dprintf("Trackball RGBW i2c_status_t: %d\n", status);
 }
 
 i2c_status_t read_pimoroni_trackball(pimoroni_data_t* data) {
     i2c_status_t status = i2c_readReg(PIMORONI_TRACKBALL_ADDRESS << 1, PIMORONI_TRACKBALL_REG_LEFT, (uint8_t*)data, sizeof(*data), PIMORONI_TRACKBALL_TIMEOUT);
-#ifdef CONSOLE_ENABLE
-    if (debug_mouse) {
-        static uint16_t d_timer;
-        if (timer_elapsed(d_timer) > PIMORONI_TRACKBALL_DEBUG_INTERVAL) {
-            dprintf("Trackball READ i2c_status_t: %d L: %d R: %d Up: %d D: %d SW: %d\n", status, data->left, data->right, data->up, data->down, data->click);
-            d_timer = timer_read();
-        }
+
+#ifdef POINTING_DEVICE_DEBUG
+    static uint16_t d_timer;
+    if (timer_elapsed(d_timer) > PIMORONI_TRACKBALL_DEBUG_INTERVAL) {
+        pd_dprintf("Trackball READ i2c_status_t: %d L: %d R: %d Up: %d D: %d SW: %d\n", status, data->left, data->right, data->up, data->down, data->click);
+        d_timer = timer_read();
     }
 #endif
 

--- a/drivers/sensors/pmw33xx_common.c
+++ b/drivers/sensors/pmw33xx_common.c
@@ -7,9 +7,8 @@
 // Copyright 2020 Ploopy Corporation
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "debug.h"
+#include "pointing_device_internal.h"
 #include "pmw33xx_common.h"
-#include "print.h"
 #include "string.h"
 #include "wait.h"
 #include "spi_master.h"
@@ -154,7 +153,7 @@ bool pmw33xx_init(uint8_t sensor) {
     pmw33xx_read(sensor, REG_Delta_Y_H);
 
     if (!pmw33xx_upload_firmware(sensor)) {
-        dprintf("PMW33XX (%d): firmware upload failed!\n", sensor);
+        pd_dprintf("PMW33XX (%d): firmware upload failed!\n", sensor);
         return false;
     }
 
@@ -170,7 +169,7 @@ bool pmw33xx_init(uint8_t sensor) {
     pmw33xx_write(sensor, REG_Lift_Config, PMW33XX_LIFTOFF_DISTANCE);
 
     if (!pmw33xx_check_signature(sensor)) {
-        dprintf("PMW33XX (%d): firmware signature verification failed!\n", sensor);
+        pd_dprintf("PMW33XX (%d): firmware signature verification failed!\n", sensor);
         return false;
     }
 
@@ -185,7 +184,7 @@ pmw33xx_report_t pmw33xx_read_burst(uint8_t sensor) {
     }
 
     if (!in_burst[sensor]) {
-        dprintf("PMW33XX (%d): burst\n", sensor);
+        pd_dprintf("PMW33XX (%d): burst\n", sensor);
         if (!pmw33xx_write(sensor, REG_Motion_Burst, 0x00)) {
             return report;
         }
@@ -208,9 +207,7 @@ pmw33xx_report_t pmw33xx_read_burst(uint8_t sensor) {
 
     spi_stop();
 
-    if (debug_config.mouse) {
-        dprintf("PMW33XX (%d): motion: 0x%x dx: %i dy: %i\n", sensor, report.motion.w, report.delta_x, report.delta_y);
-    }
+    pd_dprintf("PMW33XX (%d): motion: 0x%x dx: %i dy: %i\n", sensor, report.motion.w, report.delta_x, report.delta_y);
 
     report.delta_x *= -1;
     report.delta_y *= -1;

--- a/quantum/pointing_device/pointing_device_drivers.c
+++ b/quantum/pointing_device/pointing_device_drivers.c
@@ -17,6 +17,7 @@
  */
 
 #include "pointing_device.h"
+#include "pointing_device_internal.h"
 #include "debug.h"
 #include "wait.h"
 #include "timer.h"
@@ -32,10 +33,7 @@ report_mouse_t adns5050_get_report(report_mouse_t mouse_report) {
     report_adns5050_t data = adns5050_read_burst();
 
     if (data.dx != 0 || data.dy != 0) {
-#    ifdef CONSOLE_ENABLE
-        if (debug_mouse) dprintf("Raw ] X: %d, Y: %d\n", data.dx, data.dy);
-#    endif
-
+        pd_dprintf("Raw ] X: %d, Y: %d\n", data.dx, data.dy);
         mouse_report.x = (mouse_xy_report_t)data.dx;
         mouse_report.y = (mouse_xy_report_t)data.dy;
     }
@@ -76,9 +74,7 @@ const pointing_device_driver_t pointing_device_driver = {
 report_mouse_t analog_joystick_get_report(report_mouse_t mouse_report) {
     report_analog_joystick_t data = analog_joystick_read();
 
-#    ifdef CONSOLE_ENABLE
-    if (debug_mouse) dprintf("Raw ] X: %d, Y: %d\n", data.x, data.y);
-#    endif
+    pd_dprintf("Raw ] X: %d, Y: %d\n", data.x, data.y);
 
     mouse_report.x = data.x;
     mouse_report.y = data.y;
@@ -140,11 +136,9 @@ report_mouse_t cirque_pinnacle_get_report(report_mouse_t mouse_report) {
         return mouse_report;
     }
 
-#        if CONSOLE_ENABLE
-    if (debug_mouse && touchData.touchDown) {
-        dprintf("cirque_pinnacle touchData x=%4d y=%4d z=%2d\n", touchData.xValue, touchData.yValue, touchData.zValue);
+    if (touchData.touchDown) {
+        pd_dprintf("cirque_pinnacle touchData x=%4d y=%4d z=%2d\n", touchData.xValue, touchData.yValue, touchData.zValue);
     }
-#        endif
 
     // Scale coordinates to arbitrary X, Y resolution
     cirque_pinnacle_scale_data(&touchData, cirque_pinnacle_get_scale(), cirque_pinnacle_get_scale());
@@ -227,9 +221,7 @@ const pointing_device_driver_t pointing_device_driver = {
 report_mouse_t paw3204_get_report(report_mouse_t mouse_report) {
     report_paw3204_t data = paw3204_read();
     if (data.isMotion) {
-#    ifdef CONSOLE_ENABLE
-        dprintf("Raw ] X: %d, Y: %d\n", data.x, data.y);
-#    endif
+        pd_dprintf("Raw ] X: %d, Y: %d\n", data.x, data.y);
 
         mouse_report.x = data.x;
         mouse_report.y = data.y;
@@ -329,7 +321,7 @@ report_mouse_t pmw33xx_get_report(report_mouse_t mouse_report) {
 
     if (!in_motion) {
         in_motion = true;
-        dprintf("PWM3360 (0): starting motion\n");
+        pd_dprintf("PWM3360 (0): starting motion\n");
     }
 
     mouse_report.x = CONSTRAIN_HID_XY(report.delta_x);

--- a/quantum/pointing_device_internal.h
+++ b/quantum/pointing_device_internal.h
@@ -1,0 +1,14 @@
+// Copyright 2022 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#ifdef POINTING_DEVICE_DEBUG
+#    include "debug.h"
+#    include "print.h"
+#    define pd_dprintf(...) dprintf(__VA_ARGS__)
+#else
+#    define pd_dprintf(...) \
+        do {                \
+        } while (0)
+#endif


### PR DESCRIPTION
## Description

Spun out of #17613

...as debug messages from the pointing device drivers can be come quite verbose. These can be enabled with `POINTING_DEVICE_DEBUG` define on a keyboard level.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
