### PR TITLE
fix data-driven split handedness pin assignement

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -576,7 +576,15 @@
                         }
                     }
                 },
+                "main": {
+                    "$comment": "deprecated - see handedness instead",
+                    "deprecated": true,
+                    "type": "string",
+                    "enum": ["eeprom", "left", "matrix_grid", "pin", "right"]
+                },
                 "matrix_grid": {
+                    "$comment": "deprecated - see handedness instead",
+                    "deprecated": true,
                     "type": "array",
                     "items": {"$ref": "qmk.definitions.v1#/mcu_pin"}
                 },
@@ -608,9 +616,31 @@
                         }
                     }
                 },
-                "main": {
-                    "type": "string",
-                    "enum": ["eeprom", "left", "matrix_grid", "pin", "right"]
+                "handedness": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "method": {
+                            "type": "string",
+                            "enum": ["pin", "matrix_grid", "eeprom", "usb"]
+                        },
+                        "pin": {
+                            "$comment": "only needed if method=pin, ignored otherwise",
+                            "$ref": "qmk.definitions.v1#/mcu_pin"
+                        },
+                        "matrix_grid": {
+                            "$comment": "only needed if method=matrix_grid, ignored otherwise",
+                            "type": "array",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "items": {"$ref": "qmk.definitions.v1#/mcu_pin"}
+                        },
+                        "determined_side": {
+                            "$comment": "defined which side is determined if the method evaluates positively: pin=High, matrix_grid=Low, eeprom=(ignored), usb=Host-detected",
+                            "type": "string",
+                            "enum": ["left", "right"]
+                        }
+                    }
                 },
                 "soft_serial_pin": {"$ref": "qmk.definitions.v1#/mcu_pin"},
                 "soft_serial_speed": {

--- a/keyboards/tzarc/djinn/rev1/config.h
+++ b/keyboards/tzarc/djinn/rev1/config.h
@@ -3,7 +3,6 @@
 #pragma once
 
 // Split configuration
-#define SPLIT_HAND_PIN B11
 #ifdef USE_PLUG_DETECT_PIN
 #    define USB_VBUS_PIN B12
 #endif

--- a/keyboards/tzarc/djinn/rev1/info.json
+++ b/keyboards/tzarc/djinn/rev1/info.json
@@ -7,6 +7,11 @@
   },
   "split": {
     "soft_serial_pin": "B9",
+    "handedness": {
+      "method": "pin",
+      "pin": "B11",
+      "determined_side": "left"
+    },
     "usb_detect": {
       "enabled": true
     }

--- a/keyboards/tzarc/djinn/rev2/config.h
+++ b/keyboards/tzarc/djinn/rev2/config.h
@@ -3,7 +3,6 @@
 #pragma once
 
 // Split configuration
-#define SPLIT_HAND_PIN B9
 #define USB_VBUS_PIN B12
 #define SERIAL_USART_DRIVER SD3
 #define SERIAL_USART_PIN_SWAP

--- a/keyboards/tzarc/djinn/rev2/info.json
+++ b/keyboards/tzarc/djinn/rev2/info.json
@@ -6,6 +6,11 @@
     "max_brightness": 144
   },
   "split": {
+    "handedness": {
+      "method": "pin",
+      "pin": "B9",
+      "determined_side": "left"
+    },
     "usb_detect": {
       "enabled": false
     }

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -352,55 +352,134 @@ def _extract_secure_unlock(info_data, config_c):
         info_data['secure']['unlock_sequence'] = unlock_array
 
 
-def _extract_split_main(info_data, config_c):
-    """Populate data about the split configuration
-    """
-    # Figure out how the main half is determined
+def _extract_split_handedness(info_data, config_c):
+    _extract_split_handedness_pin(info_data, config_c)
+    _extract_split_handedness_matrix_grid(info_data, config_c)
+    _extract_split_handedness_eeprom(info_data, config_c)
+    _extract_split_handedness_usb(info_data, config_c)
+
+
+def _extract_split_handedness_pin(info_data, config_c):
     if config_c.get('SPLIT_HAND_PIN') is True:
         if 'split' not in info_data:
             info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
 
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (SPLIT_HAND_PIN) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
+        if info_data['split']['handedness'].get('method', '') == 'pin':
+            if 'pin' in info_data['split']['handedness']:
+                _log_warning(info_data, 'Split main hand is specified in both config.h (SPLIT_HAND_PIN) and info.json (split.handedness.method and split.handedness.pin) (Value: %s), the config.h value wins.' % info_data['split']['handedness']['pin'])
 
-        info_data['split']['main'] = 'pin'
+        info_data['split']['handedness'] = 'pin'
+        info_data['split']['handedness']['pin'] = _extract_pins(config_c['SPLIT_HAND_PIN'])[0]
 
+    if config_c.get('SPLIT_HAND_PIN_LOW_IS_LEFT'):
+        if 'split' not in info_data:
+            info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
+
+        if info_data['split']['handedness'].get('method', '') == 'pin':
+            if info_data['split']['handedness'].get('determined_side', None) == 'left':
+                _log_warning(
+                    info_data, 'Split main hand is specified in both config.h (SPLIT_HAND_PIN_LOW_IS_LEFT) and info.json (split.handedness.method and split.handedness.determined_side) (Value: %s), the config.h value wins.' %
+                    info_data['split']['handedness']['determined_side']
+                )
+
+        info_data['split']['handedness']['determined_side'] = 'right'
+    else:
+        if 'split' not in info_data:
+            info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
+        info_data['split']['handedness']['determined_side'] = 'left'
+
+
+def _extract_split_handedness_matrix_grid(info_data, config_c):
     if config_c.get('SPLIT_HAND_MATRIX_GRID'):
         if 'split' not in info_data:
             info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
 
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (SPLIT_HAND_MATRIX_GRID) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
+        if info_data['split']['handedness'].get('method', '') == 'matrix_grid':
+            if 'matrix_grid' in info_data['split']['handedness']:
+                _log_warning(
+                    info_data,
+                    'Split main hand is specified in both config.h (SPLIT_HAND_MATRIX_GRID) and info.json (split.handedness.method and split.handedness.matrix_grid) (Value: %s), the config.h value wins.' % info_data['split']['handedness']['matrix_grid']
+                )
 
-        info_data['split']['main'] = 'matrix_grid'
-        info_data['split']['matrix_grid'] = _extract_pins(config_c['SPLIT_HAND_MATRIX_GRID'])
+        info_data['split']['handedness']['method'] = 'matrix_grid'
+        info_data['split']['handedness']['matrix_grid'] = _extract_pins(config_c['SPLIT_HAND_MATRIX_GRID'])
 
+    if config_c.get('SPLIT_HAND_MATRIX_GRID_LOW_IS_RIGHT'):
+        if 'split' not in info_data:
+            info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
+
+        if info_data['split']['handedness'].get('method', '') == 'matrix_grid':
+            if info_data['split']['handedness'].get('determined_side', None) == 'right':
+                _log_warning(
+                    info_data, 'Split main hand is specified in both config.h (SPLIT_HAND_MATRIX_GRID_LOW_IS_RIGHT) and info.json (split.handedness.method and split.handedness.determined_side) (Value: %s), the config.h value wins.' %
+                    info_data['split']['handedness']['determined_side']
+                )
+
+        info_data['split']['handedness']['determined_side'] = 'right'
+    else:
+        if 'split' not in info_data:
+            info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
+        info_data['split']['handedness']['determined_side'] = 'left'
+
+
+def _extract_split_handedness_eeprom(info_data, config_c):
     if config_c.get('EE_HANDS') is True:
         if 'split' not in info_data:
             info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
 
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (EE_HANDS) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
+        if info_data['split']['handedness'].get('method', '') == 'eeprom':
+            if 'pin' in info_data['split']['handedness']:
+                _log_warning(info_data, 'Split main hand is specified in both config.h (EE_HANDS) and info.json (split.handedness.method) (Value: %s), the config.h value wins.' % info_data['split']['handedness']['method'])
 
-        info_data['split']['main'] = 'eeprom'
+        info_data['split']['handedness']['method'] = 'eeprom'
 
     if config_c.get('MASTER_RIGHT') is True:
         if 'split' not in info_data:
             info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
 
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (MASTER_RIGHT) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
+        if info_data['split']['handedness'].get('method', '') == 'usb':
+            if 'pin' in info_data['split']['handedness']:
+                _log_warning(
+                    info_data,
+                    'Split main hand is specified in both config.h (MASTER_RIGHT) and info.json (split.handedness.method and split.handedness.determined_side) (Value: %s), the config.h value wins.' % info_data['split']['handedness']['determined_side']
+                )
 
-        info_data['split']['main'] = 'right'
+        info_data['split']['handedness']['method'] = 'usb'
+        info_data['split']['handedness']['determined_side'] = 'right'
 
+
+def _extract_split_handedness_usb(info_data, config_c):
     if config_c.get('MASTER_LEFT') is True:
         if 'split' not in info_data:
             info_data['split'] = {}
+        if 'handedness' not in info_data['split']:
+            info_data['split']['handedness'] = {}
 
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (MASTER_LEFT) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
+        if info_data['split']['handedness'].get('method', '') == 'usb':
+            if 'pin' in info_data['split']['handedness']:
+                _log_warning(
+                    info_data,
+                    'Split main hand is specified in both config.h (MASTER_LEFT) and info.json (split.handedness.method and split.handedness.determined_side) (Value: %s), the config.h value wins.' % info_data['split']['handedness']['determined_side']
+                )
 
-        info_data['split']['main'] = 'left'
+        info_data['split']['handedness']['method'] = 'usb'
+        info_data['split']['handedness']['determined_side'] = 'left'
 
 
 def _extract_split_transport(info_data, config_c):
@@ -583,7 +662,7 @@ def _extract_config_h(info_data, config_c):
     _extract_matrix_info(info_data, config_c)
     _extract_audio(info_data, config_c)
     _extract_secure_unlock(info_data, config_c)
-    _extract_split_main(info_data, config_c)
+    _extract_split_handedness(info_data, config_c)
     _extract_split_transport(info_data, config_c)
     _extract_split_right_pins(info_data, config_c)
     _extract_encoders(info_data, config_c)


### PR DESCRIPTION
## Description

_(updated PR description based on changes from discussion)_

This PR fixes a number of issues with the current data-driven configuration for split handedness detection:
* There was a mix and inconsistent usage of `split.primary` and `split.main`. The generator for `config.h` was looking for a `primary` key, the but jsonschema and `info.py` only used `main`.
* `matrix_grid` config was incorrectly generated with additional `{ }` around `GP1,GP2` pin pairs
* handedness by pin high or low never was hooked up - missing pin value
* naming weirdness of `main`/`primary` - which has nothing to do with detecting which side we are on
* missing options for left or right configs when using pin or matrix_grid depending on low/high state when reading the pin or grid intersection

This PR marks the old json object `split.main` as deprecated while remaining a backwards compatible jsonschema, and introduces a new object for side detection:
```
"split": {
    "handedness": {
        "method": "pin|matrix_grid|eeprom|usb",
        "pin": "GP1",                          // only needed when using pin method
        "matrix_grid": ["GP1", "GP2"],         // only needed when using matrix_grid method
        "determined_side": "left|right"        // optional, only used with pin, matrix_grid, or fixed method
    }
}
```

This PR brings the config generation, the info command, and the only existing usage of the now deprecated data-driven config in line with the new `side_detection` schema and handles the conversion of old to new options.

This data-driven config maps to the following config.h keys:
```
#define SPLIT_HAND_PIN GP1
#define SPLIT_HAND_PIN_LOW_IS_LEFT

#define SPLIT_HAND_MATRIX_GRID GP1, GP2
#define SPLIT_HAND_MATRIX_GRID_LOW_IS_RIGHT

#define EE_HANDS

#define MASTER_LEFT
#define MASTER_RIGHT
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
