### PR TITLE
[Core] Fix ChibiOS `i2c_master` error codes

### DIFF
--- a/platforms/chibios/drivers/i2c_master.c
+++ b/platforms/chibios/drivers/i2c_master.c
@@ -116,7 +116,7 @@ static const I2CConfig i2cconfig = {
  * @return i2c_status_t QMK specific I2C status code
  */
 static i2c_status_t i2c_epilogue(const msg_t status) {
-    if (status == I2C_NO_ERROR) {
+    if (status == MSG_OK) {
         return I2C_STATUS_SUCCESS;
     }
 
@@ -125,7 +125,7 @@ static i2c_status_t i2c_epilogue(const msg_t status) {
     // hard stop in case of any error.
     i2c_stop();
 
-    return status == I2C_TIMEOUT ? I2C_STATUS_TIMEOUT : I2C_STATUS_ERROR;
+    return status == MSG_TIMEOUT ? I2C_STATUS_TIMEOUT : I2C_STATUS_ERROR;
 }
 
 __attribute__((weak)) void i2c_init(void) {


### PR DESCRIPTION
## Description

`msg_t` is `MSG_OK` in the success case and either `MSG_RESET` or `MSG_TIMEOUT` in case of errors. So actually use them in the comparison.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
