### PR TITLE
Move Bluetooth-related function calls up to host/keyboard level

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -883,8 +883,8 @@ ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
 
     ifeq ($(strip $(BLUETOOTH_DRIVER)), BluefruitLE)
         OPT_DEFS += -DBLUETOOTH_BLUEFRUIT_LE -DHAL_USE_SPI=TRUE
-        SRC += analog.c
         SRC += $(DRIVER_PATH)/bluetooth/bluefruit_le.cpp
+        QUANTUM_LIB_SRC += analog.c
         QUANTUM_LIB_SRC += spi_master.c
     endif
 

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -882,14 +882,14 @@ ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
     SRC += outputselect.c
 
     ifeq ($(strip $(BLUETOOTH_DRIVER)), BluefruitLE)
-        OPT_DEFS += -DBLUETOOTH_BLUEFRUIT_LE
+        OPT_DEFS += -DBLUETOOTH_BLUEFRUIT_LE -DHAL_USE_SPI=TRUE
         SRC += analog.c
         SRC += $(DRIVER_PATH)/bluetooth/bluefruit_le.cpp
         QUANTUM_LIB_SRC += spi_master.c
     endif
 
     ifeq ($(strip $(BLUETOOTH_DRIVER)), RN42)
-        OPT_DEFS += -DBLUETOOTH_RN42
+        OPT_DEFS += -DBLUETOOTH_RN42 -DHAL_USE_SERIAL=TRUE
         SRC += $(DRIVER_PATH)/bluetooth/rn42.c
         QUANTUM_LIB_SRC += uart.c
     endif

