### PR TITLE
Move Oneshot mod callbacks to after mods are set

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -403,9 +403,9 @@ void process_action(keyrecord_t *record, action_t action) {
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 dprint("MODS_TAP: Toggling oneshot");
+                                register_mods(mods);
                                 clear_oneshot_mods();
                                 set_oneshot_locked_mods(mods | get_oneshot_locked_mods());
-                                register_mods(mods);
 #        endif
                             } else {
                                 register_mods(mods | get_oneshot_mods());
@@ -418,16 +418,16 @@ void process_action(keyrecord_t *record, action_t action) {
                                 // Retain Oneshot mods
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                                 if (mods & get_mods()) {
+                                    unregister_mods(mods);
                                     clear_oneshot_mods();
                                     set_oneshot_locked_mods(~mods & get_oneshot_locked_mods());
-                                    unregister_mods(mods);
                                 }
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 // Toggle Oneshot Layer
 #        endif
                             } else {
-                                clear_oneshot_mods();
                                 unregister_mods(mods);
+                                clear_oneshot_mods();
                             }
                         }
                     }


### PR DESCRIPTION
## Description

The main reason for this, is so that the callbacks can effect the mods after the fact. A good case for this is enabling caps word when shift is locked.

## Types of Changes

- [x] Core

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
