### PR TITLE
Create generic Pointing Device Pin defines

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -22,11 +22,13 @@ POINTING_DEVICE_DRIVER = adns5050
 
 The ADNS 5050 sensor uses a serial type protocol for communication, and requires an additional light source. 
 
-| Setting             | Description                                                         |
-| ------------------- | ------------------------------------------------------------------- |
-| `ADNS5050_SCLK_PIN` | (Required) The pin connected to the clock pin of the sensor.        |
-| `ADNS5050_SDIO_PIN` | (Required) The pin connected to the data pin of the sensor.         |
-| `ADNS5050_CS_PIN`   | (Required) The pin connected to the cable select pin of the sensor. |
+| Setting             | Description                                                         | Default                    |
+| ------------------- | ------------------------------------------------------------------- | -------------------------- |
+| `ADNS5050_SCLK_PIN` | (Required) The pin connected to the clock pin of the sensor.        | `POINTING_DEVICE_SCLK_PIN` |
+| `ADNS5050_SDIO_PIN` | (Required) The pin connected to the data pin of the sensor.         | `POINTING_DEVICE_SDIO_PIN` |
+| `ADNS5050_CS_PIN`   | (Required) The pin connected to the cable select pin of the sensor. | `POINTING_DEVICE_CS_PIN`   |
+
+
 
 The CPI range is 125-1375, in increments of 125. Defaults to 500 CPI.
 
@@ -40,13 +42,13 @@ POINTING_DEVICE_DRIVER = adns9800
 
 The ADNS 9800 is an SPI driven optical sensor, that uses laser output for surface tracking. 
 
-| Setting                 | Description                                                            | Default       |
-| ----------------------- | ---------------------------------------------------------------------- | ------------- |
-| `ADNS9800_CLOCK_SPEED`  | (Optional) Sets the clock speed that the sensor runs at.               | `2000000`     |
-| `ADNS9800_SPI_LSBFIRST` | (Optional) Sets the Least/Most Significant Byte First setting for SPI. | `false`       |
-| `ADNS9800_SPI_MODE`     | (Optional) Sets the SPI Mode for the sensor.                           | `3`           |
-| `ADNS9800_SPI_DIVISOR`  | (Optional) Sets the SPI Divisor used for SPI communication.            | _varies_      |
-| `ADNS9800_CS_PIN`       | (Required) Sets the Cable Select pin connected to the sensor.          | _not defined_ |
+| Setting                 | Description                                                            | Default                  |
+| ----------------------- | ---------------------------------------------------------------------- | ------------------------ |
+| `ADNS9800_CLOCK_SPEED`  | (Optional) Sets the clock speed that the sensor runs at.               | `2000000`                |
+| `ADNS9800_SPI_LSBFIRST` | (Optional) Sets the Least/Most Significant Byte First setting for SPI. | `false`                  |
+| `ADNS9800_SPI_MODE`     | (Optional) Sets the SPI Mode for the sensor.                           | `3`                      |
+| `ADNS9800_SPI_DIVISOR`  | (Optional) Sets the SPI Divisor used for SPI communication.            | _varies_                 |
+| `ADNS9800_CS_PIN`       | (Required) Sets the Cable Select pin connected to the sensor.          | `POINTING_DEVICE_CS_PIN` |
 
 
 The CPI range is 800-8200, in increments of 200. Defaults to 1800 CPI. 
