### PR TITLE
Implement relative mode for Cirque trackpad

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -89,23 +89,27 @@ POINTING_DEVICE_DRIVER = cirque_pinnacle_spi
 
 This supports the Cirque Pinnacle 1CA027 Touch Controller, which is used in the TM040040, TM035035 and the TM023023 trackpads. These are I2C or SPI compatible, and both configurations are supported.
 
+#### Common settings
+
 | Setting                          | Description                                                | Default            |
 | -------------------------------- | ---------------------------------------------------------- | ------------------ |
-| `CIRQUE_PINNACLE_X_LOWER`        | (Optional) The minimum reachable X value on the sensor.    | `127`              |
-| `CIRQUE_PINNACLE_X_UPPER`        | (Optional) The maximum reachable X value on the sensor.    | `1919`             |
-| `CIRQUE_PINNACLE_Y_LOWER`        | (Optional) The minimum reachable Y value on the sensor.    | `63`               |
-| `CIRQUE_PINNACLE_Y_UPPER`        | (Optional) The maximum reachable Y value on the sensor.    | `1471`             |
 | `CIRQUE_PINNACLE_DIAMETER_MM`    | (Optional) Diameter of the trackpad sensor in millimeters. | `40`               |
 | `CIRQUE_PINNACLE_ATTENUATION`    | (Optional) Sets the attenuation of the sensor data.        | `ADC_ATTENUATE_4X` |
 | `CIRQUE_PINNACLE_CURVED_OVERLAY` | (Optional) Applies settings tuned for curved overlay.      | _not defined_      |
+| `CIRQUE_PINNACLE_POSITION_MODE`  | (Optional) Mode of operation.                              | _not defined_      |
 
-**`CIRQUE_PINNACLE_ATTENUATION`** is a measure of how much data is suppressed in regards to sensitivity. The higher the attenuation, the less sensitive the touchpad will be. 
+**`CIRQUE_PINNACLE_ATTENUATION`** is a measure of how much data is suppressed in regards to sensitivity. The higher the attenuation, the less sensitive the touchpad will be.
 
 Default attenuation is set to 4X, although if you are using a thicker overlay (such as the curved overlay) you will want a lower attenuation such as 2X. The possible values are:
 * `ADC_ATTENUATE_4X`: Least sensitive
 * `ADC_ATTENUATE_3X`
 * `ADC_ATTENUATE_2X`
 * `ADC_ATTENUATE_1X`: Most sensitive
+
+**`CIRQUE_PINNACLE_POSITION_MODE`** can be `CIRQUE_PINNACLE_ABSOLUTE_MODE` or `CIRQUE_PINNACLE_RELATIVE_MODE`. Modes differ in supported features/gestures.
+
+* `CIRQUE_PINNACLE_ABSOLUTE_MODE`: Reports absolute x, y, z (touch pressure) coordinates and up to 5 hw buttons connected to the trackpad
+* `CIRQUE_PINNACLE_RELATIVE_MODE`: Reports x/y deltas, scroll and up to 3 buttons (2 of them can be from taps, see gestures) connected to trackpad. Supports taps on secondary side of split. Saves about 2k of flash compared to absolute mode with all features.
 
 | I2C Setting               | Description                                                                     | Default |
 | ------------------------- | ------------------------------------------------------------------------------- | ------- |
@@ -124,16 +128,37 @@ Default Scaling is 1024. Actual CPI depends on trackpad diameter.
 
 Also see the `POINTING_DEVICE_TASK_THROTTLE_MS`, which defaults to 10ms when using Cirque Pinnacle, which matches the internal update rate of the position registers (in standard configuration). Advanced configuration for pen/stylus usage might require lower values.
 
-#### Cirque Trackpad gestures
+#### Absolute mode settings
 
