### PR TITLE
Fix mouse report comparison failing on shared EP (fixes KB preventing sleep)

### DIFF
--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -169,10 +169,6 @@ __attribute__((weak)) void pointing_device_send(void) {
     uint8_t buttons = local_mouse_report.buttons;
     memset(&local_mouse_report, 0, sizeof(local_mouse_report));
     local_mouse_report.buttons = buttons;
-#if defined(SPLIT_POINTING_ENABLE)
-    memset(&shared_mouse_report, 0, sizeof(shared_mouse_report));
-    shared_mouse_report.buttons = buttons;
-#endif
     memcpy(&old_report, &local_mouse_report, sizeof(local_mouse_report));
 }
 

--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -166,11 +166,13 @@ __attribute__((weak)) void pointing_device_send(void) {
         host_mouse_send(&local_mouse_report);
     }
     // send it and 0 it out except for buttons, so those stay until they are explicity over-ridden using update_pointing_device
-    local_mouse_report.x = 0;
-    local_mouse_report.y = 0;
-    local_mouse_report.v = 0;
-    local_mouse_report.h = 0;
-
+    uint8_t buttons = local_mouse_report.buttons;
+    memset(&local_mouse_report, 0, sizeof(local_mouse_report));
+    local_mouse_report.buttons = buttons;
+#if defined(SPLIT_POINTING_ENABLE)
+    memset(&shared_mouse_report, 0, sizeof(shared_mouse_report));
+    shared_mouse_report.buttons = buttons;
+#endif
     memcpy(&old_report, &local_mouse_report, sizeof(local_mouse_report));
 }
 


### PR DESCRIPTION
Reset report ID that gets changed when sending mouse report to host.

## Description

Properly reset the in-memory mouse report, so that it's not sent all the time. Current behavior prevents power saving on host.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
