### PR TITLE
Move bootloader.mk to platforms

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -428,7 +428,6 @@ include $(BUILDDEFS_PATH)/common_features.mk
 include $(BUILDDEFS_PATH)/generic_features.mk
 include $(TMK_PATH)/protocol.mk
 include $(PLATFORM_PATH)/common.mk
-include $(BUILDDEFS_PATH)/bootloader.mk
 
 SRC += $(patsubst %.c,%.clib,$(LIB_SRC))
 SRC += $(patsubst %.c,%.clib,$(QUANTUM_LIB_SRC))
@@ -443,6 +442,7 @@ ifneq ($(REQUIRE_PLATFORM_KEY),)
     endif
 endif
 
+-include $(PLATFORM_PATH)/$(PLATFORM_KEY)/bootloader.mk
 include $(PLATFORM_PATH)/$(PLATFORM_KEY)/platform.mk
 -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/flash.mk
 

--- a/keyboards/handwired/pytest/basic/rules.mk
+++ b/keyboards/handwired/pytest/basic/rules.mk
@@ -1,1 +1,0 @@
-MCU = atmega32u4

--- a/keyboards/handwired/pytest/has_community/rules.mk
+++ b/keyboards/handwired/pytest/has_community/rules.mk
@@ -1,3 +1,1 @@
-MCU = atmega32u4
-
 LAYOUTS = ortho_1x1

--- a/keyboards/handwired/pytest/has_template/rules.mk
+++ b/keyboards/handwired/pytest/has_template/rules.mk
@@ -1,1 +1,0 @@
-MCU = atmega32u4

--- a/keyboards/handwired/pytest/info.json
+++ b/keyboards/handwired/pytest/info.json
@@ -6,5 +6,7 @@
         "vid": "0xFEED",
         "pid": "0x6465",
         "device_version": "0.0.1"
-    }
+    },
+    "processor": "atmega32u4",
+    "bootloader": "atmel-dfu"
 }

--- a/keyboards/handwired/pytest/macro/rules.mk
+++ b/keyboards/handwired/pytest/macro/rules.mk
@@ -1,1 +1,0 @@
-MCU = atmega32u4

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -755,9 +755,6 @@ def arm_processor_rules(info_data, rules):
     info_data['processor_type'] = 'arm'
     info_data['protocol'] = 'ChibiOS'
 
-    if 'bootloader' not in info_data:
-        info_data['bootloader'] = 'unknown'
-
     if 'STM32' in info_data['processor']:
         info_data['platform'] = 'STM32'
     elif 'MCU_SERIES' in rules:
@@ -774,9 +771,6 @@ def avr_processor_rules(info_data, rules):
     info_data['processor_type'] = 'avr'
     info_data['platform'] = rules['ARCH'] if 'ARCH' in rules else 'unknown'
     info_data['protocol'] = 'V-USB' if rules.get('MCU') in VUSB_PROCESSORS else 'LUFA'
-
-    if 'bootloader' not in info_data:
-        info_data['bootloader'] = 'atmel-dfu'
 
     # FIXME(fauxpark/anyone): Eventually we should detect the protocol by looking at PROTOCOL inherited from mcu_selection.mk:
     # info_data['protocol'] = 'V-USB' if rules.get('PROTOCOL') == 'VUSB' else 'LUFA'

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -412,7 +412,7 @@ def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=Fa
     rules = rules_mk(keyboard)
     names = set()
 
-    if rules:
+    if rules is not None:
         keyboards_dir = Path('keyboards')
         kb_path = keyboards_dir / keyboard
 

--- a/platforms/arm_atsam/bootloader.mk
+++ b/platforms/arm_atsam/bootloader.mk
@@ -1,0 +1,46 @@
+# Copyright 2017 Jack Humbert
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# If it's possible that multiple bootloaders can be used for one project,
+# you can leave this unset, and the correct size will be selected
+# automatically.
+#
+# Sets the bootloader defined in the keyboard's/keymap's rules.mk
+#
+# Current options for ARM (ATSAM):
+#     md-boot      Atmel SAM-BA (only used by Drop boards)
+#
+# If you need to provide your own implementation, you can set inside `rules.mk`
+# `BOOTLOADER = custom` -- you'll need to provide your own implementations. See
+# the respective file under `platforms/<PLATFORM>/bootloaders/custom.c` to see
+# which functions may be overridden.
+
+ifeq ($(strip $(BOOTLOADER)), custom)
+    OPT_DEFS += -DBOOTLOADER_CUSTOM
+    BOOTLOADER_TYPE = custom
+endif
+
+ifeq ($(strip $(BOOTLOADER)), md-boot)
+    OPT_DEFS += -DBOOTLOADER_MD_BOOT
+    BOOTLOADER_TYPE = md_boot
+endif
+
+ifeq ($(strip $(BOOTLOADER_TYPE)),)
+    ifneq ($(strip $(BOOTLOADER)),)
+        $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,Invalid bootloader specified. Please set an appropriate bootloader in your rules.mk or info.json.)
+    else
+        $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,No bootloader specified. Please set an appropriate bootloader in your rules.mk or info.json.)
+    endif
+endif

