### PR TITLE
Use LT_ZCAR in place of LT_PLUS for modded kc definitions of keymap_lithuanian_qwerty.h

### DIFF
--- a/quantum/keymap_extras/keymap_lithuanian_qwerty.h
+++ b/quantum/keymap_extras/keymap_lithuanian_qwerty.h
@@ -137,7 +137,7 @@
 #define LT_6    ALGR(LT_SCAR) // 6
 #define LT_7    ALGR(LT_UOGO) // 7
 #define LT_8    ALGR(LT_UMAC) // 8
-#define LT_EQL  ALGR(LT_PLUS) // =
+#define LT_EQL  ALGR(LT_ZCAR) // =
 // Row 2
 #define LT_EURO ALGR(LT_E)    // €
 
@@ -163,4 +163,4 @@
 #define LT_CIRC S(ALGR(LT_SCAR)) // ^
 #define LT_AMPR S(ALGR(LT_UOGO)) // &
 #define LT_ASTR S(ALGR(LT_UMAC)) // *
-#define LT_PLUS S(ALGR(LT_PLUS)) // +
+#define LT_PLUS S(ALGR(LT_ZCAR)) // +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The QWERTY Lithuanian '+' (`LT_PLUS`) is on `S(ALGR(KC_EQL))`, and yet `LT_PLUS` was used to compose the keycode aliases for other modded keycodes involving `KC_EQL`, when `LT_ZCAR` would have been more appropriate.

The file even contained a definition of `LT_PLUS` in terms of itself:
```c
#define LT_PLUS S(ALGR(LT_PLUS)) // +
```

![screenshot of gkbd --layout lt](https://i.imgur.com/GhMcQBS.png)
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
