### PR TITLE
Fix inverted encoders on BDN9 rev. 2

### DIFF
--- a/keyboards/keebio/bdn9/rev2/config.h
+++ b/keyboards/keebio/bdn9/rev2/config.h
@@ -38,8 +38,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 }
 
 // Left, Right, Middle
-#define ENCODERS_PAD_A { A8, B3, A10 }
-#define ENCODERS_PAD_B { A4, A15, A9 }
+#define ENCODERS_PAD_A { A4, A15, A9 }
+#define ENCODERS_PAD_B { A8, B3, A10 }
 #define TAP_CODE_DELAY 10
 
 #define RGB_DI_PIN B15


### PR DESCRIPTION
## Description

Without ENCODER_DIRECTION_FLIP, the 'clockwise' argument to encoder_update_user() is inverted.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
