### PR TITLE
Fix QK_MAKE's reboot check

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -411,7 +411,7 @@ bool process_record_quantum(keyrecord_t *record) {
                     SEND_STRING_DELAY(" compile ", TAP_CODE_DELAY);
                 }
                 SEND_STRING_DELAY("-kb " QMK_KEYBOARD " -km " QMK_KEYMAP SS_TAP(X_ENTER), TAP_CODE_DELAY);
-                if (temp_mod & MOD_MASK_CS) {
+                if (temp_mod & MOD_MASK_SHIFT && temp_mod & MOD_MASK_CTRL) {
                     reset_keyboard();
                 }
             }


### PR DESCRIPTION
## Description

Was checking for `MOD_MASK_CS` which will trigger on shift or control, not just control+shift, which is not intended behavior.

This fixes the check so that it properly triggers on control+shift.

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