--- a/platforms/avr/bootloader.mk
+++ b/platforms/avr/bootloader.mk
@@ -1,0 +1,144 @@
+# Copyright 2017 Jack Humbert
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# If it's possible that multiple bootloaders can be used for one project,
+# you can leave this unset, and the correct size will be selected
+# automatically.
+#
+# Sets the bootloader defined in the keyboard's/keymap's rules.mk
+#
+# Current options for AVR:
+#     halfkay      PJRC Teensy
+#     caterina     Pro Micro (Sparkfun/generic)
+#     atmel-dfu    Atmel factory DFU
+#     lufa-dfu     LUFA DFU
+#     qmk-dfu      QMK DFU (LUFA + blinkenlight)
+#     qmk-hid      QMK HID (LUFA + blinkenlight)
+#     bootloadhid  HIDBootFlash compatible (ATmega32A)
+#     usbasploader USBaspLoader (ATmega328P)
+#
+# If you need to provide your own implementation, you can set inside `rules.mk`
+# `BOOTLOADER = custom` -- you'll need to provide your own implementations. See
+# the respective file under `platforms/<PLATFORM>/bootloaders/custom.c` to see
+# which functions may be overridden.
+#
+# BOOTLOADER_SIZE can still be defined manually, but it's recommended
+# you add any possible configuration to this list
+
+ifeq ($(strip $(BOOTLOADER)), custom)
+    OPT_DEFS += -DBOOTLOADER_CUSTOM
+    BOOTLOADER_TYPE = custom
+endif
+
+ifeq ($(strip $(BOOTLOADER)), atmel-dfu)
+    OPT_DEFS += -DBOOTLOADER_ATMEL_DFU
+    OPT_DEFS += -DBOOTLOADER_DFU
+    BOOTLOADER_TYPE = dfu
+
+    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
+        BOOTLOADER_SIZE = 4096
+    endif
+    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
+        BOOTLOADER_SIZE = 8192
+    endif
+endif
+ifeq ($(strip $(BOOTLOADER)), lufa-dfu)
+    OPT_DEFS += -DBOOTLOADER_LUFA_DFU
+    OPT_DEFS += -DBOOTLOADER_DFU
+    BOOTLOADER_TYPE = dfu
+
+    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
+        BOOTLOADER_SIZE ?= 4096
+    endif
+    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
+        BOOTLOADER_SIZE ?= 8192
+    endif
+endif
+ifeq ($(strip $(BOOTLOADER)), qmk-dfu)
+    OPT_DEFS += -DBOOTLOADER_QMK_DFU
+    OPT_DEFS += -DBOOTLOADER_DFU
+    BOOTLOADER_TYPE = dfu
+
+    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
+        BOOTLOADER_SIZE ?= 4096
+    endif
+    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
+        BOOTLOADER_SIZE ?= 8192
+    endif
+endif
+ifeq ($(strip $(BOOTLOADER)), qmk-hid)
+    OPT_DEFS += -DBOOTLOADER_QMK_HID
+    OPT_DEFS += -DBOOTLOADER_HID
+    BOOTLOADER_TYPE = dfu
+
+    BOOTLOADER_SIZE ?= 4096
+endif
+ifeq ($(strip $(BOOTLOADER)), halfkay)
+    OPT_DEFS += -DBOOTLOADER_HALFKAY
+    BOOTLOADER_TYPE = halfkay
+
+    # Teensy 2.0
+    ifeq ($(strip $(MCU)), atmega32u4)
+        BOOTLOADER_SIZE = 512
+    endif
+    # Teensy 2.0++
+    ifeq ($(strip $(MCU)), at90usb1286)
+        BOOTLOADER_SIZE = 1024
+    endif
+endif
+ifeq ($(strip $(BOOTLOADER)), caterina)
+    OPT_DEFS += -DBOOTLOADER_CATERINA
+    BOOTLOADER_TYPE = caterina
+
+    BOOTLOADER_SIZE = 4096
+endif
+ifeq ($(strip $(BOOTLOADER)), bootloadhid)
+    OPT_DEFS += -DBOOTLOADER_BOOTLOADHID
+    BOOTLOADER_TYPE = bootloadhid
+
+    BOOTLOADER_SIZE = 4096
+endif
+ifeq ($(strip $(BOOTLOADER)), usbasploader)
+    OPT_DEFS += -DBOOTLOADER_USBASP
+    BOOTLOADER_TYPE = usbasploader
+
+    BOOTLOADER_SIZE = 4096
+endif
+ifeq ($(strip $(BOOTLOADER)), lufa-ms)
+    OPT_DEFS += -DBOOTLOADER_MS
+    BOOTLOADER_TYPE = dfu
+
+    BOOTLOADER_SIZE ?= 8192
+    FIRMWARE_FORMAT = bin
+cpfirmware: lufa_warning
+.INTERMEDIATE: lufa_warning
+lufa_warning: $(FIRMWARE_FORMAT)
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
+	$(info LUFA MASS STORAGE Bootloader selected)
+	$(info DO NOT USE THIS BOOTLOADER IN NEW PROJECTS!)
+	$(info It is extremely prone to bricking, and is only included to support existing boards.)
+	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
+endif
+ifdef BOOTLOADER_SIZE
+    OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))
+endif
+
+ifeq ($(strip $(BOOTLOADER_TYPE)),)
+    ifneq ($(strip $(BOOTLOADER)),)
+        $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,Invalid bootloader specified. Please set an appropriate bootloader in your rules.mk or info.json.)
+    else
+        $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,No bootloader specified. Please set an appropriate bootloader in your rules.mk or info.json.)
+    endif
+endif

