### PR TITLE
Change build order for post_config and post_rules

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -118,6 +118,15 @@ MAIN_KEYMAP_PATH_5 := $(KEYBOARD_PATH_5)/keymaps/$(KEYMAP)
 INFO_RULES_MK = $(shell $(QMK_BIN) generate-rules-mk --quiet --escape --keyboard $(KEYBOARD) --output $(KEYBOARD_OUTPUT)/src/info_rules.mk)
 include $(INFO_RULES_MK)
 
+# Userspace setup and definitions
+ifeq ("$(USER_NAME)","")
+    USER_NAME := $(KEYMAP)
+endif
+USER_PATH := users/$(USER_NAME)
+
+# Pull in user level rules.mk between keyboard and keymap level
+-include $(USER_PATH)/rules.mk
+
 # Check for keymap.json first, so we can regenerate keymap.c
 include $(BUILDDEFS_PATH)/build_json.mk
 
@@ -356,17 +365,12 @@ generated-files: $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/def
 
 .INTERMEDIATE : generated-files
 
-# Userspace setup and definitions
-ifeq ("$(USER_NAME)","")
-    USER_NAME := $(KEYMAP)
-endif
-USER_PATH := users/$(USER_NAME)
-
-# Pull in user level rules.mk
--include $(USER_PATH)/rules.mk
+# Pull in Userspace config
 ifneq ("$(wildcard $(USER_PATH)/config.h)","")
     CONFIG_H += $(USER_PATH)/config.h
 endif
+
+# Pull in Userspace post_config
 ifneq ("$(wildcard $(USER_PATH)/post_config.h)","")
     POST_CONFIG_H += $(USER_PATH)/post_config.h
 endif
@@ -389,6 +393,10 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_4)/post_rules.mk)","")
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_5)/post_rules.mk)","")
     include $(KEYBOARD_PATH_5)/post_rules.mk
+endif
+
+ifneq ("$(wildcard $(USER_PATH)/post_rules.mk)","")
+    include $(USER_PATH)/post_rules.mk
 endif
 
 ifneq ("$(wildcard $(KEYMAP_PATH)/config.h)","")

--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -395,6 +395,7 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_5)/post_rules.mk)","")
     include $(KEYBOARD_PATH_5)/post_rules.mk
 endif
 
+# Pull iin post_rules.mk file from the userspace folder
 ifneq ("$(wildcard $(USER_PATH)/post_rules.mk)","")
     include $(USER_PATH)/post_rules.mk
 endif

--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -365,16 +365,6 @@ generated-files: $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/def
 
 .INTERMEDIATE : generated-files
 
-# Pull in Userspace config
-ifneq ("$(wildcard $(USER_PATH)/config.h)","")
-    CONFIG_H += $(USER_PATH)/config.h
-endif
-
-# Pull in Userspace post_config
-ifneq ("$(wildcard $(USER_PATH)/post_config.h)","")
-    POST_CONFIG_H += $(USER_PATH)/post_config.h
-endif
-
 # Disable features that a keyboard doesn't support
 -include $(BUILDDEFS_PATH)/disable_features.mk
 
@@ -395,16 +385,30 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_5)/post_rules.mk)","")
     include $(KEYBOARD_PATH_5)/post_rules.mk
 endif
 
-# Pull iin post_rules.mk file from the userspace folder
-ifneq ("$(wildcard $(USER_PATH)/post_rules.mk)","")
-    include $(USER_PATH)/post_rules.mk
-endif
-
 ifneq ("$(wildcard $(KEYMAP_PATH)/config.h)","")
     CONFIG_H += $(KEYMAP_PATH)/config.h
 endif
 ifneq ("$(KEYMAP_H)","")
     CONFIG_H += $(KEYMAP_H)
+endif
+
+ifneq ("$(wildcard $(KEYMAP_PATH)/post_config.h)","")
+    POST_CONFIG_H += $(KEYMAP_PATH)/post_config.h
+endif
+
+# Pull in Userspace post_config
+ifneq ("$(wildcard $(USER_PATH)/post_config.h)","")
+    POST_CONFIG_H += $(USER_PATH)/post_config.h
+endif
+
+# Pull iin post_rules.mk file from the userspace folder
+ifneq ("$(wildcard $(USER_PATH)/post_rules.mk)","")
+    include $(USER_PATH)/post_rules.mk
+endif
+
+# Pull in Userspace config
+ifneq ("$(wildcard $(USER_PATH)/config.h)","")
+    CONFIG_H += $(USER_PATH)/config.h
 endif
 
 OPT_DEFS += -DKEYMAP_C=\"$(KEYMAP_C)\"

