### PR TITLE
Add via support for 6key

### DIFF
--- a/keyboards/handwired/6key/6key.h
+++ b/keyboards/handwired/6key/6key.h
@@ -17,7 +17,7 @@
 
 #include "quantum.h"
 
-#define LAYOUT_all( \
+#define LAYOUT( \
       k00, k01, k02,    \
       k03, k04, k05     \
 ) \

--- a/keyboards/handwired/6key/6key.h
+++ b/keyboards/handwired/6key/6key.h
@@ -1,27 +1,27 @@
- /* Copyright 2020 Bratzworth 
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ /* Copyright 2020 Bratzworth
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 #pragma once
 
 #include "quantum.h"
 
-#define LAYOUT( \
+#define LAYOUT_all( \
       k00, k01, k02,    \
       k03, k04, k05     \
 ) \
 { \
     { k00, k01, k02 },  \
     { k03, k04, k05 }   \
-} 
+}

--- a/keyboards/handwired/6key/config.h
+++ b/keyboards/handwired/6key/config.h
@@ -18,14 +18,6 @@
 
 #include "config_common.h"
 
-/* USB Device descriptor parameter */
-#define VENDOR_ID       0xD143
-#define PRODUCT_ID      0x0007
-#define DEVICE_VER      0x0002
-
-#define MANUFACTURER    bratzworth
-#define PRODUCT         6key
-
 /* key matrix size */
 #define MATRIX_ROWS 2
 #define MATRIX_COLS 3

--- a/keyboards/handwired/6key/config.h
+++ b/keyboards/handwired/6key/config.h
@@ -1,22 +1,30 @@
- /* Copyright 2020 Bratzworth 
-  * 
-  * This program is free software: you can redistribute it and/or modify 
-  * it under the terms of the GNU General Public License as published by 
-  * the Free Software Foundation, either version 2 of the License, or 
-  * (at your option) any later version. 
-  * 
-  * This program is distributed in the hope that it will be useful, 
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of 
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-  * GNU General Public License for more details. 
-  * 
-  * You should have received a copy of the GNU General Public License 
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ /* Copyright 2020 Bratzworth
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
 
 #pragma once
 
 #include "config_common.h"
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xD143
+#define PRODUCT_ID      0x0007
+#define DEVICE_VER      0x0002
+
+#define MANUFACTURER    bratzworth
+#define PRODUCT         6key
 
 /* key matrix size */
 #define MATRIX_ROWS 2

