### PR TITLE
MacroCat Refactor

### DIFF
--- a/keyboards/macrocat/info.json
+++ b/keyboards/macrocat/info.json
@@ -1,7 +1,7 @@
 {
     "manufacturer": "Catmunch",
     "keyboard_name": "MacroCat Keyboard",
-    "maintainer": "Catmunch",
+    "maintainer": "Catmunch, starcatmeow",
     "bootloader": "atmel-dfu",
     "diode_direction": "COL2ROW",
     "features": {

--- a/keyboards/macrocat/info.json
+++ b/keyboards/macrocat/info.json
@@ -24,8 +24,11 @@
         "pid": "0x8086",
         "vid": "0x2022"
     },
+    "layout_aliases": {
+        "LAYOUT_numpad_4x4": "LAYOUT_ortho_4x4"
+    },
     "layouts": {
-        "LAYOUT_numpad_4x4": {
+        "LAYOUT_ortho_4x4": {
             "layout": [
                 { "matrix": [0, 0], "x": 0, "y": 0 },
                 { "matrix": [0, 1], "x": 1, "y": 0 },

--- a/keyboards/macrocat/keymaps/default/keymap.c
+++ b/keyboards/macrocat/keymaps/default/keymap.c
@@ -4,16 +4,16 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = {
-        {KC_PLUS,   KC_9,       KC_8,   KC_7 },
-        {KC_MINS,   KC_6,       KC_5,   KC_4 },
-        {KC_DOT,    KC_3,       KC_2,   KC_1 },
-        {KC_ENT,    KC_SPACE,   KC_0,   MO(1)}
-    },
-    [1] = {
-        {KC_ASTR,   KC_MPRV,    KC_MPLY,KC_MNXT},
-        {KC_SLSH,   KC_LPRN,    KC_UP,  KC_RPRN},
-        {KC_COMM,   KC_LEFT,    KC_DOWN,KC_RIGHT},
-        {KC_TAB,    KC_BSPC,    KC_0,   KC_TRNS}
-    }
+    [0] = LAYOUT_ortho_4x4(
+        KC_PLUS,   KC_9,       KC_8,   KC_7 ,
+        KC_MINS,   KC_6,       KC_5,   KC_4 ,
+        KC_DOT,    KC_3,       KC_2,   KC_1 ,
+        KC_ENT,    KC_SPACE,   KC_0,   MO(1)
+    ),
+    [1] = LAYOUT_ortho_4x4(
+        KC_ASTR,   KC_MPRV,    KC_MPLY,KC_MNXT,
+        KC_SLSH,   KC_LPRN,    KC_UP,  KC_RPRN,
+        KC_COMM,   KC_LEFT,    KC_DOWN,KC_RIGHT,
+        KC_TAB,    KC_BSPC,    KC_0,   KC_TRNS
+    )
 };

--- a/keyboards/macrocat/keymaps/oled/keymap.c
+++ b/keyboards/macrocat/keymaps/oled/keymap.c
@@ -4,28 +4,28 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = {
-        {KC_PLUS,   KC_9,       KC_8,   KC_7 },
-        {KC_MINS,   KC_6,       KC_5,   KC_4 },
-        {KC_DOT,    KC_3,       KC_2,   KC_1 },
-        {KC_ENT,    KC_SPACE,   KC_0,   MO(1)}
-    },
-    [1] = {
-        {KC_ASTR,   KC_MPRV,    KC_MPLY,KC_MNXT},
-        {KC_SLSH,   KC_LPRN,    KC_UP,  KC_RPRN},
-        {KC_COMM,   KC_LEFT,    KC_DOWN,KC_RIGHT},
-        {KC_TAB,    KC_BSPC,    KC_0,   KC_TRNS}
-    },
-    [2] = {
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO}
-    },
-    [3] = {
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO}
-    }
+    [0] = LAYOUT_ortho_4x4(
+        KC_PLUS,   KC_9,       KC_8,   KC_7 ,
+        KC_MINS,   KC_6,       KC_5,   KC_4 ,
+        KC_DOT,    KC_3,       KC_2,   KC_1 ,
+        KC_ENT,    KC_SPACE,   KC_0,   MO(1)
+    ),
+    [1] = LAYOUT_ortho_4x4(
+        KC_ASTR,   KC_MPRV,    KC_MPLY,KC_MNXT,
+        KC_SLSH,   KC_LPRN,    KC_UP,  KC_RPRN,
+        KC_COMM,   KC_LEFT,    KC_DOWN,KC_RIGHT,
+        KC_TAB,    KC_BSPC,    KC_0,   KC_TRNS
+    ),
+    [2] = LAYOUT_ortho_4x4(
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO
+    ),
+    [3] = LAYOUT_ortho_4x4(
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO
+    )
 };

--- a/keyboards/macrocat/keymaps/via/keymap.c
+++ b/keyboards/macrocat/keymaps/via/keymap.c
@@ -4,28 +4,28 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = {
-        {KC_PPLS,   KC_9,       KC_8,   KC_7 },
-        {KC_PMNS,   KC_6,       KC_5,   KC_4 },
-        {KC_PDOT,   KC_3,       KC_2,   KC_1 },
-        {KC_PENT,   KC_SPACE,   KC_P0,  MO(1)}
-    },
-    [1] = {
-        {KC_PAST,   KC_NO,      KC_NO,  KC_NO},
-        {KC_PSLS,   KC_LPRN,    KC_UP,  KC_RPRN},
-        {KC_COMM,   KC_LEFT,    KC_DOWN,KC_RIGHT},
-        {KC_TAB,    KC_BSPC,    KC_P0,  KC_TRNS}
-    },
-    [2] = {
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO}
-    },
-    [3] = {
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO},
-        {KC_NO,     KC_NO,      KC_NO,  KC_NO}
-    }
+    [0] = LAYOUT_ortho_4x4(
+        KC_PPLS,   KC_9,       KC_8,   KC_7 ,
+        KC_PMNS,   KC_6,       KC_5,   KC_4 ,
+        KC_PDOT,   KC_3,       KC_2,   KC_1 ,
+        KC_PENT,   KC_SPACE,   KC_P0,  MO(1)
+    ),
+    [1] = LAYOUT_ortho_4x4(
+        KC_PAST,   KC_NO,      KC_NO,  KC_NO,
+        KC_PSLS,   KC_LPRN,    KC_UP,  KC_RPRN,
+        KC_COMM,   KC_LEFT,    KC_DOWN,KC_RIGHT,
+        KC_TAB,    KC_BSPC,    KC_P0,  KC_TRNS
+    ),
+    [2] = LAYOUT_ortho_4x4(
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO
+    ),
+    [3] = LAYOUT_ortho_4x4(
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO,
+        KC_NO,     KC_NO,      KC_NO,  KC_NO
+    )
 };

