### PR TITLE
add encoder mapping, keyboard-level OLED + encoder definitions for mechwild/murphpad

### DIFF
--- a/keyboards/mechwild/murphpad/keymaps/default/keymap.c
+++ b/keyboards/mechwild/murphpad/keymaps/default/keymap.c
@@ -18,10 +18,10 @@
 // Defines names for use in layer keycodes and the keymap
 
 enum layer_names {
-  _BASE,
-  _FN1,
-	_FN2,
-	_FN3
+    _BASE,
+    _FN1,
+    _FN2,
+    _FN3
 };
 
 
@@ -29,7 +29,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Base */
     [_BASE] = LAYOUT(
                   KC_F1,   KC_F2,   KC_F3,   KC_F4,
-				          KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
+                  KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
                   KC_P7,   KC_P8,   KC_P9,   KC_PPLS,
         KC_MUTE,  KC_P4,   KC_P5,   KC_P6,   _______,
         MO(_FN1), KC_P1,   KC_P2,   KC_P3,   KC_PENT,
@@ -49,7 +49,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                  _______, _______, _______
 
     ),
-	  [_FN2] = LAYOUT(
+    [_FN2] = LAYOUT(
                   _______, _______, _______, _______,
                   _______, _______, _______, _______,
                   _______, _______, _______, _______,
@@ -60,7 +60,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                   _______, _______, _______
 
     ),
-	  [_FN3] = LAYOUT(
+    [_FN3] = LAYOUT(
                   _______, _______, _______, _______,
                   _______, _______, _______, _______,
                   _______, _______, _______, _______,
@@ -73,76 +73,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     )
 };
 
-#ifdef ENCODER_ENABLE
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    switch (index) {
-        case 0:
-            if (clockwise) {
-                tap_code(KC_VOLU);
-            } else {
-                tap_code(KC_VOLD);
-            }
-        break;
-		case 1:
-            if (clockwise) {
-                tap_code(KC_BRIU);
-            } else {
-                tap_code(KC_BRID);
-            }
-        break;
-    }
-    return true;
-}
-#endif
-
-#ifdef OLED_ENABLE
-	oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-		return OLED_ROTATION_270;       // flips the display 270 degrees
-	}
-
-	static void render_logo(void) {     // Render MechWild "MW" Logo
-		static const char PROGMEM logo_1[] = {0x8A, 0x8B, 0x8C, 0x8D, 0x00};
-		static const char PROGMEM logo_2[] = {0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0x00};
-		static const char PROGMEM logo_3[] = {0xCA, 0xCB, 0xCC, 0xCD, 0x00};
-		static const char PROGMEM logo_4[] = {0x20, 0x8E, 0x8F, 0x90, 0x00};
-		oled_set_cursor(0,0);
-		oled_write_P(logo_1, false);
-		oled_set_cursor(0,1);
-		oled_write_P(logo_2, false);
-		oled_set_cursor(0,2);
-		oled_write_P(logo_3, false);
-		oled_set_cursor(0,3);
-		oled_write_P(logo_4, false);
-	}
-
-	bool oled_task_user(void) {
-		render_logo();
-		oled_set_cursor(0,6);
-
-		oled_write_ln_P(PSTR("Layer"), false);
-
-    switch (get_highest_layer(layer_state)) {
-        case _BASE:
-            oled_write_ln_P(PSTR("Base"), false);
-            break;
-        case _FN1:
-            oled_write_ln_P(PSTR("FN 1"), false);
-            break;
-        case _FN2:
-            oled_write_ln_P(PSTR("FN 2"), false);
-            break;
-        case _FN3:
-            oled_write_ln_P(PSTR("FN 3"), false);
-            break;
-        default:
-            oled_write_ln_P(PSTR("Undef"), false);
-    }
-	oled_write_ln_P(PSTR(""), false);
-    // Host Keyboard LED Status
-    led_t led_state = host_keyboard_led_state();
-    oled_write_ln_P(led_state.num_lock ? PSTR("NUM ") : PSTR("    "), false);
-    oled_write_ln_P(led_state.caps_lock ? PSTR("CAP ") : PSTR("    "), false);
-    oled_write_ln_P(led_state.scroll_lock ? PSTR("SCR ") : PSTR("    "), false);
-    return false;
-	}
+#ifdef ENCODER_MAP_ENABLE
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
+    [_BASE] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU), ENCODER_CCW_CW(KC_BRID, KC_BRIU) },
+    [_FN1]  = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS) },
+    [_FN2]  = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS) },
+    [_FN3]  = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS) },
+};
 #endif

