### PR TITLE
Constrain Cirque Pinnacle coordinates

### DIFF
--- a/quantum/pointing_device/pointing_device_drivers.c
+++ b/quantum/pointing_device/pointing_device_drivers.c
@@ -117,11 +117,11 @@ void cirque_pinnacle_configure_cursor_glide(float trigger_px) {
 #    endif
 
 report_mouse_t cirque_pinnacle_get_report(report_mouse_t mouse_report) {
-    pinnacle_data_t          touchData = cirque_pinnacle_read_data();
-    mouse_xy_report_t        report_x = 0, report_y = 0;
-    static mouse_xy_report_t x = 0, y = 0;
+    pinnacle_data_t   touchData = cirque_pinnacle_read_data();
+    mouse_xy_report_t report_x = 0, report_y = 0;
+    static uint16_t   x = 0, y = 0;
 #    ifdef POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE
-    cursor_glide_t           glide_report = {0};
+    cursor_glide_t    glide_report = {0};
 
     if (cursor_glide_enable) {
         glide_report = cursor_glide_check(&glide);
@@ -154,8 +154,8 @@ report_mouse_t cirque_pinnacle_get_report(report_mouse_t mouse_report) {
 
     if (!cirque_pinnacle_gestures(&mouse_report, touchData)) {
         if (x && y && touchData.xValue && touchData.yValue) {
-            report_x = (mouse_xy_report_t)(touchData.xValue - x);
-            report_y = (mouse_xy_report_t)(touchData.yValue - y);
+            report_x = CONSTRAIN_HID_XY((int16_t)(touchData.xValue - x));
+            report_y = CONSTRAIN_HID_XY((int16_t)(touchData.yValue - y));
         }
         x = touchData.xValue;
         y = touchData.yValue;


### PR DESCRIPTION
Static `x` & `y` should be the same type as `touchData.xValue` & `touchData.yValue`: `uint16_t`.
Their delta could be larger than `int8_t` and should be constrained to `mouse_xy_report_t`.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
