### PR TITLE
Remove deprecated RESET keycode alias

### DIFF
--- a/quantum/keymap.h
+++ b/quantum/keymap.h
@@ -19,37 +19,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "platform_deps.h"
 #include "action.h"
-#if defined(__AVR__)
-#    include <avr/pgmspace.h>
-#elif defined PROTOCOL_CHIBIOS
-// We need to ensure that chibios is include before redefining reset
-#    include <ch.h>
-#endif
 #include "keycode.h"
 #include "report.h"
 #include "host.h"
-// #include "print.h"
 #include "debug.h"
 #include "keycode_config.h"
 #include "gpio.h" // for pin_t
 
-// ChibiOS uses RESET in its FlagStatus enumeration
-// Therefore define it as QK_BOOTLOADER here, to avoid name collision
-#if defined(PROTOCOL_CHIBIOS)
-#    define RESET QK_BOOTLOADER
-#endif
-// Gross hack, remove me and change RESET keycode to QK_BOOT
-#if defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1287__)
-#    undef RESET
-#endif
-
 #include "quantum_keycodes.h"
-
-// Gross hack, remove me and change RESET keycode to QK_BOOT
-#if defined(MCU_RP)
-#    undef RESET
-#endif
 
 // translates key to keycode
 uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key);

--- a/quantum/quantum_keycodes_legacy.h
+++ b/quantum/quantum_keycodes_legacy.h
@@ -4,7 +4,6 @@
 
 // Deprecated Quantum keycodes
 
-#define RESET        QK_BOOTLOADER
 #define DEBUG        QK_DEBUG_TOGGLE
 #define GRAVE_ESC    QK_GRAVE_ESCAPE
 #define EEPROM_RESET QK_CLEAR_EEPROM
@@ -14,3 +13,4 @@
 
 #define TERM_ON _Static_assert(false, "The Terminal feature has been removed from QMK. Please remove use of TERM_ON/TERM_OFF from your keymap.")
 #define TERM_OFF _Static_assert(false, "The Terminal feature has been removed from QMK.. Please remove use of TERM_ON/TERM_OFF from your keymap.")
+// #define RESET _Static_assert(false, "The RESET keycode has been removed from QMK.. Please remove use from your keymap.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`_Static_assert` currently cannot be added as it throws errors where the previous `RESET` bodges were required.

However, limiting legacy keycodes to only files where `QMK_KEYBOARD_H` is used makes it slightly happy. Mocked up in 2cbf950c6ea1ce8ae6ff5efa68e8c2add367fba9.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
