### PR TITLE
shell.nix: Fix compatibility with Nix >= 2.10.0 on `x86_64-darwin`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -48,7 +48,7 @@ in
 mkShell {
   name = "qmk-firmware";
 
-  buildInputs = [ clang-tools dfu-programmer dfu-util diffutils git pythonEnv poetry niv ]
+  buildInputs = [ clang-tools dfu-programmer dfu-util diffutils git pythonEnv niv ]
     ++ lib.optional avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8


### PR DESCRIPTION
## Description

The `poetry` package from the used Nixpkgs snapshot is no longer buildable when using the official binary releases of Nix >= 2.10.0 on `x86_64-darwin` due to a regex compatibility issue (https://github.com/NixOS/nix/issues/4758). The failure looks like:
```
error: invalid regular expression '^.*?(egg|tar|tar.bz2|tar.gz|tar.lz|tar.lzma|tar.xz|tbz|tgz|tlz|txz|whl|zip)'
       at /nix/store/gm4rp1786ligd81v2qz420nkrwy0r50k-nixpkgs-src/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix:42:42:
           41|           matchesVersion = fname: builtins.match ("^.*" + builtins.replaceStrings [ "." ] [ "\\." ] version + ".*$") fname != null;
           42|           hasSupportedExtension = fname: builtins.match supportedRegex fname != null;
             |                                          ^
           43|           isCompatibleEgg = fname: ! lib.strings.hasSuffix ".egg" fname || lib.strings.hasSuffix "py${python.pythonVersion}.egg" fname;
```
In addition, all `poetry` version earlier than 1.1.14 became effectively non-functional after a breaking change of the PyPI JSON API (https://github.com/python-poetry/poetry/pull/5973) — they generate broken `poetry.lock` files without any hash values, therefore the old version of `poetry` that was added to the Nix shell environment became useless anyway.

Updating the `poetry` package to the most recent stable release (1.1.14 at the moment) without bumping `nixpkgs` is not trivial:
- Just adding `poetry = ">=1.1.14"` to `pyproject.toml` does not work due to dependency version conflicts with other modules.
- Although `poetry2nix` exports a `poetry` package, it makes that package available only as a flake output (it could be possible to import `overlay.nix` from there directly, but that is not documented; this would also require changing the arguments added in #16602 — `poetry2nix ? pkgs.callPackage (import sources.poetry2nix) { }` would no longer be sufficient).

Given those facts, looks like the only way to fix the problem without major changes is to remove the `poetry` package from the Nix shell environment. This should not cause any problems for QMK users, because the `poetry` tool is not needed to compile the QMK firmware — it may be needed only if someone wants to update the Nix shell environment itself, and in that case something like `nix run github:NixOS/nixpkgs/nixos-unstable#poetry` could be used for now.

I don't actually have any Apple hardware to test this on, but the failure could be observed on the `macos-*` machines provided by GitHub (e.g., https://github.com/sigprof/qmk-nix-support/actions/runs/2666127722 — failed tests are for the `master` code without this change). The failure started to happen after the Nix 2.10.0 release a couple of days ago (`cachix/install-nix-action` installs the latest stable Nix release by default); Nix 2.10.1 did not change anything.

Cc: @purcell @astridyu @andresilva

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
