### PR TITLE
Add SS_ROPT and SS_LOPT

### DIFF
--- a/quantum/send_string/send_string_keycodes.h
+++ b/quantum/send_string/send_string_keycodes.h
@@ -419,6 +419,7 @@
 #define SS_LSFT(string) SS_DOWN(X_LSFT) string SS_UP(X_LSFT)
 #define SS_LALT(string) SS_DOWN(X_LALT) string SS_UP(X_LALT)
 #define SS_LGUI(string) SS_DOWN(X_LGUI) string SS_UP(X_LGUI)
+#define SS_LOPT(string) SS_LALT(string)
 #define SS_LCMD(string) SS_LGUI(string)
 #define SS_LWIN(string) SS_LGUI(string)
 
@@ -426,6 +427,7 @@
 #define SS_RSFT(string) SS_DOWN(X_RSFT) string SS_UP(X_RSFT)
 #define SS_RALT(string) SS_DOWN(X_RALT) string SS_UP(X_RALT)
 #define SS_RGUI(string) SS_DOWN(X_RGUI) string SS_UP(X_RGUI)
+#define SS_ROPT(string) SS_RALT(string)
 #define SS_ALGR(string) SS_RALT(string)
 #define SS_RCMD(string) SS_RGUI(string)
 #define SS_RWIN(string) SS_RGUI(string)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add `SS_ROPT` and `SS_LOPT` aliases for the alt send string macros, which were listed in the docs but not present in the code.

> There’s also a couple of mod shortcuts you can use:

-    SS_LCTL(string)
-    SS_LSFT(string)
-    SS_LALT(string) or SS_LOPT(string)
-    SS_LGUI(string), SS_LCMD(string) or SS_LWIN(string)
-    SS_RCTL(string)
-    SS_RSFT(string)
-    SS_RALT(string), SS_ROPT(string) or SS_ALGR(string)
-   SS_RGUI(string), SS_RCMD(string) or SS_RWIN(string)
<!--- Describe your changes in detail here. -->
https://docs.qmk.fm/#/feature_macros?id=tap-down-and-up
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
