### PR TITLE
Fix PID value for the Keyboardio Atreus 2 bootloader

### DIFF
--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -88,7 +88,7 @@ BOOTLOADER_VIDS_PIDS = {
     'md-boot': {("03eb", "6124")},
     'caterina': {
         # pid.codes shared PID
-        ("1209", "9203"),  # Keyboardio Atreus 2 Bootloader
+        ("1209", "2302"),  # Keyboardio Atreus 2 Bootloader
         # Spark Fun Electronics
         ("1b4f", "9203"),  # Pro Micro 3V3/8MHz
         ("1b4f", "9205"),  # Pro Micro 5V/16MHz


### PR DESCRIPTION
## Description

Apparently my suggestion in https://github.com/qmk/qmk_firmware/pull/16584#discussion_r945332867 contained a wrong PID value (copied from another entry nearby). 🤦‍♂️

Copy the correct PID for the Keyboardio Atreus 2 bootloader from [`util/udev/50-qmk.rules`](https://github.com/qmk/qmk_firmware/blob/d2accb48e784030637f5517dfec66b13f1eab609/util/udev/50-qmk.rules#L38).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* `⚠ Missing or outdated udev rules for 'caterina' boards. Run 'sudo cp …/util/udev/50-qmk.rules /etc/udev/rules.d/'.`


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
