### PR TITLE
[Keyboard] Fix compilation issues for Mechlovin Adelais

### DIFF
--- a/keyboards/mechlovin/adelais/keymaps/default/keymap.c
+++ b/keyboards/mechlovin/adelais/keymaps/default/keymap.c
@@ -51,15 +51,13 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
         } else {
             tap_code(KC_VOLU);
         }
-    }
-    else if (index == 1) {
+    } else if (index == 1) {
         if (clockwise) {
             tap_code(KC_LEFT);
         } else {
             tap_code(KC_RGHT);
         }
-    }
-    else if (index == 2) {
+    } else if (index == 2) {
         if (clockwise) {
             tap_code(KC_UP);
         } else {
@@ -69,44 +67,46 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-  #endif
+#endif
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  if (record->event.pressed) {
-    switch(keycode) {
-        case KC_F13: // toggle rgb matrix
-            rgb_matrix_toggle();
-            return false;
-        case KC_F14:
-            rgb_matrix_step();
-            return false;
-        case KC_F15:
-            rgb_matrix_increase_speed();
-            return false;
-        case KC_F16:
-            rgb_matrix_decrease_speed();
-            return false;
-        case KC_F17:
-            rgb_matrix_increase_hue();
-            return false;
-        case KC_F18:
-            rgb_matrix_decrease_hue();
-            return false;
-        case KC_F19:
-            rgb_matrix_increase_sat();
-            return false;
-        case KC_F20:
-            rgb_matrix_decrease_sat();
-            return false;
-        case KC_F21:
-            rgb_matrix_increase_val();
-            return false;
-        case KC_F22:
-            rgb_matrix_decrease_val();
-            return false;
-        default:
-        break;
+    if (record->event.pressed) {
+        switch (keycode) {
+#ifdef RGB_MATRIX_ENABLE
+            case KC_F13: // toggle rgb matrix
+                rgb_matrix_toggle();
+                return false;
+            case KC_F14:
+                rgb_matrix_step();
+                return false;
+            case KC_F15:
+                rgb_matrix_increase_speed();
+                return false;
+            case KC_F16:
+                rgb_matrix_decrease_speed();
+                return false;
+            case KC_F17:
+                rgb_matrix_increase_hue();
+                return false;
+            case KC_F18:
+                rgb_matrix_decrease_hue();
+                return false;
+            case KC_F19:
+                rgb_matrix_increase_sat();
+                return false;
+            case KC_F20:
+                rgb_matrix_decrease_sat();
+                return false;
+            case KC_F21:
+                rgb_matrix_increase_val();
+                return false;
+            case KC_F22:
+                rgb_matrix_decrease_val();
+                return false;
+#endif
+            default:
+                break;
+        }
     }
-  }
-  return true;
+    return true;
 }

--- a/keyboards/mechlovin/adelais/keymaps/via/keymap.c
+++ b/keyboards/mechlovin/adelais/keymaps/via/keymap.c
@@ -65,15 +65,13 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
         } else {
             tap_code(KC_VOLU);
         }
-    }
-    else if (index == 1) {
+    } else if (index == 1) {
         if (clockwise) {
             tap_code(KC_LEFT);
         } else {
             tap_code(KC_RGHT);
         }
-    }
-    else if (index == 2) {
+    } else if (index == 2) {
         if (clockwise) {
             tap_code(KC_UP);
         } else {
@@ -83,44 +81,46 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
     return true;
 }
 
-  #endif
+#endif
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  if (record->event.pressed) {
-    switch(keycode) {
-        case BL_TOG: // toggle rgb matrix
-            rgb_matrix_toggle();
-            return false;
-        case BL_EFFECT:
-            rgb_matrix_step();
-            return false;
-        case BL_ISPD:
-            rgb_matrix_increase_speed();
-            return false;
-        case BL_DSPD:
-            rgb_matrix_decrease_speed();
-            return false;
-        case BL_IHUE:
-            rgb_matrix_increase_hue();
-            return false;
-        case BL_DHUE:
-            rgb_matrix_decrease_hue();
-            return false;
-        case BL_ISAT:
-            rgb_matrix_increase_sat();
-            return false;
-        case BL_DSAT:
-            rgb_matrix_decrease_sat();
-            return false;
-        case BL_IVAL:
-            rgb_matrix_increase_val();
-            return false;
-        case BL_DVAL:
-            rgb_matrix_decrease_val();
-            return false;
-        default:
-        break;
+    if (record->event.pressed) {
+        switch (keycode) {
+#ifdef RGB_MATRIX_ENABLE
+            case BL_TOG: // toggle rgb matrix
+                rgb_matrix_toggle();
+                return false;
+            case BL_EFFECT:
+                rgb_matrix_step();
+                return false;
+            case BL_ISPD:
+                rgb_matrix_increase_speed();
+                return false;
+            case BL_DSPD:
+                rgb_matrix_decrease_speed();
+                return false;
+            case BL_IHUE:
+                rgb_matrix_increase_hue();
+                return false;
+            case BL_DHUE:
+                rgb_matrix_decrease_hue();
+                return false;
+            case BL_ISAT:
+                rgb_matrix_increase_sat();
+                return false;
+            case BL_DSAT:
+                rgb_matrix_decrease_sat();
+                return false;
+            case BL_IVAL:
+                rgb_matrix_increase_val();
+                return false;
+            case BL_DVAL:
+                rgb_matrix_decrease_val();
+                return false;
+#endif
+            default:
+                break;
+        }
     }
-  }
-  return true;
+    return true;
 }


### PR DESCRIPTION
## Description

Hide rgb keycodes behind preprocessors in adelais keymaps

## Types of Changes

- [x] Bugfix
- [x] Keymap/layout/userspace (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