--- a/docs/hardware_keyboard_guidelines.md
+++ b/docs/hardware_keyboard_guidelines.md
@@ -89,12 +89,14 @@ The `config.h` files can also be placed in sub-folders, and the order in which t
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/config.h`
           * [`.build/objs_<keyboard>/src/info_config.h`](data_driven_config.md#add-code-to-generate-it) see [Data Driven Configuration](data_driven_config.md)
           * `users/a_user_folder/config.h`
-          * `keyboards/top_folder/keymaps/a_keymap/config.h`
-        * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_config.h`
-      * `keyboards/top_folder/sub_1/sub_2/sub_3/post_config.h`
-    * `keyboards/top_folder/sub_1/sub_2/post_config.h`
-  * `keyboards/top_folder/sub_1/post_config.h`
-* `keyboards/top_folder/post_config.h`
+            * `keyboards/top_folder/keymaps/a_keymap/config.h`
+          * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_config.h`
+        * `keyboards/top_folder/sub_1/sub_2/sub_3/post_config.h`
+      * `keyboards/top_folder/sub_1/sub_2/post_config.h`
+    * `keyboards/top_folder/sub_1/post_config.h`
+  * `keyboards/top_folder/post_config.h`
+* `users/a_user_folder/post_config.h`
+
 
 The `post_config.h` file can be used for additional post-processing, depending on what is specified in the `config.h` file. For example, if you define the `IOS_DEVICE_ENABLE` macro in your keymap-level `config.h` file as follows, you can configure more detailed settings accordingly in the `post_config.h` file:
 
@@ -143,13 +145,14 @@ The `rules.mk` file can also be placed in a sub-folder, and its reading order is
     * `keyboards/top_folder/sub_1/sub_2/rules.mk`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/rules.mk`
-          * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
           * `users/a_user_folder/rules.mk`
-        * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
-      * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`
-    * `keyboards/top_folder/sub_1/sub_2/post_rules.mk`
-  * `keyboards/top_folder/sub_1/post_rules.mk`
-* `keyboards/top_folder/post_rules.mk`
+            * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
+          * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
+        * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`
+      * `keyboards/top_folder/sub_1/sub_2/post_rules.mk`
+    * `keyboards/top_folder/sub_1/post_rules.mk`
+  * `keyboards/top_folder/post_rules.mk`
+* `users/a_user_folder/post_rules.mk`
 * `common_features.mk`
 
 Many of the settings written in the `rules.mk` file are interpreted by `common_features.mk`, which sets the necessary source files and compiler options.

