### PR TITLE
Fix test logic to check for both keymaps

### DIFF
--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -97,13 +97,15 @@ def test_list_keyboards():
 def test_list_keymaps():
     result = check_subcommand('list-keymaps', '-kb', 'handwired/pytest/basic')
     check_returncode(result)
-    assert 'default' and 'default_json' in result.stdout
+    assert 'default' in result.stdout
+    assert 'default_json' in result.stdout
 
 
 def test_list_keymaps_long():
     result = check_subcommand('list-keymaps', '--keyboard', 'handwired/pytest/basic')
     check_returncode(result)
-    assert 'default' and 'default_json' in result.stdout
+    assert 'default' in result.stdout
+    assert 'default_json' in result.stdout
 
 
 def test_list_keymaps_community():
@@ -115,19 +117,22 @@ def test_list_keymaps_community():
 def test_list_keymaps_kb_only():
     result = check_subcommand('list-keymaps', '-kb', 'contra')
     check_returncode(result)
-    assert 'default' and 'via' in result.stdout
+    assert 'default' in result.stdout
+    assert 'via' in result.stdout
 
 
 def test_list_keymaps_vendor_kb():
     result = check_subcommand('list-keymaps', '-kb', 'ai03/lunar')
     check_returncode(result)
-    assert 'default' and 'via' in result.stdout
+    assert 'default' in result.stdout
+    assert 'via' in result.stdout
 
 
 def test_list_keymaps_vendor_kb_rev():
     result = check_subcommand('list-keymaps', '-kb', 'kbdfans/kbd67/mkiirgb/v2')
     check_returncode(result)
-    assert 'default' and 'via' in result.stdout
+    assert 'default' in result.stdout
+    assert 'via' in result.stdout
 
 
 def test_list_keymaps_no_keyboard_found():


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Python will evaluate first the left and then the right side of the and operator.
The left side would previously return True based on the truthiness logic that treats any non-emptry string as true. It would not check if the desired keymap exists.
If the left side is true it will evaluate the right side which will check for the existance of a specific keymap.
With this change the check for existance of two keymaps is implemented.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
