### PR TITLE
[Core] RGB matrix pause rendering for static animations to save CPU cycles

### DIFF
--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -429,17 +429,18 @@ void rgb_matrix_task(void) {
     uint8_t effect = suspend_backlight || !rgb_matrix_config.enable ? 0 : rgb_matrix_config.mode;
 
     // only for static modes or upon initialisation
-    if (( // static animation always enabled
+    if ((
 #ifdef ENABLE_RGB_MATRIX_ALPHAS_MODS
-        rgb_matrix_config.mode != RGB_MATRIX_ALPHAS_MODS &&
+            rgb_matrix_config.mode != RGB_MATRIX_ALPHAS_MODS &&
 #endif
 #ifdef ENABLE_RGB_MATRIX_GRADIENT_UP_DOWN
-        rgb_matrix_config.mode != RGB_MATRIX_GRADIENT_UP_DOWN &&
+            rgb_matrix_config.mode != RGB_MATRIX_GRADIENT_UP_DOWN &&
 #endif
 #ifdef ENABLE_RGB_MATRIX_GRADIENT_LEFT_RIGHT
-        rgb_matrix_config.mode != RGB_MATRIX_GRADIENT_LEFT_RIGHT &&
+            rgb_matrix_config.mode != RGB_MATRIX_GRADIENT_LEFT_RIGHT &&
 #endif
-    rgb_matrix_config.mode != 1 ) || rgb_effect_params.init) {
+            rgb_matrix_config.mode != 1) || // static animation always enabled
+        rgb_effect_params.init) {
         render_update = true;
     }
 

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -155,7 +155,7 @@ void eeconfig_update_rgb_matrix_default(void) {
     rgb_matrix_config.hsv    = (HSV){RGB_MATRIX_STARTUP_HUE, RGB_MATRIX_STARTUP_SAT, RGB_MATRIX_STARTUP_VAL};
     rgb_matrix_config.speed  = RGB_MATRIX_STARTUP_SPD;
     rgb_matrix_config.flags  = LED_FLAG_ALL;
-    render_update = true;
+    render_update            = true;
     eeconfig_flush_rgb_matrix(true);
 }
 
@@ -429,7 +429,17 @@ void rgb_matrix_task(void) {
     uint8_t effect = suspend_backlight || !rgb_matrix_config.enable ? 0 : rgb_matrix_config.mode;
 
     // only for static modes or upon initialisation
-    if (rgb_matrix_config.mode > 4 || rgb_effect_params.init) {
+    if (( // static animation always enabled
+#ifdef ENABLE_RGB_MATRIX_ALPHAS_MODS
+        rgb_matrix_config.mode != RGB_MATRIX_ALPHAS_MODS &&
+#endif
+#ifdef ENABLE_RGB_MATRIX_GRADIENT_UP_DOWN
+        rgb_matrix_config.mode != RGB_MATRIX_GRADIENT_UP_DOWN &&
+#endif
+#ifdef ENABLE_RGB_MATRIX_GRADIENT_LEFT_RIGHT
+        rgb_matrix_config.mode != RGB_MATRIX_GRADIENT_LEFT_RIGHT &&
+#endif
+    rgb_matrix_config.mode != 1 ) || rgb_effect_params.init) {
         render_update = true;
     }
 

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -428,10 +428,7 @@ void rgb_matrix_task(void) {
 
     uint8_t effect = suspend_backlight || !rgb_matrix_config.enable ? 0 : rgb_matrix_config.mode;
 
-    // some logic for render_update
-    // only for static modes
-    // solid_color_anim and alpha_mods_anim
-
+    // only for static modes or upon initialisation
     if (rgb_matrix_config.mode > 4 || rgb_effect_params.init) {
         render_update = true;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Pauses RGB matrix for static animations to save CPU cycles enabling greater scan rate.

Tested on dawn60/rev1_qmk and pachi/rgb/rev2.

https://user-images.githubusercontent.com/17491233/182007703-9ce08590-a010-412d-b0c2-def2f1e943c4.mp4

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
