### PR TITLE
i2c_master: improve documentation

### DIFF
--- a/docs/i2c_driver.md
+++ b/docs/i2c_driver.md
@@ -251,7 +251,7 @@ Reads from a register with a 16-bit address (big endian) on the I2C device.
    The register address to read from.
  - `uint16_t length`  
  The number of bytes to read. Take care not to overrun the length of `data`.
- - `uint16_t timeout`
+ - `uint16_t timeout`  
    The time in milliseconds to wait for a response from the target device.
 
 #### Return Value
@@ -271,9 +271,9 @@ Start an I2C transaction.
 
 #### Arguments
 
- - `uint8_t address`
+ - `uint8_t address`  
    The 7-bit I2C address of the device (ie. without the read/write bit - this will be set automatically).
- - `uint16_t timeout`
+ - `uint16_t timeout`  
    On AVR only.
    The time in milliseconds to wait for a response from the target device.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

while working on a new incarnation of an existing avr-keyboard, with now a chibios-based MCU i ran into compile-time issues for a driver that relies on the platform specific i2c_master implementation

it turned out that a "misaligned" signature in the chibios variant was the culprit... 

these two patches re-align the "i2c_start" method with the documentation and the current avr implementation, by adding a "timeout" parameter 

this PR possibly contributes a little to #8297

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
