### PR TITLE
Use `TAP_CODE_DELAY` for encoder mapping by default. Add docs.

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -88,6 +88,14 @@ const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
 #endif
 ```
 
+Using encoder mapping pumps events through the normal QMK keycode processing pipeline, resulting in a _keydown/keyup_ combination pushed through `process_record_xxxxx()`. To configure the amount of time between the encoder "keyup" and "keydown", you can add the following to your `config.h`:
+
+```c
+#define ENCODER_MAP_KEY_DELAY 10
+```
+
+?> By default, the encoder map delay matches the value of `TAP_CODE_DELAY`.
+
 ## Callbacks
 
 When not using `ENCODER_MAP_ENABLE = yes`, the callback functions can be inserted into your `<keyboard>.c`:
@@ -119,7 +127,7 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 }
 ```
 
-!> If you return `true`, it will allow the keyboard level code to run as well. Returning `false` will override the keyboard level code, depending on how the keyboard function is set up. 
+!> If you return `true`, it will allow the keyboard level code to run as well. Returning `false` will override the keyboard level code, depending on how the keyboard function is set up.
 
 Layer conditions can also be used with the callback function like the following:
 
@@ -172,7 +180,7 @@ The A an B lines of the encoders should be wired directly to the MCU, and the C/
 Multiple encoders may share pins so long as each encoder has a distinct pair of pins when the following conditions are met:
 - using detent encoders
 - pads must be high at the detent stability point which is called 'default position' in QMK
-- no more than two encoders sharing a pin can be turned at the same time 
+- no more than two encoders sharing a pin can be turned at the same time
 
 For example you can support two encoders using only 3 pins like this
 ```
@@ -185,4 +193,4 @@ You could even support three encoders using only three pins (one per encoder) ho
 #define ENCODERS_PAD_A { B1, B1, B2 }
 #define ENCODERS_PAD_B { B2, B3, B3 }
 ```
-Here rotating Encoder 0 `B1 B2` and Encoder 1 `B1 B3` could be interpreted as rotating Encoder 2 `B2 B3` or `B3 B2` depending on the timing. This may still be a useful configuration depending on your use case 
+Here rotating Encoder 0 `B1 B2` and Encoder 1 `B1 B3` could be interpreted as rotating Encoder 2 `B2 B3` or `B3 B2` depending on the timing. This may still be a useful configuration depending on your use case

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -24,7 +24,8 @@
 #include <string.h>
 
 #ifndef ENCODER_MAP_KEY_DELAY
-#    define ENCODER_MAP_KEY_DELAY 2
+#    include "action.h"
+#    define ENCODER_MAP_KEY_DELAY TAP_CODE_DELAY
 #endif
 
 #if !defined(ENCODER_RESOLUTIONS) && !defined(ENCODER_RESOLUTION)
@@ -143,9 +144,14 @@ void encoder_init(void) {
 static void encoder_exec_mapping(uint8_t index, bool clockwise) {
     // The delays below cater for Windows and its wonderful requirements.
     action_exec(clockwise ? ENCODER_CW_EVENT(index, true) : ENCODER_CCW_EVENT(index, true));
+#    if ENCODER_MAP_KEY_DELAY > 0
     wait_ms(ENCODER_MAP_KEY_DELAY);
+#    endif // ENCODER_MAP_KEY_DELAY > 0
+
     action_exec(clockwise ? ENCODER_CW_EVENT(index, false) : ENCODER_CCW_EVENT(index, false));
+#    if ENCODER_MAP_KEY_DELAY > 0
     wait_ms(ENCODER_MAP_KEY_DELAY);
+#    endif // ENCODER_MAP_KEY_DELAY > 0
 }
 #endif // ENCODER_MAP_ENABLE
 


### PR DESCRIPTION
## Description

Use `TAP_CODE_DELAY` for encoder mapping by default. Add docs for `ENCODER_MAP_KEY_DELAY` in case someone wants different values.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
