### PR TITLE
[Docs] Fix custom debug function and sample output

### DIFF
--- a/docs/faq_debug.md
+++ b/docs/faq_debug.md
@@ -59,7 +59,7 @@ When porting, or when attempting to diagnose pcb issues, it can be useful to kno
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   // If console is enabled, it will print the matrix position and status of each key pressed
 #ifdef CONSOLE_ENABLE
-    uprintf("KL: kc: 0x%04X, col: %u, row: %u, pressed: %b, time: %u, interrupt: %b, count: %u\n", keycode, record->event.key.col, record->event.key.row, record->event.pressed, record->event.time, record->tap.interrupted, record->tap.count);
+    uprintf("KL: kc: 0x%04X, col: %2u, row: %2u, pressed: %u, time: %5u, int: %u, count: %u\n", keycode, record->event.key.col, record->event.key.row, record->event.pressed, record->event.time, record->tap.interrupted, record->tap.count);
 #endif 
   return true;
 }
@@ -69,12 +69,12 @@ Example output
 ```
 Waiting for device:.......
 Listening:
-KL: kc: 169, col: 0, row: 0, pressed: 1
-KL: kc: 169, col: 0, row: 0, pressed: 0
-KL: kc: 174, col: 1, row: 0, pressed: 1
-KL: kc: 174, col: 1, row: 0, pressed: 0
-KL: kc: 172, col: 2, row: 0, pressed: 1
-KL: kc: 172, col: 2, row: 0, pressed: 0
+KL: kc: 169, col: 0, row: 0, pressed: 1, time: 15505, int: 0, count: 0
+KL: kc: 169, col: 0, row: 0, pressed: 0, time: 15510, int: 0, count: 0
+KL: kc: 174, col: 1, row: 0, pressed: 1, time: 15703, int: 0, count: 0
+KL: kc: 174, col: 1, row: 0, pressed: 0, time: 15843, int: 0, count: 0
+KL: kc: 172, col: 2, row: 0, pressed: 1, time: 16303, int: 0, count: 0
+KL: kc: 172, col: 2, row: 0, pressed: 0, time: 16411, int: 0, count: 0
 ```
 
 ### How long did it take to scan for a keypress?


### PR DESCRIPTION
## Description

Because of the print library change, the `%b` no longer works in the example.  

This fixes it to be working code.  Additionally, updates the sample output to reflect the more advanced code.

## Types of Changes

- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
