### PR TITLE
Disconnect `usb.device_ver`

### DIFF
--- a/data/mappings/info_config.json
+++ b/data/mappings/info_config.json
@@ -20,9 +20,7 @@
     "COMBO_COUNT": {"info_key": "combo.count", "value_type": "int"},
     "COMBO_TERM": {"info_key": "combo.term", "value_type": "int"},
     "DEBOUNCE": {"info_key": "debounce", "value_type": "int"},
-    "DEVICE_VER": {"info_key": "usb.device_ver", "value_type": "hex"},
-    # TODO: Replace ^^^ with vvv
-    #"DEVICE_VER": {"info_key": "usb.device_version", "value_type": "bcd_version"},
+    "DEVICE_VER": {"info_key": "usb.device_version", "value_type": "bcd_version"},
     "DIODE_DIRECTION": {"info_key": "diode_direction"},
     "DOUBLE_TAP_SHIFT_TURNS_ON_CAPS_WORD": {"info_key": "caps_word.double_tap_shift_turns_on", "value_type": "bool"},
     "FORCE_NKRO": {"info_key": "usb.force_nkro", "value_type": "bool"},

--- a/lib/python/qmk/cli/generate/layouts.py
+++ b/lib/python/qmk/cli/generate/layouts.py
@@ -9,12 +9,6 @@ from qmk.keyboard import keyboard_completer, keyboard_folder
 from qmk.path import is_keyboard, normpath
 from qmk.commands import dump_lines
 
-usb_properties = {
-    'vid': 'VENDOR_ID',
-    'pid': 'PRODUCT_ID',
-    'device_ver': 'DEVICE_VER',
-}
-
 
 @cli.argument('-o', '--output', arg_only=True, type=normpath, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -437,19 +437,6 @@ def _extract_matrix_info(info_data, config_c):
     return info_data
 
 
-# TODO: kill off usb.device_ver in favor of usb.device_version
-def _extract_device_version(info_data):
-    if info_data.get('usb'):
-        if info_data['usb'].get('device_version') and not info_data['usb'].get('device_ver'):
-            (major, minor, revision) = info_data['usb']['device_version'].split('.', 3)
-            info_data['usb']['device_ver'] = f'0x{major.zfill(2)}{minor}{revision}'
-        if not info_data['usb'].get('device_version') and info_data['usb'].get('device_ver'):
-            major = int(info_data['usb']['device_ver'][2:4])
-            minor = int(info_data['usb']['device_ver'][4])
-            revision = int(info_data['usb']['device_ver'][5])
-            info_data['usb']['device_version'] = f'{major}.{minor}.{revision}'
-
-
 def _config_to_json(key_type, config_value):
     """Convert config value using spec
     """
@@ -535,7 +522,6 @@ def _extract_config_h(info_data, config_c):
     _extract_split_right_pins(info_data, config_c)
     _extract_encoders(info_data, config_c)
     _extract_split_encoders(info_data, config_c)
-    _extract_device_version(info_data)
 
     return info_data
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The config.h mapping now points at `usb.device_version`, and the code to ensure both are populated is removed. The schema entry will remain until a version bump.

Also found an apparently unused dict in layouts.py for some reason.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