--- a/keyboards/macrocat/readme.md
+++ b/keyboards/macrocat/readme.md
@@ -4,7 +4,7 @@
 
 A cat like macro keyboard/numpad.
 
-* Keyboard Maintainer: [catmunch](https://github.com/catmunch)
+* Keyboard Maintainer: [catmunch](https://github.com/catmunch), [starcatmeow](https://github.com/starcatmeow)
 * Hardware Supported: Fully Supported
 * Hardware Availability: [MacroCat Keyboard](https://github.com/catmunch/macrocat)
 

--- a/keyboards/macrocat/readme.md
+++ b/keyboards/macrocat/readme.md
@@ -16,8 +16,6 @@ Flashing example for this keyboard:
 
     make macrocat:default:flash
 
-See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
-
 ## Bootloader
 
 Enter the bootloader in 3 ways:
@@ -25,3 +23,5 @@ Enter the bootloader in 3 ways:
 * **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
 * **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
 * **Brand new atmega32u4 chip**: Plug the cable in, it will automatically boot into bootloader
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
## Description

- renames `LAYOUT_numpad_4x4` to `LAYOUT_ortho_4x4` (keyboard layout is actually 4x4 ortholinear)
- refactor keymaps to use layout macro (previously assigned via raw matrix)
- adds starcatmeow as a listed maintainer
- switch Bootloader and Docs instructions in `readme.md`

Compilation results are unchanged; checksums verified:

```sh
$ shasum macrocat_*
5051097472b9a89dd3f9266488a02d7899761c20 *macrocat_default.hex
7388555d282f58d9f811475736bc51b4fa770c20 *macrocat_oled.hex
1addf5128c70c9964a069476afa38c907bde6154 *macrocat_via.hex
```

cc @catmunch, @starcatmeow (keyboard maintainers)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
