### PR TITLE
Caps word compatibility tap dance

### DIFF
--- a/docs/feature_caps_word.md
+++ b/docs/feature_caps_word.md
@@ -154,3 +154,19 @@ void caps_word_set_user(bool active) {
 }
 ```
 
+
+### Using Caps Word with Tap Dance :id=using-caps-word-with-tap-dance
+
+Include `process_caps_word.h` in your `keymap.c` file. You can then use the
+feature as follows from your Tap Dance handler:
+
+```c
+#ifndef NO_ACTION_ONESHOT
+    const uint8_t mods = get_mods() | get_oneshot_mods();
+#else
+    const uint8_t mods = get_mods();
+#endif // NO_ACTION_ONESHOT
+
+    process_caps_word_key(keycode, mods, 0); // Set up the weak modifier
+    tap_code16(keycode)                      // Your existing call to send a key code
+````

--- a/quantum/process_keycode/process_caps_word.c
+++ b/quantum/process_keycode/process_caps_word.c
@@ -87,6 +87,15 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
         return true;
     }
 
+   return process_caps_word_key(keycode, mods, record->tap.count);
+}
+
+bool process_caps_word_key(uint16_t keycode, uint8_t mods, uint8_t tap_count)
+{
+    if (!is_caps_word_on()) {
+        return true;
+    }
+
     if (!(mods & ~(MOD_MASK_SHIFT | MOD_BIT(KC_RALT)))) {
         switch (keycode) {
             // Ignore MO, TO, TG, TT, and OSL layer switch keys.
@@ -95,6 +104,7 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
             case QK_TOGGLE_LAYER ... QK_TOGGLE_LAYER_MAX:
             case QK_LAYER_TAP_TOGGLE ... QK_LAYER_TAP_TOGGLE_MAX:
             case QK_ONE_SHOT_LAYER ... QK_ONE_SHOT_LAYER_MAX:
+            case QK_TAP_DANCE ... QK_TAP_DANCE_MAX:
             // Ignore AltGr.
             case KC_RALT:
             case OSM(MOD_RALT):
@@ -102,7 +112,7 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
 
 #ifndef NO_ACTION_TAPPING
             case QK_MOD_TAP ... QK_MOD_TAP_MAX:
-                if (record->tap.count == 0) {
+                if (tap_count == 0) {
                     // Deactivate if a mod becomes active through holding
                     // a mod-tap key.
                     caps_word_off();
@@ -114,7 +124,7 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
 #    ifndef NO_ACTION_LAYER
             case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:
 #    endif // NO_ACTION_LAYER
-                if (record->tap.count == 0) {
+                if (tap_count == 0) {
                     return true;
                 }
                 keycode &= 0xff;
@@ -123,7 +133,7 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
 
 #ifdef SWAP_HANDS_ENABLE
             case QK_SWAP_HANDS ... QK_SWAP_HANDS_MAX:
-                if (keycode > 0x56F0 || record->tap.count == 0) {
+                if (keycode > 0x56F0 || tap_count == 0) {
                     return true;
                 }
                 keycode &= 0xff;

--- a/quantum/process_keycode/process_caps_word.c
+++ b/quantum/process_keycode/process_caps_word.c
@@ -87,11 +87,12 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
         return true;
     }
 
-   return process_caps_word_key(keycode, mods, record->tap.count);
+    return process_caps_word_key(keycode, mods, record->tap.count);
 }
 
-bool process_caps_word_key(uint16_t keycode, uint8_t mods, uint8_t tap_count)
-{
+/* Separate function in order to reuse this code from other places like
+   tap dance handlers */
+bool process_caps_word_key(uint16_t keycode, uint8_t mods, uint8_t tap_count) {
     if (!is_caps_word_on()) {
         return true;
     }

--- a/quantum/process_keycode/process_caps_word.h
+++ b/quantum/process_keycode/process_caps_word.h
@@ -27,6 +27,8 @@
  */
 bool process_caps_word(uint16_t keycode, keyrecord_t* record);
 
+bool process_caps_word_key(uint16_t keycode, uint8_t mods, uint8_t tap_count);
+
 /**
  * @brief Weak function for user-level Caps Word press modification.
  *

--- a/tests/caps_word/caps_word_tapdance/config.h
+++ b/tests/caps_word/caps_word_tapdance/config.h
@@ -1,0 +1,22 @@
+// Copyright 2022 Google LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "test_common.h"
+
+#define TAPPING_TERM 200
+#define AUTO_SHIFT_TIMEOUT 150
+#define RETRO_SHIFT 500

--- a/tests/caps_word/caps_word_tapdance/test.mk
+++ b/tests/caps_word/caps_word_tapdance/test.mk
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+CAPS_WORD_ENABLE = yes
+TAP_DANCE_ENABLE = yes

--- a/tests/caps_word/caps_word_tapdance/test_caps_word_tapdance.cpp
+++ b/tests/caps_word/caps_word_tapdance/test_caps_word_tapdance.cpp
@@ -1,0 +1,123 @@
+// Copyright 2022 Google LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "quantum_keycodes.h"
+#include "test_common.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::AnyOf;
+using ::testing::InSequence;
+
+class CapsWord : public TestFixture {
+   public:
+    void SetUp() override {
+        caps_word_off();
+    }
+};
+
+enum tap_dance_codes {
+    DANCE_0,
+    DANCE_1,
+};
+
+void dance_0_finished(qk_tap_dance_state_t *state, void *user_data) {}
+void dance_0_reset(qk_tap_dance_state_t *state, void *user_data) {}
+
+void dance_1_finished(qk_tap_dance_state_t *state, void *user_data) {
+    const uint8_t mods = get_mods();
+    process_caps_word_key(KC_W, mods, 0);
+    register_code16(KC_W);
+}
+
+void dance_1_reset(qk_tap_dance_state_t *state, void *user_data) {
+    wait_ms(10);
+    clear_weak_mods();
+    unregister_code16(KC_W);
+}
+
+qk_tap_dance_action_t tap_dance_actions[] = {
+    [DANCE_0] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dance_0_finished, dance_0_reset),
+    [DANCE_1] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dance_1_finished, dance_1_reset),
+};
+
+// Tests that Tap Dance key codes do not disable Caps Word
+TEST_F(CapsWord, TapDanceKeysPress) {
+    TestDriver driver;
+    KeymapKey key_a(0, 0, 0, KC_A);
+    KeymapKey key_td0(0, 1, 0, TD(DANCE_0));
+    set_keymap({key_a, key_td0});
+
+    EXPECT_CALL(driver, send_keyboard_mock(AnyOf(
+                KeyboardReport(),
+                KeyboardReport(KC_LSFT))))
+        .Times(AnyNumber());
+    
+    { // Expect: "A, A"
+        InSequence s;
+        EXPECT_REPORT(driver, (KC_LSFT, KC_A));
+        EXPECT_REPORT(driver, (KC_LSFT, KC_A));
+    }
+
+    // Turn on Caps Word and type "A", tap dance key, "A"
+    caps_word_on();
+
+    tap_key(key_a);
+    tap_key(key_td0);
+    tap_key(key_a);
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+// Tests that a Tap Dance key can pick up the Caps Word state
+// and be set to caps accordingly
+TEST_F(CapsWord, TapDanceKeysCaps) {
+    TestDriver driver;
+    KeymapKey key_a(0, 0, 0, KC_A);
+    KeymapKey key_td1(0, 1, 0, TD(DANCE_1));
+    KeymapKey key_spc(0, 2, 0, KC_SPC);
+    set_keymap({key_a, key_td1, key_spc});
+
+    EXPECT_CALL(driver, send_keyboard_mock(AnyOf(
+                KeyboardReport(),
+                KeyboardReport(KC_LSFT))))
+        .Times(AnyNumber());
+    
+    { // Expect: "A, W, space, a, w, space"
+        InSequence s;
+        EXPECT_REPORT(driver, (KC_LSFT, KC_A));
+        EXPECT_REPORT(driver, (KC_LSFT, KC_W));
+        EXPECT_REPORT(driver, (KC_SPC));
+        EXPECT_REPORT(driver, (KC_A));
+        EXPECT_REPORT(driver, (KC_W));
+        EXPECT_REPORT(driver, (KC_SPC));
+    }
+
+    // Turn on Caps Word and type "A", tap dance key, "A"
+    caps_word_on();
+
+    tap_key(key_a);
+    tap_key(key_td1);
+    tap_key(key_spc);
+    tap_key(key_a);
+    tap_key(key_td1);
+    tap_key(key_spc);
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add compatibility between Caps Word feature and Tap Dance feature.
* pressing a tap dance key no longer flips caps word state to off
* slight refactor of the caps word processing logic such that tap dance callback can take advantage of caps word. Requires additional code in keymap.c which is illustrated in the test cases
* added tests for the above

Side note. The refactor looks clunky. Open to feedback how that could be improved.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
