### PR TITLE
Avoid OOB in dynamic_keymap_reset

### DIFF
--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -146,6 +146,8 @@ void dynamic_keymap_set_encoder(uint8_t layer, uint8_t encoder_id, bool clockwis
 }
 #endif // ENCODER_MAP_ENABLE
 
+#define PGM_READ_WORD(loc) (layer < keymap_layer_count()) ? pgm_read_word(loc) : KC_TRANSPARENT
+
 void dynamic_keymap_reset(void) {
     // Reset the keymaps in EEPROM to what is in flash.
     // All keyboards using dynamic keymaps should define a layout
@@ -153,13 +155,13 @@ void dynamic_keymap_reset(void) {
     for (int layer = 0; layer < DYNAMIC_KEYMAP_LAYER_COUNT; layer++) {
         for (int row = 0; row < MATRIX_ROWS; row++) {
             for (int column = 0; column < MATRIX_COLS; column++) {
-                dynamic_keymap_set_keycode(layer, row, column, pgm_read_word(&keymaps[layer][row][column]));
+                dynamic_keymap_set_keycode(layer, row, column, PGM_READ_WORD(&keymaps[layer][row][column]));
             }
         }
 #ifdef ENCODER_MAP_ENABLE
         for (int encoder = 0; encoder < NUM_ENCODERS; encoder++) {
-            dynamic_keymap_set_encoder(layer, encoder, true, pgm_read_word(&encoder_map[layer][encoder][0]));
-            dynamic_keymap_set_encoder(layer, encoder, false, pgm_read_word(&encoder_map[layer][encoder][1]));
+            dynamic_keymap_set_encoder(layer, encoder, true, PGM_READ_WORD(&encoder_map[layer][encoder][0]));
+            dynamic_keymap_set_encoder(layer, encoder, false, PGM_READ_WORD(&encoder_map[layer][encoder][1]));
         }
 #endif // ENCODER_MAP_ENABLE
     }

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -146,22 +146,27 @@ void dynamic_keymap_set_encoder(uint8_t layer, uint8_t encoder_id, bool clockwis
 }
 #endif // ENCODER_MAP_ENABLE
 
-#define PGM_READ_WORD(loc) (layer < keymap_layer_count()) ? pgm_read_word(loc) : KC_TRANSPARENT
-
 void dynamic_keymap_reset(void) {
     // Reset the keymaps in EEPROM to what is in flash.
-    // All keyboards using dynamic keymaps should define a layout
-    // for the same number of layers as DYNAMIC_KEYMAP_LAYER_COUNT.
     for (int layer = 0; layer < DYNAMIC_KEYMAP_LAYER_COUNT; layer++) {
         for (int row = 0; row < MATRIX_ROWS; row++) {
             for (int column = 0; column < MATRIX_COLS; column++) {
-                dynamic_keymap_set_keycode(layer, row, column, PGM_READ_WORD(&keymaps[layer][row][column]));
+                if (layer < keymap_layer_count()) {
+                    dynamic_keymap_set_keycode(layer, row, column, pgm_read_word(&keymaps[layer][row][column]));
+                } else {
+                    dynamic_keymap_set_keycode(layer, row, column, KC_TRANSPARENT);
+                }
             }
         }
 #ifdef ENCODER_MAP_ENABLE
         for (int encoder = 0; encoder < NUM_ENCODERS; encoder++) {
-            dynamic_keymap_set_encoder(layer, encoder, true, PGM_READ_WORD(&encoder_map[layer][encoder][0]));
-            dynamic_keymap_set_encoder(layer, encoder, false, PGM_READ_WORD(&encoder_map[layer][encoder][1]));
+            if (layer < encodermap_layer_count()) {
+                dynamic_keymap_set_encoder(layer, encoder, true, pgm_read_word(&encoder_map[layer][encoder][0]));
+                dynamic_keymap_set_encoder(layer, encoder, false, pgm_read_word(&encoder_map[layer][encoder][1]));
+            } else {
+                dynamic_keymap_set_encoder(layer, encoder, true, KC_TRANSPARENT);
+                dynamic_keymap_set_encoder(layer, encoder, false, KC_TRANSPARENT);
+            }
         }
 #endif // ENCODER_MAP_ENABLE
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Various via keymaps are currently configured with incorrect amounts of keymap layers (`45_ats:via`, `10bleoledhub:via`, etc).

Instead of a `_Static_assert` in keymap introspection to ensure `keymap layers == dynamic keymap layer count`....
- allow fewer keymap layers
  - will allow a small amount to be shaved off total firmware size
- most layers are "empty" anyway
  - why bother having to maintain 2+ layers full of `_______`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
