### PR TITLE
Correct keyboard_name for Unicomp Classic/Ultra Classic keyboards

### DIFF
--- a/keyboards/unicomp/classic_ultracl_post_2013/info.json
+++ b/keyboards/unicomp/classic_ultracl_post_2013/info.json
@@ -1,5 +1,5 @@
 {
-    "keyboard_name": "Unicomp Spacesaver M", 
+    "keyboard_name": "Unicomp Classic / Ultra Classic (post-2013)", 
     "manufacturer": "Unicomp/Purdea Andrei",
     "url": "https://github.com/purdeaandrei/overnumpad_controller_1xb", 
     "maintainer": "purdeaandrei", 

--- a/keyboards/unicomp/classic_ultracl_pre_2013/info.json
+++ b/keyboards/unicomp/classic_ultracl_pre_2013/info.json
@@ -1,5 +1,5 @@
 {
-    "keyboard_name": "Unicomp Spacesaver M", 
+    "keyboard_name": "Unicomp Classic / Ultra Classic (pre-2013)", 
     "manufacturer": "Unicomp/Purdea Andrei",
     "url": "https://github.com/purdeaandrei/overnumpad_controller_1xb", 
     "maintainer": "purdeaandrei", 


### PR DESCRIPTION
## Description

Correct keyboard_name for Unicomp Classic/Ultra Classic keyboards.
Setting originally in config.h was wrong due to a copy-paste mistake, and then the wrong value was migrated to info.json sometime in August.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
