### PR TITLE
Add led/rgb_matrix_none_indicator_kb/user function

### DIFF
--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -227,12 +227,18 @@ void process_led_matrix(uint8_t row, uint8_t col, bool pressed) {
 #endif // defined(LED_MATRIX_FRAMEBUFFER_EFFECTS) && defined(ENABLE_LED_MATRIX_TYPING_HEATMAP)
 }
 
+void led_matrix_none_indicators(void) {
+    led_matrix_none_indicators_kb();
+    led_matrix_none_indicators_user();
+}
+
 static bool led_matrix_none(effect_params_t *params) {
     if (!params->init) {
         return false;
     }
 
     led_matrix_set_value_all(0);
+    led_matrix_none_indicators();
     return false;
 }
 
@@ -414,6 +420,10 @@ void led_matrix_indicators_advanced(effect_params_t *params) {
 __attribute__((weak)) void led_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {}
 
 __attribute__((weak)) void led_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {}
+
+__attribute__((weak)) void led_matrix_none_indicators_kb(void) {}
+
+__attribute__((weak)) void led_matrix_none_indicators_user(void) {}
 
 void led_matrix_init(void) {
     led_matrix_driver.init();

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -124,6 +124,9 @@ void led_matrix_indicators_advanced(effect_params_t *params);
 void led_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max);
 void led_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max);
 
+void led_matrix_none_indicators_kb(void);
+void led_matrix_none_indicators_user(void);
+
 void led_matrix_init(void);
 
 void        led_matrix_set_suspend_state(bool state);

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -286,12 +286,18 @@ void rgb_matrix_test(void) {
     }
 }
 
+static void rgb_matrix_none_indicators(void) {
+    rgb_matrix_none_indicators_kb();
+    rgb_matrix_none_indicators_user();
+}
+
 static bool rgb_matrix_none(effect_params_t *params) {
     if (!params->init) {
         return false;
     }
 
     rgb_matrix_set_color_all(0, 0, 0);
+    rgb_matrix_none_indicators();
     return false;
 }
 
@@ -476,6 +482,10 @@ void rgb_matrix_indicators_advanced(effect_params_t *params) {
 __attribute__((weak)) void rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {}
 
 __attribute__((weak)) void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {}
+
+__attribute__((weak)) void rgb_matrix_none_indicators_kb(void) {}
+
+__attribute__((weak)) void rgb_matrix_none_indicators_user(void) {}
 
 void rgb_matrix_init(void) {
     rgb_matrix_driver.init();

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -136,6 +136,9 @@ void rgb_matrix_indicators_advanced(effect_params_t *params);
 void rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max);
 void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max);
 
+void rgb_matrix_none_indicators_kb(void);
+void rgb_matrix_none_indicators_user(void);
+
 void rgb_matrix_init(void);
 
 void rgb_matrix_reload_from_eeprom(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add `led_matrix_none_indicators_kb()` and `led_matrix_none_indicators_user()` to led matrix files.
Add `rgb_matrix_none_indicators_kb()` and `rgb_matrix_none_indicators_user()` to rgb matrix files.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

With `led_matrix_indicators_kb` / `led_matrix_indicators_advanced_user` and `rgb_matrix_indicators_kb` 
 / `rgb_matrix_indicators_advanced_user`, it is possible to indicate Caps lock state when backlight is on, however it doesn't work when backlight is off.

With these new functions, caps lock indicating state  can be kept upon led/rbg matrix turning off. 
Additionly, when led/rbg matrix is off, with `led_update_kb` or `led_update_user`,  caps lock indicating state  can be toggled with `led_matrix_set_value` or `rgb_matrix_set_color`, followed by `led_matrix_update_pwm_buffers` / `rgb_matrix_update_pwm_buffers`.

Thus caps lock / num lock/ scroll lock indicators work no matter what led/rgb matrix status is except power down.

No sure whether it will work with all type of led drivers, but should work with most.




<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
