### PR TITLE
Improve Drop Alt compatibility with VIA

### DIFF
--- a/keyboards/massdrop/alt/keymaps/via/config.h
+++ b/keyboards/massdrop/alt/keymaps/via/config.h
@@ -1,0 +1,22 @@
+/* Copyright 2022 SlyCedix (slycedix@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Enable additional LED functionality
+#define USB_LED_INDICATOR_ENABLE
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS 
+#define RGB_MATRIX_KEYPRESSES

--- a/keyboards/massdrop/alt/keymaps/via/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/via/keymap.c
@@ -13,10 +13,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include QMK_KEYBOARD_H
 
 enum alt_keycodes {
-    U_T_AUTO = SAFE_RANGE, //USB Extra Port Toggle Auto Detect / Always Active
+    U_T_AUTO = USER00,     //USB Extra Port Toggle Auto Detect / Always Active
     U_T_AGCR,              //USB Toggle Automatic GCR control
     DBG_TOG,               //DEBUG Toggle On / Off
     DBG_MTRX,              //DEBUG Toggle Matrix Prints
@@ -41,11 +42,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______,                            _______,                            _______, _______, KC_HOME, KC_PGDN, KC_END
     ),
     [2] = LAYOUT_65_ansi_blocker(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,
-        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_HOME,
-        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP,
-        KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_PGDN,
-        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             KC_RALT, MO(1),   KC_LEFT, KC_DOWN, KC_RGHT
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______,                            _______,                            _______, _______, _______, _______, _______
+    ),
+    [3] = LAYOUT_65_ansi_blocker(
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,
+        _______, _______, _______,                            _______,                            _______, _______, _______, _______, _______
     ),
 };
 

--- a/keyboards/massdrop/alt/keymaps/via/readme.md
+++ b/keyboards/massdrop/alt/keymaps/via/readme.md
@@ -1,0 +1,24 @@
+# VIA keymap for the Drop Alt Keyboard
+## *LED Modes:*
+Enables all RGB Matrix animation modes available in QMK, all of which are selectable through VIA or using the LED mode keys
+
+```c
+#define USB_LED_INDICATOR_ENABLE
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS 
+#define RGB_MATRIX_KEYPRESSES
+```
+
+## *User Keycodes:*
+All keyboard specific keycodes are defined in the user_keycodes space, allowing for them to be placed on your keyboard through VIA
+
+```c
+enum alt_keycodes {
+    U_T_AUTO = USER00,     //USB Extra Port Toggle Auto Detect / Always Active
+    U_T_AGCR,              //USB Toggle Automatic GCR control
+    DBG_TOG,               //DEBUG Toggle On / Off
+    DBG_MTRX,              //DEBUG Toggle Matrix Prints
+    DBG_KBD,               //DEBUG Toggle Keyboard Prints
+    DBG_MOU,               //DEBUG Toggle Mouse Prints
+    MD_BOOT,               //Restart into bootloader after hold timeout
+};
+```

--- a/keyboards/massdrop/alt/keymaps/via/rules.mk
+++ b/keyboards/massdrop/alt/keymaps/via/rules.mk
@@ -1,1 +1,6 @@
 VIA_ENABLE = yes
+
+# Uncomment the following to enable specific features (Increases firmware size)
+# MOUSEKEY_ENABLE = yes			# Allow the use of keys
+# CONSOLE_ENABLE = yes         	# Console for debug
+# COMMAND_ENABLE = yes         	# Commands for debug and configuration


### PR DESCRIPTION
## Description

 * Enable all RGB Matrix Effects
 * Move keyboard-specific keycodes to the user keycodes space
 * Add additional layer to prevent issues with VIA expecting 4 layers instead of 3
 
## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
