### PR TITLE
[Bug] Add key event check to `is_tap_record` and remove `is_tap_key`

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -1099,6 +1099,10 @@ bool is_tap_key(keypos_t key) {
  * FIXME: Needs documentation.
  */
 bool is_tap_record(keyrecord_t *record) {
+    if (IS_NOEVENT(record->event)) {
+        return false;
+    }
+
 #ifdef COMBO_ENABLE
     action_t action;
     if (record->keycode) {

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -1089,15 +1089,6 @@ void clear_keyboard_but_mods_and_keys() {
  *
  * FIXME: Needs documentation.
  */
-bool is_tap_key(keypos_t key) {
-    action_t action = layer_switch_get_action(key);
-    return is_tap_action(action);
-}
-
-/** \brief Utilities for actions. (FIXME: Needs better description)
- *
- * FIXME: Needs documentation.
- */
 bool is_tap_record(keyrecord_t *record) {
     if (IS_NOEVENT(record->event)) {
         return false;

--- a/quantum/action.h
+++ b/quantum/action.h
@@ -105,7 +105,6 @@ void clear_keyboard(void);
 void clear_keyboard_but_mods(void);
 void clear_keyboard_but_mods_and_keys(void);
 void layer_switch(uint8_t new_layer);
-bool is_tap_key(keypos_t key);
 bool is_tap_record(keyrecord_t *record);
 bool is_tap_action(action_t action);
 

--- a/tests/tap_hold_configurations/default_mod_tap/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/default_mod_tap/test_tap_hold.cpp
@@ -140,8 +140,6 @@ TEST_F(DefaultTapHold, tap_regular_key_while_layer_tap_key_is_held) {
 }
 
 TEST_F(DefaultTapHold, tap_mod_tap_hold_key_two_times) {
-    GTEST_SKIP() << "TODO:Holding a modtap key results in out of bounds access to the keymap, this is a bug in QMK.";
-
     TestDriver driver;
     InSequence s;
     auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
@@ -175,8 +173,6 @@ TEST_F(DefaultTapHold, tap_mod_tap_hold_key_two_times) {
 }
 
 TEST_F(DefaultTapHold, tap_mod_tap_hold_key_twice_and_hold_on_second_time) {
-    GTEST_SKIP() << "TODO:Holding a modtap key results in out of bounds access to the keymap, this is a bug in QMK.";
-
     TestDriver driver;
     InSequence s;
     auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));


### PR DESCRIPTION
## Description

...as it is called with tick events and this would generate out of bound access `(col: 255, row: 255)` in keymaps in `keymap_key_to_keycode` though #13619 [add a mitigation.](https://github.com/tzarc/qmk_firmware/blob/46862e196f8e8cfd40e3e60599595816a751001d/quantum/keymap_common.c#L150-L162). Unit-tests that previously failed are enabled again.

`is_tap_key` is removed as well because it is not used in the code base and subject to the same bug.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Out of bounds access of keymaps when tapping keys are held longer then one iteration.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
