### PR TITLE
Allow hook to inspect leader key sequence as it grows, and provide example code to exit the leader mode early if a prefix is matched

### DIFF
--- a/docs/feature_leader_key.md
+++ b/docs/feature_leader_key.md
@@ -41,6 +41,46 @@ As you can see, you have a few functions. You can use `SEQ_ONE_KEY` for single-k
 
 Each of these accepts one or more keycodes as arguments. This is an important point: You can use keycodes from **any layer on your keyboard**. That layer would need to be active for the leader macro to fire, obviously.
 
+## Leader_new_key
+Alternatively, the leader key also offers a hook to inspect the leader sequence as it grows. This allows for short circuiting when a prefix is matched.
+
+```c
+LEADER_EXTERNS();
+
+bool leader_match(const uint16_t pattern[], const int pattern_size) {
+    if (leader_sequence_size > pattern_size) {
+        return false;
+    }
+    for (int i = 0; i < pattern_size; i++) {
+        if (pattern[i] != leader_sequence[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void leader_new_key(void) {
+    if (leader_match( (uint16_t[]) { KC_T }, 1)) { // test
+        SEND_STRING("test");
+        leading = false;
+    } else if (leader_match( (uint16_t[]) { KC_P, KC_E }, 2)) { // personal email
+        SEND_STRING("email@example.com");
+        leading = false;
+    } else if (leader_match( (uint16_t[]) { KC_P, KC_P }, 2)) { // personal phone
+        SEND_STRING("888-888-8888");
+        leading = false;
+    }
+}
+
+void leader_start(void) {}
+
+void leader_end(void) {
+    if (did_leader_succeed) {
+    } else {
+    }
+}
+```
+
 ## Adding Leader Key Support in the `rules.mk`
 
 To add support for Leader Key you simply need to add a single line to your keymap's `rules.mk`:

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -27,6 +27,8 @@ __attribute__((weak)) void leader_start(void) {}
 
 __attribute__((weak)) void leader_end(void) {}
 
+__attribute__((weak)) void leader_new_key(void) {}
+
 // Leader key stuff
 bool     leading     = false;
 uint16_t leader_time = 0;
@@ -61,6 +63,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
                 if (leader_sequence_size < (sizeof(leader_sequence) / sizeof(leader_sequence[0]))) {
                     leader_sequence[leader_sequence_size] = keycode;
                     leader_sequence_size++;
+                    leader_new_key();
                 } else {
                     leading = false;
                     leader_end();
@@ -70,6 +73,11 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
 #    endif
                 return false;
             }
+#    ifndef LEADER_NO_TIMEOUT
+            else {
+                leading = false;
+            }
+#    endif // LEADER_NO_TIMEOUT
         } else {
             if (keycode == KC_LEAD) {
                 qk_leader_start();

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -22,6 +22,7 @@ bool process_leader(uint16_t keycode, keyrecord_t *record);
 
 void leader_start(void);
 void leader_end(void);
+void leader_new_key(void);
 void qk_leader_start(void);
 
 #define SEQ_ONE_KEY(key) if (leader_sequence[0] == (key) && leader_sequence[1] == 0 && leader_sequence[2] == 0 && leader_sequence[3] == 0 && leader_sequence[4] == 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This is similar to other efforts to implement a compose key (e.g., https://github.com/qmk/qmk_firmware/pull/10063/files) but more modular, allowing for fewer code changes and more customizability for the user.

Aside from the features covered in the title, this also fixes a bug. See line 76 in `process_leader.c`. When `LEADER_NO_TIMEOUT` is defined and line `prcoess_leader.c:55` is run, `leading` will remain `true`, breaking the leading mode until a reset occurs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* `LEADER_NO_TIMEOUT` could break the leader mode

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