--- a/drivers/bluetooth/bluefruit_le.cpp
+++ b/drivers/bluetooth/bluefruit_le.cpp
@@ -79,9 +79,7 @@ struct sdep_msg {
 enum queue_type {
     QTKeyReport, // 1-byte modifier + 6-byte key report
     QTConsumer,  // 16-bit key code
-#ifdef MOUSE_ENABLE
     QTMouseMove, // 4-byte mouse report
-#endif
 };
 
 struct queue_item {
@@ -442,7 +440,7 @@ bool bluefruit_le_enable_keyboard(void) {
     // Disable command echo
     static const char kEcho[] PROGMEM = "ATE=0";
     // Make the advertised name match the keyboard
-    static const char kGapDevName[] PROGMEM = "AT+GAPDEVNAME=" STR(PRODUCT);
+    static const char kGapDevName[] PROGMEM = "AT+GAPDEVNAME=" PRODUCT;
     // Turn on keyboard support
     static const char kHidEnOn[] PROGMEM = "AT+BLEHIDEN=1";
 
@@ -658,7 +656,6 @@ void bluefruit_le_send_consumer_key(uint16_t usage) {
     }
 }
 
-#ifdef MOUSE_ENABLE
 void bluefruit_le_send_mouse_move(int8_t x, int8_t y, int8_t scroll, int8_t pan, uint8_t buttons) {
     struct queue_item item;
 
@@ -673,7 +670,6 @@ void bluefruit_le_send_mouse_move(int8_t x, int8_t y, int8_t scroll, int8_t pan,
         send_buf_send_one();
     }
 }
-#endif
 
 uint32_t bluefruit_le_read_battery_voltage(void) {
     return state.vbat;

--- a/drivers/bluetooth/bluefruit_le.cpp
+++ b/drivers/bluetooth/bluefruit_le.cpp
@@ -579,10 +579,12 @@ static bool process_queue_item(struct queue_item *item, uint16_t timeout) {
             snprintf(cmdbuf, sizeof(cmdbuf), fmtbuf, item->key.modifier, item->key.keys[0], item->key.keys[1], item->key.keys[2], item->key.keys[3], item->key.keys[4], item->key.keys[5]);
             return at_command(cmdbuf, NULL, 0, true, timeout);
 
+#ifdef EXTRAKEY_ENABLE
         case QTConsumer:
             strcpy_P(fmtbuf, PSTR("AT+BLEHIDCONTROLKEY=0x%04x"));
             snprintf(cmdbuf, sizeof(cmdbuf), fmtbuf, item->consumer);
             return at_command(cmdbuf, NULL, 0, true, timeout);
+#endif
 
 #ifdef MOUSE_ENABLE
         case QTMouseMove:

--- a/drivers/bluetooth/bluefruit_le.h
+++ b/drivers/bluetooth/bluefruit_le.h
@@ -40,12 +40,10 @@ extern void bluefruit_le_send_keys(uint8_t hid_modifier_mask, uint8_t *keys, uin
  * (milliseconds) */
 extern void bluefruit_le_send_consumer_key(uint16_t usage);
 
-#ifdef MOUSE_ENABLE
 /* Send a mouse/wheel movement report.
  * The parameters are signed and indicate positive or negative direction
  * change. */
 extern void bluefruit_le_send_mouse_move(int8_t x, int8_t y, int8_t scroll, int8_t pan, uint8_t buttons);
-#endif
 
 /* Compute battery voltage by reading an analog pin.
  * Returns the integer number of millivolts */

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -107,6 +107,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #ifdef BLUETOOTH_ENABLE
 #    include "outputselect.h"
+#    ifdef BLUETOOTH_BLUEFRUIT_LE
+#        include "bluefruit_le.h"
+#    elif BLUETOOTH_RN42
+#        include "rn42.h"
+#    endif
 #endif
 #ifdef CAPS_WORD_ENABLE
 #    include "caps_word.h"
@@ -346,8 +351,14 @@ void quantum_init(void) {
 #ifdef HAPTIC_ENABLE
     haptic_init();
 #endif
-#if defined(BLUETOOTH_ENABLE) && defined(OUTPUT_AUTO_ENABLE)
+#if defined(BLUETOOTH_ENABLE)
+#    if defined(BLUETOOTH_RN42)
+    rn42_init();
+#    endif
+
+#    if defined(OUTPUT_AUTO_ENABLE)
     set_output(OUTPUT_AUTO);
+#    endif
 #endif
 }
 
@@ -668,6 +679,10 @@ void keyboard_task(void) {
 
 #ifdef PROGRAMMABLE_BUTTON_ENABLE
     programmable_button_send();
+#endif
+
+#ifdef BLUETOOTH_BLUEFRUIT_LE
+    bluefruit_le_task();
 #endif
 
     led_task();

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -351,11 +351,6 @@ void quantum_init(void) {
 #ifdef HAPTIC_ENABLE
     haptic_init();
 #endif
-#if defined(BLUETOOTH_ENABLE)
-#    if defined(BLUETOOTH_RN42)
-    rn42_init();
-#    endif
-#endif
 }
 
 /** \brief keyboard_init
@@ -416,6 +411,9 @@ void keyboard_init(void) {
 #ifdef POINTING_DEVICE_ENABLE
     // init after split init
     pointing_device_init();
+#endif
+#if defined(BLUETOOTH_RN42)
+    rn42_init();
 #endif
 
 #if defined(DEBUG_MATRIX_SCAN_RATE) && defined(CONSOLE_ENABLE)

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -355,10 +355,6 @@ void quantum_init(void) {
 #    if defined(BLUETOOTH_RN42)
     rn42_init();
 #    endif
-
-#    if defined(OUTPUT_AUTO_ENABLE)
-    set_output(OUTPUT_AUTO);
-#    endif
 #endif
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Removed some useless `MOUSE_ENABLE` ifdefs in Bluefruit LE code (which caused issues with the main change here anyway)
* Fixed Bluefruit LE device name being in quotes (due to recent USB string define changes)
* Extracted Bluetooth-related code out of lufa.c and into host.c/keyboard.c so it can be platform-agnostic

Tested on a Pro Micro and Proton-C with both RN42 and BluefruitLE drivers.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
