### PR TITLE
KR_DQUO S(KR_COLN) → KR_DQUO S(KR_QUOT) in keymap_korean.h

### DIFF
--- a/quantum/keymap_extras/keymap_korean.h
+++ b/quantum/keymap_extras/keymap_korean.h
@@ -121,7 +121,7 @@
 #define KR_PIPE S(KR_WON)  // |
 // Row 3
 #define KR_COLN S(KR_SCLN) // :
-#define KR_DQUO S(KR_COLN) // "
+#define KR_DQUO S(KR_QUOT) // "
 // Row 4
 #define KR_LABK S(KR_COMM) // <
 #define KR_RABK S(KR_DOT)  // >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

KR_DQUO was incorrectly defined as shift + KR_COLN.

```diff
diff --git a/quantum/keymap_extras/keymap_korean.h b/quantum/keymap_extras/keymap_korean.h
index 74be122dad..3d41a98b88 100644
--- a/quantum/keymap_extras/keymap_korean.h
+++ b/quantum/keymap_extras/keymap_korean.h
@@ -121,7 +121,7 @@
 #define KR_PIPE S(KR_WON)  // |
 // Row 3
 #define KR_COLN S(KR_SCLN) // :
-#define KR_DQUO S(KR_COLN) // "
+#define KR_DQUO S(KR_QUOT) // "
 // Row 4
 #define KR_LABK S(KR_COMM) // <
 #define KR_RABK S(KR_DOT)  // >
```

For reference:
```cs
75:#define KR_QUOT KC_QUOT // '
```
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
