### PR TITLE
keymaps/stapelberg: keypad layer for multimedia keys, wake on escape

### DIFF
--- a/keyboards/kinesis/keymaps/stapelberg/keymap.c
+++ b/keyboards/kinesis/keymaps/stapelberg/keymap.c
@@ -17,6 +17,7 @@
 #include QMK_KEYBOARD_H
 
 #define QWERTY 0 // Base qwerty
+#define LAYER1 1
 
 
 /****************************************************************************************************
@@ -56,7 +57,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 			   KC_LCTL,KC_LALT,
                                     KC_LGUI,
                            KC_BSPC,KC_ESC ,KC_END ,
-    KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_PSCR ,KC_SLCK  ,KC_PAUS, KC_NO, QK_BOOT,
+    KC_F9  ,KC_F10 ,KC_F11 ,KC_F12 ,KC_PSCR ,KC_SLCK  ,KC_PAUS, MO(1), QK_BOOT,
 	KC_6   ,KC_7   ,KC_8   ,KC_9   ,KC_0   ,KC_MINS,
 	KC_Y   ,KC_U   ,KC_I   ,KC_O   ,KC_P   ,KC_BSLS,
 	KC_H   ,KC_J   ,KC_K   ,KC_L   ,KC_SCLN,KC_QUOT,
@@ -65,5 +66,30 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
            KC_RALT,KC_RCTL,
            KC_PGUP,
            KC_PGDN,KC_ENTER ,KC_SPC
-    )
+    ),
+
+// LAYER1 is activated by the keypad key. It has WAKE on Escape (left-most key),
+// and volume keys on PSCR (mute), SLCK (volume down) and PAUS (volume up),
+// as printed on the Kinesis Advantage 2.
+[LAYER1] = LAYOUT(
+
+           KC_WAKE,  KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO,
+           KC_NO  ,  KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+           KC_NO  ,  KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+           KC_NO  ,  KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+           KC_NO  ,  KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+                   KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+			   KC_NO  ,KC_NO  ,
+                                    KC_NO  ,
+                           KC_NO  ,KC_NO  ,KC_NO  ,
+    KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_MUTE ,KC_VOLD  ,KC_VOLU, KC_TRNS, KC_NO  ,
+	KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+	KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+	KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+	KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+		KC_NO  ,KC_NO  ,KC_NO  ,KC_NO  ,
+           KC_NO  ,KC_NO  ,
+           KC_NO  ,
+           KC_NO  ,KC_NO    ,KC_NO
+    ),
 };


### PR DESCRIPTION
This makes more keys function as printed on the actual keyboard:

![image](https://user-images.githubusercontent.com/55506/188730127-d130edb1-45ca-4cf7-a250-7c785f88ceaa.png)

…also add a WAKE key in an easy-to-remember spot now that we have a separate layer :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
