### PR TITLE
Correct microdox/v2 pins and organize common defs

### DIFF
--- a/keyboards/boardsource/microdox/config.h
+++ b/keyboards/boardsource/microdox/config.h
@@ -19,23 +19,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
+#define MANUFACTURER Boardsource    
+#define PRODUCT microdox    
+#define PRODUCT_ID 0x0412    
+#define VENDOR_ID 0xF7E0
+
 /* key matrix size */
 // Rows are doubled-up
 #define MATRIX_ROWS 8
 #define MATRIX_COLS 5
-#define MATRIX_ROW_PINS \
-    { B2, B6, B4, B5 }
 
-// wiring of each half
-#define MATRIX_COL_PINS \
-    { F4, F5, F6, F7, B1 }
 #define USE_SERIAL
-#define SOFT_SERIAL_PIN D2
+
 /* define if matrix has ghost */
 //#define MATRIX_HAS_GHOST
-
-/* number of backlight levels */
-// #define BACKLIGHT_LEVELS 3
 
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5
@@ -47,18 +44,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 //#define LOCKING_RESYNC_ENABLE
-
-/* ws2812 RGB LED */
-#define RGB_DI_PIN D3
-#ifdef RGBLIGHT_ENABLE
-#    define RGBLED_NUM 12 // Number of LEDs
-#    define RGBLED_SPLIT \
-        { 6, 6 }
-#    define RGBLIGHT_EFFECT_BREATHING
-#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
-#    define RGBLIGHT_EFFECT_STATIC_GRADIENT
-
-#endif
 
 /*
  * Feature disable options

--- a/keyboards/boardsource/microdox/config.h
+++ b/keyboards/boardsource/microdox/config.h
@@ -19,11 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-#define MANUFACTURER Boardsource    
-#define PRODUCT microdox    
-#define PRODUCT_ID 0x0412    
-#define VENDOR_ID 0xF7E0
-
 /* key matrix size */
 // Rows are doubled-up
 #define MATRIX_ROWS 8

--- a/keyboards/boardsource/microdox/v1/config.h
+++ b/keyboards/boardsource/microdox/v1/config.h
@@ -3,18 +3,16 @@
 
 #pragma once
 
-/*
- * Feature disable options
- *  These options are also useful to firmware size reduction.
- */
+#define DEVICE_VER 0x0100
+#define RGB_DI_PIN D3
+#define RGBLED_NUM 12
+#define RGBLED_SPLIT { 6, 6 }
+#define RGBLIGHT_LIMIT_VAL 150
+#define RGBLIGHT_SLEEP
+#define SOFT_SERIAL_PIN D2
+#define RGBLIGHT_ANIMATIONS
+#define MATRIX_COL_PINS { F4, F5, F6, F7, B1 }
+#define MATRIX_ROW_PINS { B2, B6, B4, B5 }
 
-/* disable debug print */
-//#define NO_DEBUG
-
-/* disable print */
-//#define NO_PRINT
-
-/* disable action features */
-//#define NO_ACTION_LAYER
-//#define NO_ACTION_TAPPING
-//#define NO_ACTION_ONESHOT
+/* number of backlight levels */
+// #define BACKLIGHT_LEVELS 3

--- a/keyboards/boardsource/microdox/v1/config.h
+++ b/keyboards/boardsource/microdox/v1/config.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#define DEVICE_VER 0x0100
 #define RGB_DI_PIN D3
 #define RGBLED_NUM 12
 #define RGBLED_SPLIT { 6, 6 }

--- a/keyboards/boardsource/microdox/v2/config.h
+++ b/keyboards/boardsource/microdox/v2/config.h
@@ -1,8 +1,22 @@
 // Copyright 2022 jack (@waffle87)
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 #pragma once
 
-#undef RGB_DI_PIN
+#define DEVICE_VER 0x0200
+
+#define SOFT_SERIAL_PIN D3
+
+#define MATRIX_COL_PINS { D4, D7, B3, F7, F6 }
+#define MATRIX_ROW_PINS { F4, D2, C6, B1 }
+#define MATRIX_COL_PINS_RIGHT { F4, B1, D7, C6, B3 }
+#define MATRIX_ROW_PINS_RIGHT { F5, F7, F6, E6 }
+
+#define ENCODERS_PAD_A { E6 }
+#define ENCODERS_PAD_B { B2 }
+#define ENCODERS_PAD_A_RIGHT { B6 }
+#define ENCODERS_PAD_B_RIGHT { B2 }
+
 #define RGB_DI_PIN B5
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 150
 #define DRIVER_LED_TOTAL 44

--- a/keyboards/boardsource/microdox/v2/config.h
+++ b/keyboards/boardsource/microdox/v2/config.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#define DEVICE_VER 0x0200
-
 #define SOFT_SERIAL_PIN D3
 
 #define MATRIX_COL_PINS { D4, D7, B3, F7, F6 }


### PR DESCRIPTION
## Description

I flashed my v2 microdox a few days ago, but none of the switches were working. I looked at the firmware and realized that the `config.h` files were incorrectly configured. The config in the `microdox` folder defined the `v1` pins, and the `v2` config didn't override these values. The `info.json` files *are* correct, so I based the `config.h` updates of those.

I left all shared configuration in the parent `config.h`, and put version specific configs in the folders.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- But I only have a v2 microdox, so I can't test this for v1.
