### PR TITLE
Fix compilation error in Ploopy Nano maddie keymap

### DIFF
--- a/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/maddie/keymap.c
@@ -27,6 +27,10 @@
 bool scroll_enabled = false;
 bool lock_state     = false;
 
+// State
+static int8_t delta_x = 0;
+static int8_t delta_y = 0;
+
 // Dummy
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {{{ KC_NO }}};
 


### PR DESCRIPTION
## Description

Followup to #17213 to fix compilation error.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
