### PR TITLE
standardize yanghu/unicorne LAYOUT in info.json

### DIFF
--- a/keyboards/yanghu/unicorne/info.json
+++ b/keyboards/yanghu/unicorne/info.json
@@ -8,8 +8,11 @@
     "pid": "0x0204",
     "device_version": "0.0.1"
   },
+  "layout_aliases": {
+    "LAYOUT": "LAYOUT_split_3x6_4"
+  },
   "layouts": {
-    "LAYOUT_unicorne": {
+    "LAYOUT_split_3x6_4": {
       "layout": [
         {"label":"Tab", "x":0, "y":0.8},
         {"label":"Q", "x":1, "y":0.8},
@@ -65,4 +68,4 @@
       ]
     }
   }
-} 
+}


### PR DESCRIPTION
## Description

`LAYOUT_unicorne` → `LAYOUT_split_3x6_4` in info.json. The keymaps already use either `LAYOUT_split_3x6_4` or just `LAYOUT`, which has been added as an alias.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

![before_unicorne](https://user-images.githubusercontent.com/86894501/183993670-a5b35d3b-5a35-4ccb-902b-2ebad3bd3d87.png)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
