### PR TITLE
Add ability to enter bootloader mode from `QK_MAKE`

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -219,13 +219,13 @@ See also: [Basic Keycodes](keycodes_basic.md)
 
 See also: [Quantum Keycodes](quantum_keycodes.md#qmk-keycodes)
 
-|Key              |Aliases  |Description                                                                      |
-|-----------------|---------|---------------------------------------------------------------------------------|
-|`QK_BOOTLOADER`  |`QK_BOOT`|Put the keyboard into bootloader mode for flashing                               |
-|`QK_DEBUG_TOGGLE`|`DB_TOGG`|Toggle debug mode                                                                |
-|`QK_CLEAR_EEPROM`|`EE_CLR` |Reinitializes the keyboard's EEPROM (persistent memory)                          |
-|`QK_MAKE`        |         |Sends `qmk compile -kb (keyboard) -km (keymap)`, or `qmk flash` if shift is held |
-|`QK_REBOOT`      |`QK_RBT` |Resets the keyboard. Does not load the bootloader                                |
+|Key              |Aliases  |Description                                                                                                                                      |
+|-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+|`QK_BOOTLOADER`  |`QK_BOOT`|Put the keyboard into bootloader mode for flashing                                                                                               |
+|`QK_DEBUG_TOGGLE`|`DB_TOGG`|Toggle debug mode                                                                                                                                |
+|`QK_CLEAR_EEPROM`|`EE_CLR` |Reinitializes the keyboard's EEPROM (persistent memory)                                                                                          |
+|`QK_MAKE`        |         |Sends `qmk compile -kb (keyboard) -km (keymap)`, or `qmk flash` if shift is held. Puts keyboard into bootloader mode if shift & control are held |
+|`QK_REBOOT`      |`QK_RBT` |Resets the keyboard. Does not load the bootloader                                                                                                |
 
 ## Audio Keys :id=audio-keys
 

--- a/docs/quantum_keycodes.md
+++ b/docs/quantum_keycodes.md
@@ -8,10 +8,10 @@ On this page we have documented keycodes between `0x00FF` and `0xFFFF` which are
 
 ## QMK Keycodes :id=qmk-keycodes
 
-|Key              |Aliases  |Description                                                                      |
-|-----------------|---------|---------------------------------------------------------------------------------|
-|`QK_BOOTLOADER`  |`QK_BOOT`|Put the keyboard into bootloader mode for flashing                               |
-|`QK_DEBUG_TOGGLE`|`DB_TOGG`|Toggle debug mode                                                                |
-|`QK_CLEAR_EEPROM`|`EE_CLR` |Reinitializes the keyboard's EEPROM (persistent memory)                          |
-|`QK_MAKE`        |         |Sends `qmk compile -kb (keyboard) -km (keymap)`, or `qmk flash` if shift is held |
-|`QK_REBOOT`      |`QK_RBT` |Resets the keyboard. Does not load the bootloader                                |
+|Key              |Aliases  |Description                                                                                                                                      |
+|-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+|`QK_BOOTLOADER`  |`QK_BOOT`|Put the keyboard into bootloader mode for flashing                                                                                               |
+|`QK_DEBUG_TOGGLE`|`DB_TOGG`|Toggle debug mode                                                                                                                                |
+|`QK_CLEAR_EEPROM`|`EE_CLR` |Reinitializes the keyboard's EEPROM (persistent memory)                                                                                          |
+|`QK_MAKE`        |         |Sends `qmk compile -kb (keyboard) -km (keymap)`, or `qmk flash` if shift is held. Puts keyboard into bootloader mode if shift & control are held |
+|`QK_REBOOT`      |`QK_RBT` |Resets the keyboard. Does not load the bootloader                                                                                                |

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -401,7 +401,7 @@ bool process_record_quantum(keyrecord_t *record) {
                 }
                 SEND_STRING_DELAY("-kb " QMK_KEYBOARD " -km " QMK_KEYMAP SS_TAP(X_ENTER), TAP_CODE_DELAY);
                 if (temp_mod & MOD_MASK_CS) {
-                  reset_keyboard();
+                    reset_keyboard();
                 }
             }
 #endif

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -400,6 +400,9 @@ bool process_record_quantum(keyrecord_t *record) {
                     SEND_STRING_DELAY(" compile ", TAP_CODE_DELAY);
                 }
                 SEND_STRING_DELAY("-kb " QMK_KEYBOARD " -km " QMK_KEYMAP SS_TAP(X_ENTER), TAP_CODE_DELAY);
+                if (temp_mod & MOD_MASK_CS) {
+                  reset_keyboard();
+                }
             }
 #endif
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Puts keyboard in bootloader mode if shift & control are held. Omits the need for bootmagic and `QK_BOOT` keycode to compile and flash firmware.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Enhancement/optimization

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