-| Gesture Setting                                | Description                                                                                                                                                                                      | Default              |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- |
-| `CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE`       | (Optional) Enable circular scroll. Touch originating in outer ring can trigger scroll by moving along the perimeter. Near side triggers vertical scroll and far side triggers horizontal scroll. | _not defined_        |
-| `CIRQUE_PINNACLE_TAP_ENABLE`                   | (Optional) Enable tap to click. This currently only works on the master side.                                                                                                                    | _not defined_        |
-| `CIRQUE_PINNACLE_TAPPING_TERM`                 | (Optional) Length of time that a touch can be to be considered a tap.                                                                                                                            | `TAPPING_TERM`/`200` |
-| `CIRQUE_PINNACLE_TOUCH_DEBOUNCE`               | (Optional) Length of time that a touch can be to be considered a tap.                                                                                                                            | `TAPPING_TERM`/`200` |
+| Setting                          | Description                                                | Default            |
+| -------------------------------- | ---------------------------------------------------------- | ------------------ |
+| `CIRQUE_PINNACLE_X_LOWER`        | (Optional) The minimum reachable X value on the sensor.    | `127`              |
+| `CIRQUE_PINNACLE_X_UPPER`        | (Optional) The maximum reachable X value on the sensor.    | `1919`             |
+| `CIRQUE_PINNACLE_Y_LOWER`        | (Optional) The minimum reachable Y value on the sensor.    | `63`               |
+| `CIRQUE_PINNACLE_Y_UPPER`        | (Optional) The maximum reachable Y value on the sensor.    | `1471`             |
 
-Additionally, `POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE` is supported on the Cirque.
+#### Absolute mode gestures
+
+| Gesture Setting                                | Description                                                                    | Default              |
+| ---------------------------------------------- | ------------------------------------------------------------------------------ | -------------------- |
+| `CIRQUE_PINNACLE_TAP_ENABLE`                   | (Optional) Enable tap to click. This currently only works on the master side.  | _not defined_        |
+| `CIRQUE_PINNACLE_TAPPING_TERM`                 | (Optional) Length of time that a touch can be to be considered a tap.          | `TAPPING_TERM`/`200` |
+| `CIRQUE_PINNACLE_TOUCH_DEBOUNCE`               | (Optional) Length of time that a touch can be to be considered a tap.          | `TAPPING_TERM`/`200` |
+
+`POINTING_DEVICE_GESTURES_SCROLL_ENABLE` in this mode enables circular scroll. Touch originating in outer ring can trigger scroll by moving along the perimeter. Near side triggers vertical scroll and far side triggers horizontal scroll.
+
+Additionally, `POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE` is supported in this mode.
+
+#### Relative mode gestures
+
+| Gesture Setting                        | Description                                                                                                                                                                               | Default       |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `CIRQUE_PINNACLE_TAP_ENABLE`           | (Optional) Enable tap to "left click". Works on both sides of a split keyboard.                                                                                                           | _not defined_ |
+| `CIRQUE_PINNACLE_SECONDARY_TAP_ENABLE` | (Optional) Tap in upper right corner (half of the finger needs to be outside of the trackpad) of the trackpad will result in "right click". `CIRQUE_PINNACLE_TAP_ENABLE` must be enabled. | _not defined_ |
+
+Tapping term and debounce are not configurable in this mode since it's handled by trackpad internally.
+
+`POINTING_DEVICE_GESTURES_SCROLL_ENABLE` in this mode enables side scroll. Touch originating on the right side can trigger vertical scroll (IntelliSense trackpad style).
 
 ### PAW 3204 Sensor
 
@@ -151,7 +176,6 @@ The paw 3204 sensor uses a serial type protocol for communication, and requires 
 |`PAW3204_SDIO_PIN` | (Required) The pin connected to the data pin of the sensor.         |
 
 The CPI range is 400-1600, with supported values of (400, 500, 600, 800, 1000, 1200 and 1600).  Defaults to 1000 CPI.
-
 
 ### Pimoroni Trackball
 
@@ -254,17 +278,18 @@ void           pointing_device_driver_set_cpi(uint16_t cpi) {}
 
 ## Common Configuration
 
