### PR TITLE
Add support for PAW3204 Optical Sensor

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -126,7 +126,7 @@ ifeq ($(strip $(MOUSEKEY_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/mousekey.c
 endif
 
-VALID_POINTING_DEVICE_DRIVER_TYPES := adns5050 adns9800 analog_joystick cirque_pinnacle_i2c cirque_pinnacle_spi pmw3360 pmw3389 pimoroni_trackball custom
+VALID_POINTING_DEVICE_DRIVER_TYPES := adns5050 adns9800 analog_joystick cirque_pinnacle_i2c cirque_pinnacle_spi paw3204 pmw3360 pmw3389 pimoroni_trackball custom
 ifeq ($(strip $(POINTING_DEVICE_ENABLE)), yes)
     ifeq ($(filter $(POINTING_DEVICE_DRIVER),$(VALID_POINTING_DEVICE_DRIVER_TYPES)),)
         $(call CATASTROPHIC_ERROR,Invalid POINTING_DEVICE_DRIVER,POINTING_DEVICE_DRIVER="$(POINTING_DEVICE_DRIVER)" is not a valid pointing device type)

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -136,6 +136,31 @@ Also see the `POINTING_DEVICE_TASK_THROTTLE_MS`, which defaults to 10ms when usi
 
 **`POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE`** is not specific to Cirque trackpad; any pointing device with a lift/contact status can integrate this gesture into its driver. e.g. PMW3360 can use Lift_Stat from Motion register. Note that `POINTING_DEVICE_MOTION_PIN` cannot be used with this feature; continuous polling of `pointing_device_get_report()` is needed to generate glide reports.
 
+### PAW 3204 Sensor
+
+To use the paw 3204 sensor, add this to your `rules.mk`
+
+```make
+POINTING_DEVICE_DRIVER = paw3204
+```
+
+The paw 3204 sensor uses a serial type protocol for communication, and requires an additional light source. 
+
+| Setting            | Description                                                         |
+|--------------------|---------------------------------------------------------------------|
+|`PAW3204_SCLK` | (Required) The pin connected to the clock pin of the sensor.        |
+|`PAW3204_SDIO` | (Required) The pin connected to the data pin of the sensor.         |
+
+Output resolution setting
+bit:
+000 = 400 
+001 = 500
+010 = 600
+011 = 800
+100 = 1000 (Default)
+101 = 1200
+110 = 1600 
+
 ### Pimoroni Trackball
 
 To use the Pimoroni Trackball module, add this to your `rules.mk`:

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -148,18 +148,11 @@ The paw 3204 sensor uses a serial type protocol for communication, and requires 
 
 | Setting            | Description                                                         |
 |--------------------|---------------------------------------------------------------------|
-|`PAW3204_SCLK` | (Required) The pin connected to the clock pin of the sensor.        |
-|`PAW3204_SDIO` | (Required) The pin connected to the data pin of the sensor.         |
+|`PAW3204_SCLK_PIN` | (Required) The pin connected to the clock pin of the sensor.        |
+|`PAW3204_SDIO_PIN` | (Required) The pin connected to the data pin of the sensor.         |
 
-Output resolution setting
-bit:
-000 = 400 
-001 = 500
-010 = 600
-011 = 800
-100 = 1000 (Default)
-101 = 1200
-110 = 1600 
+The CPI range is 400-1600, with supported values of (400, 500, 600, 800, 1000, 1200 and 1600).  Defaults to 1000 CPI.
+
 
 ### Pimoroni Trackball
 

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -76,20 +76,16 @@ uint8_t paw3204_serial_read(void) {
 
 void paw3204_serial_write(uint8_t data) {
     datatogglestate = readPin(PAW3204_SDIO_PIN);
-    if (datatogglestate == 1) {
-        writePinLow(PAW3204_SDIO_PIN);
-    } else {
-        writePinLow(PAW3204_SDIO_PIN);
-    }
+    writePinLow(PAW3204_SDIO_PIN);
     setPinOutput(PAW3204_SDIO_PIN);
 
     for (int8_t b = 7; b >= 0; b--) {
         writePinLow(PAW3204_SCLK_PIN);
-        if (data & (1 << b))
+        if (data & (1 << b)) {
             writePinHigh(PAW3204_SDIO_PIN);
-        else
+        } else {
             writePinLow(PAW3204_SDIO_PIN);
-        // wait_us(2);
+        }
         writePinHigh(PAW3204_SCLK_PIN);
     }
 

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// https://github.com/shinoaliceKabocha/choco60_track/tree/master/keymaps/default
+
 #include "paw3204.h"
 #include "wait.h"
 #include "debug.h"
@@ -93,10 +95,11 @@ void paw3204_serial_write(uint8_t data) {
 }
 
 int8_t convert_twoscomp(uint8_t data) {
-    if ((data & 0x80) == 0x80)
+    if ((data & 0x80) == 0x80) {
         return -128 + (data & 0x7F);
-    else
+    } else {
         return data;
+    }
 }
 
 report_paw3204_t paw3204_read(void) {

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -1,0 +1,133 @@
+/* Copyright 2021 Gompa (@Gompa)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "paw3204.h"
+#include "wait.h"
+#include "debug.h"
+#include "gpio.h"
+
+uint8_t datatogglestate;
+#define REG_PID1 0x00
+#define REG_PID2 0x01
+#define REG_STAT 0x02
+#define REG_X 0x03
+#define REG_Y 0x04
+
+#define REG_SETUP 0x06
+#define REG_IMGQUAL 0x07
+#define REG_IMGREC 0x0E
+#define REG_IMGTRASH 0x0D
+
+void PAW3204_init(void) {
+    setPinOutput(PAW3204_SCLK);    // setclockpin to output
+    setPinInputHigh(PAW3204_DATA); // set datapin input high
+
+    PAW3204_write_reg(REG_SETUP, 0x86); // reset sensor and set 1600cpi
+    wait_us(5);
+
+    PAW3204_read_reg(0x00); // read id
+    PAW3204_read_reg(0x01); // read id2
+    // PAW3204_write_reg(REG_SETUP,0x06);  // dont reset sensor and set cpi 1600
+    PAW3204_write_reg(REG_IMGTRASH, 0x32); // write image trashhold
+}
+
+uint8_t PAW3204_serial_read(void) {
+    setPinInput(PAW3204_DATA);
+    uint8_t byte = 0;
+
+    for (uint8_t i = 0; i < 8; ++i) {
+        writePinLow(PAW3204_SCLK);
+        wait_us(1);
+
+        byte = (byte << 1) | readPin(PAW3204_DATA);
+
+        writePinHigh(PAW3204_SCLK);
+        wait_us(1);
+    }
+
+    return byte;
+}
+
+void PAW3204_serial_write(uint8_t data) {
+    datatogglestate = readPin(PAW3204_DATA);
+    if (datatogglestate == 1) {
+        writePinLow(PAW3204_DATA);
+    } else {
+        writePinLow(PAW3204_DATA);
+    }
+    setPinOutput(PAW3204_DATA);
+
+    for (int8_t b = 7; b >= 0; b--) {
+        writePinLow(PAW3204_SCLK);
+        if (data & (1 << b))
+            writePinHigh(PAW3204_DATA);
+        else
+            writePinLow(PAW3204_DATA);
+        // wait_us(2);
+        writePinHigh(PAW3204_SCLK);
+    }
+
+    wait_us(4);
+}
+
+int8_t convert_twoscomp(uint8_t data) {
+    if ((data & 0x80) == 0x80)
+        return -128 + (data & 0x7F);
+    else
+        return data;
+}
+
+report_paw3204_t PAW3204_read(void) {
+    report_paw3204_t data;
+    uint8_t          pid  = read_pid_paw3204();
+    uint8_t          stat = PAW3204_read_reg(REG_STAT);
+    if (pid == 0x30 && (stat == 0x84 || stat == 0x86)) {
+        data.x = convert_twoscomp(PAW3204_read_reg(REG_X));
+        data.y = convert_twoscomp(PAW3204_read_reg(REG_Y));
+    }
+
+    return data;
+}
+
+void PAW3204_write_reg(uint8_t reg_addr, uint8_t data) {
+    PAW3204_serial_write(0b10000000 | reg_addr);
+    PAW3204_serial_write(data);
+}
+
+uint8_t PAW3204_read_reg(uint8_t reg_addr) {
+    PAW3204_serial_write(reg_addr);
+
+    wait_us(5);
+
+    uint8_t byte = PAW3204_serial_read();
+
+    return byte;
+}
+
+void PAW3204_set_cpi(uint16_t cpi) {
+    uint8_t cpival = constrain((cpi / 200) - 2, 0x0, 0x6);
+    PAW3204_write_reg(REG_SETUP, cpival);
+}
+
+uint16_t PAW3204_get_cpi(void) {
+    uint8_t cpival = PAW3204_read_reg(REG_SETUP);
+    return (uint16_t)(cpival + 2) * 200;
+}
+
+uint8_t read_pid_paw3204(void) {
+    uint8_t byte = PAW3204_read_reg(REG_PID1);
+    return byte;
+}

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -45,6 +45,11 @@ enum cpi_values {
     CPI1600, // 0b110
 };
 
+uint8_t paw3204_serial_read(void);
+void    paw3204_serial_write(uint8_t reg_addr);
+uint8_t paw3204_read_reg(uint8_t reg_addr);
+void    paw3204_write_reg(uint8_t reg_addr, uint8_t data);
+
 void paw3204_init(void) {
     setPinOutput(PAW3204_SCLK_PIN);    // setclockpin to output
     setPinInputHigh(PAW3204_SDIO_PIN); // set datapin input high

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -93,14 +93,6 @@ void paw3204_serial_write(uint8_t data) {
     wait_us(4);
 }
 
-int8_t convert_twoscomp(uint8_t data) {
-    if ((data & 0x80) == 0x80) {
-        return -128 + (data & 0x7F);
-    } else {
-        return data;
-    }
-}
-
 report_paw3204_t paw3204_read(void) {
     report_paw3204_t data = {0};
 

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -21,7 +21,6 @@
 #include "debug.h"
 #include "gpio.h"
 
-uint8_t datatogglestate;
 #define REG_PID1 0x00
 #define REG_PID2 0x01
 #define REG_STAT 0x02
@@ -77,7 +76,7 @@ uint8_t paw3204_serial_read(void) {
 }
 
 void paw3204_serial_write(uint8_t data) {
-    datatogglestate = readPin(PAW3204_SDIO_PIN);
+    (void)readPin(PAW3204_SDIO_PIN);
     writePinLow(PAW3204_SDIO_PIN);
     setPinOutput(PAW3204_SDIO_PIN);
 
@@ -106,8 +105,8 @@ report_paw3204_t paw3204_read(void) {
     report_paw3204_t data = {0};
 
     data.isMotion = paw3204_read_reg(REG_STAT) & (1 << 7); // check for motion only (bit 7 in field)
-    data.x        = convert_twoscomp(paw3204_read_reg(REG_X));
-    data.y        = convert_twoscomp(paw3204_read_reg(REG_Y));
+    data.x        = (int8_t)paw3204_read_reg(REG_X);
+    data.y        = (int8_t)paw3204_read_reg(REG_Y);
 
     return data;
 }
@@ -118,13 +117,9 @@ void paw3204_write_reg(uint8_t reg_addr, uint8_t data) {
 }
 
 uint8_t paw3204_read_reg(uint8_t reg_addr) {
-    uint8_t byte = 0;
-
     paw3204_serial_write(reg_addr);
     wait_us(5);
-    byte = paw3204_serial_read();
-
-    return byte;
+    return paw3204_serial_read();
 }
 
 void paw3204_set_cpi(uint16_t cpi) {

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -76,7 +76,6 @@ uint8_t paw3204_serial_read(void) {
 }
 
 void paw3204_serial_write(uint8_t data) {
-    (void)readPin(PAW3204_SDIO_PIN);
     writePinLow(PAW3204_SDIO_PIN);
     setPinOutput(PAW3204_SDIO_PIN);
 

--- a/drivers/sensors/paw3204.h
+++ b/drivers/sensors/paw3204.h
@@ -38,10 +38,5 @@ typedef struct {
 
 void             paw3204_init(void);
 report_paw3204_t paw3204_read(void);
-uint8_t          paw3204_serial_read(void);
-void             paw3204_serial_write(uint8_t reg_addr);
-uint8_t          paw3204_read_reg(uint8_t reg_addr);
-void             paw3204_write_reg(uint8_t reg_addr, uint8_t data);
-uint8_t          read_pid_paw3204(void);
 void             paw3204_set_cpi(uint16_t cpi);
 uint16_t         paw3204_get_cpi(void);

--- a/drivers/sensors/paw3204.h
+++ b/drivers/sensors/paw3204.h
@@ -1,0 +1,63 @@
+/* Copyright 2021 Gompa (@Gompa)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifndef PAW3204_SCLK
+#    error "No clock pin defined -- missing PAW3204_SCLK"
+#endif
+
+#ifndef PAW3204_DATA
+#    error "No data pin defined -- missing PAW3204_DATA"
+#endif
+#define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
+
+// CPI values
+// clang-format off
+#define CPI400  0x00
+#define CPI500  0x01
+#define CPI600  0x02
+#define CPI800  0x03
+#define CPI1000  0x04
+#define CPI1200  0x05
+#define CPI1600 0x06
+// clang-format on
+
+typedef struct {
+    int8_t x;
+    int8_t y;
+} report_paw3204_t;
+
+// A bunch of functions to implement the paw3204-specific serial protocol.
+// Note that the "serial.h" driver is insufficient, because it does not
+// manually manipulate a serial clock signal.
+
+void             PAW3204_init(void);
+// void              adns5050_sync(void);
+report_paw3204_t PAW3204_read(void);
+uint8_t          PAW3204_serial_read(void);
+void             PAW3204_serial_write(uint8_t reg_addr);
+uint8_t          PAW3204_read_reg(uint8_t reg_addr);
+void             PAW3204_write_reg(uint8_t reg_addr, uint8_t data);
+// void              PAW3204_set_cpi(uint16_t cpi);
+// uint16_t          PAW3204_get_cpi(void);
+int8_t           convert_twoscomp(uint8_t data);
+uint8_t	         read_pid_paw3204(void) ;
+void             PAW3204_set_cpi(uint16_t cpi);
+uint16_t         PAW3204_get_cpi(void);
+

--- a/drivers/sensors/paw3204.h
+++ b/drivers/sensors/paw3204.h
@@ -42,7 +42,6 @@ uint8_t          paw3204_serial_read(void);
 void             paw3204_serial_write(uint8_t reg_addr);
 uint8_t          paw3204_read_reg(uint8_t reg_addr);
 void             paw3204_write_reg(uint8_t reg_addr, uint8_t data);
-int8_t           convert_twoscomp(uint8_t data);
 uint8_t          read_pid_paw3204(void);
 void             paw3204_set_cpi(uint16_t cpi);
 uint16_t         paw3204_get_cpi(void);

--- a/drivers/sensors/paw3204.h
+++ b/drivers/sensors/paw3204.h
@@ -29,14 +29,40 @@
 typedef struct {
     int16_t x;
     int16_t y;
-    bool  isMotion;
+    bool    isMotion;
 } report_paw3204_t;
 
-// A bunch of functions to implement the paw3204-specific serial protocol.
-// Note that the "serial.h" driver is insufficient, because it does not
-// manually manipulate a serial clock signal.
+/**
+ * @brief Initializes the sensor so it is in a working state and ready to
+ * be polled for data.
+ *
+ * @return true Initialization was a success
+ * @return false Initialization failed, do not proceed operation
+ */
+void paw3204_init(void);
 
-void             paw3204_init(void);
+/**
+ * @brief Reads and clears the current delta, and motion register values on the
+ * given sensor.
+ *
+ * @return pmw33xx_report_t Current values of the sensor, if errors occurred all
+ * fields are set to zero
+ */
+
 report_paw3204_t paw3204_read(void);
-void             paw3204_set_cpi(uint16_t cpi);
-uint16_t         paw3204_get_cpi(void);
+/**
+ * @brief Sets the given CPI value the sensor. CPI is  often refereed to
+ * as the sensors sensitivity. Values outside of the allowed range are
+ * constrained into legal values.
+ *
+ * @param cpi CPI value to set
+ */
+void paw3204_set_cpi(uint16_t cpi);
+
+/**
+ * @brief Gets the currently set CPI value from the sensor. CPI is often
+ * refereed to as the sensors sensitivity.
+ *
+ * @return uint16_t Current CPI value of the sensor
+ */
+uint16_t paw3204_get_cpi(void);

--- a/drivers/sensors/paw3204.h
+++ b/drivers/sensors/paw3204.h
@@ -17,47 +17,32 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
-#ifndef PAW3204_SCLK
-#    error "No clock pin defined -- missing PAW3204_SCLK"
+#ifndef PAW3204_SCLK_PIN
+#    error "No clock pin defined -- missing PAW3204_SCLK_PIN"
 #endif
-
-#ifndef PAW3204_DATA
-#    error "No data pin defined -- missing PAW3204_DATA"
+#ifndef PAW3204_SDIO_PIN
+#    error "No data pin defined -- missing PAW3204_SDIO_PIN"
 #endif
-#define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
-
-// CPI values
-// clang-format off
-#define CPI400  0x00
-#define CPI500  0x01
-#define CPI600  0x02
-#define CPI800  0x03
-#define CPI1000  0x04
-#define CPI1200  0x05
-#define CPI1600 0x06
-// clang-format on
 
 typedef struct {
-    int8_t x;
-    int8_t y;
+    int16_t x;
+    int16_t y;
+    bool  isMotion;
 } report_paw3204_t;
 
 // A bunch of functions to implement the paw3204-specific serial protocol.
 // Note that the "serial.h" driver is insufficient, because it does not
 // manually manipulate a serial clock signal.
 
-void             PAW3204_init(void);
-// void              adns5050_sync(void);
-report_paw3204_t PAW3204_read(void);
-uint8_t          PAW3204_serial_read(void);
-void             PAW3204_serial_write(uint8_t reg_addr);
-uint8_t          PAW3204_read_reg(uint8_t reg_addr);
-void             PAW3204_write_reg(uint8_t reg_addr, uint8_t data);
-// void              PAW3204_set_cpi(uint16_t cpi);
-// uint16_t          PAW3204_get_cpi(void);
+void             paw3204_init(void);
+report_paw3204_t paw3204_read(void);
+uint8_t          paw3204_serial_read(void);
+void             paw3204_serial_write(uint8_t reg_addr);
+uint8_t          paw3204_read_reg(uint8_t reg_addr);
+void             paw3204_write_reg(uint8_t reg_addr, uint8_t data);
 int8_t           convert_twoscomp(uint8_t data);
-uint8_t	         read_pid_paw3204(void) ;
-void             PAW3204_set_cpi(uint16_t cpi);
-uint16_t         PAW3204_get_cpi(void);
-
+uint8_t          read_pid_paw3204(void);
+void             paw3204_set_cpi(uint16_t cpi);
+uint16_t         paw3204_get_cpi(void);

--- a/quantum/pointing_device.h
+++ b/quantum/pointing_device.h
@@ -33,6 +33,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "drivers/sensors/cirque_pinnacle.h"
 #    include "drivers/sensors/cirque_pinnacle_gestures.h"
 #    include "pointing_device_gestures.h"
+#elif defined(POINTING_DEVICE_DRIVER_paw3204)
+#    include "drivers/sensors/paw3204.h"
 #elif defined(POINTING_DEVICE_DRIVER_pimoroni_trackball)
 #    include "i2c_master.h"
 #    include "drivers/sensors/pimoroni_trackball.h"

--- a/quantum/pointing_device_drivers.c
+++ b/quantum/pointing_device_drivers.c
@@ -26,6 +26,7 @@
 #define CONSTRAIN_HID_XY(amt) ((amt) < XY_REPORT_MIN ? XY_REPORT_MIN : ((amt) > XY_REPORT_MAX ? XY_REPORT_MAX : (amt)))
 
 // get_report functions should probably be moved to their respective drivers.
+
 #if defined(POINTING_DEVICE_DRIVER_adns5050)
 report_mouse_t adns5050_get_report(report_mouse_t mouse_report) {
     report_adns5050_t data = adns5050_read_burst();
@@ -198,7 +199,27 @@ const pointing_device_driver_t pointing_device_driver = {
     .get_cpi    = cirque_pinnacle_get_cpi
 };
 // clang-format on
+#elif defined(POINTING_DEVICE_DRIVER_paw3204)
 
+report_mouse_t paw3204_get_report(report_mouse_t mouse_report) {
+    report_paw3204_t data = PAW3204_read();
+    if (data.x != 0 || data.y != 0) {
+#    ifdef CONSOLE_ENABLE
+        dprintf("Raw ] X: %d, Y: %d\n", data.x, data.y);
+#    endif
+
+        mouse_report.x = data.x;
+        mouse_report.y = data.y;
+    }
+
+    return mouse_report;
+}
+const pointing_device_driver_t pointing_device_driver = {
+    .init       = PAW3204_init,
+    .get_report = paw3204_get_report,
+    .set_cpi    = PAW3204_set_cpi,
+    .get_cpi    = PAW3204_get_cpi,
+};
 #elif defined(POINTING_DEVICE_DRIVER_pimoroni_trackball)
 
 mouse_xy_report_t pimoroni_trackball_adapt_values(clamp_range_t* offset) {

--- a/quantum/pointing_device_drivers.c
+++ b/quantum/pointing_device_drivers.c
@@ -202,8 +202,8 @@ const pointing_device_driver_t pointing_device_driver = {
 #elif defined(POINTING_DEVICE_DRIVER_paw3204)
 
 report_mouse_t paw3204_get_report(report_mouse_t mouse_report) {
-    report_paw3204_t data = PAW3204_read();
-    if (data.x != 0 || data.y != 0) {
+    report_paw3204_t data = paw3204_read();
+    if (data.isMotion) {
 #    ifdef CONSOLE_ENABLE
         dprintf("Raw ] X: %d, Y: %d\n", data.x, data.y);
 #    endif
@@ -215,10 +215,10 @@ report_mouse_t paw3204_get_report(report_mouse_t mouse_report) {
     return mouse_report;
 }
 const pointing_device_driver_t pointing_device_driver = {
-    .init       = PAW3204_init,
+    .init       = paw3204_init,
     .get_report = paw3204_get_report,
-    .set_cpi    = PAW3204_set_cpi,
-    .get_cpi    = PAW3204_get_cpi,
+    .set_cpi    = paw3204_set_cpi,
+    .get_cpi    = paw3204_get_cpi,
 };
 #elif defined(POINTING_DEVICE_DRIVER_pimoroni_trackball)
 


### PR DESCRIPTION
## Description

Adds support for the PAW3204 low powered optical sensor.

This is basic support, as the device supports multiple power modes and more, but aren't actually implemented here.

Uses bitbanged communication

## Types of Changes

- [x] Core
- [x] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
