### PR TITLE
qmk new-keyboard: Add default bootloader for `RP2040`

### DIFF
--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -25,6 +25,7 @@ MCU2BOOTLOADER = {
     "MK20DX128": "halfkay",
     "MK20DX256": "halfkay",
     "MK66FX1M0": "halfkay",
+    "RP2040" : "rp2040",
     "STM32F042": "stm32-dfu",
     "STM32F072": "stm32-dfu",
     "STM32F103": "stm32duino",


### PR DESCRIPTION
Use `rp2040` instead of `custom` when MCU is `RP2040`.

NOTE: This was already working for `kb2040` and `promicro_rp2040` as
they derive their bootloader from `data/mappings/defaults.json`.
However, if you selected `RP2040` as MCU then you would end up with
`custom`, which I'm not sure is ever useful.