### PR TITLE
Fix AVR compilation of FNV by using standard integer typenames.

### DIFF
--- a/lib/fnv/fnv.h
+++ b/lib/fnv/fnv.h
@@ -76,7 +76,8 @@
 #if !defined(__FNV_H__)
 #define __FNV_H__
 
-#include <sys/types.h>
+#include <stdlib.h>
+#include <stdint.h>
 
 #define FNV_VERSION "5.0.2"	/* @(#) FNV Version */
 
@@ -84,7 +85,7 @@
 /*
  * 32 bit FNV-0 hash type
  */
-typedef u_int32_t Fnv32_t;
+typedef uint32_t Fnv32_t;
 
 
 /*
@@ -122,10 +123,10 @@ typedef u_int32_t Fnv32_t;
  * 64 bit FNV-0 hash
  */
 #if defined(HAVE_64BIT_LONG_LONG)
-typedef u_int64_t Fnv64_t;
+typedef uint64_t Fnv64_t;
 #else /* HAVE_64BIT_LONG_LONG */
 typedef struct {
-    u_int32_t w32[2]; /* w32[0] is low order, w32[1] is high order word */
+    uint32_t w32[2]; /* w32[0] is low order, w32[1] is high order word */
 } Fnv64_t;
 #endif /* HAVE_64BIT_LONG_LONG */
 


### PR DESCRIPTION
## Description

Fix AVR compilation of the FNV library.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
