### PR TITLE
Fix Bépo's BP_NNBS (narrow non-breaking space)

### DIFF
--- a/quantum/keymap_extras/keymap_bepo.h
+++ b/quantum/keymap_extras/keymap_bepo.h
@@ -237,4 +237,4 @@
 #define BP_DDAG S(ALGR(BP_H))    // ‡
 #define BP_FORD S(ALGR(BP_F))    // ª
 // Row 5
-#define BP_NNBS S(ALGR(BP_))     //   (narrow non-breaking space)
+#define BP_NNBS S(ALGR(KC_SPC))     //   (narrow non-breaking space)

--- a/quantum/keymap_extras/keymap_bepo.h
+++ b/quantum/keymap_extras/keymap_bepo.h
@@ -237,4 +237,4 @@
 #define BP_DDAG S(ALGR(BP_H))    // ‡
 #define BP_FORD S(ALGR(BP_F))    // ª
 // Row 5
-#define BP_NNBS S(ALGR(KC_SPC))     //   (narrow non-breaking space)
+#define BP_NNBS S(ALGR(KC_SPC))  //   (narrow non-breaking space)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
```diff
diff --git a/quantum/keymap_extras/keymap_bepo.h b/quantum/keymap_extras/keymap_bepo.h
index 72d5b81f32..036aa128e7 100644
--- a/quantum/keymap_extras/keymap_bepo.h
+++ b/quantum/keymap_extras/keymap_bepo.h
@@ -237,4 +237,4 @@
 #define BP_DDAG S(ALGR(BP_H))    // ‡
 #define BP_FORD S(ALGR(BP_F))    // ª
 // Row 5
-#define BP_NNBS S(ALGR(BP_))     //   (narrow non-breaking space)
+#define BP_NNBS S(ALGR(KC_SPC))     //   (narrow non-breaking space)
```

`BP_` isn't a valid macro.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
