### PR TITLE
Ensure all keyboards have a bootloader set

### DIFF
--- a/keyboards/clueboard/17/info.json
+++ b/keyboards/clueboard/17/info.json
@@ -4,6 +4,7 @@
   "maintainer": "skullydazed",
   "diode_direction": "COL2ROW",
   "processor": "atmega32u4",
+  "bootloader": "atmel-dfu",
   "features": {
     "backlight": true,
     "bootmagic": false,

--- a/keyboards/clueboard/66/rev1/info.json
+++ b/keyboards/clueboard/66/rev1/info.json
@@ -3,6 +3,7 @@
   "keyboard_name": "Clueboard 66%",
   "maintainer": "skullydazed",
   "processor": "atmega32u4",
+  "bootloader": "atmel-dfu",
   "debounce": 5,
   "diode_direction": "COL2ROW",
   "features": {

--- a/keyboards/clueboard/66/rev2/info.json
+++ b/keyboards/clueboard/66/rev2/info.json
@@ -3,6 +3,7 @@
   "keyboard_name": "Clueboard 66%",
   "maintainer": "skullydazed",
   "processor": "atmega32u4",
+  "bootloader": "atmel-dfu",
   "debounce": 5,
   "diode_direction": "COL2ROW",
   "features": {

--- a/keyboards/clueboard/66/rev3/info.json
+++ b/keyboards/clueboard/66/rev3/info.json
@@ -3,6 +3,7 @@
   "keyboard_name": "Clueboard 66% rev3",
   "maintainer": "skullydazed",
   "processor": "atmega32u4",
+  "bootloader": "atmel-dfu",
   "debounce": 5,
   "diode_direction": "COL2ROW",
   "features": {

--- a/keyboards/clueboard/66_hotswap/prototype/info.json
+++ b/keyboards/clueboard/66_hotswap/prototype/info.json
@@ -5,6 +5,7 @@
   "debounce": 5,
   "diode_direction": "COL2ROW",
   "processor": "atmega32u4",
+  "bootloader": "atmel-dfu",
   "features": {
     "audio": true,
     "backlight": true,

--- a/keyboards/clueboard/card/info.json
+++ b/keyboards/clueboard/card/info.json
@@ -4,6 +4,7 @@
   "maintainer": "skullydazed",
   "debounce": 20,
   "processor": "atmega32u4",
+  "bootloader": "atmel-dfu",
   "diode_direction": "ROW2COL",
   "features": {
     "audio": true,

--- a/keyboards/handwired/3dortho14u/rev1/info.json
+++ b/keyboards/handwired/3dortho14u/rev1/info.json
@@ -4,6 +4,7 @@
     "url": "",
     "maintainer": "xia0",
     "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
     "debounce": 5,
     "diode_direction": "COL2ROW",
     "features": {

--- a/keyboards/handwired/3dortho14u/rev2/info.json
+++ b/keyboards/handwired/3dortho14u/rev2/info.json
@@ -4,6 +4,7 @@
     "url": "",
     "maintainer": "xia0",
     "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
     "debounce": 5,
     "diode_direction": "COL2ROW",
     "features": {

--- a/keyboards/handwired/dactyl_manuform/4x5_5/rules.mk
+++ b/keyboards/handwired/dactyl_manuform/4x5_5/rules.mk
@@ -3,7 +3,7 @@
 MCU = atmega32u4
 
 # BOOTLOADER for Elite-C
-# BOOTLOADER = atmel-dfu
+BOOTLOADER = atmel-dfu
 # BOOTLOADER for Pro Micro
 # BOOTLOADER = caterina
 

--- a/keyboards/handwired/dactyl_manuform/dmote/62key/info.json
+++ b/keyboards/handwired/dactyl_manuform/dmote/62key/info.json
@@ -3,6 +3,8 @@
     "manufacturer": "tshort",
     "url": "",
     "maintainer": "veikman",
+    "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
     "usb": {
         "vid": "0x444D",
         "pid": "0x3632",

--- a/keyboards/handwired/hillside/46/info.json
+++ b/keyboards/handwired/hillside/46/info.json
@@ -8,6 +8,7 @@
     "tags": ["split", "column stagger", "choc v1", "choc spaced" ],
 
     "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
 
     "matrix_pins": {
         "rows": ["C6", "D7", "E6", "B5"],

--- a/keyboards/handwired/hillside/48/info.json
+++ b/keyboards/handwired/hillside/48/info.json
@@ -8,6 +8,7 @@
     "tags": ["split", "column stagger", "choc v1", "choc spaced" ],
 
     "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
 
     "matrix_pins": {
         "rows": ["D7", "E6", "B4", "B5"],

--- a/keyboards/handwired/hillside/52/info.json
+++ b/keyboards/handwired/hillside/52/info.json
@@ -8,6 +8,7 @@
     "tags": ["split", "column stagger", "choc v1", "choc spaced" ],
 
     "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
 
     "matrix_pins": {
         "rows": ["C6", "D7", "E6", "B4", "B5"],

--- a/keyboards/handwired/wakizashi40/info.json
+++ b/keyboards/handwired/wakizashi40/info.json
@@ -4,6 +4,7 @@
   "maintainer": "xia0",
   "debounce": 5,
   "processor": "atmega32u4",
+  "bootloader": "atmel-dfu",
   "diode_direction": "COL2ROW",
   "features": {
     "audio": false,

--- a/keyboards/lfkeyboards/lfk65_hs/rules.mk
+++ b/keyboards/lfkeyboards/lfk65_hs/rules.mk
@@ -1,8 +1,5 @@
 MCU = atmega32u4
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
-FLASH_SIZE_KB = 32
-BOOT_SECTION_SIZE_KB = 4
-BOOT_LOADER = BootloaderHID
+BOOTLOADER = atmel-dfu
 
 # Extra source files for IS3731 lighting
 SRC = TWIlib.c issi.c lighting.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As a result of #18228 removing the default bootloader assignment and adjusting the makefile logic to complain if no bootloader is set, or an invalid one for the given platform:

```
Failing builds:
  clueboard/17:default
  clueboard/66/rev1:default
  clueboard/66/rev1:via
  clueboard/66/rev2:default
  clueboard/66/rev2:via
  clueboard/66/rev3:default
  clueboard/66/rev3:via
  clueboard/66_hotswap/prototype:default
  clueboard/card:default
  handwired/3dortho14u/rev1:default
  handwired/3dortho14u/rev1:via
  handwired/3dortho14u/rev2:default
  handwired/3dortho14u/rev2:via
  handwired/dactyl_manuform/4x5_5:default
  handwired/dactyl_manuform/dmote/62key:default
  handwired/hillside/46:default
  handwired/hillside/46:via
  handwired/hillside/48:default
  handwired/hillside/48:via
  handwired/hillside/52:default
  handwired/hillside/52:via
  handwired/wakizashi40:default
  handwired/wakizashi40:via
  lfkeyboards/lfk65_hs:default
```

I was worried there'd be much more, honestly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
