### PR TITLE
Prevent tap dance from wiping dynamic macros

### DIFF
--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -263,8 +263,6 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
                             dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
                             break;
                     }
-                } else {
-                    dprintln("dynamic macro: ignoring invalid keys");
                 }
                 return true;
                 break;

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -45,6 +45,10 @@ __attribute__((weak)) void dynamic_macro_record_end_user(int8_t direction) {
     dynamic_macro_led_blink();
 }
 
+__attribute__((weak)) bool dynamic_macro_valid_key_user(uint16_t keycode, keyrecord_t *record) {
+    return true;
+}
+
 /* Convenience macros used for retrieving the debug info. All of them
  * need a `direction` variable accessible at the call site.
  */
@@ -249,14 +253,18 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
                 return false;
 #endif
             default:
-                /* Store the key in the macro buffer and process it normally. */
-                switch (macro_id) {
-                    case 1:
-                        dynamic_macro_record_key(macro_buffer, &macro_pointer, r_macro_end, +1, record);
-                        break;
-                    case 2:
-                        dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
-                        break;
+                if (dynamic_macro_valid_key_user(keycode, record)) {
+                    /* Store the key in the macro buffer and process it normally. */
+                    switch (macro_id) {
+                        case 1:
+                            dynamic_macro_record_key(macro_buffer, &macro_pointer, r_macro_end, +1, record);
+                            break;
+                        case 2:
+                            dynamic_macro_record_key(r_macro_buffer, &macro_pointer, macro_end, -1, record);
+                            break;
+                    }
+                } else {
+                    dprintln("dynamic macro: ignoring invalid keys");
                 }
                 return true;
                 break;


### PR DESCRIPTION
## Description
This pull request introduces the userspace function `dynamic_macro_valid_key_user` to allow the user to omit certain events from being stored in the dynamic macros. This is particularly important when `DYN_*` keycodes are mapped to tap-dance keys; prior to these changes, `DYN_*` keys (e.g. `DYN_REC_START*` and `DYN_REC_STOP` are triggered upon executing the macro (since `TD(DYN)` records are stored in the buffer), leading to the bug where recorded macros can only be executed once before they are wiped.

An example keymap implemented using this function is available [here](https://github.com/jasonkena/qmk_firmware/blob/288e318b8f0fe1bfe22e4decac686527df3910cd/keyboards/ferris/keymaps/jasonkena/custom.c#L4).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
