### PR TITLE
[Keymap] Fix bootmagic compilation issue with Drashna keymaps

### DIFF
--- a/users/drashna/bootmagic_better.c
+++ b/users/drashna/bootmagic_better.c
@@ -1,0 +1,56 @@
+// Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "drashna.h"
+#include "bootmagic_lite.h"
+
+void bootmagic_lite(void) {
+    bool perform_reset = false;
+    // We need multiple scans because debouncing can't be turned off.
+    matrix_scan();
+#if defined(DEBOUNCE) && DEBOUNCE > 0
+    wait_ms(DEBOUNCE * 2);
+#else
+    wait_ms(30);
+#endif
+    matrix_scan();
+
+    // If the configured key (commonly Esc) is held down on power up,
+    // reset the EEPROM valid state and jump to bootloader.
+    // This isn't very generalized, but we need something that doesn't
+    // rely on user's keymaps in firmware or EEPROM.
+    uint8_t row = BOOTMAGIC_LITE_ROW, col = BOOTMAGIC_LITE_COLUMN;
+#if defined(BOOTMAGIC_LITE_EEPROM_ROW) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN)
+    uint8_t row_e = BOOTMAGIC_LITE_EEPROM_ROW, col_e = BOOTMAGIC_LITE_EEPROM_COLUMN;
+#endif
+
+#if defined(SPLIT_KEYBOARD) && defined(BOOTMAGIC_LITE_ROW_RIGHT) && defined(BOOTMAGIC_LITE_COLUMN_RIGHT)
+    if (!is_keyboard_left()) {
+        row = BOOTMAGIC_LITE_ROW_RIGHT;
+        col = BOOTMAGIC_LITE_COLUMN_RIGHT;
+#if defined(BOOTMAGIC_LITE_EEPROM_ROW) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN) && defined(BOOTMAGIC_LITE_EEPROM_ROW_RIGHT) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN_RIGHT)
+        row_e = BOOTMAGIC_LITE_EEPROM_ROW_RIGHT;
+        col_e = BOOTMAGIC_LITE_EEPROM_COLUMN_RIGHT;
+#    endif
+    }
+#endif
+
+#if defined(BOOTMAGIC_LITE_EEPROM_ROW) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN)
+    if (matrix_get_row(row_e) & (1 << col_e)) {
+        eeconfig_disable();
+        perform_reset = true;
+    }
+#endif
+    if (matrix_get_row(row) & (1 << col)) {
+        perform_reset = true;
+    }
+#ifdef STM32F411xE
+    if (!readPin(A0)) {
+        perform_reset = true;
+    }
+#endif
+
+    if (perform_reset) {
+        bootloader_jump();
+    }
+}

--- a/users/drashna/drashna.c
+++ b/users/drashna/drashna.c
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "drashna.h"
-#ifdef __AVR__
-#    include <avr/wdt.h>
-#endif
 
 userspace_config_t userspace_config;
 
@@ -132,54 +129,3 @@ void keyboard_post_init_i2c(void) {
     scan_timer = timer_read();
 }
 #endif
-
-void bootmagic_lite(void) {
-    bool perform_reset = false;
-    // We need multiple scans because debouncing can't be turned off.
-    matrix_scan();
-#if defined(DEBOUNCE) && DEBOUNCE > 0
-    wait_ms(DEBOUNCE * 2);
-#else
-    wait_ms(30);
-#endif
-    matrix_scan();
-
-    // If the configured key (commonly Esc) is held down on power up,
-    // reset the EEPROM valid state and jump to bootloader.
-    // This isn't very generalized, but we need something that doesn't
-    // rely on user's keymaps in firmware or EEPROM.
-    uint8_t row = BOOTMAGIC_LITE_ROW, col = BOOTMAGIC_LITE_COLUMN;
-#if defined(BOOTMAGIC_LITE_EEPROM_ROW) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN)
-    uint8_t row_e = BOOTMAGIC_LITE_EEPROM_ROW, col_e = BOOTMAGIC_LITE_EEPROM_COLUMN;
-#endif
-
-#if defined(SPLIT_KEYBOARD) && defined(BOOTMAGIC_LITE_ROW_RIGHT) && defined(BOOTMAGIC_LITE_COLUMN_RIGHT)
-    if (!is_keyboard_left()) {
-        row = BOOTMAGIC_LITE_ROW_RIGHT;
-        col = BOOTMAGIC_LITE_COLUMN_RIGHT;
-#if defined(BOOTMAGIC_LITE_EEPROM_ROW) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN) && defined(BOOTMAGIC_LITE_EEPROM_ROW_RIGHT) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN_RIGHT)
-        row_e = BOOTMAGIC_LITE_EEPROM_ROW_RIGHT;
-        col_e = BOOTMAGIC_LITE_EEPROM_COLUMN_RIGHT;
-#    endif
-    }
-#endif
-
-#if defined(BOOTMAGIC_LITE_EEPROM_ROW) && defined(BOOTMAGIC_LITE_EEPROM_COLUMN)
-    if (matrix_get_row(row_e) & (1 << col_e)) {
-        eeconfig_disable();
-        perform_reset = true;
-    }
-#endif
-    if (matrix_get_row(row) & (1 << col)) {
-        perform_reset = true;
-    }
-#ifdef STM32F411xE
-    if (!readPin(A0)) {
-        perform_reset = true;
-    }
-#endif
-
-    if (perform_reset) {
-        bootloader_jump();
-    }
-}

--- a/users/drashna/rules.mk
+++ b/users/drashna/rules.mk
@@ -133,3 +133,7 @@ ifeq ($(strip $(AUTOCORRECTION_ENABLE)), yes)
     $(shell touch $(USER_PATH)/keyrecords/autocorrection/autocorrection.c)
     OPT_DEFS += -DAUTOCORRECTION_ENABLE
 endif
+
+ifeq ($(strip $(BOOTMAGIC_ENABLE)), yes)
+    SRC += bootmagic_better.c
+endif


### PR DESCRIPTION
## Description

Fix issue with compilation where I don't have defines for bootmagic specified.

## Types of Changes

- [x] Bugfix
- [x] Keymap/layout/userspace (addition or update)


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
