### PR TITLE
fix syntax error in header file

### DIFF
--- a/quantum/keymap_extras/keymap_turkish_f.h
+++ b/quantum/keymap_extras/keymap_turkish_f.h
@@ -187,7 +187,7 @@
 #define TR_CURR S(ALGR(TR_4))    // ¤
 #define TR_IQUE S(ALGR(TR_SLSH)) // ¿
 // Row 2
-#define TR_REGD S(ALGR(TR_I)     // ®
+#define TR_REGD S(ALGR(TR_I))    // ®
 // Row 3
 #define TR_SECT S(ALGR(TR_IDOT)) // §
 #define TR_FORD S(ALGR(TR_A))    // ª


### PR DESCRIPTION
quantum/keymap_extras/keymap_turkish_f.h won't compile without this fix.

## Description

the one character change is really self explanatory

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
