### PR TITLE
Add Caps Lock and Scroll Lock indicators to some Wilba Tech PCBs

### DIFF
--- a/keyboards/wilba_tech/wt60_a/config.h
+++ b/keyboards/wilba_tech/wt60_a/config.h
@@ -108,8 +108,8 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
-// enable the RGB indicator for WT75-A
-#define MONO_BACKLIGHT_WT75_A
+// enable the specific indicators
+#define MONO_BACKLIGHT_WT60_A
 
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0

--- a/keyboards/wilba_tech/wt65_a/config.h
+++ b/keyboards/wilba_tech/wt65_a/config.h
@@ -108,6 +108,9 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
+// enable the specific indicators
+#define MONO_BACKLIGHT_WT65_A
+
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0
 

--- a/keyboards/wilba_tech/wt65_b/config.h
+++ b/keyboards/wilba_tech/wt65_b/config.h
@@ -108,6 +108,9 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
+// enable the specific indicators
+#define MONO_BACKLIGHT_WT65_B
+
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0
 

--- a/keyboards/wilba_tech/wt75_b/config.h
+++ b/keyboards/wilba_tech/wt75_b/config.h
@@ -108,6 +108,9 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
+// enable the specific indicators
+#define MONO_BACKLIGHT_WT75_B
+
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0
 

--- a/keyboards/wilba_tech/wt75_c/config.h
+++ b/keyboards/wilba_tech/wt75_c/config.h
@@ -108,6 +108,9 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
+// enable the specific indicators
+#define MONO_BACKLIGHT_WT75_C
+
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0
 

--- a/keyboards/wilba_tech/wt80_a/config.h
+++ b/keyboards/wilba_tech/wt80_a/config.h
@@ -108,6 +108,9 @@
 // enable the mono backlight
 #define MONO_BACKLIGHT_ENABLED 1
 
+// enable the specific indicators
+#define MONO_BACKLIGHT_WT80_A
+
 // disable backlight when USB suspended (PC sleep/hibernate/shutdown)
 #define MONO_BACKLIGHT_DISABLE_WHEN_USB_SUSPENDED 0
 

--- a/keyboards/wilba_tech/wt_mono_backlight.c
+++ b/keyboards/wilba_tech/wt_mono_backlight.c
@@ -173,6 +173,33 @@ void backlight_effect_indicators(void)
     IS31FL3736_mono_set_brightness(63, rgb.g);
     IS31FL3736_mono_set_brightness(71, rgb.b);
 #endif // MONO_BACKLIGHT_WT75_A
+
+// This pairs with "All Off" already setting zero brightness,
+// and "All On" already setting non-zero brightness.
+#if defined(MONO_BACKLIGHT_WT60_A) || \
+defined(MONO_BACKLIGHT_WT65_A) || \
+defined(MONO_BACKLIGHT_WT65_B) || \
+defined(MONO_BACKLIGHT_WT75_A) || \
+defined(MONO_BACKLIGHT_WT75_B) || \
+defined(MONO_BACKLIGHT_WT75_C) || \
+defined(MONO_BACKLIGHT_WT80_A)
+    if ( g_indicator_state & (1<<USB_LED_CAPS_LOCK) ) {
+        // Caps Lock: D1 -> (4*8+0)
+        IS31FL3736_mono_set_brightness(32, 255);
+    }
+#endif
+#if defined(MONO_BACKLIGHT_WT80_A) 
+    if ( g_indicator_state & (1<<USB_LED_SCROLL_LOCK) ) {
+        // Scroll Lock: G7 -> (6*8+6)
+        IS31FL3736_mono_set_brightness(54, 255);
+    }
+#endif
+#if defined(MONO_BACKLIGHT_WT75_C) 
+    if ( g_indicator_state & (1<<USB_LED_SCROLL_LOCK) ) {
+        // Scroll Lock: G8 -> (6*8+7)
+        IS31FL3736_mono_set_brightness(55, 255);
+    }
+#endif
 }
 
 ISR(TIMER3_COMPA_vect)


### PR DESCRIPTION
Some Wilba Tech PCBs which use a LED driver IC for mono through-hole LEDs only implemented a backlight function.
Some people really want just Caps Lock and Scroll Lock LEDs.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