--- a/docs/hardware_keyboard_guidelines.md
+++ b/docs/hardware_keyboard_guidelines.md
@@ -147,11 +147,10 @@ The `rules.mk` file can also be placed in a sub-folder, and its reading order is
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/rules.mk`
           * `users/a_user_folder/rules.mk`
             * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
-          * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
-        * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`
-      * `keyboards/top_folder/sub_1/sub_2/post_rules.mk`
-    * `keyboards/top_folder/sub_1/post_rules.mk`
-  * `keyboards/top_folder/post_rules.mk`
+          * `keyboards/top_folder/post_rules.mk`
+        * `keyboards/top_folder/sub_1/sub_2/post_rules.mk`
+      * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`
+    * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
 * `users/a_user_folder/post_rules.mk`
 * `common_features.mk`
 

--- a/docs/hardware_keyboard_guidelines.md
+++ b/docs/hardware_keyboard_guidelines.md
@@ -88,14 +88,14 @@ The `config.h` files can also be placed in sub-folders, and the order in which t
       * `keyboards/top_folder/sub_1/sub_2/sub_3/config.h`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/config.h`
           * [`.build/objs_<keyboard>/src/info_config.h`](data_driven_config.md#add-code-to-generate-it) see [Data Driven Configuration](data_driven_config.md)
-            * `keyboards/top_folder/keymaps/a_keymap/config.h`
-              * `users/a_user_folder/config.h`
+            * `keyboards/top_folder/keymaps/a_keymap/config.h` or `layouts/community/a_layout/a_keymap/config.h` (see [feature_layouts.md](Community Layouts))
+              * `users/a_user_folder/config.h` (see [Userspace](feature_userspace.md))
             * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_config.h`
           * `keyboards/top_folder/sub_1/sub_2/sub_3/post_config.h`
         * `keyboards/top_folder/sub_1/sub_2/post_config.h`
       * `keyboards/top_folder/sub_1/post_config.h`
     * `keyboards/top_folder/post_config.h`
-  * `keyboards/top_folder/keymaps/a_keymap/post_config.h`
+  * `keyboards/top_folder/keymaps/a_keymap/post_config.h` or `layouts/community/a_layout/a_keymap/post_config.h` 
 * `users/a_user_folder/post_config.h`
 
 
@@ -146,13 +146,13 @@ The `rules.mk` file can also be placed in a sub-folder, and its reading order is
     * `keyboards/top_folder/sub_1/sub_2/rules.mk`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/rules.mk`
-          * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
-            * `users/a_user_folder/rules.mk`
+          * `keyboards/top_folder/keymaps/a_keymap/rules.mk` or `layouts/community/a_layout/a_keymap/rules.mk` (see [feature_layouts.md](Community Layouts))
+            * `users/a_user_folder/rules.mk` (see [Userspace](feature_userspace.md))
           * `keyboards/top_folder/post_rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/post_rules.mk`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`
     * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
-  * `users/a_user_folder/post_rules.mk`
+* `users/a_user_folder/post_rules.mk`
 * `common_features.mk`
 
 Many of the settings written in the `rules.mk` file are interpreted by `common_features.mk`, which sets the necessary source files and compiler options.

--- a/docs/hardware_keyboard_guidelines.md
+++ b/docs/hardware_keyboard_guidelines.md
@@ -88,13 +88,14 @@ The `config.h` files can also be placed in sub-folders, and the order in which t
       * `keyboards/top_folder/sub_1/sub_2/sub_3/config.h`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/config.h`
           * [`.build/objs_<keyboard>/src/info_config.h`](data_driven_config.md#add-code-to-generate-it) see [Data Driven Configuration](data_driven_config.md)
-          * `users/a_user_folder/config.h`
             * `keyboards/top_folder/keymaps/a_keymap/config.h`
-          * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_config.h`
-        * `keyboards/top_folder/sub_1/sub_2/sub_3/post_config.h`
-      * `keyboards/top_folder/sub_1/sub_2/post_config.h`
-    * `keyboards/top_folder/sub_1/post_config.h`
-  * `keyboards/top_folder/post_config.h`
+              * `users/a_user_folder/config.h`
+            * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_config.h`
+          * `keyboards/top_folder/sub_1/sub_2/sub_3/post_config.h`
+        * `keyboards/top_folder/sub_1/sub_2/post_config.h`
+      * `keyboards/top_folder/sub_1/post_config.h`
+    * `keyboards/top_folder/post_config.h`
+  * `keyboards/top_folder/keymaps/a_keymap/post_config.h`
 * `users/a_user_folder/post_config.h`
 
 
@@ -145,13 +146,13 @@ The `rules.mk` file can also be placed in a sub-folder, and its reading order is
     * `keyboards/top_folder/sub_1/sub_2/rules.mk`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/rules.mk`
-          * `users/a_user_folder/rules.mk`
-            * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
+          * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
+            * `users/a_user_folder/rules.mk`
           * `keyboards/top_folder/post_rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/post_rules.mk`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`
     * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
-* `users/a_user_folder/post_rules.mk`
+  * `users/a_user_folder/post_rules.mk`
 * `common_features.mk`
 
 Many of the settings written in the `rules.mk` file are interpreted by `common_features.mk`, which sets the necessary source files and compiler options.


### PR DESCRIPTION
## Description

Fully extends rules+config processing to userspace and enforce generic to specific flow.

Redo of #14852 because apparently force pushing prevents re-opening.

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  - Moderately tested on local boards. Doesn't appear to be broken. 