### PR TITLE
Use a macro to compute the size of arrays at compile time

### DIFF
--- a/docs/feature_combo.md
+++ b/docs/feature_combo.md
@@ -255,7 +255,7 @@ bool combo_should_trigger(uint16_t combo_index, combo_t *combo, uint16_t keycode
 ```
 
 ## Variable Length Combos
-If you leave `COMBO_COUNT` undefined in `config.h`, it allows you to programmatically declare the size of the Combo data structure and avoid updating `COMBO_COUNT`. Instead a variable called `COMBO_LEN` has to be set. It can be set with something similar to the following in `keymap.c`: `uint16_t COMBO_LEN = sizeof(key_combos) / sizeof(key_combos[0]);` or by adding `COMBO_LENGTH` as the *last* entry in the combo enum and then `uint16_t COMBO_LEN = COMBO_LENGTH;` as such:
+If you leave `COMBO_COUNT` undefined in `config.h`, it allows you to programmatically declare the size of the Combo data structure and avoid updating `COMBO_COUNT`. Instead a variable called `COMBO_LEN` has to be set. It can be set with something similar to the following in `keymap.c`: `uint16_t COMBO_LEN = ARRAY_SIZE(key_combos);` or by adding `COMBO_LENGTH` as the *last* entry in the combo enum and then `uint16_t COMBO_LEN = COMBO_LENGTH;` as such:
 ```c
 enum myCombos {
     ...,

--- a/drivers/haptic/solenoid.c
+++ b/drivers/haptic/solenoid.c
@@ -20,6 +20,7 @@
 #include "haptic.h"
 #include "gpio.h"
 #include "usb_device_state.h"
+#include "util.h"
 #include <stdlib.h>
 
 uint8_t      solenoid_dwell  = SOLENOID_DEFAULT_DWELL;

--- a/drivers/haptic/solenoid.c
+++ b/drivers/haptic/solenoid.c
@@ -24,7 +24,7 @@
 
 uint8_t      solenoid_dwell  = SOLENOID_DEFAULT_DWELL;
 static pin_t solenoid_pads[] = SOLENOID_PINS;
-#define NUMBER_OF_SOLENOIDS (sizeof(solenoid_pads) / sizeof(pin_t))
+#define NUMBER_OF_SOLENOIDS ARRAY_SIZE(solenoid_pads)
 bool     solenoid_on[NUMBER_OF_SOLENOIDS]      = {false};
 bool     solenoid_buzzing[NUMBER_OF_SOLENOIDS] = {false};
 uint16_t solenoid_start[NUMBER_OF_SOLENOIDS]   = {0};
@@ -147,7 +147,7 @@ void solenoid_check(void) {
 void solenoid_setup(void) {
 #ifdef SOLENOID_PINS_ACTIVE_STATE
     bool    state_temp[] = SOLENOID_PINS_ACTIVE_STATE;
-    uint8_t bound_check  = (sizeof(state_temp) / sizeof(bool));
+    uint8_t bound_check  = ARRAY_SIZE(state_temp);
 #endif
 
     for (uint8_t i = 0; i < NUMBER_OF_SOLENOIDS; i++) {

--- a/drivers/sensors/pmw33xx_common.c
+++ b/drivers/sensors/pmw33xx_common.c
@@ -19,9 +19,9 @@ extern const uint8_t pmw33xx_firmware_data[PMW33XX_FIRMWARE_LENGTH] PROGMEM;
 extern const uint8_t pmw33xx_firmware_signature[3] PROGMEM;
 
 static const pin_t cs_pins[]                                 = PMW33XX_CS_PINS;
-static bool        in_burst[sizeof(cs_pins) / sizeof(pin_t)] = {0};
+static bool        in_burst[ARRAY_SIZE(cs_pins)] = {0};
 
-const size_t pmw33xx_number_of_sensors = sizeof(cs_pins) / sizeof(pin_t);
+const size_t pmw33xx_number_of_sensors = ARRAY_SIZE(cs_pins);
 
 bool __attribute__((cold)) pmw33xx_upload_firmware(uint8_t sensor);
 bool __attribute__((cold)) pmw33xx_check_signature(uint8_t sensor);

--- a/drivers/sensors/pmw33xx_common.c
+++ b/drivers/sensors/pmw33xx_common.c
@@ -18,7 +18,7 @@
 extern const uint8_t pmw33xx_firmware_data[PMW33XX_FIRMWARE_LENGTH] PROGMEM;
 extern const uint8_t pmw33xx_firmware_signature[3] PROGMEM;
 
-static const pin_t cs_pins[]                                 = PMW33XX_CS_PINS;
+static const pin_t cs_pins[]                     = PMW33XX_CS_PINS;
 static bool        in_burst[ARRAY_SIZE(cs_pins)] = {0};
 
 const size_t pmw33xx_number_of_sensors = ARRAY_SIZE(cs_pins);

--- a/keyboards/25keys/zinc/keymaps/ginjake/keymap.c
+++ b/keyboards/25keys/zinc/keymaps/ginjake/keymap.c
@@ -333,7 +333,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       aqours_num++;
       aqours_next_color_timer_count = 0;
       target_col = 0;
-      if (aqours_num == sizeof(aqours_h) / sizeof(int)) {
+      if (aqours_num == ARRAY_SIZE(aqours_h)) {
         aqours_num = 0;
       }
     }

--- a/keyboards/acheron/shark/beta/keymaps/gondolindrim/keymap.c
+++ b/keyboards/acheron/shark/beta/keymaps/gondolindrim/keymap.c
@@ -94,7 +94,7 @@ encoder_mode_t encoder_modes[] = {
 	// Insert your custom encoder mode here
 };
 
-#define NUM_ENCODER_MODES (sizeof(encoder_modes)/sizeof(encoder_modes[0]))
+#define NUM_ENCODER_MODES ARRAY_SIZE(encoder_modes)
 
 // This counter is used to track what encoder mode is being used at a certain time
 int encoder_mode_count = 0;

--- a/keyboards/adafruit/macropad/lib/ssd1306_sh1106.c
+++ b/keyboards/adafruit/macropad/lib/ssd1306_sh1106.c
@@ -94,8 +94,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define OLED_ALL_BLOCKS_MASK (((((OLED_BLOCK_TYPE)1 << (OLED_BLOCK_COUNT - 1)) - 1) << 1) | 1)
 
-#define ARRAY_SIZE(arr) sizeof(arr)/sizeof(arr[0])
-
 // spi defines
 #define OLED_STATUS_SUCCESS SPI_STATUS_SUCCESS
 

--- a/keyboards/crkbd/keymaps/gotham/oled.c
+++ b/keyboards/crkbd/keymaps/gotham/oled.c
@@ -176,7 +176,7 @@ void add_keylog(uint16_t keycode) {
     keylog_str[i] = keylog_str[i - 1];
   }
 
-  if (keycode < (sizeof(code_to_name) / sizeof(char))) {
+  if (keycode < ARRAY_SIZE(code_to_name)) {
     keylog_str[0] = pgm_read_byte(&code_to_name[keycode]);
   }
 }

--- a/keyboards/crkbd/keymaps/thunderbird2086/oled.c
+++ b/keyboards/crkbd/keymaps/thunderbird2086/oled.c
@@ -189,7 +189,7 @@ void add_keylog(uint16_t keycode) {
         keylog_str[i] = keylog_str[i - 1];
     }
 
-    if (keycode < (sizeof(code_to_name) / sizeof(char))) {
+    if (keycode < ARRAY_SIZE(code_to_name)) {
         keylog_str[0] = pgm_read_byte(&code_to_name[keycode]);
     }
 }

--- a/keyboards/dm9records/plaid/keymaps/brickbots/keymap.c
+++ b/keyboards/dm9records/plaid/keymaps/brickbots/keymap.c
@@ -242,7 +242,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void led_keypress_update(uint8_t led, uint8_t led_mode, uint16_t keycode, keyrecord_t *record) {
     switch (led_mode) {
       case LEDMODE_MODS:
-        for (int i=0;i<sizeof(modifiers) / sizeof(modifiers[0]);i++) {
+        for (int i=0;i<ARRAY_SIZE(modifiers);i++) {
           if(keycode==modifiers[i]) {
             if (record->event.pressed) {
               writePinHigh(led);

--- a/keyboards/dm9records/plaid/keymaps/default/keymap.c
+++ b/keyboards/dm9records/plaid/keymaps/default/keymap.c
@@ -245,7 +245,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void led_keypress_update(uint8_t led, uint8_t led_mode, uint16_t keycode, keyrecord_t *record) {
     switch (led_mode) {
       case LEDMODE_MODS:
-        for (int i=0;i<sizeof(modifiers) / sizeof(modifiers[0]);i++) {
+        for (int i=0;i<ARRAY_SIZE(modifiers);i++) {
           if(keycode==modifiers[i]) {
             if (record->event.pressed) {
               writePinHigh(led);

--- a/keyboards/dm9records/plaid/keymaps/stephen-huan/keymap.c
+++ b/keyboards/dm9records/plaid/keymaps/stephen-huan/keymap.c
@@ -184,7 +184,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void led_keypress_update(uint8_t led, uint8_t led_mode, uint16_t keycode, keyrecord_t *record) {
     switch (led_mode) {
       case LEDMODE_MODS:
-        for (int i=0;i<sizeof(modifiers) / sizeof(modifiers[0]);i++) {
+        for (int i=0;i<ARRAY_SIZE(modifiers);i++) {
           if(keycode==modifiers[i]) {
             if (record->event.pressed) {
               writePinHigh(led);

--- a/keyboards/dmqdesign/spin/keymaps/spidey3_pad/keymap.c
+++ b/keyboards/dmqdesign/spin/keymaps/spidey3_pad/keymap.c
@@ -111,7 +111,7 @@ const rgblight_segment_t *const PROGMEM _rgb_layers[] = {
 };
 // clang-format off
 
-const uint8_t PROGMEM _n_rgb_layers = sizeof(_rgb_layers) / sizeof(_rgb_layers[0]) - 1;
+const uint8_t PROGMEM _n_rgb_layers = ARRAY_SIZE(_rgb_layers) - 1;
 
 void clear_rgb_layers(void) {
     dprint("clear_rgb_layers()\n");

--- a/keyboards/evolv/keymaps/gondolindrim/keymap.c
+++ b/keyboards/evolv/keymaps/gondolindrim/keymap.c
@@ -129,7 +129,7 @@ const encoder_mode_t encoder_modes[] = {
 	// Insert your custom encoder mode here
 };
 
-#define NUM_ENCODER_MODES (sizeof(encoder_modes)/sizeof(encoder_modes[0])) // DO NOT CHANGE THIS. NUM_ENCODER_MODES calculates how many modes there are.
+#define NUM_ENCODER_MODES ARRAY_SIZE(encoder_modes) // DO NOT CHANGE THIS. NUM_ENCODER_MODES calculates how many modes there are.
 
 // This counter is used to track what encoder mode is being used at a certain time
 int encoder_mode_count = 0;

--- a/keyboards/gboards/butterstick/keymaps/default/keymap.c
+++ b/keyboards/gboards/butterstick/keymaps/default/keymap.c
@@ -180,4 +180,4 @@ uint32_t processQwerty(bool lookup) {
 }
 
 // Don't fuck with this, thanks.
-size_t keymapsCount  = sizeof(keymaps)/sizeof(keymaps[0]);
+size_t keymapsCount  = ARRAY_SIZE(keymaps);

--- a/keyboards/gboards/butterstick/sten.c
+++ b/keyboards/gboards/butterstick/sten.c
@@ -21,7 +21,7 @@ uint32_t tChord			= 0;		// Protects state of cChord
 
 #ifndef STENOLAYERS
 uint32_t stenoLayers[] = { PWR };
-size_t 	 stenoLayerCount = sizeof(stenoLayers)/sizeof(stenoLayers[0]);
+size_t 	 stenoLayerCount = ARRAY_SIZE(stenoLayers);
 #endif
 
 // Mode state

--- a/keyboards/gboards/engine/keymap_engine.h
+++ b/keyboards/gboards/engine/keymap_engine.h
@@ -114,8 +114,8 @@ void testCollisions(void) {
 #include "dicts.def"
 
 // Get size data back into the engine
-size_t funcsLen   = sizeof(funDict) / sizeof(funDict[0]);
-size_t stringLen  = sizeof(strDict) / sizeof(strDict[0]);
-size_t keyLen     = sizeof(keyDict) / sizeof(keyDict[0]);
-size_t comboLen   = sizeof(cmbDict) / sizeof(cmbDict[0]);
-size_t specialLen = sizeof(spcDict) / sizeof(spcDict[0]);
+size_t funcsLen   = ARRAY_SIZE(funDict);
+size_t stringLen  = ARRAY_SIZE(strDict);
+size_t keyLen     = ARRAY_SIZE(keyDict);
+size_t comboLen   = ARRAY_SIZE(cmbDict);
+size_t specialLen = ARRAY_SIZE(spcDict);

--- a/keyboards/gboards/g/keymap_engine.h
+++ b/keyboards/gboards/g/keymap_engine.h
@@ -115,8 +115,8 @@ void testCollisions(void) {
 #include "dicts.def"
 
 // Get size data back into the engine
-size_t funcsLen   = sizeof(funDict) / sizeof(funDict[0]);
-size_t stringLen  = sizeof(strDict) / sizeof(strDict[0]);
-size_t keyLen     = sizeof(keyDict) / sizeof(keyDict[0]);
-size_t comboLen   = sizeof(cmbDict) / sizeof(cmbDict[0]);
-size_t specialLen = sizeof(spcDict) / sizeof(spcDict[0]);
+size_t funcsLen   = ARRAY_SIZE(funDict);
+size_t stringLen  = ARRAY_SIZE(strDict);
+size_t keyLen     = ARRAY_SIZE(keyDict);
+size_t comboLen   = ARRAY_SIZE(cmbDict);
+size_t specialLen = ARRAY_SIZE(spcDict);

--- a/keyboards/gboards/georgi/keymaps/colemak-dh/keymap.c
+++ b/keyboards/gboards/georgi/keymaps/colemak-dh/keymap.c
@@ -302,5 +302,5 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 // Don't fuck with this, thanks.
-size_t keymapsCount  = sizeof(keymaps)/sizeof(keymaps[0]);
-size_t stenoLayerCount = sizeof(stenoLayers)/sizeof(stenoLayers[0]);
+size_t keymapsCount  = ARRAY_SIZE(keymaps);
+size_t stenoLayerCount = ARRAY_SIZE(stenoLayers);

--- a/keyboards/gboards/georgi/keymaps/default-flipped/keymap.c
+++ b/keyboards/gboards/georgi/keymaps/default-flipped/keymap.c
@@ -234,4 +234,4 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 // Don't fuck with this, thanks.
-size_t keymapsCount  = sizeof(keymaps)/sizeof(keymaps[0]);
+size_t keymapsCount  = ARRAY_SIZE(keymaps);

--- a/keyboards/gboards/georgi/keymaps/default/keymap.c
+++ b/keyboards/gboards/georgi/keymaps/default/keymap.c
@@ -244,4 +244,4 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 // Don't fuck with this, thanks.
-size_t keymapsCount  = sizeof(keymaps)/sizeof(keymaps[0]);
+size_t keymapsCount  = ARRAY_SIZE(keymaps);

--- a/keyboards/gboards/georgi/keymaps/minimal/keymap.c
+++ b/keyboards/gboards/georgi/keymaps/minimal/keymap.c
@@ -219,4 +219,4 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     )
 };
 // Don't fuck with this, thanks.
-size_t keymapsCount  = sizeof(keymaps)/sizeof(keymaps[0]);
+size_t keymapsCount  = ARRAY_SIZE(keymaps);

--- a/keyboards/gboards/georgi/keymaps/norman/keymap.c
+++ b/keyboards/gboards/georgi/keymaps/norman/keymap.c
@@ -263,4 +263,4 @@ KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,       KC_PGDN, KC_LEFT, KC
 			  KC_TRNS, KC_TRNS, KC_TRNS,	                        KC_TRNS, KC_TRNS, KC_TRNS)
 };
 // Don't fuck with this, thanks.
-size_t keymapsCount  = sizeof(keymaps)/sizeof(keymaps[0]);
+size_t keymapsCount  = ARRAY_SIZE(keymaps);

--- a/keyboards/gboards/georgi/sten.c
+++ b/keyboards/gboards/georgi/sten.c
@@ -21,7 +21,7 @@ uint32_t tChord			= 0;		// Protects state of cChord
 
 #ifndef STENOLAYERS
 uint32_t stenoLayers[] = { PWR };
-size_t 	 stenoLayerCount = sizeof(stenoLayers)/sizeof(stenoLayers[0]);
+size_t 	 stenoLayerCount = ARRAY_SIZE(stenoLayers);
 #endif
 
 // Mode state

--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/cedrikl/keymap.c
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/cedrikl/keymap.c
@@ -107,16 +107,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     // Capslock, Scroll lock and Numlock  indicator on Left side lights.
     void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
-        loop_colorset(LED_REGION_A,      (sizeof(LED_REGION_A) / sizeof(LED_REGION_A[0])),           hsv_cl_blue);
-        loop_colorset(LED_REGION_B,      (sizeof(LED_REGION_B) / sizeof(LED_REGION_B[0])),           hsv_cl_purple);
-        loop_colorset(LED_REGION_L_SIDE, (sizeof(LED_REGION_L_SIDE) / sizeof(LED_REGION_L_SIDE[0])), hsv_cl_purple);
-        loop_colorset(LED_REGION_R_SIDE, (sizeof(LED_REGION_R_SIDE) / sizeof(LED_REGION_R_SIDE[0])), hsv_cl_purple);
+        loop_colorset(LED_REGION_A,      ARRAY_SIZE(LED_REGION_A),
+                                 hsv_cl_blue);
+        loop_colorset(LED_REGION_B,      ARRAY_SIZE(LED_REGION_B),
+                                 hsv_cl_purple);
+        loop_colorset(LED_REGION_L_SIDE, ARRAY_SIZE(LED_REGION_L_SIDE),
+                      hsv_cl_purple);
+        loop_colorset(LED_REGION_R_SIDE, ARRAY_SIZE(LED_REGION_R_SIDE),
+                      hsv_cl_purple);
 
         switch(get_highest_layer(layer_state)){  // special handling per layer
             case 1:  //layer 1
                 //rgb_matrix_set_color_all(RGB_AZURE);
-                loop_colorset(LED_REGION_NUMPAD, (sizeof(LED_REGION_NUMPAD) / sizeof(LED_REGION_NUMPAD[0])), hsv_cl_numpad);
-                loop_colorset(LED_REGION_OTHER,  (sizeof(LED_REGION_OTHER) / sizeof(LED_REGION_OTHER[0])),   hsv_cl_mods);
+                loop_colorset(LED_REGION_NUMPAD,
+                              ARRAY_SIZE(LED_REGION_NUMPAD), hsv_cl_numpad);
+                loop_colorset(LED_REGION_OTHER,  ARRAY_SIZE(LED_REGION_OTHER),
+                                 hsv_cl_mods);
             break;
             default: //layer 0
                 //
@@ -148,7 +154,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
             rgb_matrix_set_color(LED_L6,   bad_rgb.r, bad_rgb.g, bad_rgb.b);
             rgb_matrix_set_color(LED_L7,   bad_rgb.r, bad_rgb.g, bad_rgb.b);
             rgb_matrix_set_color(LED_L8,   bad_rgb.r, bad_rgb.g, bad_rgb.b);
-            loop_colorset(LED_REGION_CAPS, (sizeof(LED_REGION_CAPS) / sizeof(LED_REGION_CAPS[0])), hsv_cl_bad);
+            loop_colorset(LED_REGION_CAPS, ARRAY_SIZE(LED_REGION_CAPS),
+                          hsv_cl_bad);
         }
     }
 #endif

--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/keymap.c
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/gourdo1/keymap.c
@@ -538,7 +538,7 @@ void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
 
         } else if (paddle_lives == 0) {
             // Game over
-            for (uint8_t i = 0; i < sizeof(LED_GAME_OVER) / sizeof(LED_GAME_OVER[0]); i++) {
+            for (uint8_t i = 0; i < ARRAY_SIZE(LED_GAME_OVER); i++) {
                 rgb_matrix_set_color(LED_GAME_OVER[i], RGB_RED);
             }
 

--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/paddlegame/keymap.c
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/paddlegame/keymap.c
@@ -201,15 +201,15 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 				else { ++rgb_value.r; }
 			}
 			
-            for (uint8_t i=0; i<sizeof(LED_RGB)/sizeof(LED_RGB[0]); i++) {
+            for (uint8_t i=0; i<ARRAY_SIZE(LED_RGB); i++) {
                 rgb_matrix_set_color(LED_RGB[i], rgb_value.r, rgb_value.g, rgb_value.b);
             }
 			
-            for (uint8_t i=0; i<sizeof(LED_WHITE)/sizeof(LED_WHITE[0]); i++) {
+            for (uint8_t i=0; i<ARRAY_SIZE(LED_WHITE); i++) {
                 rgb_matrix_set_color(LED_WHITE[i], RGB_WHITE);
             }
 
-            for (uint8_t i=0; i<sizeof(LED_GREEN)/sizeof(LED_GREEN[0]); i++) {
+            for (uint8_t i=0; i<ARRAY_SIZE(LED_GREEN); i++) {
                 rgb_matrix_set_color(LED_GREEN[i], RGB_GREEN);
             }
 			
@@ -274,7 +274,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 			} else if (paddle_lives == 0) {
 				// Game over
-				for (uint8_t i=0; i<sizeof(LED_GAME_OVER)/sizeof(LED_GAME_OVER[0]); i++) {
+				for (uint8_t i=0; i<ARRAY_SIZE(LED_GAME_OVER); i++) {
 					rgb_matrix_set_color(LED_GAME_OVER[i], RGB_RED);
 				}
 			
@@ -439,12 +439,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
             rgb_matrix_set_color(LED_CAPS, RGB_WHITE);
             if (caps_flash_on) {
-				for (uint8_t i=0; i<sizeof(LED_SIDE_LEFT)/sizeof(LED_SIDE_LEFT[0]); i++) {
+				for (uint8_t i=0; i<ARRAY_SIZE(LED_SIDE_LEFT); i++) {
 					rgb_matrix_set_color(LED_SIDE_LEFT[i], RGB_RED);
 					rgb_matrix_set_color(LED_SIDE_RIGHT[i], RGB_RED);
 				}
 			} else {
-				for (uint8_t i=0; i<sizeof(LED_SIDE_LEFT)/sizeof(LED_SIDE_LEFT[0]); i++) {
+				for (uint8_t i=0; i<ARRAY_SIZE(LED_SIDE_LEFT); i++) {
 					rgb_matrix_set_color(LED_SIDE_LEFT[i], 0, 0, 0);
 					rgb_matrix_set_color(LED_SIDE_RIGHT[i], 0, 0, 0);
 				}

--- a/keyboards/gmmk/pro/rev1/iso/keymaps/chofstede/keymap.c
+++ b/keyboards/gmmk/pro/rev1/iso/keymaps/chofstede/keymap.c
@@ -84,7 +84,7 @@ void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
         }
     HSV tempHSV = {.h = 0, .s = 255, .v = current_value};
     RGB tempRGB = hsv_to_rgb(tempHSV);
-    for (uint8_t i = 0; i < sizeof(left_side_leds) / sizeof(left_side_leds[0]); i++) {
+    for (uint8_t i = 0; i < ARRAY_SIZE(left_side_leds); i++) {
         rgb_matrix_set_color(left_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
         rgb_matrix_set_color(right_side_leds[i], tempRGB.r, tempRGB.g, tempRGB.b);
         }
@@ -95,7 +95,7 @@ void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
        case 2:  //layer one
          break;
        case 1:
-         for (uint8_t i = 0; i < sizeof(l2_functions) / sizeof(l2_functions[0]); i++) {
+         for (uint8_t i = 0; i < ARRAY_SIZE(l2_functions); i++) {
              RGB_MATRIX_INDICATOR_SET_COLOR(l2_functions[i], 255, 0, 0);
          }
          break;

--- a/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/keymap.c
+++ b/keyboards/gmmk/pro/rev1/iso/keymaps/gourdo1/keymap.c
@@ -551,7 +551,7 @@ void rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
 
         } else if (paddle_lives == 0) {
             // Game over
-            for (uint8_t i = 0; i < sizeof(LED_GAME_OVER) / sizeof(LED_GAME_OVER[0]); i++) {
+            for (uint8_t i = 0; i < ARRAY_SIZE(LED_GAME_OVER); i++) {
                 rgb_matrix_set_color(LED_GAME_OVER[i], RGB_RED);
             }
 

--- a/keyboards/gopolar/gg86/keymaps/horrortroll/keymap_stuff.h
+++ b/keyboards/gopolar/gg86/keymaps/horrortroll/keymap_stuff.h
@@ -118,7 +118,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     {{205, 250, 255}, {140, 215, 125}, false },
     };
 
-    uint8_t gp_length = sizeof(gradient_presets)/sizeof(gradient_presets[0]);
+    uint8_t gp_length = ARRAY_SIZE(gradient_presets);
 
     switch (keycode) {
         case G1_HUI:

--- a/keyboards/gopolar/gg86/lib/wave.h
+++ b/keyboards/gopolar/gg86/lib/wave.h
@@ -69,7 +69,7 @@ void add_keylog(uint16_t keycode) {
         keycode = 0;
     }
 
-    if (keycode < (sizeof(code_to_name) / sizeof(char))) {
+    if (keycode < ARRAY_SIZE(code_to_name)) {
         char log_char = pgm_read_byte(&code_to_name[keycode]);
 
         for (uint8_t j = 0; j < OLED_FONT_WIDTH; j++) {

--- a/keyboards/handwired/lagrange/keymaps/dpapavas/keymap.c
+++ b/keyboards/handwired/lagrange/keymaps/dpapavas/keymap.c
@@ -191,8 +191,8 @@ void keyboard_post_init_user(void) {
     const pin_t pins[] = {D0, D1, D2};
     uint8_t i, j;
 
-    for (i = 0 ; i < sizeof(pins) / sizeof(pins[0]) + 2 ; i += 1) {
-        for (j = 0 ; j < sizeof(pins) / sizeof(pins[0]) ; j += 1) {
+    for (i = 0 ; i < ARRAY_SIZE(pins) + 2 ; i += 1) {
+        for (j = 0 ; j < ARRAY_SIZE(pins); j += 1) {
             setPinOutput(pins[j]);
             writePin(pins[j], (j == i || j == i - 1));
         }

--- a/keyboards/handwired/myskeeb/oled.c
+++ b/keyboards/handwired/myskeeb/oled.c
@@ -183,7 +183,7 @@ void add_keylog(uint16_t keycode) {
         keylog_str[i] = keylog_str[i - 1];
     }
 
-    if (keycode < (sizeof(code_to_name) / sizeof(char))) {
+    if (keycode < ARRAY_SIZE(code_to_name)) {
         keylog_str[0] = pgm_read_byte(&code_to_name[keycode]);
     }
 }

--- a/keyboards/handwired/nicekey/keymaps/default/keymap.c
+++ b/keyboards/handwired/nicekey/keymaps/default/keymap.c
@@ -116,7 +116,7 @@ PGM_P const sentences[] PROGMEM = {
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
-        int sentences_size = sizeof(sentences) / sizeof(sentences[0]);
+        int sentences_size = ARRAY_SIZE(sentences);
         int i = rand() % sentences_size;
 
         switch (keycode) {

--- a/keyboards/handwired/onekey/keymaps/chibios_waiting_test/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/chibios_waiting_test/keymap.c
@@ -34,11 +34,11 @@ static const uint32_t waiting_values[] = {0, 1, 5, 10, 25, 50, 100, 150, 200, 50
 void housekeeping_task_user(void) {
     static uint32_t last_bench = 0;
     if (timer_elapsed32(last_bench) > 500) {
-        for (int i = 0; i < (sizeof(waiting_values) / sizeof(waiting_values[0])); i++) {
+        for (int i = 0; i < ARRAY_SIZE(waiting_values); i++) {
             wait_us_polling_with_strobe(waiting_values[i]);
             wait_us(10);
         }
-        for (int i = 0; i < (sizeof(waiting_values) / sizeof(waiting_values[0])); i++) {
+        for (int i = 0; i < ARRAY_SIZE(waiting_values); i++) {
             wait_us_yield_with_strobe(waiting_values[i]);
             wait_us(10);
         }

--- a/keyboards/handwired/promethium/keymaps/default/keymap.c
+++ b/keyboards/handwired/promethium/keymaps/default/keymap.c
@@ -55,7 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #include "outputselect.h"
 #include "led.h"
-#define COUNT(x) (sizeof (x) / sizeof (*(x)))
+#define COUNT(x) ARRAY_SIZE((x))
 
 #define KC_WWWB KC_WWW_BACK
 #define KC_WWWF KC_WWW_FORWARD

--- a/keyboards/handwired/promethium/keymaps/priyadi/keymap.c
+++ b/keyboards/handwired/promethium/keymaps/priyadi/keymap.c
@@ -57,7 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "outputselect.h"
 #endif
 #include "led.h"
-#define COUNT(x) (sizeof (x) / sizeof (*(x)))
+#define COUNT(x) ARRAY_SIZE((x))
 
 #define KC_WWWB KC_WWW_BACK
 #define KC_WWWF KC_WWW_FORWARD

--- a/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
+++ b/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
@@ -159,7 +159,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
         do {
             MATRIX_DEBUG_DELAY_START();
             is_pressed = false;
-            for (uint8_t i = 0; i < sizeof(delay_ports) / sizeof(pin_t); i++) {
+            for (uint8_t i = 0; i < ARRAY_SIZE(delay_ports); i++) {
 #            ifdef MATRIX_IO_DELAY_MULSEL
                 writePin(MATRIX_MUL_SELECT, delay_sel[i]);
                 waitInputPinDelay();

--- a/keyboards/horrortroll/handwired_k552/keymaps/default/keymap_stuff.h
+++ b/keyboards/horrortroll/handwired_k552/keymaps/default/keymap_stuff.h
@@ -110,7 +110,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     {{205, 250, 255}, {140, 215, 125}, false },
     };
 
-    uint8_t gp_length = sizeof(gradient_presets)/sizeof(gradient_presets[0]);
+    uint8_t gp_length = ARRAY_SIZE(gradient_presets);
 
     switch (keycode) {
         case G1_HUI:

--- a/keyboards/horrortroll/handwired_k552/keymaps/via/keymap_stuff.h
+++ b/keyboards/horrortroll/handwired_k552/keymaps/via/keymap_stuff.h
@@ -110,7 +110,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     {{205, 250, 255}, {140, 215, 125}, false },
     };
 
-    uint8_t gp_length = sizeof(gradient_presets)/sizeof(gradient_presets[0]);
+    uint8_t gp_length = ARRAY_SIZE(gradient_presets);
 
     switch (keycode) {
         case G1_HUI:

--- a/keyboards/horrortroll/handwired_k552/lib/wave.c
+++ b/keyboards/horrortroll/handwired_k552/lib/wave.c
@@ -68,7 +68,7 @@ void add_keylog(uint16_t keycode) {
         keycode = 0;
     }
 
-    if (keycode < (sizeof(code_to_name) / sizeof(char))) {
+    if (keycode < ARRAY_SIZE(code_to_name)) {
         char log_char = pgm_read_byte(&code_to_name[keycode]);
 
         for (uint8_t j = 0; j < OLED_FONT_WIDTH; j++) {

--- a/keyboards/lfkeyboards/lfkpad/keymaps/pascalpfeil/keymap.c
+++ b/keyboards/lfkeyboards/lfkpad/keymaps/pascalpfeil/keymap.c
@@ -58,7 +58,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 const uint8_t number_leds[] = {8, 9, 10, 11, 12, 13, 15, 16, 17};
-const uint8_t number_leds_size = sizeof(number_leds) / sizeof(uint8_t);
+const uint8_t number_leds_size = ARRAY_SIZE(number_leds);
 
 bool led_update_user(led_t led_state) {
     for (uint8_t i = 0; i < number_leds_size; i++)

--- a/keyboards/massdrop/ctrl/keymaps/responsive_pattern/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/responsive_pattern/keymap.c
@@ -129,8 +129,7 @@ static uint8_t COLOR_PATTERNS[][COLOR_PATTERN_RGB_COUNT][3] = {
         { 66,  66,  66}, { 45,  45,  45}, { 23,  23,  23},
     },
 };
-static const uint8_t COLOR_PATTERNS_COUNT = (
-        sizeof(COLOR_PATTERNS) / sizeof(COLOR_PATTERNS[0]));
+static const uint8_t COLOR_PATTERNS_COUNT = ARRAY_SIZE(COLOR_PATTERNS);
 
 /**
  * trimed down version of `ISSI3733_LED_MAP`:

--- a/keyboards/mechwild/mercutio/keymaps/fearless_spiff/keymap.c
+++ b/keyboards/mechwild/mercutio/keymaps/fearless_spiff/keymap.c
@@ -83,7 +83,7 @@ static const encoder_key PROGMEM encoder_keys[] = {
     {"Play", "", "", KC_MEDIA_PLAY_PAUSE}
 };
 
-#define NUMBER_OF_ENCODER_KEYS sizeof(encoder_keys)/sizeof(encoder_keys[0])
+#define NUMBER_OF_ENCODER_KEYS ARRAY_SIZE(encoder_keys)
 
 static uint8_t selected_encoder_key_id = 0;
 static encoder_key selected_encoder_key;

--- a/keyboards/mechwild/mercutio/keymaps/fearless_spiff_en/keymap.c
+++ b/keyboards/mechwild/mercutio/keymaps/fearless_spiff_en/keymap.c
@@ -82,7 +82,7 @@ static const encoder_key PROGMEM encoder_keys[] = {
     {"Play", "", "", KC_MEDIA_PLAY_PAUSE}
 };
 
-#define NUMBER_OF_ENCODER_KEYS sizeof(encoder_keys)/sizeof(encoder_keys[0])
+#define NUMBER_OF_ENCODER_KEYS ARRAY_SIZE(encoder_keys)
 
 static uint8_t selected_encoder_key_id = 0;
 static encoder_key selected_encoder_key;

--- a/keyboards/mechwild/mercutio/keymaps/jonavin/keymap.c
+++ b/keyboards/mechwild/mercutio/keymaps/jonavin/keymap.c
@@ -71,7 +71,7 @@ static const keycodedescType PROGMEM keyselection[] = {
         {"FLASH",   QK_BOOT},   // firmware flash mode
 };
 
-#define MAX_KEYSELECTION sizeof(keyselection)/sizeof(keyselection[0])
+#define MAX_KEYSELECTION ARRAY_SIZE(keyselection)
 
 static uint8_t selectedkey_idx = 0;
 static keycodedescType selectedkey_rec;

--- a/keyboards/mechwild/murphpad/keymaps/jonavin/keymap.c
+++ b/keyboards/mechwild/murphpad/keymaps/jonavin/keymap.c
@@ -178,7 +178,7 @@ static const keycodedescType PROGMEM keyselection[] = {
         {"QK_BOOT",   QK_BOOT},   // firmware flash mode
 };
 
-#define MAX_KEYSELECTION sizeof(keyselection)/sizeof(keyselection[0])
+#define MAX_KEYSELECTION ARRAY_SIZE(keyselection)
 
 static uint8_t selectedkey_idx = 0;
 static keycodedescType selectedkey_rec;

--- a/keyboards/mechwild/puckbuddy/puckbuddy.c
+++ b/keyboards/mechwild/puckbuddy/puckbuddy.c
@@ -16,7 +16,7 @@
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = GLIDEPOINT_DPI_OPTIONS;
-#define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))
+#define DPI_OPTION_SIZE ARRAY_SIZE(dpi_array)
 
 void board_init(void) {
     // B9 is configured as I2C1_SDA in the board file; that function must be

--- a/keyboards/mitosis/keymaps/datagrok/keymap.c
+++ b/keyboards/mitosis/keymaps/datagrok/keymap.c
@@ -97,7 +97,7 @@ const bool defaultlayers[] = {
   [_xN] = false,
   [_xF] = false,
 };
-const size_t defaultlayers_n = sizeof(defaultlayers) / sizeof(defaultlayers[0]);
+const size_t defaultlayers_n = ARRAY_SIZE(defaultlayers);
 
 // New keycode KC_LAYO rotates between available default layers (for e.g.,
 // selecting a base layout). Shift+KC_LAYO makes the current one persistent.

--- a/keyboards/mwstudio/mw65_rgb/keymaps/horrortroll/keymap_stuff.h
+++ b/keyboards/mwstudio/mw65_rgb/keymaps/horrortroll/keymap_stuff.h
@@ -116,7 +116,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     {{205, 250, 255}, {140, 215, 125}, false },
     };
 
-    uint8_t gp_length = sizeof(gradient_presets)/sizeof(gradient_presets[0]);
+    uint8_t gp_length = ARRAY_SIZE(gradient_presets);
 
     switch (keycode) {
         case G1_HUI:

--- a/keyboards/mxss/keymaps/default/keymap.c
+++ b/keyboards/mxss/keymaps/default/keymap.c
@@ -27,7 +27,7 @@ hs_set layer_colors[4] = {
     [2] = {.hue = 36,    .sat = 255},  // Color for Layer 2
     [3] = {.hue = 185,   .sat = 255},  // Color for Layer 3
 };
-size_t lc_size = sizeof(layer_colors) / sizeof(uint16_t);
+size_t lc_size = ARRAY_SIZE(layer_colors);
 
 // Use NEW_SAFE_RANGE to define new custom keycodes in order to not overwrite the ones used for front LED control
 enum custom_keycodes {

--- a/keyboards/mxss/mxss_frontled.c
+++ b/keyboards/mxss/mxss_frontled.c
@@ -36,7 +36,7 @@ __attribute__ ((weak))
 hs_set caps_color;
 
 __attribute__ ((weak))
-size_t lc_size = sizeof(layer_colors) / sizeof(hs_set);
+size_t lc_size = ARRAY_SIZE(layer_colors);
 
 void fled_init(void) {
     // This checks both an EEPROM reset (from bootmagic lite, keycodes)

--- a/keyboards/mxss/templates/keymap.c
+++ b/keyboards/mxss/templates/keymap.c
@@ -27,7 +27,7 @@ hs_set layer_colors[4] = {
     [2] = {.hue = 36,    .sat = 255},  // Color for Layer 2
     [3] = {.hue = 185,   .sat = 255},  // Color for Layer 3
 };
-size_t lc_size = sizeof(layer_colors) / sizeof(uint16_t);
+size_t lc_size = ARRAY_SIZE(layer_colors);
 
 // Use NEW_SAFE_RANGE to define new custom keycodes in order to not overwrite the ones used for front LED control
 enum custom_keycodes {

--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -49,7 +49,7 @@
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
-#define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))
+#define DPI_OPTION_SIZE ARRAY_SIZE(dpi_array)
 
 // TODO: Implement libinput profiles
 // https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html

--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -202,7 +202,7 @@ void keyboard_pre_init_kb(void) {
 #ifdef UNUSABLE_PINS
     const pin_t unused_pins[] = UNUSABLE_PINS;
 
-    for (uint8_t i = 0; i < (sizeof(unused_pins) / sizeof(pin_t)); i++) {
+    for (uint8_t i = 0; i < ARRAY_SIZE(unused_pins); i++) {
         setPinOutput(unused_pins[i]);
         writePinLow(unused_pins[i]);
     }

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -207,7 +207,7 @@ void keyboard_pre_init_kb(void) {
 #ifdef UNUSABLE_PINS
     const pin_t unused_pins[] = UNUSABLE_PINS;
 
-    for (uint8_t i = 0; i < (sizeof(unused_pins) / sizeof(pin_t)); i++) {
+    for (uint8_t i = 0; i < ARRAY_SIZE(unused_pins); i++) {
         setPinOutput(unused_pins[i]);
         writePinLow(unused_pins[i]);
     }

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -49,7 +49,7 @@
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
-#define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))
+#define DPI_OPTION_SIZE ARRAY_SIZE(dpi_array)
 
 // TODO: Implement libinput profiles
 // https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html

--- a/keyboards/ploopyco/trackball_mini/trackball_mini.c
+++ b/keyboards/ploopyco/trackball_mini/trackball_mini.c
@@ -57,7 +57,7 @@
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
-#define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))
+#define DPI_OPTION_SIZE ARRAY_SIZE(dpi_array)
 
 // TODO: Implement libinput profiles
 // https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html

--- a/keyboards/ploopyco/trackball_mini/trackball_mini.c
+++ b/keyboards/ploopyco/trackball_mini/trackball_mini.c
@@ -203,7 +203,7 @@ void keyboard_pre_init_kb(void) {
 #ifdef UNUSABLE_PINS
     const pin_t unused_pins[] = UNUSABLE_PINS;
 
-    for (uint8_t i = 0; i < (sizeof(unused_pins) / sizeof(pin_t)); i++) {
+    for (uint8_t i = 0; i < ARRAY_SIZE(unused_pins); i++) {
         setPinOutput(unused_pins[i]);
         writePinLow(unused_pins[i]);
     }

--- a/keyboards/ploopyco/trackball_nano/trackball_nano.c
+++ b/keyboards/ploopyco/trackball_nano/trackball_nano.c
@@ -89,7 +89,7 @@ void keyboard_pre_init_kb(void) {
 #ifdef UNUSABLE_PINS
     const pin_t unused_pins[] = UNUSABLE_PINS;
 
-    for (uint8_t i = 0; i < (sizeof(unused_pins) / sizeof(pin_t)); i++) {
+    for (uint8_t i = 0; i < ARRAY_SIZE(unused_pins); i++) {
         setPinOutput(unused_pins[i]);
         writePinLow(unused_pins[i]);
     }

--- a/keyboards/ploopyco/trackball_nano/trackball_nano.c
+++ b/keyboards/ploopyco/trackball_nano/trackball_nano.c
@@ -50,7 +50,7 @@
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
-#define DPI_OPTION_SIZE (sizeof(dpi_array) / sizeof(uint16_t))
+#define DPI_OPTION_SIZE ARRAY_SIZE(dpi_array)
 
 void cycle_dpi(void) {
   keyboard_config.dpi_config = (keyboard_config.dpi_config + 1) % DPI_OPTION_SIZE;

--- a/keyboards/rgbkb/pan/pan.c
+++ b/keyboards/rgbkb/pan/pan.c
@@ -51,7 +51,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
 }
 
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
-    for (int i = 0; i < sizeof(rgb_matrix_ws2812_array) / sizeof(rgb_matrix_ws2812_array[0]); i++) {
+    for (int i = 0; i < ARRAY_SIZE(rgb_matrix_ws2812_array); i++) {
         setled(i, r, g, b);
     }
 }

--- a/keyboards/rgbkb/sol/keymaps/default/keymap.c
+++ b/keyboards/rgbkb/sol/keymaps/default/keymap.c
@@ -202,7 +202,7 @@ const rgb_matrix_f rgb_matrix_functions[6][2] = {
 #ifdef ENCODER_ENABLE
 
 static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
-#define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a)/sizeof(pin_t))
+#define NUMBER_OF_ENCODERS ARRAY_SIZE(encoders_pad_a)
 
 const uint16_t PROGMEM encoders[][NUMBER_OF_ENCODERS * 2][2]  = {
     [_QWERTY] = ENCODER_LAYOUT(

--- a/keyboards/rgbkb/sol/keymaps/xyverz/keymap.c
+++ b/keyboards/rgbkb/sol/keymaps/xyverz/keymap.c
@@ -232,7 +232,7 @@ const rgb_matrix_f rgb_matrix_functions[6][2] = {
 #ifdef ENCODER_ENABLE
 
 static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
-#define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a)/sizeof(pin_t))
+#define NUMBER_OF_ENCODERS ARRAY_SIZE(encoders_pad_a)
 
 const uint16_t PROGMEM encoders[][NUMBER_OF_ENCODERS * 2][2]  = {
     [_QWERTY] = ENCODER_LAYOUT( \

--- a/keyboards/rocketboard_16/keycode_lookup.c
+++ b/keyboards/rocketboard_16/keycode_lookup.c
@@ -18,7 +18,7 @@
 #include "print.h"
 #include "via.h"
 
-#define num_keycodes (sizeof(lookup_table)/sizeof(lookup_table[0]))
+#define num_keycodes ARRAY_SIZE(lookup_table)
 static char UNKNOWN_KEYCODE[] = "UNKNOWN";
 
 int cmp(const void *v1, const void *v2)

--- a/keyboards/torn/bongocat.c
+++ b/keyboards/torn/bongocat.c
@@ -18,8 +18,6 @@
 
 #ifdef OLED_ENABLE
 
-#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
-
 #define IDLE_SPEED 20 // idle below this wpm
 #define TAP_SPEED 60 // tap above this wpm
 

--- a/keyboards/tzarc/djinn/djinn_portscan_matrix.c
+++ b/keyboards/tzarc/djinn/djinn_portscan_matrix.c
@@ -92,11 +92,11 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
 
 void matrix_wait_for_interrupt(void) {
     // Set up row/col pins and attach callback
-    for (int i = 0; i < sizeof(col_pins) / sizeof(pin_t); ++i) {
+    for (int i = 0; i < ARRAY_SIZE(col_pins); ++i) {
         setPinOutput(col_pins[i]);
         writePinLow(col_pins[i]);
     }
-    for (int i = 0; i < sizeof(row_pins) / sizeof(pin_t); ++i) {
+    for (int i = 0; i < ARRAY_SIZE(row_pins); ++i) {
         setPinInputHigh(row_pins[i]);
         palEnableLineEvent(row_pins[i], PAL_EVENT_MODE_BOTH_EDGES);
     }
@@ -105,12 +105,12 @@ void matrix_wait_for_interrupt(void) {
     __WFI();
 
     // Now that the interrupt has woken us up, reset all the row/col pins back to defaults
-    for (int i = 0; i < sizeof(row_pins) / sizeof(pin_t); ++i) {
+    for (int i = 0; i < ARRAY_SIZE(row_pins); ++i) {
         palDisableLineEvent(row_pins[i]);
         writePinHigh(row_pins[i]);
         setPinInputHigh(row_pins[i]);
     }
-    for (int i = 0; i < sizeof(col_pins) / sizeof(pin_t); ++i) {
+    for (int i = 0; i < ARRAY_SIZE(col_pins); ++i) {
         writePinHigh(col_pins[i]);
         setPinInputHigh(col_pins[i]);
     }

--- a/keyboards/ymdk/melody96/keymaps/konstantin/keymap.c
+++ b/keyboards/ymdk/melody96/keymaps/konstantin/keymap.c
@@ -2,7 +2,7 @@
 #include "konstantin.h"
 
 static const HSV *colors[] = { &godspeed_blue, &godspeed_yellow };
-static const size_t cnum = sizeof colors / sizeof *colors;
+static const size_t cnum = ARRAY_SIZE(colors);
 static size_t cidx = 0;
 
 enum keycodes_keymap {

--- a/lib/usbhost/USB_Host_Shield_2.0/SPP.cpp
+++ b/lib/usbhost/USB_Host_Shield_2.0/SPP.cpp
@@ -757,7 +757,7 @@ size_t SPP::write(const uint8_t *data, size_t size) {
 void SPP::write(const uint8_t *data, size_t size) {
 #endif
         for(uint8_t i = 0; i < size; i++) {
-                if(sppIndex >= sizeof (sppOutputBuffer) / sizeof (sppOutputBuffer[0]))
+                if(sppIndex >= ARRAY_SIZE(sppOutputBuffer))
                         send(); // Send the current data in the buffer
                 sppOutputBuffer[sppIndex++] = data[i]; // All the bytes are put into a buffer and then send using the send() function
         }

--- a/lib/usbhost/USB_Host_Shield_2.0/examples/Bluetooth/PS3Multi/PS3Multi.ino
+++ b/lib/usbhost/USB_Host_Shield_2.0/examples/Bluetooth/PS3Multi/PS3Multi.ino
@@ -19,7 +19,7 @@ USB Usb;
 
 BTD Btd(&Usb); // You have to create the Bluetooth Dongle instance like so
 PS3BT *PS3[2]; // We will use this pointer to store the two instance, you can easily make it larger if you like, but it will use a lot of RAM!
-const uint8_t length = sizeof(PS3) / sizeof(PS3[0]); // Get the lenght of the array
+const uint8_t length = ARRAY_SIZE(PS3); // Get the lenght of the array
 bool printAngle[length];
 bool oldControllerState[length];
 

--- a/lib/usbhost/USB_Host_Shield_2.0/examples/Bluetooth/WiiMulti/WiiMulti.ino
+++ b/lib/usbhost/USB_Host_Shield_2.0/examples/Bluetooth/WiiMulti/WiiMulti.ino
@@ -19,7 +19,7 @@ USB Usb;
 
 BTD Btd(&Usb); // You have to create the Bluetooth Dongle instance like so
 WII *Wii[2]; // We will use this pointer to store the two instance, you can easily make it larger if you like, but it will use a lot of RAM!
-const uint8_t length = sizeof(Wii) / sizeof(Wii[0]); // Get the lenght of the array
+const uint8_t length = ARRAY_SIZE(Wii); // Get the lenght of the array
 bool printAngle[length];
 bool oldControllerState[length];
 

--- a/lib/usbhost/USB_Host_Shield_2.0/examples/HID/le3dp/le3dp_rptparser.h
+++ b/lib/usbhost/USB_Host_Shield_2.0/examples/HID/le3dp/le3dp_rptparser.h
@@ -25,7 +25,7 @@ public:
 	virtual void OnGamePadChanged(const GamePadEventData *evt);
 };
 
-#define RPT_GAMEPAD_LEN	sizeof(GamePadEventData)/sizeof(uint8_t)
+#define RPT_GAMEPAD_LEN	sizeof(GamePadEventData)
 
 class JoystickReportParser : public HIDReportParser
 {

--- a/lib/usbhost/USB_Host_Shield_2.0/examples/HID/scale/scale_rptparser.h
+++ b/lib/usbhost/USB_Host_Shield_2.0/examples/HID/scale/scale_rptparser.h
@@ -38,7 +38,7 @@ public:
 	virtual void OnScaleChanged(const ScaleEventData *evt);
 };
 
-#define RPT_SCALE_LEN	sizeof(ScaleEventData)/sizeof(uint8_t)
+#define RPT_SCALE_LEN	sizeof(ScaleEventData)
 
 class ScaleReportParser : public HIDReportParser
 {

--- a/platforms/chibios/drivers/ws2812_spi.c
+++ b/platforms/chibios/drivers/ws2812_spi.c
@@ -200,9 +200,9 @@ void ws2812_setleds(LED_TYPE* ledarray, uint16_t leds) {
     // Instead spiSend can be used to send synchronously (or the thread logic can be added back).
 #ifndef WS2812_SPI_USE_CIRCULAR_BUFFER
 #    ifdef WS2812_SPI_SYNC
-    spiSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
+    spiSend(&WS2812_SPI, ARRAY_SIZE(txbuf), txbuf);
 #    else
-    spiStartSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
+    spiStartSend(&WS2812_SPI, ARRAY_SIZE(txbuf), txbuf);
 #    endif
 #endif
 }

--- a/platforms/chibios/drivers/ws2812_spi.c
+++ b/platforms/chibios/drivers/ws2812_spi.c
@@ -181,7 +181,7 @@ void ws2812_init(void) {
     spiStart(&WS2812_SPI, &spicfg); /* Setup transfer parameters.       */
     spiSelect(&WS2812_SPI);         /* Slave Select assertion.          */
 #ifdef WS2812_SPI_USE_CIRCULAR_BUFFER
-    spiStartSend(&WS2812_SPI, sizeof(txbuf) / sizeof(txbuf[0]), txbuf);
+    spiStartSend(&WS2812_SPI, ARRAY_SIZE(txbuf), txbuf);
 #endif
 }
 

--- a/quantum/backlight/backlight_driver_common.c
+++ b/quantum/backlight/backlight_driver_common.c
@@ -9,7 +9,7 @@
 #if defined(BACKLIGHT_PINS)
 static const pin_t backlight_pins[] = BACKLIGHT_PINS;
 #    ifndef BACKLIGHT_LED_COUNT
-#        define BACKLIGHT_LED_COUNT (sizeof(backlight_pins) / sizeof(pin_t))
+#        define BACKLIGHT_LED_COUNT ARRAY_SIZE(backlight_pins)
 #    endif
 
 #    define FOR_EACH_LED(x)                                 \

--- a/quantum/backlight/backlight_software.c
+++ b/quantum/backlight/backlight_software.c
@@ -26,7 +26,7 @@ static const uint16_t backlight_duty_table[] = {
     0b1110111011101110,
     0b1111111111111111,
 };
-#define backlight_duty_table_size (sizeof(backlight_duty_table) / sizeof(backlight_duty_table[0]))
+#define backlight_duty_table_size ARRAY_SIZE(backlight_duty_table)
 
 // clang-format on
 

--- a/quantum/dip_switch.c
+++ b/quantum/dip_switch.c
@@ -33,7 +33,7 @@
 #endif
 
 #ifdef DIP_SWITCH_PINS
-#    define NUMBER_OF_DIP_SWITCHES (sizeof(dip_switch_pad) / sizeof(pin_t))
+#    define NUMBER_OF_DIP_SWITCHES (ARRAY_SIZE(dip_switch_pad))
 static pin_t dip_switch_pad[] = DIP_SWITCH_PINS;
 #endif
 
@@ -43,7 +43,7 @@ typedef struct matrix_index_t {
     uint8_t col;
 } matrix_index_t;
 
-#    define NUMBER_OF_DIP_SWITCHES (sizeof(dip_switch_pad) / sizeof(matrix_index_t))
+#    define NUMBER_OF_DIP_SWITCHES (ARRAY_SIZE(dip_switch_pad))
 static matrix_index_t dip_switch_pad[] = DIP_SWITCH_MATRIX_GRID;
 extern bool           peek_matrix(uint8_t row_index, uint8_t col_index, bool read_raw);
 static uint16_t       scan_count;

--- a/quantum/encoder.h
+++ b/quantum/encoder.h
@@ -32,17 +32,17 @@ void encoder_state_raw(uint8_t* slave_state);
 void encoder_update_raw(uint8_t* slave_state);
 
 #    if defined(ENCODERS_PAD_A_RIGHT)
-#        define NUM_ENCODERS_LEFT (sizeof(((pin_t[])ENCODERS_PAD_A)) / sizeof(pin_t))
-#        define NUM_ENCODERS_RIGHT (sizeof(((pin_t[])ENCODERS_PAD_A_RIGHT)) / sizeof(pin_t))
+#        define NUM_ENCODERS_LEFT ARRAY_SIZE(((pin_t[])ENCODERS_PAD_A))
+#        define NUM_ENCODERS_RIGHT ARRAY_SIZE(((pin_t[])ENCODERS_PAD_A_RIGHT))
 #    else
-#        define NUM_ENCODERS_LEFT (sizeof(((pin_t[])ENCODERS_PAD_A)) / sizeof(pin_t))
+#        define NUM_ENCODERS_LEFT ARRAY_SIZE(((pin_t[])ENCODERS_PAD_A))
 #        define NUM_ENCODERS_RIGHT NUM_ENCODERS_LEFT
 #    endif
 #    define NUM_ENCODERS (NUM_ENCODERS_LEFT + NUM_ENCODERS_RIGHT)
 
 #else // SPLIT_KEYBOARD
 
-#    define NUM_ENCODERS (sizeof(((pin_t[])ENCODERS_PAD_A)) / sizeof(pin_t))
+#    define NUM_ENCODERS ARRAY_SIZE(((pin_t[])ENCODERS_PAD_A))
 #    define NUM_ENCODERS_LEFT NUM_ENCODERS
 #    define NUM_ENCODERS_RIGHT 0
 

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -58,7 +58,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
                     keycode = keycode & 0xFF;
                 }
 #    endif // LEADER_KEY_STRICT_KEY_PROCESSING
-                if (leader_sequence_size < (sizeof(leader_sequence) / sizeof(leader_sequence[0]))) {
+                if (leader_sequence_size < ARRAY_SIZE(leader_sequence)) {
                     leader_sequence[leader_sequence_size] = keycode;
                     leader_sequence_size++;
                 } else {

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -25,7 +25,7 @@ bool             unicode_saved_num_lock;
 
 #if UNICODE_SELECTED_MODES != -1
 static uint8_t selected[]     = {UNICODE_SELECTED_MODES};
-static int8_t  selected_count = sizeof selected / sizeof *selected;
+static int8_t  selected_count = ARRAY_SIZE(selected);
 static int8_t  selected_index;
 #endif
 

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -369,7 +369,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
 }
 
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
-    for (int i = 0; i < sizeof(rgb_matrix_ws2812_array) / sizeof(rgb_matrix_ws2812_array[0]); i++) {
+    for (int i = 0; i < ARRAY_SIZE(rgb_matrix_ws2812_array); i++) {
         setled(i, r, g, b);
     }
 }

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -3,6 +3,7 @@
 
 #include "secure.h"
 #include "timer.h"
+#include "util.h"
 
 #ifndef SECURE_UNLOCK_TIMEOUT
 #    define SECURE_UNLOCK_TIMEOUT 5000

--- a/quantum/secure.c
+++ b/quantum/secure.c
@@ -59,7 +59,7 @@ void secure_activity_event(void) {
 
 void secure_keypress_event(uint8_t row, uint8_t col) {
     static const uint8_t sequence[][2] = SECURE_UNLOCK_SEQUENCE;
-    static const uint8_t sequence_len  = sizeof(sequence) / sizeof(sequence[0]);
+    static const uint8_t sequence_len  = ARRAY_SIZE(sequence);
 
     static uint8_t offset = 0;
     if ((sequence[offset][0] == row) && (sequence[offset][1] == col)) {

--- a/quantum/util.h
+++ b/quantum/util.h
@@ -1,19 +1,7 @@
-/*
-Copyright 2011 Jun Wako <wakojun@gmail.com>
+// Copyright 2022 Stefan Kerkmann (KarlK90)
+// Copyright 2011 Jun Wako <wakojun@gmail.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
 #pragma once
 
 #include "bitwise.h"
@@ -28,4 +16,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if !defined(MAX)
 #    define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#endif
+
+#if !defined(CEILING)
+/**
+ * @brief Computes the rounded up result of a division of two integers at
+ * compile time.
+ */
+#    define CEILING(dividend, divisor) (((dividend) + (divisor)-1) / (divisor))
+#endif
+
+#if !defined(ARRAY_SIZE)
+/**
+ * @brief Computes the number of elements of the given array at compile time.
+ * This Macro can only be used for statically allocated arrays that have not
+ * been decayed into a pointer.
+ */
+#    define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 #endif

--- a/quantum/util.h
+++ b/quantum/util.h
@@ -26,11 +26,23 @@
 #    define CEILING(dividend, divisor) (((dividend) + (divisor)-1) / (divisor))
 #endif
 
+#if !defined(IS_ARRAY)
+/**
+ * @brief Returns true if the value is an array, false if it's a pointer.
+ *
+ * This macro is ill-formed for scalars, which is OK for its intended use in
+ * ARRAY_SIZE.
+ */
+#    define IS_ARRAY(value) (!__builtin_types_compatible_p(typeof((value)), typeof(&(value)[0])))
+#endif
+
 #if !defined(ARRAY_SIZE)
 /**
  * @brief Computes the number of elements of the given array at compile time.
+ *
  * This Macro can only be used for statically allocated arrays that have not
- * been decayed into a pointer.
+ * been decayed into a pointer. This is detected at compile time, though the
+ * error message for scalar values is poor.
  */
-#    define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+#    define ARRAY_SIZE(array) (__builtin_choose_expr(IS_ARRAY((array)), sizeof((array)) / sizeof((array)[0]), (void)0))
 #endif

--- a/tmk_core/protocol/arm_atsam/md_rgb_matrix_programs.c
+++ b/tmk_core/protocol/arm_atsam/md_rgb_matrix_programs.c
@@ -95,7 +95,7 @@ led_setup_t leds_rainbow_s[] = {
 
 void *led_setups[] = {leds_rainbow_s, leds_rainbow_ns, leds_teal_salmon, leds_yellow, leds_red, leds_green, leds_blue, leds_white, leds_white_with_red_stripe, leds_black_with_red_stripe, leds_off};
 
-const uint8_t led_setups_count = sizeof(led_setups) / sizeof(led_setups[0]);
+const uint8_t led_setups_count = ARRAY_SIZE(led_setups);
 
 #    endif // USE_MASSDROP_CONFIGURATOR
 #endif     // RGB_MATRIX_ENABLE

--- a/users/brandonschlack/rgb_bs.c
+++ b/users/brandonschlack/rgb_bs.c
@@ -75,7 +75,7 @@ void rgb_theme_step_reverse(void) {
 
 rgb_theme_color_t get_rgb_theme_color(uint8_t index) {
     rgb_theme_t theme = get_rgb_theme();
-    size_t rgb_theme_color_max = sizeof theme.colors / sizeof *theme.colors;
+    size_t rgb_theme_color_max = ARRAY_SIZE(theme.colors);
 
     if (index == _ADJUST) {
         return default_adjust;

--- a/users/curry/oled.c
+++ b/users/curry/oled.c
@@ -41,7 +41,7 @@ void add_keylog(uint16_t keycode) {
         keylog_str[i] = keylog_str[i - 1];
     }
 
-    if (keycode < (sizeof(code_to_name) / sizeof(char))) {
+    if (keycode < ARRAY_SIZE(code_to_name)) {
         keylog_str[0] = pgm_read_byte(&code_to_name[keycode]);
     }
 

--- a/users/davidkristoffersen/util/functions.c
+++ b/users/davidkristoffersen/util/functions.c
@@ -33,14 +33,14 @@ code_set_t EN_SHIFT_CODES [] = {
 const shift_code_t SHIFT_CODES [] = {
 #ifdef LAYER_NO
     {.lang = LAYER_NO,
-     .size = ARR_LEN(NO_SHIFT_CODES),
+     .size = ARRAY_SIZE(NO_SHIFT_CODES),
      .codes = NO_SHIFT_CODES},
 #endif
     {.lang = LAYER_EN,
-     .size = ARR_LEN(EN_SHIFT_CODES),
+     .size = ARRAY_SIZE(EN_SHIFT_CODES),
      .codes = EN_SHIFT_CODES},
 };
-const int SHIFT_CODES_SIZE = ARR_LEN(SHIFT_CODES);
+const int SHIFT_CODES_SIZE = ARRAY_SIZE(SHIFT_CODES);
 #endif
 
 #ifdef LAYER_NO
@@ -72,7 +72,7 @@ const code_set_t EN2NO_CODES [] = {
     {KC_DLR,  NO_DLR},
     {KC_GRV,  NO_GRV}
 };
-const int EN2NO_CODES_SIZE = ARR_LEN(EN2NO_CODES);
+const int EN2NO_CODES_SIZE = ARRAY_SIZE(EN2NO_CODES);
 #endif
 
 // Check if layer is an active default layer

--- a/users/davidkristoffersen/util/functions.h
+++ b/users/davidkristoffersen/util/functions.h
@@ -15,8 +15,6 @@
 
 // Return false if test equal false
 #define HANDLE_FALSE(bool) if (!bool) return false;
-// Generic array lenght define
-#define ARR_LEN(arr) ARRAY_SIZE((arr))
 // Printf-like functionality for send_string
 #define SEND_VAR(str, ...) \
     do { \

--- a/users/davidkristoffersen/util/functions.h
+++ b/users/davidkristoffersen/util/functions.h
@@ -16,7 +16,7 @@
 // Return false if test equal false
 #define HANDLE_FALSE(bool) if (!bool) return false;
 // Generic array lenght define
-#define ARR_LEN(arr) (sizeof(arr) / sizeof(arr)[0])
+#define ARR_LEN(arr) ARRAY_SIZE((arr))
 // Printf-like functionality for send_string
 #define SEND_VAR(str, ...) \
     do { \

--- a/users/drashna/keyrecords/tap_dance.md
+++ b/users/drashna/keyrecords/tap_dance.md
@@ -88,7 +88,7 @@ void diablo_tapdance_master(qk_tap_dance_state_t *state, void *user_data) {
     diablo_timer[diablo_keys->index].keycode = diablo_keys->keycode;
 
     // if the tapdance is hit more than the number of elemints in the array, reset
-    if (state->count >= (sizeof(diablo_times) / sizeof(uint8_t) ) ) {
+    if (state->count >= ARRAY_SIZE(diablo_times) ) {
         diablo_timer[diablo_keys->index].key_interval = 0;
         reset_tap_dance(state);
     }  else { // else set the interval (tapdance count starts at 1, array starts at 0, so offset by one)

--- a/users/drashna/keyrecords/tap_dances.c
+++ b/users/drashna/keyrecords/tap_dances.c
@@ -23,7 +23,7 @@ void diablo_tapdance_master(qk_tap_dance_state_t *state, void *user_data) {
     diablo_timer[diablo_keys->index].keycode = diablo_keys->keycode;
 
     // if the tapdance is hit more than the number of elemints in the array, reset
-    if (state->count >= (sizeof(diablo_times) / sizeof(uint8_t))) {
+    if (state->count >= ARRAY_SIZE(diablo_times)) {
         diablo_timer[diablo_keys->index].key_interval = 0;
         reset_tap_dance(state);
     } else { // else set the interval (tapdance count starts at 1, array starts at 0, so offset by one)

--- a/users/drashna/keyrecords/unicode.c
+++ b/users/drashna/keyrecords/unicode.c
@@ -43,7 +43,7 @@ typedef uint32_t (*translator_function_t)(bool is_shifted, uint32_t keycode);
     static inline uint32_t translator_name(bool is_shifted, uint32_t keycode) { \
         static const uint32_t translation[] = {__VA_ARGS__};                    \
         uint32_t              ret           = keycode;                          \
-        if ((keycode - KC_A) < (sizeof(translation) / sizeof(uint32_t))) {      \
+        if ((keycode - KC_A) < ARRAY_SIZE(translation)) {      \
             ret = translation[keycode - KC_A];                                  \
         }                                                                       \
         return ret;                                                             \

--- a/users/drashna/oled/oled_stuff.c
+++ b/users/drashna/oled/oled_stuff.c
@@ -87,7 +87,7 @@ void add_keylog(uint16_t keycode, keyrecord_t *record) {
 
     memmove(keylog_str, keylog_str + 1, OLED_KEYLOGGER_LENGTH - 1);
 
-    if (keycode < (sizeof(code_to_name) / sizeof(char))) {
+    if (keycode < ARRAY_SIZE(code_to_name)) {
         keylog_str[(OLED_KEYLOGGER_LENGTH - 1)] = pgm_read_byte(&code_to_name[keycode]);
     }
 

--- a/users/gourdo1/gourdo1.h
+++ b/users/gourdo1/gourdo1.h
@@ -17,9 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-// DEFINE MACROS
-#define ARRAYSIZE(arr) sizeof(arr) / sizeof(arr[0])
-
 // LAYERS -- Note: to avoid compile problems, make sure total layers matches DYNAMIC_KEYMAP_LAYER_COUNT defined in config.h (where _COLEMAK layer is defined)
 enum custom_user_layers {
     _BASE,

--- a/users/jonavin/jonavin.h
+++ b/users/jonavin/jonavin.h
@@ -17,9 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-// DEFINE MACROS
-#define ARRAYSIZE(arr)  sizeof(arr)/sizeof(arr[0])
-
 
 // LAYERS
 enum custom_user_layers {

--- a/users/spidey3/layer_rgb.c
+++ b/users/spidey3/layer_rgb.c
@@ -97,7 +97,7 @@ const rgblight_segment_t *const PROGMEM _rgb_layers[] = {
 
 // clang-format on
 
-const uint8_t PROGMEM _n_rgb_layers = sizeof(_rgb_layers) / sizeof(_rgb_layers[0]) - 1;
+const uint8_t PROGMEM _n_rgb_layers = ARRAY_SIZE(_rgb_layers) - 1;
 
 void clear_rgb_layers() {
     for (uint8_t i = 0; i < _n_rgb_layers; i++) {

--- a/users/uqs/uqs.c
+++ b/users/uqs/uqs.c
@@ -78,9 +78,9 @@ const rgblight_segment_t* const PROGMEM my_rgb_layers[] = {
     my_rgb_segments[L_MOUSE],
 };
 
-_Static_assert(sizeof(my_rgb_layers) / sizeof(my_rgb_layers[0]) ==
-        sizeof(my_rgb_segments) / sizeof(my_rgb_segments[0]),
-        "Number of rgb_segment definitions does not match up!");
+_Static_assert(ARRAY_SIZE(my_rgb_layers) ==
+	       ARRAY_SIZE(my_rgb_segments),
+	       "Number of rgb_segment definitions does not match up!");
 #endif
 
 #ifdef COMBO_ENABLE
@@ -125,7 +125,7 @@ const uint16_t PROGMEM my_combos[][4] = {
     {KC_BTN1, KC_BTN2, KC_BTN3, COMBO_END},
 };
 
-const uint16_t COMBO_LEN = sizeof(my_action_combos) / sizeof(my_action_combos[0]) + sizeof(my_combos) / sizeof(my_combos[0]);
+const uint16_t COMBO_LEN = ARRAY_SIZE(my_action_combos) + ARRAY_SIZE(my_combos);
 
 #define MY_ACTION_COMBO(ck) \
     [ck] = { .keys = &(my_action_combos[ck][0]) }
@@ -162,11 +162,11 @@ combo_t key_combos[] = {
   MY_COMBO(14),
 };
 
-_Static_assert(sizeof(key_combos) / sizeof(key_combos[0]) ==
-        (sizeof(my_action_combos) / sizeof(my_action_combos[0]) + sizeof(my_combos) / sizeof(my_combos[0])),
-        "Number of combo definitions does not match up!");
+_Static_assert(ARRAY_SIZE(key_combos) ==
+	       (ARRAY_SIZE(my_action_combos) + ARRAY_SIZE(my_combos)),
+	       "Number of combo definitions does not match up!");
 #else
-combo_t key_combos[sizeof(my_action_combos) / sizeof(my_action_combos[0]) + sizeof(my_combos) / sizeof(my_combos[0])];
+combo_t key_combos[ARRAY_SIZE(my_action_combos) + ARRAY_SIZE(my_combos)];
 #endif
 
 void process_combo_event(uint16_t combo_index, bool pressed) {
@@ -235,10 +235,10 @@ void keyboard_post_init_user(void) {
 #endif
 #if defined(COMBO_ENABLE) && !defined(COMBO_STATICALLY)
     uint8_t i = 0;
-    for (; i < sizeof(my_action_combos) / sizeof(my_action_combos[0]); i++) {
+    for (; i < ARRAY_SIZE(my_action_combos); i++) {
         key_combos[i].keys = &(my_action_combos[i][0]);
     }
-    for (uint8_t j = 0; j < sizeof(my_combos) / sizeof(my_combos[0]); j++, i++) {
+    for (uint8_t j = 0; j < ARRAY_SIZE(my_combos); j++, i++) {
         key_combos[i].keycode = my_combos[j][0];
         key_combos[i].keys = &(my_combos[j][1]);
     }


### PR DESCRIPTION
While commenting on #18006 I noted that the project didn't have a common macro for implementing compile time array size computation, which was instead done at each site "in the usual way".

This PR takes the change from #18006 for `quantum/util.h`, then uses a "semantic patch" to change sites that could be identified automatically to use the new construct.  The semantic patch was simply taken from https://github.com/alterapraxisptyltd/coccinelle-coreboot/blob/master/ARRAY_SIZE.cocci -- I did not develop it myself.

Then, a few straggling items I identified were fixed manually.

I took the two added macros in `util.h` in the hopes that it would allow git to see that #18006 and this PR do not conflict.  It's worth noting that coreboot also has a semantic patch to convert sites that should have used a CEILING-type macro, that could be fun to run next if the project deems these kinds of changes worthwhile.