### PR TITLE
Move Pointing Device Initialization to after Split Post Initialization

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -384,9 +384,6 @@ void keyboard_init(void) {
 #ifdef STENO_ENABLE_ALL
     steno_init();
 #endif
-#ifdef POINTING_DEVICE_ENABLE
-    pointing_device_init();
-#endif
 #if defined(NKRO_ENABLE) && defined(FORCE_NKRO)
     keymap_config.nkro = 1;
     eeconfig_update_keymap(keymap_config.raw);
@@ -402,6 +399,10 @@ void keyboard_init(void) {
 #endif
 #ifdef SPLIT_KEYBOARD
     split_post_init();
+#endif
+#ifdef POINTING_DEVICE_ENABLE
+    // init after split init
+    pointing_device_init();
 #endif
 
 #if defined(DEBUG_MATRIX_SCAN_RATE) && defined(CONSOLE_ENABLE)


### PR DESCRIPTION
## Description

If both pointing device and split is enabled, the pointing device init needs to be called after the split post init, otherwise the connection (serial/etc) isn't initialized yet, and any commands that need to send data over (such as calling the set cpi command) never get sent over.


Experienced this with the charybdis, confirmed that moving later fixes the issue.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Experienced by myself and reported by others

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