-| Setting                            | Description                                                                                                                      | Default       |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `MOUSE_EXTENDED_REPORT`            | (Optional) Enables support for extended mouse reports. (-32767 to 32767, instead of just -127 to 127).                           | _not defined_ |
-| `POINTING_DEVICE_ROTATION_90`      | (Optional) Rotates the X and Y data by  90 degrees.                                                                              | _not defined_ |
-| `POINTING_DEVICE_ROTATION_180`     | (Optional) Rotates the X and Y data by 180 degrees.                                                                              | _not defined_ |
-| `POINTING_DEVICE_ROTATION_270`     | (Optional) Rotates the X and Y data by 270 degrees.                                                                              | _not defined_ |
-| `POINTING_DEVICE_INVERT_X`         | (Optional) Inverts the X axis report.                                                                                            | _not defined_ |
-| `POINTING_DEVICE_INVERT_Y`         | (Optional) Inverts the Y axis report.                                                                                            | _not defined_ |
-| `POINTING_DEVICE_MOTION_PIN`       | (Optional) If supported, will only read from sensor if pin is active.                                                            | _not defined_ |
-| `POINTING_DEVICE_TASK_THROTTLE_MS` | (Optional) Limits the frequency that the sensor is polled for motion.                                                            | _not defined_ |
-| `POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE` | (Optional) Enable inertial cursor. Cursor continues moving after a flick gesture and slows down by kinetic friction. | _not defined_ |
+| Setting                                        | Description                                                                                                                      | Default       |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `MOUSE_EXTENDED_REPORT`                        | (Optional) Enables support for extended mouse reports. (-32767 to 32767, instead of just -127 to 127).                           | _not defined_ |
+| `POINTING_DEVICE_ROTATION_90`                  | (Optional) Rotates the X and Y data by  90 degrees.                                                                              | _not defined_ |
+| `POINTING_DEVICE_ROTATION_180`                 | (Optional) Rotates the X and Y data by 180 degrees.                                                                              | _not defined_ |
+| `POINTING_DEVICE_ROTATION_270`                 | (Optional) Rotates the X and Y data by 270 degrees.                                                                              | _not defined_ |
+| `POINTING_DEVICE_INVERT_X`                     | (Optional) Inverts the X axis report.                                                                                            | _not defined_ |
+| `POINTING_DEVICE_INVERT_Y`                     | (Optional) Inverts the Y axis report.                                                                                            | _not defined_ |
+| `POINTING_DEVICE_MOTION_PIN`                   | (Optional) If supported, will only read from sensor if pin is active.                                                            | _not defined_ |
+| `POINTING_DEVICE_TASK_THROTTLE_MS`             | (Optional) Limits the frequency that the sensor is polled for motion.                                                            | _not defined_ |
+| `POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE` | (Optional) Enable inertial cursor. Cursor continues moving after a flick gesture and slows down by kinetic friction.             | _not defined_ |
+| `POINTING_DEVICE_GESTURES_SCROLL_ENABLE`       | (Optional) Enable scroll gesture. The gesture that activates the scroll is device dependent.                                     | _not defined_ |
 
 !> When using `SPLIT_POINTING_ENABLE` the `POINTING_DEVICE_MOTION_PIN` functionality is not supported and `POINTING_DEVICE_TASK_THROTTLE_MS` will default to `1`. Increasing this value will increase transport performance at the cost of possible mouse responsiveness.
 

--- a/drivers/sensors/cirque_pinnacle.h
+++ b/drivers/sensors/cirque_pinnacle.h
@@ -21,24 +21,35 @@
 #    define CIRQUE_PINNACLE_DIAMETER_MM 40
 #endif
 
+#if CIRQUE_PINNACLE_POSITION_MODE
 // Coordinate scaling values