--- a/keyboards/mechwild/murphpad/keymaps/default/rules.mk
+++ b/keyboards/mechwild/murphpad/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+ENCODER_MAP_ENABLE = yes

--- a/keyboards/mechwild/murphpad/keymaps/jonavin/keymap.c
+++ b/keyboards/mechwild/murphpad/keymaps/jonavin/keymap.c
@@ -274,7 +274,7 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
                 break;
             }
         }
-        return true;
+        return false;
     }
 #endif
 
@@ -296,6 +296,10 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
 	}
 
     #ifdef LANDSCAPE_MODE
+    oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+       return OLED_ROTATION_0;       // do not flip the display
+    }
+
     bool oled_task_user(void) {
 
         render_logo();
@@ -365,10 +369,6 @@ bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
 
     // regular mode
     #ifndef LANDSCAPE_MODE
- 	oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-		return OLED_ROTATION_270;       // flips the display 270 degrees
-	}
-
     bool oled_task_user(void) {
 		render_logo();
 		oled_set_cursor(0,5);

--- a/keyboards/mechwild/murphpad/keymaps/via/keymap.c
+++ b/keyboards/mechwild/murphpad/keymaps/via/keymap.c
@@ -16,24 +16,26 @@
 #include QMK_KEYBOARD_H
 
 // Defines names for use in layer keycodes and the keymap
+
 enum layer_names {
-  _BASE,
-  _FN1,
-	_FN2,
-	_FN3
+    _BASE,
+    _FN1,
+    _FN2,
+    _FN3
 };
+
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Base */
     [_BASE] = LAYOUT(
                   KC_F1,   KC_F2,   KC_F3,   KC_F4,
-				          KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
+                  KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
                   KC_P7,   KC_P8,   KC_P9,   KC_PPLS,
         KC_MUTE,  KC_P4,   KC_P5,   KC_P6,   _______,
         MO(_FN1), KC_P1,   KC_P2,   KC_P3,   KC_PENT,
         KC_BSPC,  KC_P0,   _______, KC_PDOT, _______,
 
-				          KC_F5,   KC_F6,   KC_F7
+                  KC_F5,   KC_F6,   KC_F7
 
     ),
     [_FN1] = LAYOUT(
@@ -58,7 +60,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                   _______, _______, _______
 
     ),
-	  [_FN3] = LAYOUT(
+    [_FN3] = LAYOUT(
                   _______, _______, _______, _______,
                   _______, _______, _______, _______,
                   _______, _______, _______, _______,
@@ -71,76 +73,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     )
 };
 
-#ifdef ENCODER_ENABLE
-bool encoder_update_user(uint8_t index, bool clockwise) {
-    switch (index) {
-        case 0:
-            if (clockwise) {
-                tap_code(KC_VOLU);
-            } else {
-                tap_code(KC_VOLD);
-            }
-        break;
-		case 1:
-            if (clockwise) {
-                tap_code(KC_BRIU);
-            } else {
-                tap_code(KC_BRID);
-            }
-        break;
-    }
-    return true;
-}
-#endif
-
-#ifdef OLED_ENABLE
-	oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-		return OLED_ROTATION_270;       // flips the display 270 degrees
-	}
-
-	static void render_logo(void) {     // Render MechWild "MW" Logo
-		static const char PROGMEM logo_1[] = {0x8A, 0x8B, 0x8C, 0x8D, 0x00};
-		static const char PROGMEM logo_2[] = {0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0x00};
-		static const char PROGMEM logo_3[] = {0xCA, 0xCB, 0xCC, 0xCD, 0x00};
-		static const char PROGMEM logo_4[] = {0x20, 0x8E, 0x8F, 0x90, 0x00};
-		oled_set_cursor(0,0);
-		oled_write_P(logo_1, false);
-		oled_set_cursor(0,1);
-		oled_write_P(logo_2, false);
-		oled_set_cursor(0,2);
-		oled_write_P(logo_3, false);
-		oled_set_cursor(0,3);
-		oled_write_P(logo_4, false);
-	}
-
-	bool oled_task_user(void) {
-		render_logo();
-		oled_set_cursor(0,6);
-
-		oled_write_ln_P(PSTR("Layer"), false);
-
-    switch (get_highest_layer(layer_state)) {
-        case _BASE:
-            oled_write_ln_P(PSTR("Base"), false);
-            break;
-        case _FN1:
-            oled_write_ln_P(PSTR("FN 1"), false);
-            break;
-        case _FN2:
-            oled_write_ln_P(PSTR("FN 2"), false);
-            break;
-        case _FN3:
-            oled_write_ln_P(PSTR("FN 3"), false);
-            break;
-        default:
-            oled_write_ln_P(PSTR("Undef"), false);
-    }
-	oled_write_ln_P(PSTR(""), false);
-    // Host Keyboard LED Status
-    led_t led_state = host_keyboard_led_state();
-    oled_write_ln_P(led_state.num_lock ? PSTR("NUM ") : PSTR("    "), false);
-    oled_write_ln_P(led_state.caps_lock ? PSTR("CAP ") : PSTR("    "), false);
-    oled_write_ln_P(led_state.scroll_lock ? PSTR("SCR ") : PSTR("    "), false);
-    return false;
-	}
+#ifdef ENCODER_MAP_ENABLE
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
+    [_BASE] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU), ENCODER_CCW_CW(KC_BRID, KC_BRIU) },
+    [_FN1]  = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS) },
+    [_FN2]  = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS) },
+    [_FN3]  = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS), ENCODER_CCW_CW(KC_TRNS, KC_TRNS) },
+};
 #endif