@@ -116,13 +118,13 @@ Default attenuation is set to 4X, although if you are using a thicker overlay (s
 | `CIRQUE_PINNACLE_ADDR`    | (Required) Sets the I2C Address for the Cirque Trackpad                         | `0x2A`  |
 | `CIRQUE_PINNACLE_TIMEOUT` | (Optional) The timeout for i2c communication with the trackpad in milliseconds. | `20`    |
 
-| SPI Setting                    | Description                                                            | Default       |
-| ------------------------------ | ---------------------------------------------------------------------- | ------------- |
-| `CIRQUE_PINNACLE_CLOCK_SPEED`  | (Optional) Sets the clock speed that the sensor runs at.               | `1000000`     |
-| `CIRQUE_PINNACLE_SPI_LSBFIRST` | (Optional) Sets the Least/Most Significant Byte First setting for SPI. | `false`       |
-| `CIRQUE_PINNACLE_SPI_MODE`     | (Optional) Sets the SPI Mode for the sensor.                           | `1`           |
-| `CIRQUE_PINNACLE_SPI_DIVISOR`  | (Optional) Sets the SPI Divisor used for SPI communication.            | _varies_      |
-| `CIRQUE_PINNACLE_SPI_CS_PIN`   | (Required) Sets the Cable Select pin connected to the sensor.          | _not defined_ |
+| SPI Setting                    | Description                                                            | Default                  |
+| ------------------------------ | ---------------------------------------------------------------------- | ------------------------ |
+| `CIRQUE_PINNACLE_CLOCK_SPEED`  | (Optional) Sets the clock speed that the sensor runs at.               | `1000000`                |
+| `CIRQUE_PINNACLE_SPI_LSBFIRST` | (Optional) Sets the Least/Most Significant Byte First setting for SPI. | `false`                  |
+| `CIRQUE_PINNACLE_SPI_MODE`     | (Optional) Sets the SPI Mode for the sensor.                           | `1`                      |
+| `CIRQUE_PINNACLE_SPI_DIVISOR`  | (Optional) Sets the SPI Divisor used for SPI communication.            | _varies_                 |
+| `CIRQUE_PINNACLE_SPI_CS_PIN`   | (Required) Sets the Cable Select pin connected to the sensor.          | `POINTING_DEVICE_CS_PIN` |
 
 Default Scaling is 1024. Actual CPI depends on trackpad diameter.
 
@@ -170,10 +172,10 @@ POINTING_DEVICE_DRIVER = paw3204
 
 The paw 3204 sensor uses a serial type protocol for communication, and requires an additional light source. 
 
-| Setting            | Description                                                         |
-|--------------------|---------------------------------------------------------------------|
-|`PAW3204_SCLK_PIN` | (Required) The pin connected to the clock pin of the sensor.        |
-|`PAW3204_SDIO_PIN` | (Required) The pin connected to the data pin of the sensor.         |
+| Setting            | Description                                                    | Default                    |
+| ------------------ |--------------------------------------------------------------- | -------------------------- |
+| `PAW3204_SCLK_PIN` | (Required) The pin connected to the clock pin of the sensor.   | `POINTING_DEVICE_SCLK_PIN` |
+| `PAW3204_SDIO_PIN` | (Required) The pin connected to the data pin of the sensor.    | `POINTING_DEVICE_SDIO_PIN` |
 
 The CPI range is 400-1600, with supported values of (400, 500, 600, 800, 1000, 1200 and 1600).  Defaults to 1000 CPI.
 
@@ -217,15 +219,15 @@ The CPI range is 50-16000, in increments of 50. Defaults to 2000 CPI.
 
 Both PMW 3360 and PMW 3389 are SPI driven optical sensors, that use a built in IR LED for surface tracking.
 
-| Setting                      | Description                                                                                 | Default       |
-| ---------------------------- | ------------------------------------------------------------------------------------------- | ------------- |
-| `PMW33XX_CS_PIN`             | (Required) Sets the Cable Select pin connected to the sensor.                               | _not defined_ |
-| `PMW33XX_CS_PINS`            | (Alternative) Sets the Cable Select pins connected to multiple sensors.                     | _not defined_ |
-| `PMW33XX_CPI`                | (Optional) Sets counts per inch sensitivity of the sensor.                                  | _varies_      |
-| `PMW33XX_CLOCK_SPEED`        | (Optional) Sets the clock speed that the sensor runs at.                                    | `2000000`     |
-| `PMW33XX_SPI_DIVISOR`        | (Optional) Sets the SPI Divisor used for SPI communication.                                 | _varies_      |
-| `PMW33XX_LIFTOFF_DISTANCE`   | (Optional) Sets the lift off distance at run time                                           | `0x02`        |
-| `ROTATIONAL_TRANSFORM_ANGLE` | (Optional) Allows for the sensor data to be rotated +/- 127 degrees directly in the sensor. | `0`           |
+| Setting                      | Description                                                                                 | Default                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------- | ------------------------ |
+| `PMW33XX_CS_PIN`             | (Required) Sets the Cable Select pin connected to the sensor.                               | `POINTING_DEVICE_CS_PIN` |
+| `PMW33XX_CS_PINS`            | (Alternative) Sets the Cable Select pins connected to multiple sensors.                     | _not defined_            |
+| `PMW33XX_CPI`                | (Optional) Sets counts per inch sensitivity of the sensor.                                  | _varies_                 |
+| `PMW33XX_CLOCK_SPEED`        | (Optional) Sets the clock speed that the sensor runs at.                                    | `2000000`                |
+| `PMW33XX_SPI_DIVISOR`        | (Optional) Sets the SPI Divisor used for SPI communication.                                 | _varies_                 |
+| `PMW33XX_LIFTOFF_DISTANCE`   | (Optional) Sets the lift off distance at run time                                           | `0x02`                   |
+| `ROTATIONAL_TRANSFORM_ANGLE` | (Optional) Allows for the sensor data to be rotated +/- 127 degrees directly in the sensor. | `0`                      |
 
 To use multiple sensors, instead of setting `PMW33XX_CS_PIN` you need to set `PMW33XX_CS_PINS` and also handle and merge the read from this sensor in user code.
 Note that different (per sensor) values of CPI, speed liftoff, rotational angle or flipping of X/Y is not currently supported.
@@ -290,9 +292,13 @@ void           pointing_device_driver_set_cpi(uint16_t cpi) {}
 | `POINTING_DEVICE_TASK_THROTTLE_MS`             | (Optional) Limits the frequency that the sensor is polled for motion.                                                            | _not defined_ |
 | `POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE` | (Optional) Enable inertial cursor. Cursor continues moving after a flick gesture and slows down by kinetic friction.             | _not defined_ |
 | `POINTING_DEVICE_GESTURES_SCROLL_ENABLE`       | (Optional) Enable scroll gesture. The gesture that activates the scroll is device dependent.                                     | _not defined_ |
+| `POINTING_DEVICE_CS_PIN`                       | (Optional) Provides a default CS pin, useful for supporting multiple sensor configs.                                             | _not defined_ |
+| `POINTING_DEVICE_SDIO_PIN`                     | (Optional) Provides a default SDIO pin, useful for supporting multiple sensor configs.                                           | _not defined_ |
+| `POINTING_DEVICE_SCLK_PIN`                     | (Optional) Provides a default SCLK pin, useful for supporting multiple sensor configs.                                           | _not defined_ |
 
 !> When using `SPLIT_POINTING_ENABLE` the `POINTING_DEVICE_MOTION_PIN` functionality is not supported and `POINTING_DEVICE_TASK_THROTTLE_MS` will default to `1`. Increasing this value will increase transport performance at the cost of possible mouse responsiveness.
 
+The `POINTING_DEVICE_CS_PIN`, `POINTING_DEVICE_SDIO_PIN`, and `POINTING_DEVICE_SCLK_PIN` provide a convenient way to define a single pin that can be used for an interchangeable sensor config.  This allows you to have a single config, without defining each device.  Each sensor allows for this to be overridden with their own defines. 
 
 !> **`POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE`** can be used with any pointing device with a lift/contact status can integrate this gesture into its driver. e.g. PMW3360 can use Lift_Stat from Motion register. Note that `POINTING_DEVICE_MOTION_PIN` cannot be used with this feature; continuous polling of `pointing_device_get_report()` is needed to generate glide reports.
 

--- a/drivers/sensors/adns5050.h
+++ b/drivers/sensors/adns5050.h
@@ -56,10 +56,10 @@
 #endif
 
 #ifndef ADNS5050_CS_PIN
-#    ifdef POINTING_DEVICE_SPI_CS_PIN
-#        define ADNS5050_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#    ifdef POINTING_DEVICE_CS_PIN
+#        define ADNS5050_CS_PIN POINTING_DEVICE_CS_PIN
 #    else
-#        error "No chip select pin defined -- missing POINTING_DEVICE_SPI_CS_PIN or ADNS5050_CS_PIN define"
+#        error "No chip select pin defined -- missing POINTING_DEVICE_CS_PIN or ADNS5050_CS_PIN define"
 #    endif
 #endif
 

--- a/drivers/sensors/adns5050.h
+++ b/drivers/sensors/adns5050.h
@@ -40,15 +40,27 @@
 
 // Definitions for the ADNS serial line.
 #ifndef ADNS5050_SCLK_PIN
-#    error "No clock pin defined -- missing ADNS5050_SCLK_PIN"
+#    ifdef POINTING_DEVICE_SCLK_PIN
+#        define ADNS5050_SCLK_PIN POINTING_DEVICE_SCLK_PIN
+#    else
+#        error "No clock pin defined -- missing POINTING_DEVICE_SCLK_PIN or ADNS5050_SCLK_PIN"
+#    endif
 #endif
 
 #ifndef ADNS5050_SDIO_PIN
-#    error "No data pin defined -- missing ADNS5050_SDIO_PIN"
+#    ifdef POINTING_DEVICE_SDIO_PIN
+#        define ADNS5050_SDIO_PIN POINTING_DEVICE_SDIO_PIN
+#    else
+#        error "No data pin defined -- missing POINTING_DEVICE_SDIO_PIN or ADNS5050_SDIO_PIN"
+#    endif
 #endif
 
 #ifndef ADNS5050_CS_PIN
-#    error "No chip select pin defined -- missing ADNS5050_CS_PIN"
+#    ifdef POINTING_DEVICE_SPI_CS_PIN
+#        define ADNS5050_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#    else
+#        error "No chip select pin defined -- missing POINTING_DEVICE_SPI_CS_PIN or ADNS5050_CS_PIN define"
+#    endif
 #endif
 
 typedef struct {

--- a/drivers/sensors/adns9800.h
+++ b/drivers/sensors/adns9800.h
@@ -43,10 +43,10 @@
 #endif
 
 #ifndef ADNS9800_CS_PIN
-#    ifdef POINTING_DEVICE_SPI_CS_PIN
-#        define ADNS5050_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#    ifdef POINTING_DEVICE_CS_PIN
+#        define ADNS9800_CS_PIN POINTING_DEVICE_CS_PIN
 #    else
-#        error "No chip select pin defined -- missing ADNS9800_CS_PIN"
+#        error "No chip select pin defined -- missing POINTING_DEVICE_CS_PIN or ADNS9800_CS_PIN"
 #    endif
 #endif
 

--- a/drivers/sensors/adns9800.h
+++ b/drivers/sensors/adns9800.h
@@ -43,7 +43,11 @@
 #endif
 
 #ifndef ADNS9800_CS_PIN
-#    error "No chip select pin defined -- missing ADNS9800_CS_PIN"
+#    ifdef POINTING_DEVICE_SPI_CS_PIN
+#        define ADNS5050_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#    else
+#        error "No chip select pin defined -- missing ADNS9800_CS_PIN"
+#    endif
 #endif
 
 typedef struct {

--- a/drivers/sensors/cirque_pinnacle.h
+++ b/drivers/sensors/cirque_pinnacle.h
@@ -78,10 +78,10 @@
 #            define CIRQUE_PINNACLE_SPI_DIVISOR 64
 #        endif
 #        ifndef CIRQUE_PINNACLE_SPI_CS_PIN
-#            ifdef POINTING_DEVICE_SPI_CS_PIN
-#                define CIRQUE_PINNACLE_SPI_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#            ifdef POINTING_DEVICE_CS_PIN
+#                define CIRQUE_PINNACLE_SPI_CS_PIN POINTING_DEVICE_CS_PIN
 #            else
-#                error "No Chip Select pin has been defined -- missing POINTING_DEVICE_SPI_CS_PIN or CIRQUE_PINNACLE_SPI_CS_PIN define"
+#                error "No Chip Select pin has been defined -- missing POINTING_DEVICE_CS_PIN or CIRQUE_PINNACLE_SPI_CS_PIN define"
 #            endif
 #        endif
 #    endif

--- a/drivers/sensors/cirque_pinnacle.h
+++ b/drivers/sensors/cirque_pinnacle.h
@@ -78,7 +78,11 @@
 #            define CIRQUE_PINNACLE_SPI_DIVISOR 64
 #        endif
 #        ifndef CIRQUE_PINNACLE_SPI_CS_PIN
-#            error "No Chip Select pin has been defined -- missing CIRQUE_PINNACLE_SPI_CS_PIN define"
+#            ifdef POINTING_DEVICE_SPI_CS_PIN
+#                define CIRQUE_PINNACLE_SPI_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#            else
+#                error "No Chip Select pin has been defined -- missing POINTING_DEVICE_SPI_CS_PIN or CIRQUE_PINNACLE_SPI_CS_PIN define"
+#            endif
 #        endif
 #    endif
 #endif

--- a/drivers/sensors/paw3204.h
+++ b/drivers/sensors/paw3204.h
@@ -20,10 +20,18 @@
 #include <stdbool.h>
 
 #ifndef PAW3204_SCLK_PIN
-#    error "No clock pin defined -- missing PAW3204_SCLK_PIN"
+#    ifdef POINTING_DEVICE_SCLK_PIN
+#        define PAW3204_SCLK_PIN POINTING_DEVICE_SCLK_PIN
+#    else
+#        error "No clock pin defined -- missing POINTING_DEVICE_SCLK_PIN or PAW3204_SCLK_PIN"
+#    endif
 #endif
 #ifndef PAW3204_SDIO_PIN
-#    error "No data pin defined -- missing PAW3204_SDIO_PIN"
+#    ifdef POINTING_DEVICE_SDIO_PIN
+#        define PAW3204_SDIO_PIN POINTING_DEVICE_SDIO_PIN
+#    else
+#        error "No data pin defined -- missing POINTING_DEVICE_SDIO_PIN or PAW3204_SDIO_PIN"
+#    endif
 #endif
 
 typedef struct {

--- a/drivers/sensors/pmw33xx_common.h
+++ b/drivers/sensors/pmw33xx_common.h
@@ -68,7 +68,8 @@ _Static_assert(sizeof((pmw33xx_report_t){0}.motion) == 1, "pmw33xx_report_t.moti
 #    ifndef PMW33XX_CS_PIN
 #        ifdef POINTING_DEVICE_CS_PIN
 #            define PMW33XX_CS_PIN POINTING_DEVICE_CS_PIN
-#            define PMW33XX_CS_PINS { PMW33XX_CS_PIN }
+#            define PMW33XX_CS_PINS \
+                { PMW33XX_CS_PIN }
 #        else
 #            error "No chip select pin defined -- missing PMW33XX_CS_PIN or PMW33XX_CS_PINS"
 #        endif

--- a/drivers/sensors/pmw33xx_common.h
+++ b/drivers/sensors/pmw33xx_common.h
@@ -66,7 +66,11 @@ _Static_assert(sizeof((pmw33xx_report_t){0}.motion) == 1, "pmw33xx_report_t.moti
 // Support single and plural spellings
 #ifndef PMW33XX_CS_PINS
 #    ifndef PMW33XX_CS_PIN
-#        error "No chip select pin defined -- missing PMW33XX_CS_PIN or PMW33XX_CS_PINS"
+#        ifdef POINTING_DEVICE_SPI_CS_PIN
+#            define PMW33XX_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#        else
+#            error "No chip select pin defined -- missing PMW33XX_CS_PIN or PMW33XX_CS_PINS"
+#        endif
 #    else
 #        define PMW33XX_CS_PINS \
             { PMW33XX_CS_PIN }

--- a/drivers/sensors/pmw33xx_common.h
+++ b/drivers/sensors/pmw33xx_common.h
@@ -66,8 +66,9 @@ _Static_assert(sizeof((pmw33xx_report_t){0}.motion) == 1, "pmw33xx_report_t.moti
 // Support single and plural spellings
 #ifndef PMW33XX_CS_PINS
 #    ifndef PMW33XX_CS_PIN
-#        ifdef POINTING_DEVICE_SPI_CS_PIN
-#            define PMW33XX_CS_PIN POINTING_DEVICE_SPI_CS_PIN
+#        ifdef POINTING_DEVICE_CS_PIN
+#            define PMW33XX_CS_PIN POINTING_DEVICE_CS_PIN
+#            define PMW33XX_CS_PINS { PMW33XX_CS_PIN }
 #        else
 #            error "No chip select pin defined -- missing PMW33XX_CS_PIN or PMW33XX_CS_PINS"
 #        endif


### PR DESCRIPTION
## Description

Create default defines for pin configs, so that switching between sensors is easier.

## Types of Changes

- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
