### PR TITLE
Remove old submodules if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,8 +428,14 @@ lib/%:
 
 .PHONY: git-submodule
 git-submodule:
+	[ -e lib/ugfx ] && rm -rf lib/ugfx || true
+	[ -e lib/pico-sdk ] && rm -rf lib/pico-sdk || true
+	[ -e lib/chibios-contrib/ext/mcux-sdk ] && rm -rf lib/chibios-contrib/ext/mcux-sdk || true
 	git submodule sync --recursive
 	git submodule update --init --recursive --progress
+
+.PHONY: git-submodules
+git-submodules: git-submodule
 
 .PHONY: list-keyboards
 list-keyboards:

--- a/util/size_regression.sh
+++ b/util/size_regression.sh
@@ -62,7 +62,6 @@ keyboard_target=$1
 # Helper for resetting submodule existence
 fixup_submodules() {
     [ -e lib/ugfx ] && rm -rf lib/ugfx
-    [ -e lib/lua ] && rm -rf lib/lua
     [ -e lib/pico-sdk ] && rm -rf lib/pico-sdk
     [ -e lib/chibios-contrib/ext/mcux-sdk ] && rm -rf lib/chibios-contrib/ext/mcux-sdk
     make git-submodule

--- a/util/size_regression.sh
+++ b/util/size_regression.sh
@@ -59,6 +59,15 @@ done
 shift $((OPTIND-1))
 keyboard_target=$1
 
+# Helper for resetting submodule existence
+fixup_submodules() {
+    [ -e lib/ugfx ] && rm -rf lib/ugfx
+    [ -e lib/lua ] && rm -rf lib/lua
+    [ -e lib/pico-sdk ] && rm -rf lib/pico-sdk
+    [ -e lib/chibios-contrib/ext/mcux-sdk ] && rm -rf lib/chibios-contrib/ext/mcux-sdk
+    make git-submodule
+}
+
 last_size=0
 last_line=""
 function build_executor() {
@@ -68,6 +77,7 @@ function build_executor() {
         make distclean >/dev/null 2>&1
 
         git checkout -f $revision >/dev/null 2>&1 || { echo "Failed to check out revision ${revision}" >&2 ; exit 1 ; }
+        fixup_submodules >/dev/null 2>&1
         make -j${job_count} $keyboard_target >/dev/null 2>&1 || true
         file_size=$(arm-none-eabi-size .build/*.elf 2>/dev/null | awk '/elf/ {print $1}' 2>/dev/null || true)
 


### PR DESCRIPTION
## Description

Fixes up submodules when calling `make git-submodule`, as well as when running size regression checks.

Also adds `make git-submodules` because I always type the wrong one.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
