### PR TITLE
Redefinition of MIN is avoided in midi.c

### DIFF
--- a/tmk_core/protocol/midi/midi.c
+++ b/tmk_core/protocol/midi/midi.c
@@ -19,7 +19,9 @@
 #include "midi.h"
 #include <string.h> //for memcpy
 
-#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#ifndef MIN
+#    define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#endif
 
 #ifndef NULL
 #    define NULL 0


### PR DESCRIPTION
## Description

It showed an error when tmk_core/protocol/midi/midi.c was included.

Error:
```
Compiling: tmk_core/protocol/midi/midi.c                                                           tmk_core/protocol/midi/midi.c:22: error: "MIN" redefined [-Werror]
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))

```

The same method applied to rgblight.c, audio.h, vilocikey.c, color.c and util.h is used to solve it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
