### PR TITLE
KB16-01: correct QMK Configurator key sequence

### DIFF
--- a/keyboards/doio/kb16/info.json
+++ b/keyboards/doio/kb16/info.json
@@ -9,17 +9,19 @@
                 {"label":"2@", "x":1, "y":0},
                 {"label":"3#", "x":2, "y":0},
                 {"label":"4$", "x":3, "y":0},
+
                 {"label":"Encoder 1 CCW", "x":4.25, "y":0, "w":0.5},
                 {"label":"Encoder 1", "x":4.75, "y":0},
                 {"label":"Encoder 1 CW", "x":5.75, "y":0, "w":0.5},
-                {"label":"Encoder 2 CCW", "x":6.25, "y":0, "w":0.5},
-                {"label":"Encoder 2", "x":6.75, "y":0},
-                {"label":"Encoder 2 CW", "x":7.75, "y":0, "w":0.5},
 
                 {"label":"5%", "x":0, "y":1},
                 {"label":"6^", "x":1, "y":1},
                 {"label":"7&", "x":2, "y":1},
                 {"label":"8*", "x":3, "y":1},
+
+                {"label":"Encoder 2 CCW", "x":6.25, "y":0, "w":0.5},
+                {"label":"Encoder 2", "x":6.75, "y":0},
+                {"label":"Encoder 2 CW", "x":7.75, "y":0, "w":0.5},
 
                 {"label":"9(", "x":0, "y":2},
                 {"label":"0)", "x":1, "y":2},


### PR DESCRIPTION
## Description

[title]

cc @HorrorTroll (keyboard maintainer)

## Issues Fixed or Closed by This PR

![image](https://user-images.githubusercontent.com/18669334/178810263-915fab75-0d2e-4b91-a616-d093a0954268.png)

## Types of Changes

- [x] Enhancement/optimization
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
