### PR TITLE
Quantum Painter fix for ST7789 driver

### DIFF
--- a/drivers/painter/st77xx/qp_st7789.c
+++ b/drivers/painter/st77xx/qp_st7789.c
@@ -55,7 +55,7 @@ bool qp_st7789_init(painter_device_t device, painter_rotation_t rotation) {
         ST77XX_CMD_RESET,            120,  0,
         ST77XX_CMD_SLEEP_OFF,          5,  0,
         ST77XX_SET_PIX_FMT,            0,  1, 0x55,
-        ST77XX_CMD_INVERT_ON,          0,  0,
+        ST77XX_CMD_INVERT_OFF,          0,  0,
         ST77XX_CMD_NORMAL_ON,          0,  0,
         ST77XX_CMD_DISPLAY_ON,        20,  0
     };
@@ -64,10 +64,10 @@ bool qp_st7789_init(painter_device_t device, painter_rotation_t rotation) {
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
-        [QP_ROTATION_0]   = ST77XX_MADCTL_RGB,
-        [QP_ROTATION_90]  = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MX | ST77XX_MADCTL_MV,
-        [QP_ROTATION_180] = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MX | ST77XX_MADCTL_MY,
-        [QP_ROTATION_270] = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MV | ST77XX_MADCTL_MY,
+        [QP_ROTATION_0]   = ST77XX_MADCTL_BGR,
+        [QP_ROTATION_90]  = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MX | ST77XX_MADCTL_MV,
+        [QP_ROTATION_180] = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MX | ST77XX_MADCTL_MY,
+        [QP_ROTATION_270] = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MV | ST77XX_MADCTL_MY,
     };
     qp_comms_command_databyte(device, ST77XX_SET_MADCTL, madctl[rotation]);
 

--- a/drivers/painter/st77xx/qp_st7789.c
+++ b/drivers/painter/st77xx/qp_st7789.c
@@ -55,7 +55,7 @@ bool qp_st7789_init(painter_device_t device, painter_rotation_t rotation) {
         ST77XX_CMD_RESET,            120,  0,
         ST77XX_CMD_SLEEP_OFF,          5,  0,
         ST77XX_SET_PIX_FMT,            0,  1, 0x55,
-        ST77XX_CMD_INVERT_OFF,          0,  0,
+        ST77XX_CMD_INVERT_OFF,         0,  0,
         ST77XX_CMD_NORMAL_ON,          0,  0,
         ST77XX_CMD_DISPLAY_ON,        20,  0
     };

--- a/quantum/painter/qp_stream.h
+++ b/quantum/painter/qp_stream.h
@@ -77,6 +77,6 @@ typedef struct qp_file_stream_t {
     FILE *      file;
 } qp_file_stream_t;
 
-qp_file_stream_t qo_make_file_stream(FILE *f);
+qp_file_stream_t qp_make_file_stream(FILE *f);
 
 #endif // QP_STREAM_HAS_FILE_IO


### PR DESCRIPTION
In the process of adding support for ST7735 in Quantum Painter, and in doing so I uncovered a few issues with the existing ST7789 driver 


## Description

- In qp_st7789.c, ST77XX_CMD_INVERT_ON is used in the init sequence, but this should instead default to ST77XX_CMD_INVERT_OFF
- In qp_st7789.c, ST77XX_MADCTL_RGB is assigned but it it should be ST77XX_MADCTL_BGR (which also happens to match the "BGR" settings for other QP drivers)

When I made these changes for an ST7735 display, the hardware began working correctly (i.e. colors were wrong with the original settings, but are correct with the new settings; see image displaying the correct colors). 

![LCD](https://user-images.githubusercontent.com/8145762/181877314-157bb62f-1390-4877-80d8-232cca7424d3.jpg)

I haven't actually tested on an ST7789, but everything I'm seeing suggests these two settings should be changed as these settings are handled the same for ST7789 and ST7735.


The last change is just correcting a typo I noticed elsewhere in the qp code.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


