### PR TITLE
Document loading order of community layout rules.mk & config.h

### DIFF
--- a/docs/hardware_keyboard_guidelines.md
+++ b/docs/hardware_keyboard_guidelines.md
@@ -87,10 +87,10 @@ The `config.h` files can also be placed in sub-folders, and the order in which t
     * `keyboards/top_folder/sub_1/sub_2/config.h`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/config.h`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/config.h`
-          * [`.build/objs_<keyboard>/src/info_config.h`](data_driven_config.md#add-code-to-generate-it) see [Data Driven Configuration](data_driven_config.md)
-          * `users/a_user_folder/config.h`
+          * [`.build/objs_<keyboard>/src/info_config.h`](data_driven_config.md#add-code-to-generate-it) (see [Data Driven Configuration](data_driven_config.md))
+          * `users/a_user_folder/config.h` (see [Userspace](feature_userspace.md))
           * `keyboards/top_folder/keymaps/a_keymap/config.h`
-          * `layouts/a_layout_folder/rules.mk`
+          * `layouts/a_layout_folder/rules.mk` (see [Community Layouts](feature_layouts.md))
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_config.h`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/post_config.h`
     * `keyboards/top_folder/sub_1/sub_2/post_config.h`
@@ -145,8 +145,8 @@ The `rules.mk` file can also be placed in a sub-folder, and its reading order is
       * `keyboards/top_folder/sub_1/sub_2/sub_3/rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/rules.mk`
           * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
-          * `layouts/a_layout_folder/rules.mk`
-          * `users/a_user_folder/rules.mk`
+          * `layouts/a_layout_folder/rules.mk` (see [Community Layouts](feature_layouts.md))
+          * `users/a_user_folder/rules.mk` (see [Userspace](feature_userspace.md))
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`
     * `keyboards/top_folder/sub_1/sub_2/post_rules.mk`

--- a/docs/hardware_keyboard_guidelines.md
+++ b/docs/hardware_keyboard_guidelines.md
@@ -90,6 +90,7 @@ The `config.h` files can also be placed in sub-folders, and the order in which t
           * [`.build/objs_<keyboard>/src/info_config.h`](data_driven_config.md#add-code-to-generate-it) see [Data Driven Configuration](data_driven_config.md)
           * `users/a_user_folder/config.h`
           * `keyboards/top_folder/keymaps/a_keymap/config.h`
+          * `layouts/a_layout_folder/rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_config.h`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/post_config.h`
     * `keyboards/top_folder/sub_1/sub_2/post_config.h`
@@ -144,6 +145,7 @@ The `rules.mk` file can also be placed in a sub-folder, and its reading order is
       * `keyboards/top_folder/sub_1/sub_2/sub_3/rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/rules.mk`
           * `keyboards/top_folder/keymaps/a_keymap/rules.mk`
+          * `layouts/a_layout_folder/rules.mk`
           * `users/a_user_folder/rules.mk`
         * `keyboards/top_folder/sub_1/sub_2/sub_3/sub_4/post_rules.mk`
       * `keyboards/top_folder/sub_1/sub_2/sub_3/post_rules.mk`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add documentation of loading order of community layout `rules.mk` and `config.h` files to [QMK Keyboard Guidelines](https://docs.qmk.fm/#/hardware_keyboard_guidelines?id=rulesmk)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

_none_ 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
