### PR TITLE
GMMK2: Fix 'ISO' within product name

### DIFF
--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -45,6 +45,9 @@
 #    include "joystick.h"
 #endif
 
+// TODO: wb32 support defines ISO macro which breaks PRODUCT stringification
+#undef ISO
+
 // clang-format off
 
 /*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`p65/iso` / `p96/iso` currently produce:
```sh
$ lsusb
Bus 001 Device 115: ID 320f:504a Glorious GMMK V2 65 (( ISO_TypeDef *) ((((uint32_t)0x40000000UL) + 0x10000) + 0x6000))
```
Same garbage displays on windows.

This is due to the macro,
```sh
$ rg ISO_TypeDef
lib/chibios-contrib/os/common/ext/CMSIS/WB32/WB32F3G71xx/wb32f3g71xx.h
407:} ISO_TypeDef;
1074:#define ISO                       ((        ISO_TypeDef *)          ISO_BASE)
```
and PRODUCT code gen spitting out non quoted strings.

### NOTES
* super short term bodge while a better fix can target develop
* alternative could be to just lower case the iso part?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