--- a/keyboards/mechwild/murphpad/keymaps/via/rules.mk
+++ b/keyboards/mechwild/murphpad/keymaps/via/rules.mk
@@ -1,2 +1,3 @@
 VIA_ENABLE = yes
 LTO_ENABLE = yes
+ENCODER_MAP_ENABLE = yes

--- a/keyboards/mechwild/murphpad/murphpad.c
+++ b/keyboards/mechwild/murphpad/murphpad.c
@@ -15,3 +15,79 @@
  */
 
 #include "murphpad.h"
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) {
+        return false;
+    }
+
+    switch (index) {
+        case 0:
+            if (clockwise) {
+                tap_code(KC_VOLU);
+            } else {
+                tap_code(KC_VOLD);
+            }
+        break;
+        case 1:
+            if (clockwise) {
+                tap_code(KC_BRIU);
+            } else {
+                tap_code(KC_BRID);
+            }
+        break;
+    }
+    return true;
+}
+#endif
+
+#ifdef OLED_ENABLE
+static const char PROGMEM mw_logo[] = {
+    0x8A, 0x8B, 0x8C, 0x8D, '\r',
+    0xAA, 0xAB, 0xAC, 0xAD, 0xAE,
+    0xCA, 0xCB, 0xCC, 0xCD, '\r',
+    0x20, 0x8E, 0x8F, 0x90, 0x00};
+
+oled_rotation_t oled_init_kb(oled_rotation_t rotation) {
+    return OLED_ROTATION_270;       // flips the display 270 degrees
+}
+
+bool oled_task_kb(void) {
+    if (!oled_task_user()) {
+        return false;
+    }
+
+    oled_write_P(mw_logo, false);     // Render MechWild "MW" Logo
+    oled_set_cursor(0,6);
+
+    oled_write_ln_P(PSTR("Layer"), false);
+
+    switch (get_highest_layer(layer_state)) {
+        case 0:
+            oled_write_ln_P(PSTR("Base"), false);
+            break;
+        case 1:
+            oled_write_ln_P(PSTR("FN 1"), false);
+            break;
+        case 2:
+            oled_write_ln_P(PSTR("FN 2"), false);
+            break;
+        case 3:
+            oled_write_ln_P(PSTR("FN 3"), false);
+            break;
+        default:
+            oled_write_ln_P(PSTR("Undef"), false);
+    }
+
+    oled_write_ln_P(PSTR(""), false);
+
+    // Host Keyboard LED Status
+    led_t led_state = host_keyboard_led_state();
+    oled_write_ln_P(led_state.num_lock ? PSTR("NUM ") : PSTR("    "), false);
+    oled_write_ln_P(led_state.caps_lock ? PSTR("CAP ") : PSTR("    "), false);
+    oled_write_ln_P(led_state.scroll_lock ? PSTR("SCR ") : PSTR("    "), false);
+
+    return true;
+}
+#endif


### PR DESCRIPTION
## Description

(tl;dr: qmk#17767, but for MurphPad.)
- Updates two non-user keymaps (default, via) to utilize encoder mapping
- Migrates common OLED & encoder callbacks to keyboard level, so firmware generated by QMK Configurator will have these features
- Updates @jonavin's keymap so it is not impacted by the new keyboard-level implementations
-  :sparkles: **bonus** :sparkles: Extremely minor formatting improvements.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
