### PR TITLE
Refactor/rename postprocess_steno_user → post_process_steno_user

### DIFF
--- a/docs/feature_stenography.md
+++ b/docs/feature_stenography.md
@@ -133,7 +133,7 @@ bool process_steno_user(uint16_t keycode, keyrecord_t *record) { return true; }
 This function is called when a keypress has come in, before it is processed. The keycode should be one of `QK_STENO_BOLT`, `QK_STENO_GEMINI`, or one of the `STN_*` key values.
 
 ```c
-bool postprocess_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[MAX_STROKE_SIZE], int8_t n_pressed_keys);
+bool post_process_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[MAX_STROKE_SIZE], int8_t n_pressed_keys);
 ```
 
 This function is called after a key has been processed, but before any decision about whether or not to send a chord. This is where to put hooks for things like, say, live displays of steno chords or keys.

--- a/docs/ja/feature_stenography.md
+++ b/docs/ja/feature_stenography.md
@@ -77,7 +77,7 @@ bool process_steno_user(uint16_t keycode, keyrecord_t *record) { return true; }
 この関数はキーが押されるとキーが処理される前に呼び出されます。キーコードは `QK_STENO_BOLT`、`QK_STENO_GEMINI` あるいは `STN_*` キー値のいずれかでなければなりません。
 
 ```c
-bool postprocess_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[6], int8_t pressed);
+bool post_process_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[6], int8_t pressed);
 ```
 
 この関数はキーが処理された後、ただしコードを送信するかどうかを決める前に呼び出されます。`IS_PRESSED(record->event)` が false で、`pressed` が 0 または 1 の場合は、コードはまもなく送信されますが、まだ送信されてはいません。ここが速記コードあるいはキーのライブ表示などのフックを配置する場所です。

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -148,7 +148,7 @@ __attribute__((weak)) bool send_steno_chord_user(steno_mode_t mode, uint8_t chor
     return true;
 }
 
-__attribute__((weak)) bool postprocess_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[MAX_STROKE_SIZE], int8_t n_pressed_keys) {
+__attribute__((weak)) bool post_process_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[MAX_STROKE_SIZE], int8_t n_pressed_keys) {
     return true;
 }
 
@@ -209,12 +209,12 @@ bool process_steno(uint16_t keycode, keyrecord_t *record) {
                     default:
                         return false;
                 }
-                if (!postprocess_steno_user(keycode, record, mode, chord, n_pressed_keys)) {
+                if (!post_process_steno_user(keycode, record, mode, chord, n_pressed_keys)) {
                     return false;
                 }
             } else { // is released
                 n_pressed_keys--;
-                if (!postprocess_steno_user(keycode, record, mode, chord, n_pressed_keys)) {
+                if (!post_process_steno_user(keycode, record, mode, chord, n_pressed_keys)) {
                     return false;
                 }
                 if (n_pressed_keys > 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Small refactor to bring the post processing steno callback function in line with every other post processing QMK function.

```zsh
❯ git checkout develop
Switched to branch 'develop'
Your branch is up to date with 'upstream/develop'.

~/qmk_firmware on develop *3 ⨤4                                                                                                                                                                       
❯ which grepqmk
grepqmk: aliased to fd -t f -E docs -E keyboards -E layouts -E users -E lib -X grep -n --color

~/qmk_firmware on develop *3 ⨤4                                                                                                                                                                       
❯ grepqmk "post_\?process"
quantum/action.c:223:__attribute__((weak)) void post_process_record_quantum(keyrecord_t *record) {}
quantum/action.c:269:    post_process_record_quantum(record);
quantum/action.h:93:void post_process_record_quantum(keyrecord_t *record);
quantum/process_keycode/process_steno.c:151:__attribute__((weak)) bool postprocess_steno_user(uint16_t keycode, keyrecord_t *record, steno_mode_t mode, uint8_t chord[MAX_STROKE_SIZE], int8_t n_pressed_keys) {
quantum/process_keycode/process_steno.c:212:                if (!postprocess_steno_user(keycode, record, mode, chord, n_pressed_keys)) {
quantum/process_keycode/process_steno.c:217:                if (!postprocess_steno_user(keycode, record, mode, chord, n_pressed_keys)) {
quantum/quantum.c:129:__attribute__((weak)) void post_process_record_kb(uint16_t keycode, keyrecord_t *record) {
quantum/quantum.c:130:    post_process_record_user(keycode, record);
quantum/quantum.c:133:__attribute__((weak)) void post_process_record_user(uint16_t keycode, keyrecord_t *record) {}
quantum/quantum.c:216:void post_process_record_quantum(keyrecord_t *record) {
quantum/quantum.c:218:    post_process_record_kb(keycode, record);
quantum/quantum.h:255:void     post_process_record_kb(uint16_t keycode, keyrecord_t *record);
quantum/quantum.h:256:void     post_process_record_user(uint16_t keycode, keyrecord_t *record);
```
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
