### PR TITLE
mcp23018: add return status to init

### DIFF
--- a/drivers/gpio/mcp23018.c
+++ b/drivers/gpio/mcp23018.c
@@ -18,14 +18,20 @@ enum {
     CMD_GPIOB  = 0x13,
 };
 
-void mcp23018_init(uint8_t addr) {
+bool mcp23018_init(uint8_t slave_addr) {
     static uint8_t s_init = 0;
-    if (!s_init) {
+    uint8_t        addr   = SLAVE_TO_ADDR(slave_addr);
+    if (0 == s_init) {
         i2c_init();
-        wait_ms(1000);
+        wait_ms(100);
 
-        s_init = 1;
+        // probe that the expander is actually connected by reading from it
+        uint8_t data = 0;
+        if (I2C_STATUS_SUCCESS == i2c_readReg(addr, 0, &data, sizeof(data), 150)) {
+            s_init = 1;
+        }
     }
+    return (s_init > 0);
 }
 
 bool mcp23018_set_config(uint8_t slave_addr, mcp23018_port_t port, uint8_t conf) {

--- a/drivers/gpio/mcp23018.h
+++ b/drivers/gpio/mcp23018.h
@@ -33,7 +33,7 @@ enum {
 /**
  * Init expander and any other dependent drivers
  */
-void mcp23018_init(uint8_t slave_addr);
+bool mcp23018_init(uint8_t slave_addr);
 
 /**
  * Configure input/output to a given port


### PR DESCRIPTION
include a "is the device actually connected?" check into the init
function, that now returns a boolean, which can be handled by a
keyboard to - for example - decide not to query an unconnected
portexpander during each matrix scan; avoiding i2c
spam/errors/timeouts

Signed-off-by: Johannes Schneider <JohSchneider@googlemail.com>

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