-#ifndef CIRQUE_PINNACLE_X_LOWER
-#    define CIRQUE_PINNACLE_X_LOWER 127 // min "reachable" X value
-#endif
-#ifndef CIRQUE_PINNACLE_X_UPPER
-#    define CIRQUE_PINNACLE_X_UPPER 1919 // max "reachable" X value
-#endif
-#ifndef CIRQUE_PINNACLE_Y_LOWER
-#    define CIRQUE_PINNACLE_Y_LOWER 63 // min "reachable" Y value
-#endif
-#ifndef CIRQUE_PINNACLE_Y_UPPER
-#    define CIRQUE_PINNACLE_Y_UPPER 1471 // max "reachable" Y value
-#endif
-#ifndef CIRQUE_PINNACLE_X_RANGE
-#    define CIRQUE_PINNACLE_X_RANGE (CIRQUE_PINNACLE_X_UPPER - CIRQUE_PINNACLE_X_LOWER)
-#endif
-#ifndef CIRQUE_PINNACLE_Y_RANGE
-#    define CIRQUE_PINNACLE_Y_RANGE (CIRQUE_PINNACLE_Y_UPPER - CIRQUE_PINNACLE_Y_LOWER)
+#    ifndef CIRQUE_PINNACLE_X_LOWER
+#        define CIRQUE_PINNACLE_X_LOWER 127 // min "reachable" X value
+#    endif
+#    ifndef CIRQUE_PINNACLE_X_UPPER
+#        define CIRQUE_PINNACLE_X_UPPER 1919 // max "reachable" X value
+#    endif
+#    ifndef CIRQUE_PINNACLE_Y_LOWER
+#        define CIRQUE_PINNACLE_Y_LOWER 63 // min "reachable" Y value
+#    endif
+#    ifndef CIRQUE_PINNACLE_Y_UPPER
+#        define CIRQUE_PINNACLE_Y_UPPER 1471 // max "reachable" Y value
+#    endif
+#    ifndef CIRQUE_PINNACLE_X_RANGE
+#        define CIRQUE_PINNACLE_X_RANGE (CIRQUE_PINNACLE_X_UPPER - CIRQUE_PINNACLE_X_LOWER)
+#    endif
+#    ifndef CIRQUE_PINNACLE_Y_RANGE
+#        define CIRQUE_PINNACLE_Y_RANGE (CIRQUE_PINNACLE_Y_UPPER - CIRQUE_PINNACLE_Y_LOWER)
+#    endif
+#    if defined(POINTING_DEVICE_GESTURE_SCROLL_ENABLE)
+#        define CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE
+#    endif
+#else
+#    define CIRQUE_PINNACLE_X_RANGE 256
+#    define CIRQUE_PINNACLE_Y_RANGE 256
+#    if defined(POINTING_DEVICE_GESTURE_SCROLL_ENABLE)
+#        define CIRQUE_PINNACLE_SIDE_SCROLL_ENABLE
+#    endif
 #endif
 #if !defined(POINTING_DEVICE_TASK_THROTTLE_MS)
 #    define POINTING_DEVICE_TASK_THROTTLE_MS 10 // Cirque Pinnacle in normal operation produces data every 10ms. Advanced configuration for pen/stylus usage might require lower values.
@@ -86,9 +97,9 @@ typedef struct {
     uint8_t  buttonFlags;
     bool     touchDown;
 #else
-    uint8_t xDelta;
-    uint8_t yDelta;
-    uint8_t wheelCount;
+    int16_t xDelta;
+    int16_t yDelta;
+    int8_t  wheelCount;
     uint8_t buttons;
 #endif
 } pinnacle_data_t;

--- a/drivers/sensors/cirque_pinnacle_gestures.c
+++ b/drivers/sensors/cirque_pinnacle_gestures.c
@@ -24,11 +24,11 @@
 #    include "keyboard.h"
 #endif
 
-#if defined(CIRQUE_PINNACLE_TAP_ENABLE) || defined(CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE)
+#if (defined(CIRQUE_PINNACLE_TAP_ENABLE) || defined(CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE)) && CIRQUE_PINNACLE_POSITION_MODE
 static cirque_pinnacle_features_t features = {.tap_enable = true, .circular_scroll_enable = true};
 #endif
 
