### PR TITLE
Fix check when compiling HID Joystick with digital driver

### DIFF
--- a/quantum/process_keycode/process_joystick.c
+++ b/quantum/process_keycode/process_joystick.c
@@ -106,7 +106,7 @@ bool process_joystick_analogread_quantum() {
 
         wait_us(10);
 
-#    if defined(__AVR__) || defined(PROTOCOL_CHIBIOS)
+#    if defined(ANALOG_JOYSTICK_ENABLE) && (defined(__AVR__) || defined(PROTOCOL_CHIBIOS))
         int16_t axis_val = analogReadPin(joystick_axes[axis_index].input_pin);
 #    else
         // default to resting position


### PR DESCRIPTION
## Description

Analog read is not hidden behind a pre-processor, so will try to run even if analog isn't enabled/set as the driver.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* fixes #17825

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
