### PR TITLE
fixing a typo in config.h of momoka_ergo

### DIFF
--- a/keyboards/momoka_ergo/config.h
+++ b/keyboards/momoka_ergo/config.h
@@ -119,7 +119,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BOOTMAGIC_KEY_SALT     KC_RSFT||KC_LSFT
 #define BOOTMAGIC_KEY_SKIP 	KC_ESC
 #define BOOTMAGIC_KEY_EEPROM_CLEAR 	KC_NO
-#define OOTMAGIC_KEY_BOOTLOADER 	KC_RCTL||KC_LCTL
+#define BOOTMAGIC_KEY_BOOTLOADER 	KC_RCTL||KC_LCTL
 #define BOOTMAGIC_KEY_EE_HANDS_LEFT 	KC_T
 #define BOOTMAGIC_KEY_EE_HANDS_RIGHT 	KC_Y
 #define USE_SERIAL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
fixed a typo in one of the `#define`s of `keyboards/momoka_ergo/config.h`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