--- a/platforms/chibios/bootloader.mk
+++ b/platforms/chibios/bootloader.mk
@@ -18,135 +18,38 @@
 # automatically.
 #
 # Sets the bootloader defined in the keyboard's/keymap's rules.mk
-# Current options:
 #
-# AVR:
-#     halfkay      PJRC Teensy
-#     caterina     Pro Micro (Sparkfun/generic)
-#     atmel-dfu    Atmel factory DFU
-#     lufa-dfu     LUFA DFU
-#     qmk-dfu      QMK DFU (LUFA + blinkenlight)
-#     qmk-hid      QMK HID (LUFA + blinkenlight)
-#     bootloadhid  HIDBootFlash compatible (ATmega32A)
-#     usbasploader USBaspLoader (ATmega328P)
-# ARM:
+# Current options for ARM:
 #     halfkay      PJRC Teensy
 #     kiibohd      Input:Club Kiibohd bootloader (only used on their boards)
 #     stm32duino   STM32Duino (STM32F103x8)
 #     stm32-dfu    STM32 USB DFU in ROM
 #     apm32-dfu    APM32 USB DFU in ROM
-# RISC-V:
+#     wb32-dfu     WB32 USB DFU in ROM
+#     tinyuf2      TinyUF2
+#     rp2040       Raspberry Pi RP2040
+# Current options for RISC-V:
 #     gd32v-dfu    GD32V USB DFU in ROM
 #
 # If you need to provide your own implementation, you can set inside `rules.mk`
 # `BOOTLOADER = custom` -- you'll need to provide your own implementations. See
 # the respective file under `platforms/<PLATFORM>/bootloaders/custom.c` to see
 # which functions may be overridden.
-#
-# BOOTLOADER_SIZE can still be defined manually, but it's recommended
-# you add any possible configuration to this list
 
 ifeq ($(strip $(BOOTLOADER)), custom)
     OPT_DEFS += -DBOOTLOADER_CUSTOM
     BOOTLOADER_TYPE = custom
 endif
-ifeq ($(strip $(BOOTLOADER)), atmel-dfu)
-    OPT_DEFS += -DBOOTLOADER_ATMEL_DFU
-    OPT_DEFS += -DBOOTLOADER_DFU
-    BOOTLOADER_TYPE = dfu
 
-    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
-        BOOTLOADER_SIZE = 4096
-    endif
-    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
-        BOOTLOADER_SIZE = 8192
-    endif
-endif
-ifeq ($(strip $(BOOTLOADER)), lufa-dfu)
-    OPT_DEFS += -DBOOTLOADER_LUFA_DFU
-    OPT_DEFS += -DBOOTLOADER_DFU
-    BOOTLOADER_TYPE = dfu
-
-    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
-        BOOTLOADER_SIZE ?= 4096
-    endif
-    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
-        BOOTLOADER_SIZE ?= 8192
-    endif
-endif
-ifeq ($(strip $(BOOTLOADER)), qmk-dfu)
-    OPT_DEFS += -DBOOTLOADER_QMK_DFU
-    OPT_DEFS += -DBOOTLOADER_DFU
-    BOOTLOADER_TYPE = dfu
-
-    ifneq (,$(filter $(MCU), at90usb162 atmega16u2 atmega32u2 atmega16u4 atmega32u4 at90usb646 at90usb647))
-        BOOTLOADER_SIZE ?= 4096
-    endif
-    ifneq (,$(filter $(MCU), at90usb1286 at90usb1287))
-        BOOTLOADER_SIZE ?= 8192
-    endif
-endif
-ifeq ($(strip $(BOOTLOADER)), qmk-hid)
-    OPT_DEFS += -DBOOTLOADER_QMK_HID
-    OPT_DEFS += -DBOOTLOADER_HID
-    BOOTLOADER_TYPE = dfu
-
-    BOOTLOADER_SIZE ?= 4096
-endif
 ifeq ($(strip $(BOOTLOADER)), halfkay)
     OPT_DEFS += -DBOOTLOADER_HALFKAY
     BOOTLOADER_TYPE = halfkay
 