-#ifdef CIRQUE_PINNACLE_TAP_ENABLE
+#if defined(CIRQUE_PINNACLE_TAP_ENABLE) && CIRQUE_PINNACLE_POSITION_MODE
 static trackpad_tap_context_t tap;
 
 static report_mouse_t trackpad_tap(report_mouse_t mouse_report, pinnacle_data_t touchData) {
@@ -62,6 +62,9 @@ void cirque_pinnacle_enable_tap(bool enable) {
 #endif
 
 #ifdef CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE
+#    if !CIRQUE_PINNACLE_POSITION_MODE
+#        error "Circular scroll is not supported in relative mode"
+#    endif
 /* To set a trackpad exclusively as scroll wheel: outer_ring_pct = 100, trigger_px = 0, trigger_ang = 0 */
 static circular_scroll_context_t scroll = {.config = {.outer_ring_pct = 33,
                                                       .trigger_px     = 16,
@@ -213,6 +216,9 @@ bool cirque_pinnacle_gestures(report_mouse_t* mouse_report, pinnacle_data_t touc
     bool suppress_mouse_update = false;
 
 #ifdef CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE
+#    if !CIRQUE_PINNACLE_POSITION_MODE
+#        error "Circular scroll is not supported in relative mode"
+#    endif
     circular_scroll_t scroll_report;
     if (features.circular_scroll_enable) {
         scroll_report         = circular_scroll(touchData);
@@ -222,7 +228,7 @@ bool cirque_pinnacle_gestures(report_mouse_t* mouse_report, pinnacle_data_t touc
     }
 #endif
 
-#ifdef CIRQUE_PINNACLE_TAP_ENABLE
+#if defined(CIRQUE_PINNACLE_TAP_ENABLE) && CIRQUE_PINNACLE_POSITION_MODE
     if (features.tap_enable) {
         *mouse_report = trackpad_tap(*mouse_report, touchData);
     }

--- a/drivers/sensors/cirque_pinnacle_gestures.h
+++ b/drivers/sensors/cirque_pinnacle_gestures.h
@@ -24,7 +24,7 @@ typedef struct {
     bool circular_scroll_enable;
 } cirque_pinnacle_features_t;
 
-#ifdef CIRQUE_PINNACLE_TAP_ENABLE
+#if defined(CIRQUE_PINNACLE_TAP_ENABLE) && CIRQUE_PINNACLE_POSITION_MODE
 #    ifndef CIRQUE_PINNACLE_TAPPING_TERM
 #        include "action.h"
 #        include "action_tapping.h"
@@ -44,6 +44,9 @@ void cirque_pinnacle_enable_tap(bool enable);
 #endif
 
 #ifdef CIRQUE_PINNACLE_CIRCULAR_SCROLL_ENABLE
+#    if !CIRQUE_PINNACLE_POSITION_MODE
+#        error "Circular scroll is not supported in relative mode"
+#    endif
 typedef enum {
     SCROLL_UNINITIALIZED,
     SCROLL_DETECTING,

--- a/drivers/sensors/cirque_pinnacle_regdefs.h
+++ b/drivers/sensors/cirque_pinnacle_regdefs.h
@@ -384,7 +384,7 @@
 #define EXTREG__TRACK_ADCCONFIG                                     0x0187
 // ADC-attenuation settings (held in BIT_7 and BIT_6)
 // 1X = most sensitive, 4X = least sensitive
-#    define EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_MASK             0x3F
+#    define EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_MASK             0xC0
 #        define EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_1X           0x00
 #        define EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_2X           0x40
 #        define EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_3X           0x80


### PR DESCRIPTION
Implement relative mode for Cirque trackpad

## Description

Cirque can work in absolute or relative mode, they differ in features. Give user a choice to use one of them. Also relative mode saves a lot of space.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
