### PR TITLE
Add deprecated check for RGBLIGHT_ANIMATIONS

### DIFF
--- a/data/mappings/info_config.json
+++ b/data/mappings/info_config.json
@@ -56,7 +56,6 @@
     "RGB_DI_PIN": {"info_key": "rgblight.pin"},
     "RGBLED_NUM": {"info_key": "rgblight.led_count", "value_type": "int"},
     "RGBLED_SPLIT": {"info_key": "rgblight.split_count", "value_type": "array.int"},
-    "RGBLIGHT_ANIMATIONS": {"info_key": "rgblight.animations.all", "value_type": "bool"},
     "RGBLIGHT_EFFECT_ALTERNATING": {"info_key": "rgblight.animations.alternating", "value_type": "bool"},
     "RGBLIGHT_EFFECT_BREATHING": {"info_key": "rgblight.animations.breathing", "value_type": "bool"},
     "RGBLIGHT_EFFECT_CHRISTMAS": {"info_key": "rgblight.animations.christmas", "value_type": "bool"},
@@ -114,4 +113,5 @@
     "DESCRIPTION": {"info_key": "_invalid.usb_description", "invalid": true},
     "DEBOUNCING_DELAY": {"info_key": "_invalid.debouncing_delay", "invalid": true},
     "PREVENT_STUCK_MODIFIERS": {"info_key": "_invalid.prevent_stuck_mods", "invalid": true},
+    "RGBLIGHT_ANIMATIONS": {"info_key": "rgblight.animations.all", "value_type": "bool", "deprecated": true},
 }

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -218,8 +218,6 @@ If you define these options you will enable the associated feature, which may in
 
 * `#define RGB_DI_PIN D7`
   * pin the DI on the WS2812 is hooked-up to
-* `#define RGBLIGHT_ANIMATIONS`
-  * run RGB animations
 * `#define RGBLIGHT_LAYERS`
   * Lets you define [lighting layers](feature_rgblight.md?id=lighting-layers) that can be toggled on or off. Great for showing the current keyboard layer or caps lock state.
 * `#define RGBLIGHT_MAX_LAYERS`

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -105,7 +105,7 @@ Your RGB lighting can be configured by placing these `#define`s in your `config.
 ## Effects and Animations
 
 Not only can this lighting be whatever color you want,
-if `RGBLIGHT_EFFECT_xxxx` or `RGBLIGHT_ANIMATIONS` is defined, you also have a number of animation modes at your disposal:
+if `RGBLIGHT_EFFECT_xxxx` is defined, you also have a number of animation modes at your disposal:
 
 |Mode number symbol           |Additional number  |Description                            |
 |-----------------------------|-------------------|---------------------------------------|
@@ -125,13 +125,14 @@ Check out [this video](https://youtube.com/watch?v=VKrpPAHlisY) for a demonstrat
 
 Note: For versions older than 0.6.117, The mode numbers were written directly. In `quantum/rgblight/rgblight.h` there is a contrast table between the old mode number and the current symbol.
 
+
 ### Effect and Animation Toggles
 
 Use these defines to add or remove animations from the firmware. When you are running low on flash space, it can be helpful to disable animations you are not using.
 
 |Define                              |Default      |Description                                                              |
 |------------------------------------|-------------|-------------------------------------------------------------------------|
-|`RGBLIGHT_ANIMATIONS`               |*Not defined*|Enable all additional animation modes.                                   |
+|`RGBLIGHT_ANIMATIONS`               |*Not defined*|Enable all additional animation modes.  (deprecated)                     |
 |`RGBLIGHT_EFFECT_ALTERNATING`       |*Not defined*|Enable alternating animation mode.                                       |
 |`RGBLIGHT_EFFECT_BREATHING`         |*Not defined*|Enable breathing animation mode.                                         |
 |`RGBLIGHT_EFFECT_CHRISTMAS`         |*Not defined*|Enable christmas animation mode.                                         |
@@ -142,6 +143,8 @@ Use these defines to add or remove animations from the firmware. When you are ru
 |`RGBLIGHT_EFFECT_SNAKE`             |*Not defined*|Enable snake animation mode.                                             |
 |`RGBLIGHT_EFFECT_STATIC_GRADIENT`   |*Not defined*|Enable static gradient mode.                                             |
 |`RGBLIGHT_EFFECT_TWINKLE`           |*Not defined*|Enable twinkle animation mode.                                           |
+
+!> `RGBLIGHT_ANIMATIONS` is being deprecated and animation modes should be explicitly defined.
 
 ### Effect and Animation Settings
 
@@ -162,14 +165,12 @@ The following options are used to tweak the various animations:
 |`RGBLIGHT_EFFECT_TWINKLE_PROBABILITY`|`1/127`     |Adjusts how likely each LED is to twinkle (on each animation step)                             |
 
 ### Example Usage to Reduce Memory Footprint
-  1. Remove `RGBLIGHT_ANIMATIONS` from `config.h`.
-  1. Selectively add the animations you want to enable. The following would enable two animations and save about 4KiB:
+  1. Selectively disable the animations you want to enable. The following would enable two animations and save about 4KiB:
 
 ```diff
  #undef RGBLED_NUM
--#define RGBLIGHT_ANIMATIONS
-+#define RGBLIGHT_EFFECT_STATIC_GRADIENT
-+#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
++#undef RGBLIGHT_EFFECT_STATIC_GRADIENT
++#undef RGBLIGHT_EFFECT_RAINBOW_SWIRL
  #define RGBLED_NUM 12
  #define RGBLIGHT_HUE_STEP 8
  #define RGBLIGHT_SAT_STEP 8

--- a/docs/ja/config_options.md
+++ b/docs/ja/config_options.md
@@ -196,8 +196,6 @@ QMK での全ての利用可能な設定にはデフォルトがあります。�
 
 * `#define RGB_DI_PIN D7`
   * WS2812 の DI 端子につなぐピン
-* `#define RGBLIGHT_ANIMATIONS`
-  * RGB アニメーションを実行します
 * `#define RGBLIGHT_LAYERS`
   * オンとオフを切り替えることができる [ライトレイヤー](ja/feature_rgblight.md?id=lighting-layers) を定義できます。現在のキーボードレイヤーまたは Caps Lock 状態を表示するのに最適です。
 * `#define RGBLIGHT_MAX_LAYERS`


### PR DESCRIPTION
## Description

Adds a lint check for RGBLIGHT_ANIMATIONS, to start deprecating the define in favor of explicitly enabled animations

## Types of Changes

- [x] Core

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
