### PR TITLE
Add clang-format rules to more closely follow coding conventions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
 BasedOnStyle: Google
+IndentPPDirectives: AfterHash
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: 'true'
 AlignConsecutiveDeclarations: 'true'
@@ -8,6 +9,8 @@ AllowAllParametersOfDeclarationOnNextLine: 'false'
 AllowShortCaseLabelsOnASingleLine: 'false'
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortLoopsOnASingleLine: 'false'
+AllowShortEnumsOnASingleLine: 'false'
+AllowShortBlocksOnASingleLine: 'false'
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: 'false'


### PR DESCRIPTION
## Description
Add rules to the .clang-format style file to more closely follow the QMK coding conventions.

* IndentPPDirectives: AfterHash
Indent preprocessor directives following the QMK coding convention,
> When indenting, keep the hash at the start of the line and add whitespace between # and if, starting with 4 spaces after the #.
* AllowShortEnumsOnASingleLine: 'false'
  AllowShortBlocksOnASingleLine: 'false'
Do not collapse enums or code blocks onto a single line.

While working on some keymap contributions (#17218 and #17213), I was using `clang-format` to format my code before committing, and ran into issues with it incorrectly formatting some code according to the QMK coding conventions.  Adding these rules locally helped make the auto-formatting closer to the coding conventions.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
