### PR TITLE
[Keyboard] use correct function in Dilemma splinky

### DIFF
--- a/keyboards/bastardkb/dilemma/splinky/splinky.c
+++ b/keyboards/bastardkb/dilemma/splinky/splinky.c
@@ -20,7 +20,7 @@
 // Forward declare RP2040 SDK declaration.
 void gpio_init(uint gpio);
 
-void keyboard_pre_init_user(void) {
+void keyboard_pre_init_kb(void) {
     // Ensures that GP26 through GP29 are initialized as digital inputs (as
     // opposed to analog inputs).  These GPIOs are shared with A0 through A3,
     // respectively.  On RP2040-B2 and later, the digital inputs are disabled by
@@ -29,4 +29,5 @@ void keyboard_pre_init_user(void) {
     gpio_init(GP27);
     gpio_init(GP28);
     gpio_init(GP29);
+    keyboard_pre_init_user();
 }


### PR DESCRIPTION
## Description

It's using the user function, when it should be using the kb function

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
