### PR TITLE
Add bepo variant to massdrop/thekey keymaps

### DIFF
--- a/keyboards/massdrop/thekey/keymaps/default-bepo/keymap.c
+++ b/keyboards/massdrop/thekey/keymaps/default-bepo/keymap.c
@@ -1,0 +1,24 @@
+/* Copyright 2022 Benjamin Collet <benjamin.collet@protonmail.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "keymap_bepo.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [0] = LAYOUT(KC_LCTL, BP_C, BP_V),
+
+};

--- a/keyboards/massdrop/thekey/keymaps/url-copy-paste-bepo/keymap.c
+++ b/keyboards/massdrop/thekey/keymaps/url-copy-paste-bepo/keymap.c
@@ -1,0 +1,41 @@
+/* Copyright 2022 Benjamin Collet <benjamin.collet@protonmail.ch>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "sendstring_bepo.h"
+
+enum custom_keycodes {
+    TK_URL = SAFE_RANGE,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(TK_URL, C(BP_C), C(BP_V)),
+};
+
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case TK_URL:
+            if (record->event.pressed) {
+                // when keycode TK_URL is pressed
+                SEND_STRING("https://stackoverflow.com/");
+            }
+            break;
+        default:
+            break;
+    }
+    return true;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The [bépo layout](https://bepo.fr/wiki/Accueil) move most of the letters compared to qwerty or even azerty. This mean that the default keymap for The Key is basically useless for bépo user.

This PR provide a bepo variant for both the default and the url-copy-paste keymaps for massdrop/thekey.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation. - N/A
- [ ] I have updated the documentation accordingly. - N/A
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes. - N/A
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