-    # Teensy 2.0
-    ifeq ($(strip $(MCU)), atmega32u4)
-        BOOTLOADER_SIZE = 512
-    endif
-    # Teensy 2.0++
-    ifeq ($(strip $(MCU)), at90usb1286)
-        BOOTLOADER_SIZE = 1024
-    endif
     # Teensy LC, 3.0, 3.1/2, 3.5, 3.6
     ifneq (,$(filter $(MCU_ORIG), MKL26Z64 MK20DX128 MK20DX256 MK64FX512 MK66FX1M0))
         FIRMWARE_FORMAT = hex
     endif
 endif
-ifeq ($(strip $(BOOTLOADER)), caterina)
-    OPT_DEFS += -DBOOTLOADER_CATERINA
-    BOOTLOADER_TYPE = caterina
-
-    BOOTLOADER_SIZE = 4096
-endif
-ifeq ($(strip $(BOOTLOADER)), bootloadhid)
-    OPT_DEFS += -DBOOTLOADER_BOOTLOADHID
-    BOOTLOADER_TYPE = bootloadhid
-
-    BOOTLOADER_SIZE = 4096
-endif
-ifeq ($(strip $(BOOTLOADER)), usbasploader)
-    OPT_DEFS += -DBOOTLOADER_USBASP
-    BOOTLOADER_TYPE = usbasploader
-
-    BOOTLOADER_SIZE = 4096
-endif
-ifeq ($(strip $(BOOTLOADER)), lufa-ms)
-    OPT_DEFS += -DBOOTLOADER_MS
-    BOOTLOADER_TYPE = dfu
-
-    BOOTLOADER_SIZE ?= 8192
-    FIRMWARE_FORMAT = bin
-cpfirmware: lufa_warning
-.INTERMEDIATE: lufa_warning
-lufa_warning: $(FIRMWARE_FORMAT)
-	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
-	$(info LUFA MASS STORAGE Bootloader selected)
-	$(info DO NOT USE THIS BOOTLOADER IN NEW PROJECTS!)
-	$(info It is extremely prone to bricking, and is only included to support existing boards.)
-	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
-endif
-ifdef BOOTLOADER_SIZE
-    OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))
-endif
-
 ifeq ($(strip $(BOOTLOADER)), stm32-dfu)
     OPT_DEFS += -DBOOTLOADER_STM32_DFU
     BOOTLOADER_TYPE = stm32_dfu
@@ -205,19 +108,15 @@ ifeq ($(strip $(BOOTLOADER)), rp2040)
     OPT_DEFS += -DBOOTLOADER_RP2040
     BOOTLOADER_TYPE = rp2040
 endif
-ifeq ($(strip $(BOOTLOADER)), halfkay)
-    OPT_DEFS += -DBOOTLOADER_HALFKAY
-    BOOTLOADER_TYPE = halfkay
-endif
-ifeq ($(strip $(BOOTLOADER)), md-boot)
-    OPT_DEFS += -DBOOTLOADER_MD_BOOT
-    BOOTLOADER_TYPE = md_boot
-endif
 ifeq ($(strip $(BOOTLOADER)), wb32-dfu)
     OPT_DEFS += -DBOOTLOADER_WB32_DFU
     BOOTLOADER_TYPE = wb32_dfu
 endif
 
 ifeq ($(strip $(BOOTLOADER_TYPE)),)
-    $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,No bootloader specified. Please set an appropriate 'BOOTLOADER' in your keyboard's 'rules.mk' file.)
+    ifneq ($(strip $(BOOTLOADER)),)
+        $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,Invalid bootloader specified. Please set an appropriate bootloader in your rules.mk or info.json.)
+    else
+        $(call CATASTROPHIC_ERROR,Invalid BOOTLOADER,No bootloader specified. Please set an appropriate bootloader in your rules.mk or info.json.)
+    endif
 endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

At this point every keyboard should have either a valid bootloader set, or `custom`. Anything else should generate an error.

This change splits up bootloader.mk into platform-specific makefiles, to further lock out anything that is invalid (eg. `md-boot` for `atmega32u4`). This would fail to compile anyway as there is no `md-boot.c` under the AVR bootloaders directory, but now it should spit out a more user friendly error.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
