### PR TITLE
Remove duplicate COMBINING HORN in keymap_us_extended.h

### DIFF
--- a/quantum/keymap_extras/keymap_us_extended.h
+++ b/quantum/keymap_extras/keymap_us_extended.h
@@ -145,7 +145,7 @@
 #define US_CURR ALGR(US_4)    // ¤
 #define US_EURO ALGR(US_5)    // €
 #define US_DCIR ALGR(US_6)    // ^ (dead)
-#define US_HORN ALGR(US_7)    // ̛̛  (dead)
+#define US_HORN ALGR(US_7)    // ̛  (dead)
 #define US_OGON ALGR(US_8)    // ˛ (dead)
 #define US_LSQU ALGR(US_9)    // ‘
 #define US_RSQU ALGR(US_0)    // ’


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is another one of those PRs where you can't see any difference in the diff, sorry.

```py
[ins] In [29]: import unicodedata as uc

[ins] In [30]: before = "// ̛̛  (dead)"

[ins] In [31]: after = "// ̛  (dead)"

[ins] In [32]: list(map(uc.name, before))
Out[32]: 
['SOLIDUS',
 'SOLIDUS',
 'SPACE',
 'COMBINING HORN',
 'COMBINING HORN',
 'SPACE',
 'SPACE',
 'LEFT PARENTHESIS',
 'LATIN SMALL LETTER D',
 'LATIN SMALL LETTER E',
 'LATIN SMALL LETTER A',
 'LATIN SMALL LETTER D',
 'RIGHT PARENTHESIS']

[ins] In [33]: list(map(uc.name, after))
Out[33]: 
['SOLIDUS',
 'SOLIDUS',
 'SPACE',
 'COMBINING HORN',
 'SPACE',
 'SPACE',
 'LEFT PARENTHESIS',
 'LATIN SMALL LETTER D',
 'LATIN SMALL LETTER E',
 'LATIN SMALL LETTER A',
 'LATIN SMALL LETTER D',
 'RIGHT PARENTHESIS']

[ins] In [34]: horn_comment_from_keymap_bepo = "// ̛  (dead)"

[ins] In [35]: list(map(uc.name, horn_comment_from_keymap_bepo))
Out[35]: 
['SOLIDUS',
 'SOLIDUS',
 'SPACE',
 'COMBINING HORN',
 'SPACE',
 'SPACE',
 'LEFT PARENTHESIS',
 'LATIN SMALL LETTER D',
 'LATIN SMALL LETTER E',
 'LATIN SMALL LETTER A',
 'LATIN SMALL LETTER D',
 'RIGHT PARENTHESIS']
```

I care about this invisible change because as a part of [adding support for intl/locale legends to QMK configurator](https://github.com/qmk/qmk_configurator/pull/1161), I wrote a script that converts keymap_extras header files from qmk_firmware into JS objects that the QMK configurator can use to display the correct key legends. For display purposes, as is the standard, [I combine diacritics with the dotted circle (◌)](https://github.com/qmk/qmk_configurator/blob/7a22895efe2fdd8c82fe6c45f344e98e883bb772/src/i18n/keymap_extras/convert_keymap_extras_header.js#L161...L173) but if there are two combining diacritics, then two dotted circles are displayed; not desirable.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization (as in better comments)
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
