### PR TITLE
Enable mousekeys by default for RGBKB Sol3

### DIFF
--- a/keyboards/rgbkb/sol3/rules.mk
+++ b/keyboards/rgbkb/sol3/rules.mk
@@ -14,7 +14,7 @@ QUANTUM_LIB_SRC += i2c_master.c
 #   change yes to no to disable
 #
 BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
+MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = yes        # Console for debug
 COMMAND_ENABLE = no         # Commands for debug and configuration


### PR DESCRIPTION
## Description

Enable Mousekeys by default.

Many of our users have asked for this, they just want to use the configurator and easily map scrolling to encoders or touchbars.

## Types of Changes

- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
