### PR TITLE
Add missing indicator LED defines for Dolice

### DIFF
--- a/keyboards/linworks/dolice/config.h
+++ b/keyboards/linworks/dolice/config.h
@@ -16,8 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-/* Set 1 kHz polling rate and force USB NKRO */
-#define USB_POLLING_INTERVAL_MS 1
+/* Force USB NKRO */
 #define FORCE_NKRO
 
 /* key matrix size */
@@ -38,3 +37,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BACKLIGHT_PIN B5 // Timer 1 on mega32u4
 #define BACKLIGHT_BREATHING
 #define BACKLIGHT_ON_STATE 1
+
+/* Indicator LEDs */
+#define LED_NUM_LOCK_PIN B6
+#define LED_CAPS_LOCK_PIN C7
+#define LED_SCROLL_LOCK_PIN C6
+#define LED_PIN_ON_STATE 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This PR adds support for the indicator LED hardware present on the Dolice keyboard PCB. It also removes an outdated 1000 Hz USB polling rate define, since that is QMK default now.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Indicator LEDs not working on Dolice keyboard

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
