### PR TITLE
Handle escaping of manufacturer/product strings

### DIFF
--- a/keyboards/adpenrose/shisaku/info.json
+++ b/keyboards/adpenrose/shisaku/info.json
@@ -1,5 +1,6 @@
 {
     "keyboard_name": "shisaku",
+    "manufacturer": "ADPenrose",
     "url": "https://github.com/ADPenrose/shisaku_keeb",
     "maintainer": "ADPenrose",
     "usb": {

--- a/keyboards/karlb/kbic65/info.json
+++ b/keyboards/karlb/kbic65/info.json
@@ -1,5 +1,6 @@
 {
     "keyboard_name": "KBIC65",
+    "manufacturer": "b-karl",
     "url": "https://karlb.eu/kbic65/",
     "maintainer": "b-karl",
     "diode_direction": "ROW2COL",

--- a/keyboards/keebio/bamfk4/info.json
+++ b/keyboards/keebio/bamfk4/info.json
@@ -1,5 +1,6 @@
 {
     "keyboard_name": "BAMFK-4",
+    "manufacturer": "Keebio",
     "url": "https://keeb.io",
     "maintainer": "nooges",
     "usb": {

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -117,9 +117,10 @@ def generate_config_items(kb_info_json, config_h_lines):
                 config_h_lines.append(f'#   define {key} {value}')
                 config_h_lines.append(f'#endif // {key}')
         elif key_type == 'str':
+            escaped_str = config_value.replace('\\', '\\\\').replace('"', '\\"')
             config_h_lines.append('')
             config_h_lines.append(f'#ifndef {config_key}')
-            config_h_lines.append(f'#   define {config_key} "{config_value}"')
+            config_h_lines.append(f'#   define {config_key} "{escaped_str}"')
             config_h_lines.append(f'#endif // {config_key}')
         elif key_type == 'bcd_version':
             (major, minor, revision) = config_value.split('.')

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -479,7 +479,7 @@ def _config_to_json(key_type, config_value):
         return int(config_value)
 
     elif key_type == 'str':
-        return config_value.strip('"')
+        return config_value.strip('"').replace('\\"', '"').replace('\\\\', '\\')
 
     elif key_type == 'bcd_version':
         major = int(config_value[2:4])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Second fix for #18183, double quotes need to be escaped and unescaped as necessary inside string literals:

```c
#define MANUFACTURER "Hello "World" 123"
// should be
#define MANUFACTURER "Hello \"World\" 123"
```
as well as backslashes:
```c
#define MANUFACTURER "Hello\ world 123\" // comment"
// should be
#define MANUFACTURER "Hello\\ world 123\\" // comment
```

Additionally, there were a couple of boards which did not have a `manufacturer` key in info.json.

```
Failing builds:
  adpenrose/shisaku:default
  adpenrose/shisaku:via
  handwired/baredev/rev1:default
  handwired/baredev/rev1:via
  hotdox:default
  hotdox:via
  karlb/kbic65:default
  karlb/kbic65:via
  keebio/bamfk4:default
  keebio/bamfk4:via
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
