### PR TITLE
[Bug] RP2040 tentative fix for XIP cache misses and subsequent lockups

### DIFF
--- a/platforms/chibios/boards/GENERIC_PROMICRO_RP2040/configs/chconf.h
+++ b/platforms/chibios/boards/GENERIC_PROMICRO_RP2040/configs/chconf.h
@@ -5,9 +5,15 @@
 
 #define CH_CFG_SMP_MODE                     TRUE
 #define CH_CFG_ST_RESOLUTION                32
-#define CH_CFG_ST_FREQUENCY                 1000000
+#define CH_CFG_ST_FREQUENCY                 10000
 #define CH_CFG_INTERVALS_SIZE               32
 #define CH_CFG_TIME_TYPES_SIZE              32
-#define CH_CFG_ST_TIMEDELTA                 20
+#define CH_CFG_ST_TIMEDELTA                 0
+
+/* Workaround a bug in chibios where port_timer_enable is not defined for RP2040 in tick mode */
+#if !defined(_FROM_ASM_)
+void stBind(void);
+#define port_timer_enable(oip) stBind()
+#endif
 
 #include_next <chconf.h>

--- a/platforms/chibios/boards/GENERIC_RP_RP2040/configs/chconf.h
+++ b/platforms/chibios/boards/GENERIC_RP_RP2040/configs/chconf.h
@@ -5,9 +5,15 @@
 
 #define CH_CFG_SMP_MODE                     TRUE
 #define CH_CFG_ST_RESOLUTION                32
-#define CH_CFG_ST_FREQUENCY                 1000000
+#define CH_CFG_ST_FREQUENCY                 10000
 #define CH_CFG_INTERVALS_SIZE               32
 #define CH_CFG_TIME_TYPES_SIZE              32
-#define CH_CFG_ST_TIMEDELTA                 20
+#define CH_CFG_ST_TIMEDELTA                 0
+
+/* Workaround a bug in chibios where port_timer_enable is not defined for RP2040 in tick mode */
+#if !defined(_FROM_ASM_)
+void stBind(void);
+#define port_timer_enable(oip) stBind()
+#endif
 
 #include_next <chconf.h>

--- a/platforms/chibios/boards/QMK_PM2040/configs/chconf.h
+++ b/platforms/chibios/boards/QMK_PM2040/configs/chconf.h
@@ -5,9 +5,16 @@
 
 #define CH_CFG_SMP_MODE                     TRUE
 #define CH_CFG_ST_RESOLUTION                32
-#define CH_CFG_ST_FREQUENCY                 1000000
+#define CH_CFG_ST_FREQUENCY                 10000
 #define CH_CFG_INTERVALS_SIZE               32
 #define CH_CFG_TIME_TYPES_SIZE              32
-#define CH_CFG_ST_TIMEDELTA                 20
+#define CH_CFG_ST_TIMEDELTA                 0
+
+/* Workaround a bug in chibios where port_timer_enable is not defined for RP2040 in tick mode */
+#if !defined(_FROM_ASM_)
+void stBind(void);
+#define port_timer_enable(oip) stBind()
+#endif
+
 
 #include_next <chconf.h>


### PR DESCRIPTION
## Description

Due to unpredictable spikes in execution when the XIP cache is missed and code / data has to be fetched from the external flash the virtual timers in ChibiOS could lockup. Until a proposed patch is merged into ChibiOS and lands in QMK we switch to the classic periodic tick implementation which is immune to the spike in the critical execution path.

Note: This change affects how short we could possibly sleep by yielding the current thread, but as we already use busy waiting for very short sleeps this change has no perceivable effect for us.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
