### PR TITLE
Always run pointing device init

### DIFF
--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -139,14 +139,15 @@ __attribute__((weak)) uint8_t pointing_device_handle_buttons(uint8_t buttons, bo
  */
 __attribute__((weak)) void pointing_device_init(void) {
 #if defined(SPLIT_POINTING_ENABLE)
-    if (!(POINTING_DEVICE_THIS_SIDE)) {
-        return;
-    }
+    if ((POINTING_DEVICE_THIS_SIDE))
 #endif
-    pointing_device_driver.init();
+    {
+        pointing_device_driver.init();
 #ifdef POINTING_DEVICE_MOTION_PIN
-    setPinInputHigh(POINTING_DEVICE_MOTION_PIN);
+        setPinInputHigh(POINTING_DEVICE_MOTION_PIN);
 #endif
+    }
+
     pointing_device_init_kb();
     pointing_device_init_user();
 }


### PR DESCRIPTION
## Description

pointing device init kb/user functions aren't called if the master doesn't have the pointing device.  This leads to issues if you're trying to call code for it (like setting up acceleration, default dpi, etc). 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
