### PR TITLE
Add unicode mode change callbacks

### DIFF
--- a/docs/feature_unicode.md
+++ b/docs/feature_unicode.md
@@ -206,6 +206,17 @@ The functions for starting and finishing Unicode input on your platform can be o
 
 You can find the default implementations of these functions in [`process_unicode_common.c`](https://github.com/qmk/qmk_firmware/blob/master/quantum/process_keycode/process_unicode_common.c).
 
+### Input Mode Callbacks
+
+There are callbacks functions available that are called whenever the unicode input mode changes. The new input mode is passed to the function.
+
+|Callback                                           |Description                                          |
+|---------------------------------------------------|-----------------------------------------------------|
+| `unicode_input_mode_set_kb(uint8_t input_mode)`   | Callback for unicode input mode set, for keyboard.  |
+| `unicode_input_mode_set_user(uint8_t input_mode)` | Callback for unicode input mode set, for users.     |
+
+This feature can be used, for instance, to implement LED indicators for the current unicode input mode.
+
 ### Input Key Configuration
 
 You can customize the keys used to trigger Unicode input for macOS, Linux and WinCompose by adding corresponding defines to your `config.h`. The default values match the platforms' default settings, so you shouldn't need to change this unless Unicode input isn't working, or you want to use a different key (e.g. in order to free up left or right Alt).

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -33,8 +33,7 @@ static int8_t  selected_index;
  *
  * Run user code on unicode input mode change
  */
-__attribute__((weak)) void unicode_input_mode_set_user(uint8_t input_mode) {
-}
+__attribute__((weak)) void unicode_input_mode_set_user(uint8_t input_mode) {}
 
 /** \brief unicode input mode set at keyboard level
  *

--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -29,6 +29,21 @@ static int8_t  selected_count = ARRAY_SIZE(selected);
 static int8_t  selected_index;
 #endif
 
+/** \brief Uunicode input mode set at user level
+ *
+ * Run user code on unicode input mode change
+ */
+__attribute__((weak)) void unicode_input_mode_set_user(uint8_t input_mode) {
+}
+
+/** \brief unicode input mode set at keyboard level
+ *
+ *  Run keyboard code on unicode input mode change
+ */
+__attribute__((weak)) void unicode_input_mode_set_kb(uint8_t input_mode) {
+    unicode_input_mode_set_user(input_mode);
+}
+
 void unicode_input_mode_init(void) {
     unicode_config.raw = eeprom_read_byte(EECONFIG_UNICODEMODE);
 #if UNICODE_SELECTED_MODES != -1
@@ -50,6 +65,7 @@ void unicode_input_mode_init(void) {
     unicode_config.input_mode = selected[selected_index = 0];
 #    endif
 #endif
+    unicode_input_mode_set_kb(unicode_config.input_mode);
     dprintf("Unicode input mode init to: %u\n", unicode_config.input_mode);
 }
 
@@ -60,6 +76,7 @@ uint8_t get_unicode_input_mode(void) {
 void set_unicode_input_mode(uint8_t mode) {
     unicode_config.input_mode = mode;
     persist_unicode_input_mode();
+    unicode_input_mode_set_kb(mode);
     dprintf("Unicode input mode set to: %u\n", unicode_config.input_mode);
 }
 
@@ -73,6 +90,7 @@ void cycle_unicode_input_mode(int8_t offset) {
 #    if UNICODE_CYCLE_PERSIST
     persist_unicode_input_mode();
 #    endif
+    unicode_input_mode_set_kb(unicode_config.input_mode);
     dprintf("Unicode input mode cycle to: %u\n", unicode_config.input_mode);
 #endif
 }

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -87,6 +87,9 @@ void unicode_input_start(void);
 void unicode_input_finish(void);
 void unicode_input_cancel(void);
 
+void unicode_input_mode_set_user(uint8_t input_mode);
+void unicode_input_mode_set_kb(uint8_t input_mode);
+
 void register_hex(uint16_t hex);
 void register_hex32(uint32_t hex);
 void register_unicode(uint32_t code_point);

--- a/users/spidey3/layer_rgb.c
+++ b/users/spidey3/layer_rgb.c
@@ -112,8 +112,7 @@ void do_rgb_layers(layer_state_t state, uint8_t start, uint8_t end) {
     }
 }
 
-void do_rgb_unicode(void) {
-    uint8_t uc_mode = get_unicode_input_mode();
+void do_rgb_unicode(uint8_t uc_mode) {
     for (uint8_t i = 0; i < UC__COUNT; i++) {
         bool is_on = i == uc_mode;
         rgblight_set_layer_state(UNICODE_OFFSET + i, is_on);
@@ -123,7 +122,7 @@ void do_rgb_unicode(void) {
 void do_rgb_all(void) {
     do_rgb_layers(default_layer_state, LAYER_BASE_DEFAULT, LAYER_BASE_REGULAR);
     do_rgb_layers(layer_state, LAYER_BASE_REGULAR, LAYER_BASE_END);
-    do_rgb_unicode();
+    do_rgb_unicode(get_unicode_input_mode());
     rgblight_set_layer_state(MISC_OFFSET + 0, spi_gflock);
     rgblight_set_layer_state(MISC_OFFSET + 1, spi_replace_mode != SPI_NORMAL);
 }
@@ -148,7 +147,7 @@ extern rgblight_status_t rgblight_status;
 #    define STARTUP_ANIMATION_CYCLE_STEP 2
 #    define STARTUP_ANIMATION_RAMP_TO_STEPS 70
 #    define STARTUP_ANIMATION_STEP_TIME 10
-#    define STARTUP_ANIMATION_INITIAL_DELAY 0  // milliseconds, must be < 255 * STEP_TIME
+#    define STARTUP_ANIMATION_INITIAL_DELAY 0 // milliseconds, must be < 255 * STEP_TIME
 
 // clang-format off
 typedef enum {
@@ -382,6 +381,13 @@ bool led_update_user_rgb(led_t led_state) {
     return true;
 }
 
+#if defined(UNICODE_COMMON_ENABLE)
+void unicode_input_mode_set_user_rgb(uint8_t input_mode) {
+    rgb_layer_ack(ACK_MEH);
+    do_rgb_unicode(input_mode);
+}
+#endif
+
 void rgb_layer_ack_yn(bool yn) { rgb_layer_ack(yn ? ACK_YES : ACK_NO); }
 
 void rgb_layer_ack(layer_ack_t n) {
@@ -458,7 +464,7 @@ void post_process_record_user_rgb(uint16_t keycode, keyrecord_t *record) {
             break;
 
         case RGB_TOG:
-            // Hack - we only get called on the press for RGB_TOG, 
+            // Hack - we only get called on the press for RGB_TOG,
             // but the flag is only flipped on the release...
             rgb_layer_ack_yn(!rgblight_config.enable);
             break;
@@ -474,21 +480,6 @@ void post_process_record_user_rgb(uint16_t keycode, keyrecord_t *record) {
         case NK_ON:
         case NK_OFF:
             rgb_layer_ack_yn(keymap_config.nkro);
-            break;
-#endif
-
-#if defined(UNICODE_COMMON_ENABLE)
-        case UC_M_MA:
-        case UC_M_LN:
-        case UC_M_WI:
-        case UC_M_BS:
-        case UC_M_WC:
-        case UC_M_EM:
-
-        case UC_MOD:
-        case UC_RMOD:
-            rgb_layer_ack(ACK_MEH);
-            do_rgb_unicode();
             break;
 #endif
     }

--- a/users/spidey3/spidey3.c
+++ b/users/spidey3/spidey3.c
@@ -393,6 +393,5 @@ void unicode_input_mode_set_user(uint8_t input_mode) {
 #    ifdef RGBLIGHT_ENABLE
     unicode_input_mode_set_user_rgb(input_mode);
 #    endif
-    dprintf("spidey3: unicode input mode set to %d\n", input_mode);
 }
 #endif

--- a/users/spidey3/spidey3.c
+++ b/users/spidey3/spidey3.c
@@ -98,14 +98,14 @@ bool process_record_glyph_replacement(uint16_t keycode, keyrecord_t *record, uin
                     clear_oneshot_mods();
 #endif
 
-                    bool caps = host_keyboard_led_state().caps_lock;
+                    bool     caps = host_keyboard_led_state().caps_lock;
                     uint32_t base = ((shifted == caps) ? baseAlphaLower : baseAlphaUpper);
                     _register(base + (keycode - KC_A));
                     set_mods(temp_mod);
                 }
                 return false;
             case KC_0:
-                if (shifted) {  // skip shifted numbers, so that we can still use symbols etc.
+                if (shifted) { // skip shifted numbers, so that we can still use symbols etc.
                     return true;
                 }
                 if (record->event.pressed) {
@@ -113,7 +113,7 @@ bool process_record_glyph_replacement(uint16_t keycode, keyrecord_t *record, uin
                 }
                 return false;
             case KC_1 ... KC_9:
-                if (shifted) {  // skip shifted numbers, so that we can still use symbols etc.
+                if (shifted) { // skip shifted numbers, so that we can still use symbols etc.
                     return true;
                 }
                 if (record->event.pressed) {
@@ -122,7 +122,7 @@ bool process_record_glyph_replacement(uint16_t keycode, keyrecord_t *record, uin
                 return false;
             case KC_SPACE:
                 if (record->event.pressed) {
-                    _register(spaceGlyph);  // em space
+                    _register(spaceGlyph); // em space
                 }
                 return false;
         }
@@ -338,7 +338,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                     set_mods(mods);
                     return false;
                 }
-            } else {  // on release of KC_BSPC
+            } else { // on release of KC_BSPC
                 // In case KC_DEL is still being sent even after the release of KC_BSPC
                 if (delkey_registered) {
                     unregister_code(KC_DEL);
@@ -387,3 +387,12 @@ bool led_update_user(led_t led_state) {
     return true;
 #endif
 }
+
+#if defined(UNICODE_COMMON_ENABLE)
+void unicode_input_mode_set_user(uint8_t input_mode) {
+#    ifdef RGBLIGHT_ENABLE
+    unicode_input_mode_set_user_rgb(input_mode);
+#    endif
+    dprintf("spidey3: unicode input mode set to %d\n", input_mode);
+}
+#endif

--- a/users/spidey3/spidey3.h
+++ b/users/spidey3/spidey3.h
@@ -17,9 +17,9 @@ enum userspace_layers {
 };
 
 enum custom_keycodes {
-    CH_CPNL = SAFE_RANGE,  // AL Control Panel
-    CH_ASST,               // AL Context-aware Desktop Assistant
-    CH_SUSP,               // Suspend
+    CH_CPNL = SAFE_RANGE, // AL Control Panel
+    CH_ASST,              // AL Context-aware Desktop Assistant
+    CH_SUSP,              // Suspend
 
     SPI_NORMAL,
     SPI_WIDE,
@@ -65,6 +65,11 @@ void          rgb_layer_ack(layer_ack_t n);
 void          rgb_layer_ack_yn(bool yn);
 void          clear_rgb_layers(void);
 void          shutdown_user_rgb(void);
+
+#    if defined(UNICODE_COMMON_ENABLE)
+void unicode_input_mode_set_user_rgb(uint8_t input_mode);
+#    endif
+
 #endif
 
 #ifdef UNICODEMAP_ENABLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change adds the following callbacks, to make the implementation indicators for the current unicode input mode easier:

|Callback                                                                          |Description                                                                 |
|-------------------------------------------------------------------------|---------------------------------------------------------------------|
| `unicode_input_mode_set_kb(uint8_t input_mode)`     | Callback for unicode input mode set, for keyboard.  |
| `unicode_input_mode_set_user(uint8_t input_mode)`  | Callback for unicode input mode set, for users.        |

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* _none_

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
