### PR TITLE
Move fake EE_HANDS from EEPROM init.

### DIFF
--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -57,16 +57,6 @@ void eeconfig_init_quantum(void) {
     eeprom_update_dword(EECONFIG_RGB_MATRIX, 0);
     eeprom_update_word(EECONFIG_RGB_MATRIX_EXTENDED, 0);
 
-    // TODO: Remove once ARM has a way to configure EECONFIG_HANDEDNESS
-    //        within the emulated eeprom via dfu-util or another tool
-#if defined INIT_EE_HANDS_LEFT
-#    pragma message "Faking EE_HANDS for left hand"
-    eeprom_update_byte(EECONFIG_HANDEDNESS, 1);
-#elif defined INIT_EE_HANDS_RIGHT
-#    pragma message "Faking EE_HANDS for right hand"
-    eeprom_update_byte(EECONFIG_HANDEDNESS, 0);
-#endif
-
 #if defined(HAPTIC_ENABLE)
     haptic_reset();
 #else

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -139,6 +139,20 @@ void split_pre_init(void) {
     if (!eeconfig_is_enabled()) {
         eeconfig_init();
     }
+    // TODO: Remove once ARM has a way to configure EECONFIG_HANDEDNESS within the emulated eeprom via dfu-util or another tool
+#    if defined(INIT_EE_HANDS_LEFT) || defined(INIT_EE_HANDS_RIGHT)
+#        if defined(INIT_EE_HANDS_LEFT)
+#            pragma message "Faking EE_HANDS for left hand"
+    const bool should_be_left = true;
+#        else
+#            pragma message "Faking EE_HANDS for right hand"
+    const bool should_be_left = false;
+#        endif
+    bool       is_left        = eeconfig_read_handedness();
+    if (is_left != should_be_left) {
+        eeconfig_update_handedness(should_be_left);
+    }
+#    endif // defined(INIT_EE_HANDS_LEFT) || defined(INIT_EE_HANDS_RIGHT)
 #endif
     isLeftHand = is_keyboard_left();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Moves and adds some logic so fake EE_HANDS no longer requires a EEPROM init. 

Triggering a EEPROM init can be a pain with split keyboards that make use of `_RIGHT` defines for the matrix. This also emulates AVR better when flashing with left/right bootloader targets.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
