### PR TITLE
Fixup compilation of printf-like functions with uint32_t args.

### DIFF
--- a/drivers/flash/flash_spi.c
+++ b/drivers/flash/flash_spi.c
@@ -207,7 +207,7 @@ flash_status_t flash_erase_sector(uint32_t addr) {
 
     /* Check that the address exceeds the limit. */
     if ((addr + (EXTERNAL_FLASH_SECTOR_SIZE)) >= (EXTERNAL_FLASH_SIZE) || ((addr % (EXTERNAL_FLASH_SECTOR_SIZE)) != 0)) {
-        dprintf("Flash erase sector address over limit! [addr:0x%x]\n", (uint32_t)addr);
+        dprintf("Flash erase sector address over limit! [addr:0x%lx]\n", (uint32_t)addr);
         return FLASH_STATUS_ERROR;
     }
 
@@ -247,7 +247,7 @@ flash_status_t flash_erase_block(uint32_t addr) {
 
     /* Check that the address exceeds the limit. */
     if ((addr + (EXTERNAL_FLASH_BLOCK_SIZE)) >= (EXTERNAL_FLASH_SIZE) || ((addr % (EXTERNAL_FLASH_BLOCK_SIZE)) != 0)) {
-        dprintf("Flash erase block address over limit! [addr:0x%x]\n", (uint32_t)addr);
+        dprintf("Flash erase block address over limit! [addr:0x%lx]\n", (uint32_t)addr);
         return FLASH_STATUS_ERROR;
     }
 
@@ -303,7 +303,7 @@ flash_status_t flash_read_block(uint32_t addr, void *buf, size_t len) {
     }
 
 #if defined(CONSOLE_ENABLE) && defined(DEBUG_FLASH_SPI_OUTPUT)
-    dprintf("[SPI FLASH R] 0x%08lX: ", addr);
+    dprintf("[SPI FLASH R] 0x%08lx: ", addr);
     for (size_t i = 0; i < len; ++i) {
         dprintf(" %02X", (int)(((uint8_t *)read_buf)[i]));
     }
@@ -339,7 +339,7 @@ flash_status_t flash_write_block(uint32_t addr, const void *buf, size_t len) {
         }
 
 #if defined(CONSOLE_ENABLE) && defined(DEBUG_FLASH_SPI_OUTPUT)
-        dprintf("[SPI FLASH W] 0x%08lX: ", addr);
+        dprintf("[SPI FLASH W] 0x%08lx: ", addr);
         for (size_t i = 0; i < write_length; i++) {
             dprintf(" %02X", (int)(uint8_t)(write_buf[i]));
         }

--- a/platforms/chibios/drivers/eeprom/eeprom_stm32.c
+++ b/platforms/chibios/drivers/eeprom/eeprom_stm32.c
@@ -250,7 +250,7 @@ uint16_t EEPROM_Init(void) {
                 }
                 wvalue = ~*log_addr;
                 if (!wvalue) {
-                    eeprom_printf("Incomplete write at log_addr: 0x%04x;\n", (uint32_t)log_addr);
+                    eeprom_printf("Incomplete write at log_addr: 0x%04lx;\n", (uint32_t)log_addr);
                     /* Possibly incomplete write.  Ignore and continue */
                     continue;
                 }
@@ -261,7 +261,7 @@ uint16_t EEPROM_Init(void) {
             } else {
                 /* Reserved for future use */
                 if (address & FEE_VALUE_RESERVED) {
-                    eeprom_printf("Reserved encoded value at log_addr: 0x%04x;\n", (uint32_t)log_addr);
+                    eeprom_printf("Reserved encoded value at log_addr: 0x%04lx;\n", (uint32_t)log_addr);
                     continue;
                 }
                 /* Optimization for 0 or 1 values. */
@@ -273,7 +273,7 @@ uint16_t EEPROM_Init(void) {
                 eeprom_printf("DataBuf[0x%04x] = 0x%04x;\n", address, wvalue);
                 *(uint16_t *)(&DataBuf[address]) = wvalue;
             } else {
-                eeprom_printf("DataBuf[0x%04x] cannot be set to 0x%04x [BAD ADDRESS]\n", address, wvalue);
+                eeprom_printf("DataBuf[0x%04x] cannot be set to 0x%04lx [BAD ADDRESS]\n", address, wvalue);
             }
         }
     }
@@ -293,14 +293,14 @@ static void eeprom_clear(void) {
     FLASH_Unlock();
 
     for (uint16_t page_num = 0; page_num < FEE_PAGE_COUNT; ++page_num) {
-        eeprom_printf("FLASH_ErasePage(0x%04x)\n", (uint32_t)(FEE_PAGE_BASE_ADDRESS + (page_num * FEE_PAGE_SIZE)));
+        eeprom_printf("FLASH_ErasePage(0x%04lx)\n", (uint32_t)(FEE_PAGE_BASE_ADDRESS + (page_num * FEE_PAGE_SIZE)));
         FLASH_ErasePage(FEE_PAGE_BASE_ADDRESS + (page_num * FEE_PAGE_SIZE));
     }
 
     FLASH_Lock();
 
     empty_slot = (uint16_t *)FEE_WRITE_LOG_BASE_ADDRESS;
-    eeprom_printf("eeprom_clear empty_slot: 0x%08x\n", (uint32_t)empty_slot);
+    eeprom_printf("eeprom_clear empty_slot: 0x%08lx\n", (uint32_t)empty_slot);
 }
 
 /* Erase emulated eeprom */
@@ -328,7 +328,7 @@ static uint8_t eeprom_compact(void) {
     for (; dest < FEE_COMPACTED_LAST_ADDRESS; ++src, dest += 2) {
         value = *src;
         if (value) {
-            eeprom_printf("FLASH_ProgramHalfWord(0x%04x, 0x%04x)\n", (uint32_t)dest, ~value);
+            eeprom_printf("FLASH_ProgramHalfWord(0x%04lx, 0x%04x)\n", (uint32_t)dest, ~value);
             FLASH_Status status = FLASH_ProgramHalfWord(dest, ~value);
             if (status != FLASH_COMPLETE) final_status = status;
         }
@@ -355,7 +355,7 @@ static uint8_t eeprom_write_direct_entry(uint16_t Address) {
 
         FLASH_Unlock();
 
-        eeprom_printf("FLASH_ProgramHalfWord(0x%08x, 0x%04x) [DIRECT]\n", (uint32_t)directAddress, value);
+        eeprom_printf("FLASH_ProgramHalfWord(0x%08lx, 0x%04x) [DIRECT]\n", (uint32_t)directAddress, value);
         FLASH_Status status = FLASH_ProgramHalfWord(directAddress, value);
 
         FLASH_Lock();
@@ -397,12 +397,12 @@ static uint8_t eeprom_write_log_word_entry(uint16_t Address) {
     FLASH_Unlock();
 
     /* address */
-    eeprom_printf("FLASH_ProgramHalfWord(0x%08x, 0x%04x)\n", (uint32_t)empty_slot, Address);
+    eeprom_printf("FLASH_ProgramHalfWord(0x%08lx, 0x%04x)\n", (uint32_t)empty_slot, Address);
     final_status = FLASH_ProgramHalfWord((uintptr_t)empty_slot++, Address);
 
     /* value */
     if (encoding == (FEE_WORD_ENCODING | FEE_VALUE_NEXT)) {
-        eeprom_printf("FLASH_ProgramHalfWord(0x%08x, 0x%04x)\n", (uint32_t)empty_slot, ~value);
+        eeprom_printf("FLASH_ProgramHalfWord(0x%08lx, 0x%04x)\n", (uint32_t)empty_slot, ~value);
         FLASH_Status status = FLASH_ProgramHalfWord((uintptr_t)empty_slot++, ~value);
         if (status != FLASH_COMPLETE) final_status = status;
     }
@@ -428,7 +428,7 @@ static uint8_t eeprom_write_log_byte_entry(uint16_t Address) {
     uint16_t value = (Address << 8) | DataBuf[Address];
 
     /* write to flash */
-    eeprom_printf("FLASH_ProgramHalfWord(0x%08x, 0x%04x)\n", (uint32_t)empty_slot, value);
+    eeprom_printf("FLASH_ProgramHalfWord(0x%08lx, 0x%04x)\n", (uint32_t)empty_slot, value);
     FLASH_Status status = FLASH_ProgramHalfWord((uintptr_t)empty_slot++, value);
 
     FLASH_Lock();


### PR DESCRIPTION
## Description

Compilation errors with `make annepro2/c18:default CONSOLE_ENABLE=yes`.
Fixes up relevant format specifiers to match the input type.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
