### PR TITLE
Add Elite-C to converters

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -38,7 +38,7 @@
         },
         "pin_compatible": {
             "type": "string",
-            "enum": ["promicro"]
+            "enum": ["promicro", "elite_c"]
         },
         "processor": {
             "type": "string",

--- a/docs/feature_converters.md
+++ b/docs/feature_converters.md
@@ -19,6 +19,7 @@ Currently the following converters are available:
 | `promicro` | `bonsai_c4`       |
 | `promicro` | `elite_pi`        |
 | `elite_c`  | `stemcell`        |
+| `elite_c`  | `elite_pi`        |
 
 See below for more in depth information on each converter.
 
@@ -162,16 +163,22 @@ No peripherals are enabled by default at this time, but example code to enable S
 
 If a board currently supported in QMK uses an [Elite-C](https://keeb.io/products/elite-c-low-profile-version-usb-c-pro-micro-replacement-atmega32u4), the supported alternative controllers are:
 
-| Device                                               | Target            |
-|------------------------------------------------------|-------------------|
-| [STeMCell](https://github.com/megamind4089/STeMCell) | `stemcell`        |
+| Device                                                                           | Target            |
+|----------------------------------------------------------------------------------|-------------------|
+| [STeMCell](https://github.com/megamind4089/STeMCell)                             | `stemcell`        |
+| [Elite-Pi](https://keeb.io/products/elite-pi-usb-c-pro-micro-replacement-rp2040) | `elite_pi`        |
 
 Converter summary:
 
 | Target            | Argument                        | `rules.mk`                   | Condition                           |
 |-------------------|---------------------------------|------------------------------|-------------------------------------|
 | `stemcell`        | `-e CONVERT_TO=stemcell`        | `CONVERT_TO=stemcell`        | `#ifdef CONVERT_TO_STEMCELL`        |
+| `elite_pi`        | `-e CONVERT_TO=elite_pi`        | `CONVERT_TO=elite_pi`        | `#ifdef CONVERT_TO_ELITE_PI`        |
 
-### STeMCell :id=stemcell_c
+### STeMCell :id=stemcell_elite
 
 Currently identical to [STeMCell](#stemcell) with support for the additional bottom row of pins.
+
+### Elite-Pi :id=elite_pi
+
+Currently identical to [Adafruit KB2040](#kb2040), with support for the additional bottom row of pins.

--- a/docs/feature_converters.md
+++ b/docs/feature_converters.md
@@ -18,6 +18,7 @@ Currently the following converters are available:
 | `promicro` | `stemcell`        |
 | `promicro` | `bonsai_c4`       |
 | `promicro` | `elite_pi`        |
+| `elite_c`  | `stemcell`        |
 
 See below for more in depth information on each converter.
 
@@ -46,6 +47,23 @@ Once a converter is enabled, it exposes the `CONVERT_TO_<target_uppercase>` flag
 #else
     // Pro Micro code
 #endif
+```
+
+### Pin Compatibility
+
+To ensure compatibly, provide validation, and power future workflows, a keyboard should declare its `pin compatibility`. For legacy reasons, this is currently assumed to be `promicro`.
+
+Currently the following pin compatibility interfaces are defined:
+
+| Pinout     | Notes                             |
+|------------|-----------------------------------|
+| `promicro` | Includes RX/TX LEDs               |
+| `elite_c`  | Includes bottom row pins, no LEDs |
+
+To declare the base for conversions, add this line to your keyboard's `rules.mk`:
+
+```makefile
+PIN_COMPATIBLE = elite_c
 ```
 
 ## Pro Micro
@@ -107,7 +125,7 @@ The following defaults are based on what has been implemented for [RP2040](platf
 
 ### SparkFun Pro Micro - RP2040, Blok, Bit-C PRO, and Elite-Pi :id=promicro_rp2040 
 
-Currently identical to  [Adafruit KB2040](#kb2040).
+Currently identical to [Adafruit KB2040](#kb2040).
 
 ### STeMCell :id=stemcell
 
@@ -138,4 +156,22 @@ The Bonsai C4 only has one on-board LED (B2), and by default, both the Pro Micro
 #define B0 PAL_LINE(GPIOA, 9)
 ```
 
-No peripherals are enabled by default at this time, but example code to enable SPI, I2C, PWM, and Serial communications can be found [here](/keyboards/custommk/bonsai_c4_template)
+No peripherals are enabled by default at this time, but example code to enable SPI, I2C, PWM, and Serial communications can be found [here](/keyboards/custommk/bonsai_c4_template) 
+
+## Elite-C
+
+If a board currently supported in QMK uses a [Elite-C](https://keeb.io/products/elite-c-low-profile-version-usb-c-pro-micro-replacement-atmega32u4), the supported alternative controllers are:
+
+| Device                                               | Target            |
+|------------------------------------------------------|-------------------|
+| [STeMCell](https://github.com/megamind4089/STeMCell) | `stemcell`        |
+
+Converter summary:
+
+| Target            | Argument                        | `rules.mk`                   | Condition                           |
+|-------------------|---------------------------------|------------------------------|-------------------------------------|
+| `stemcell`        | `-e CONVERT_TO=stemcell`        | `CONVERT_TO=stemcell`        | `#ifdef CONVERT_TO_STEMCELL`        |
+
+### STeMCell :id=stemcell_c
+
+Currently identical to [STeMCell](#stemcell) with support for the additional bottom row of pins.

--- a/docs/feature_converters.md
+++ b/docs/feature_converters.md
@@ -51,7 +51,7 @@ Once a converter is enabled, it exposes the `CONVERT_TO_<target_uppercase>` flag
 
 ### Pin Compatibility
 
-To ensure compatibly, provide validation, and power future workflows, a keyboard should declare its `pin compatibility`. For legacy reasons, this is currently assumed to be `promicro`.
+To ensure compatibility, provide validation, and power future workflows, a keyboard should declare its `pin compatibility`. For legacy reasons, this is currently assumed to be `promicro`.
 
 Currently the following pin compatibility interfaces are defined:
 
@@ -156,11 +156,11 @@ The Bonsai C4 only has one on-board LED (B2), and by default, both the Pro Micro
 #define B0 PAL_LINE(GPIOA, 9)
 ```
 
-No peripherals are enabled by default at this time, but example code to enable SPI, I2C, PWM, and Serial communications can be found [here](/keyboards/custommk/bonsai_c4_template) 
+No peripherals are enabled by default at this time, but example code to enable SPI, I2C, PWM, and Serial communications can be found [here](/keyboards/custommk/bonsai_c4_template).
 
 ## Elite-C
 
-If a board currently supported in QMK uses a [Elite-C](https://keeb.io/products/elite-c-low-profile-version-usb-c-pro-micro-replacement-atmega32u4), the supported alternative controllers are:
+If a board currently supported in QMK uses an [Elite-C](https://keeb.io/products/elite-c-low-profile-version-usb-c-pro-micro-replacement-atmega32u4), the supported alternative controllers are:
 
 | Device                                               | Target            |
 |------------------------------------------------------|-------------------|

--- a/keyboards/cozykeys/speedo/v3/rules.mk
+++ b/keyboards/cozykeys/speedo/v3/rules.mk
@@ -4,6 +4,8 @@ MCU = atmega32u4
 # Bootloader selection
 BOOTLOADER = atmel-dfu
 
+PIN_COMPATIBLE = elite_c
+
 # Build Options
 #   change yes to no to disable
 #

--- a/platforms/chibios/converters/elite_c_to_elite_pi/_pin_defs.h
+++ b/platforms/chibios/converters/elite_c_to_elite_pi/_pin_defs.h
@@ -1,0 +1,39 @@
+// Copyright 2022 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// Left side (front)
+#define D3 0U
+#define D2 1U
+//      GND
+//      GND
+#define D1 2U
+#define D0 3U
+#define D4 4U
+#define C6 5U
+#define D7 6U
+#define E6 7U
+#define B4 8U
+#define B5 9U
+
+// Right side (front)
+//      RAW
+//      GND
+//      RESET
+//      VCC
+#define F4 29U
+#define F5 28U
+#define F6 27U
+#define F7 26U
+#define B1 22U
+#define B3 20U
+#define B2 23U
+#define B6 21U
+
+// Bottom row
+#define B7 12U
+#define D5 13U
+#define C7 14U
+#define F1 15U
+#define F0 16U

--- a/platforms/chibios/converters/elite_c_to_elite_pi/converter.mk
+++ b/platforms/chibios/converters/elite_c_to_elite_pi/converter.mk
@@ -1,0 +1,9 @@
+# Elite-Pi MCU settings for converting AVR projects
+MCU := RP2040
+BOARD := QMK_PM2040
+BOOTLOADER := rp2040
+
+# These are defaults based on what has been implemented for RP2040 boards
+SERIAL_DRIVER ?= vendor
+WS2812_DRIVER ?= vendor
+BACKLIGHT_DRIVER ?= software

--- a/platforms/chibios/converters/elite_c_to_stemcell/_pin_defs.h
+++ b/platforms/chibios/converters/elite_c_to_stemcell/_pin_defs.h
@@ -1,0 +1,54 @@
+// Copyright 2022 Mega Mind (@megamind4089)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// Pindefs for v2.0.0
+// https://megamind4089.github.io/STeMCell/pinout/
+
+// Left side (front)
+#ifdef STEMCELL_UART_SWAP
+#    define D3 PAL_LINE(GPIOA, 3)
+#    define D2 PAL_LINE(GPIOA, 2)
+#else
+#    define D3 PAL_LINE(GPIOA, 2)
+#    define D2 PAL_LINE(GPIOA, 3)
+#endif
+//      GND
+//      GND
+#ifdef STEMCELL_I2C_SWAP
+#    define D1 PAL_LINE(GPIOB, 6)
+#    define D0 PAL_LINE(GPIOB, 7)
+#else
+#    define D1 PAL_LINE(GPIOB, 7)
+#    define D0 PAL_LINE(GPIOB, 6)
+#endif
+
+#define D4 PAL_LINE(GPIOA, 15)
+#define C6 PAL_LINE(GPIOB, 3)
+#define D7 PAL_LINE(GPIOB, 4)
+#define E6 PAL_LINE(GPIOB, 5)
+#define B4 PAL_LINE(GPIOB, 8)
+#define B5 PAL_LINE(GPIOB, 9)
+
+// Right side (front)
+//      RAW
+//      GND
+//      RESET
+//      VCC
+#define F4 PAL_LINE(GPIOB, 10)
+#define F5 PAL_LINE(GPIOB, 2)
+#define F6 PAL_LINE(GPIOB, 1)
+#define F7 PAL_LINE(GPIOB, 0)
+
+#define B1 PAL_LINE(GPIOA, 5)
+#define B3 PAL_LINE(GPIOA, 6)
+#define B2 PAL_LINE(GPIOA, 7)
+#define B6 PAL_LINE(GPIOA, 4)
+
+// Bottom row
+#define B7 PAL_LINE(GPIOC, 13)
+#define D5 PAL_LINE(GPIOC, 14)
+#define C7 PAL_LINE(GPIOC, 15)
+#define F1 PAL_LINE(GPIOA, 0)
+#define F0 PAL_LINE(GPIOA, 1)

--- a/platforms/chibios/converters/elite_c_to_stemcell/converter.mk
+++ b/platforms/chibios/converters/elite_c_to_stemcell/converter.mk
@@ -1,0 +1,18 @@
+# Copyright 2022 Mega Mind (@megamind4089)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+MCU := STM32F411
+BOARD := STEMCELL
+BOOTLOADER := tinyuf2
+
+SERIAL_DRIVER ?= usart
+WS2812_DRIVER ?= bitbang
+
+ifeq ($(strip $(STMC_US)), yes)
+  OPT_DEFS += -DSTEMCELL_UART_SWAP
+endif
+
+ifeq ($(strip $(STMC_IS)), yes)
+  OPT_DEFS += -DSTEMCELL_I2C_SWAP
+endif
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
#18239 broke conversions which incorrectly relied on Elite-C pinouts for Pro Micro converters.

### Future iteration
Potentially reduce duplication by inferring `promicro` compatibility when targeting `elite_c`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
