### PR TITLE
ADB to USB converter: split into rev1 and rev2

### DIFF
--- a/keyboards/converter/adb_usb/readme.md
+++ b/keyboards/converter/adb_usb/readme.md
@@ -51,16 +51,8 @@ Keymap
 ------
 To build the default keymap run this command:
 
-    $ make converter/adb_usb:default
-
-You may add your own keymap to the converter/adb_usb/keymaps directory, as you would with any other QMK-powered keyboard.
-
-To build your custom keymap, change the build command to:
-
-    $ make converter/adb_usb:my_keymap
-
-Where 'my_keymap' is the name of your custom keymap directory.
-
+    $ make converter/adb_usb/rev1:default # Pro Micro-based
+    $ make converter/adb_usb/rev2:default # Hasu 32U2 PCB
 
 Locking Caps Lock
 ----------------

--- a/keyboards/converter/adb_usb/rev1/rules.mk
+++ b/keyboards/converter/adb_usb/rev1/rules.mk
@@ -1,0 +1,5 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+BOOTLOADER = caterina

--- a/keyboards/converter/adb_usb/rev2/rules.mk
+++ b/keyboards/converter/adb_usb/rev2/rules.mk
@@ -1,0 +1,5 @@
+# MCU name
+MCU = atmega32u2
+
+# Bootloader selection
+BOOTLOADER = atmel-dfu

--- a/keyboards/converter/adb_usb/rules.mk
+++ b/keyboards/converter/adb_usb/rules.mk
@@ -1,23 +1,19 @@
-# MCU name
-MCU = atmega32u4
-
-# Bootloader selection
-BOOTLOADER = caterina
-
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = no       # Enable Bootmagic Lite
-MOUSEKEY_ENABLE  = no   # Mouse keys
-CONSOLE_ENABLE   = no   # Console for debug
-COMMAND_ENABLE   = no   # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-EXTRAKEY_ENABLE  = yes
-USB_HID_ENABLE   = yes
-BACKLIGHT_ENABLE = no
-CUSTOM_MATRIX    = yes
+BOOTMAGIC_ENABLE = no        # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = no         # Mouse keys
+EXTRAKEY_ENABLE = yes        # Audio control and System control
+CONSOLE_ENABLE = no          # Console for debug
+COMMAND_ENABLE = no          # Commands for debug and configuration
+NKRO_ENABLE = no             # Enable N-Key Rollover
+BACKLIGHT_ENABLE = no        # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = no         # Enable keyboard RGB underglow
+AUDIO_ENABLE = no            # Audio output
+CUSTOM_MATRIX = yes
 
-SRC = matrix.c adb.c led.c
+SRC += matrix.c adb.c led.c
 
-# ADB_MOUSE_ENABLE
 # OPT_DEFS += -DADB_MOUSE_ENABLE -DMOUSE_ENABLE
+
+DEFAULT_FOLDER = converter/adb_usb/rev1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Removed erroneous `USB_HID_ENABLE` rule. Split into rev1 and rev2 for Pro Micro and Hasu PCB versions.

https://geekhack.org/index.php?topic=14290.0

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
