### PR TITLE
Reduce default mouse key acceleration

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -244,11 +244,15 @@ If you define these options you will enable the associated feature, which may in
 
 ## Mouse Key Options
 
+* `#define MOUSEKEY_DELAY 10`
 * `#define MOUSEKEY_INTERVAL 20`
-* `#define MOUSEKEY_DELAY 0`
-* `#define MOUSEKEY_TIME_TO_MAX 60`
-* `#define MOUSEKEY_MAX_SPEED 7`
-* `#define MOUSEKEY_WHEEL_DELAY 0`
+* `#define MOUSEKEY_MOVE_DELTA 8`
+* `#define MOUSEKEY_MAX_SPEED 10`
+* `#define MOUSEKEY_TIME_TO_MAX 100`
+* `#define MOUSEKEY_WHEEL_DELAY 10`
+* `#define MOUSEKEY_WHEEL_INTERVAL 80`
+* `#define MOUSEKEY_WHEEL_MAX_SPEED 8`
+* `#define MOUSEKEY_WHEEL_TIME_TO_MAX 40`
 
 ## Split Keyboard Options
 

--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -63,7 +63,7 @@ This is the default mode. You can adjust the cursor and scrolling acceleration u
 |`MOUSEKEY_INTERVAL`         |20     |Time between cursor movements in milliseconds            |
 |`MOUSEKEY_MOVE_DELTA`       |8      |Step size                                                |
 |`MOUSEKEY_MAX_SPEED`        |10     |Maximum cursor speed at which acceleration stops         |
-|`MOUSEKEY_TIME_TO_MAX`      |30     |Time until maximum cursor speed is reached               |
+|`MOUSEKEY_TIME_TO_MAX`      |100    |Time until maximum cursor speed is reached               |
 |`MOUSEKEY_WHEEL_DELAY`      |10     |Delay between pressing a wheel key and wheel movement    |
 |`MOUSEKEY_WHEEL_INTERVAL`   |80     |Time between wheel movements                             |
 |`MOUSEKEY_WHEEL_MAX_SPEED`  |8      |Maximum number of scroll steps per scroll action         |

--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -63,7 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #        define MOUSEKEY_MAX_SPEED 10
 #    endif
 #    ifndef MOUSEKEY_TIME_TO_MAX
-#        define MOUSEKEY_TIME_TO_MAX 30
+#        define MOUSEKEY_TIME_TO_MAX 100
 #    endif
 #    ifndef MOUSEKEY_WHEEL_DELAY
 #        define MOUSEKEY_WHEEL_DELAY 10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Default acceleration is a tad too fast. This change reduces it further; and document a few more mouse key config options.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