--- a/keyboards/handwired/6key/info.json
+++ b/keyboards/handwired/6key/info.json
@@ -6,7 +6,7 @@
     "usb": {
       "vid": "0xD143",
       "pid": "0x0007",
-      "device_version": "0.0.2"
+      "device_version": "0.0.1"
     },
     "layouts": {
       "LAYOUT_all": {

--- a/keyboards/handwired/6key/info.json
+++ b/keyboards/handwired/6key/info.json
@@ -9,7 +9,7 @@
       "device_version": "0.0.1"
     },
     "layouts": {
-      "LAYOUT_all": {
+      "LAYOUT": {
         "layout": [
             {"label":"k00", "x":0, "y":0}, {"label":"k01", "x":1, "y":0}, {"label":"k02", "x":2, "y":0},
             {"label":"k10", "x":0, "y":1}, {"label":"k11", "x":1, "y":1}, {"label":"k12", "x":2, "y":1}

--- a/keyboards/handwired/6key/info.json
+++ b/keyboards/handwired/6key/info.json
@@ -1,16 +1,19 @@
 {
     "keyboard_name": "6key",
-    "manufacturer": "Bratzworth",
+    "manufacturer": "bratzworth",
     "url": "https://github.com/Bratzworth/6key",
     "maintainer": "bratzworth",
     "usb": {
-      "vid": "0xBEED",
+      "vid": "0xD143",
       "pid": "0x0007",
-      "device_version": "0.0.1"
+      "device_version": "0.0.2"
     },
     "layouts": {
-      "LAYOUT": {
-        "layout": [{"label":"k00", "x":0, "y":0}, {"label":"k01", "x":1, "y":0}, {"label":"k02", "x":2, "y":0}, {"label":"k10", "x":0, "y":1}, {"label":"k11", "x":1, "y":1}, {"label":"k12", "x":2, "y":1}]
+      "LAYOUT_all": {
+        "layout": [
+            {"label":"k00", "x":0, "y":0}, {"label":"k01", "x":1, "y":0}, {"label":"k02", "x":2, "y":0},
+            {"label":"k10", "x":0, "y":1}, {"label":"k11", "x":1, "y":1}, {"label":"k12", "x":2, "y":1}
+        ]
       }
     }
   }

--- a/keyboards/handwired/6key/keymaps/default/keymap.c
+++ b/keyboards/handwired/6key/keymaps/default/keymap.c
@@ -25,7 +25,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_Z, KC_Y, KC_A,
     KC_C, KC_D, KC_S
   ),
-  [_FN] = LAYOUT_all(
+  [_FN] = LAYOUT(
     KC_F13, KC_F14, KC_F15,
     KC_F16, KC_F17, KC_F18
   )

--- a/keyboards/handwired/6key/keymaps/default/keymap.c
+++ b/keyboards/handwired/6key/keymaps/default/keymap.c
@@ -21,7 +21,7 @@ enum layers{
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_MAIN] = LAYOUT_all(
+  [_MAIN] = LAYOUT(
     KC_Z, KC_Y, KC_A,
     KC_C, KC_D, KC_S
   ),

--- a/keyboards/handwired/6key/keymaps/default/keymap.c
+++ b/keyboards/handwired/6key/keymaps/default/keymap.c
@@ -20,13 +20,10 @@ enum layers{
   _FN
 };
 
-#define KC_UNDO LCTL(KC_Z)
-#define KC_REDO LCTL(KC_Y)
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [_MAIN] = LAYOUT_all(
-    LCTL(KC_Z), LCTL(KC_Y), KC_A,
-    KC_C,       KC_D,       KC_S
+    KC_Z, KC_Y, KC_A,
+    KC_C, KC_D, KC_S
   ),
   [_FN] = LAYOUT_all(
     KC_F13, KC_F14, KC_F15,

--- a/keyboards/handwired/6key/keymaps/default/keymap.c
+++ b/keyboards/handwired/6key/keymaps/default/keymap.c
@@ -15,33 +15,21 @@
   */
 #include QMK_KEYBOARD_H
 
-#define _MAIN 0
-#define _FN 1
+enum layers{
+  _MAIN,
+  _FN
+};
 
 #define KC_UNDO LCTL(KC_Z)
 #define KC_REDO LCTL(KC_Y)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_MAIN] = LAYOUT(
-    KC_UNDO,  KC_REDO,  KC_A,
-    KC_C,     KC_D,     KC_S
+  [_MAIN] = LAYOUT_all(
+    LCTL(KC_Z), LCTL(KC_Y), KC_A,
+    KC_C,       KC_D,       KC_S
   ),
-
-  [_FN] = LAYOUT(
+  [_FN] = LAYOUT_all(
     KC_F13, KC_F14, KC_F15,
     KC_F16, KC_F17, KC_F18
   )
 };
-
-bool dip_switch_update_user(uint8_t index, bool active) {
-    switch (index) {
-        case 0: {
-            if (active) {
-                set_single_persistent_default_layer(_FN);
-            } else {
-                set_single_persistent_default_layer(_MAIN);
-            }
-        }
-    }
-    return true;
-}

--- a/keyboards/handwired/6key/keymaps/default/readme.md
+++ b/keyboards/handwired/6key/keymaps/default/readme.md
@@ -1,1 +1,0 @@
-# The default keymap for the 6key

--- a/keyboards/handwired/6key/keymaps/default/readme.md
+++ b/keyboards/handwired/6key/keymaps/default/readme.md
@@ -1,0 +1,1 @@
+# The default keymap for the 6key

--- a/keyboards/handwired/6key/keymaps/via/keymap.c
+++ b/keyboards/handwired/6key/keymaps/via/keymap.c
@@ -15,25 +15,20 @@
   */
 #include QMK_KEYBOARD_H
 
-enum layers{
-  _MAIN,
-  _FN,
-};
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_MAIN] = LAYOUT_all(
+    [0] = LAYOUT(
         LCTL(KC_Z), LCTL(KC_Y), KC_A,
         KC_C,       KC_D,       KC_S
     ),
-    [_FN] = LAYOUT_all(
+    [1] = LAYOUT(
         KC_F13, KC_F14, KC_F15,
         KC_F16, KC_F17, KC_F18
     ),
-    [2] = LAYOUT_all(
+    [2] = LAYOUT(
         KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS
         ),
-    [3] = LAYOUT_all(
+    [3] = LAYOUT(
         KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS
         ),

--- a/keyboards/handwired/6key/keymaps/via/keymap.c
+++ b/keyboards/handwired/6key/keymaps/via/keymap.c
@@ -1,4 +1,4 @@
- /* Copyright 2020 Bratzworth
+ /* Copyright 2022 Bratzworth
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License as published by
@@ -13,12 +13,28 @@
   * You should have received a copy of the GNU General Public License
   * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   */
-#include "6key.h"
+#include QMK_KEYBOARD_H
 
-bool dip_switch_update_kb(uint8_t index, bool active) {
-    if (!dip_switch_update_user(index, active)) { return false; }
-    if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
-    }
-    return true;
-}
+enum layers{
+  _MAIN,
+  _FN,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_MAIN] = LAYOUT_all(
+        LCTL(KC_Z), LCTL(KC_Y), KC_A,
+        KC_C,       KC_D,       KC_S
+    ),
+    [_FN] = LAYOUT_all(
+        KC_F13, KC_F14, KC_F15,
+        KC_F16, KC_F17, KC_F18
+    ),
+    [2] = LAYOUT_all(
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS
+        ),
+    [3] = LAYOUT_all(
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS
+        ),
+};

--- a/keyboards/handwired/6key/keymaps/via/readme.md
+++ b/keyboards/handwired/6key/keymaps/via/readme.md
@@ -1,1 +1,0 @@
-# The via keymap for the 6key

--- a/keyboards/handwired/6key/keymaps/via/readme.md
+++ b/keyboards/handwired/6key/keymaps/via/readme.md
@@ -1,0 +1,1 @@
+# The via keymap for the 6key

--- a/keyboards/handwired/6key/keymaps/via/rules.mk
+++ b/keyboards/handwired/6key/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes

--- a/keyboards/handwired/6key/rules.mk
+++ b/keyboards/handwired/6key/rules.mk
@@ -8,7 +8,7 @@ BOOTLOADER = caterina
 #   change yes to no to disable
 #
 BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
+MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug
 COMMAND_ENABLE = no         # Commands for debug and configuration

--- a/keyboards/handwired/6key/rules.mk
+++ b/keyboards/handwired/6key/rules.mk
@@ -7,8 +7,8 @@ BOOTLOADER = caterina
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = no       # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug
 COMMAND_ENABLE = no         # Commands for debug and configuration


### PR DESCRIPTION
Adds via support for the 6key macropad

## Description

Adds a new keymap to the 6key macropad, and moves the dip switch configuration from the default keymap to `6key.c`. As a part of adding VIA support the vendor id was changed to be unique.

Also appropriately updates all references from LAYOUT to LAYOUT_all.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
