### PR TITLE
[Core] RP2040 disable PIO IRQs on serial timeout

### DIFF
--- a/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
@@ -206,6 +206,7 @@ static inline msg_t sync_tx(sysinterval_t timeout) {
         pio_set_irq0_source_enabled(pio, pis_sm0_tx_fifo_not_full + tx_state_machine, true);
         msg = osalThreadSuspendTimeoutS(&tx_thread, timeout);
         if (msg < MSG_OK) {
+            pio_set_irq0_source_enabled(pio, pis_sm0_tx_fifo_not_full + tx_state_machine, false);
             break;
         }
     }
@@ -265,6 +266,7 @@ static inline msg_t sync_rx(sysinterval_t timeout) {
         pio_set_irq0_source_enabled(pio, pis_sm0_rx_fifo_not_empty + rx_state_machine, true);
         msg = osalThreadSuspendTimeoutS(&rx_thread, timeout);
         if (msg < MSG_OK) {
+            pio_set_irq0_source_enabled(pio, pis_sm0_rx_fifo_not_empty + rx_state_machine, false);
             break;
         }
     }


### PR DESCRIPTION
## Description

In case the sending or receiving timeout we don't want the IRQs to fire anymore as the waiting thread has already been woken.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
