### PR TITLE
[Keyboard] Fix compilation issues for Charybdis/Dilemma

### DIFF
--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -243,10 +243,10 @@ static void debug_charybdis_config_to_console(charybdis_config_t* config) {
     dprintf("(charybdis) process_record_kb: config = {\n"
             "\traw = 0x%X,\n"
             "\t{\n"
-            "\t\tis_dragscroll_enabled=%b\n"
-            "\t\tis_sniping_enabled=%b\n"
-            "\t\tdefault_dpi=0x%X (%ld)\n"
-            "\t\tsniping_dpi=0x%X (%ld)\n"
+            "\t\tis_dragscroll_enabled=%u\n"
+            "\t\tis_sniping_enabled=%u\n"
+            "\t\tdefault_dpi=0x%X (%u)\n"
+            "\t\tsniping_dpi=0x%X (%u)\n"
             "\t}\n"
             "}\n",
             config->raw, config->is_dragscroll_enabled, config->is_sniping_enabled, config->pointer_default_dpi, get_pointer_default_dpi(config), config->pointer_sniping_dpi, get_pointer_sniping_dpi(config));
@@ -314,7 +314,9 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     }
 #        endif // !MOUSEKEY_ENABLE
 #    endif     // POINTING_DEVICE_ENABLE
-    debug_charybdis_config_to_console(&g_charybdis_config);
+    if ((keycode >= POINTER_DEFAULT_DPI_FORWARD && keycode < CHARYBDIS_SAFE_RANGE) || IS_MOUSEKEY(keycode)) {
+        debug_charybdis_config_to_console(&g_charybdis_config);
+    }
     return true;
 }
 

--- a/keyboards/bastardkb/dilemma/dilemma.c
+++ b/keyboards/bastardkb/dilemma/dilemma.c
@@ -246,10 +246,10 @@ static void debug_dilemma_config_to_console(dilemma_config_t* config) {
     dprintf("(dilemma) process_record_kb: config = {\n"
             "\traw = 0x%X,\n"
             "\t{\n"
-            "\t\tis_dragscroll_enabled=%b\n"
-            "\t\tis_sniping_enabled=%b\n"
-            "\t\tdefault_dpi=0x%X (%ld)\n"
-            "\t\tsniping_dpi=0x%X (%ld)\n"
+            "\t\tis_dragscroll_enabled=%u\n"
+            "\t\tis_sniping_enabled=%u\n"
+            "\t\tdefault_dpi=0x%X (%u)\n"
+            "\t\tsniping_dpi=0x%X (%u)\n"
             "\t}\n"
             "}\n",
             config->raw, config->is_dragscroll_enabled, config->is_sniping_enabled, config->pointer_default_dpi, get_pointer_default_dpi(config), config->pointer_sniping_dpi, get_pointer_sniping_dpi(config));
@@ -308,6 +308,9 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
 #        endif // !NO_DILEMMA_KEYCODES
 #    endif     // POINTING_DEVICE_ENABLE
     debug_dilemma_config_to_console(&g_dilemma_config);
+    if ((keycode >= POINTER_DEFAULT_DPI_FORWARD && keycode < DILEMMA_SAFE_RANGE) || IS_MOUSEKEY(keycode)) {
+        debug_dilemma_config_to_console(&g_dilemma_config);
+    }
     return true;
 }
 

--- a/keyboards/bastardkb/dilemma/rules.mk
+++ b/keyboards/bastardkb/dilemma/rules.mk
@@ -21,3 +21,5 @@ POINTING_DEVICE_DRIVER = cirque_pinnacle_i2c
 
 SPLIT_KEYBOARD = yes
 LAYOUTS = split_3x5_2
+
+DEFAULT_FOLDER = bastardkb/dilemma/splinky


### PR DESCRIPTION
## Description

* Print variables error in compilation, fixes. 
* Reduces amount of logging to just mouse related keycodes

## Types of Changes

- [x] Bugfix
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
