### PR TITLE
Tap mod swap magic

### DIFF
--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -38,93 +38,93 @@ uint16_t keycode_config(uint16_t keycode) {
             return keycode;
     }
     /* only the low byte of keycode swapped depending on the magic settings */
-    uint16_t mod = keycode & 0xff00;
+    uint16_t keycode_mask = keycode & 0xff00;
     switch (keycode & 0x00ff) {
         case KC_CAPS_LOCK:
         case KC_LOCKING_CAPS_LOCK:
             if (keymap_config.swap_control_capslock || keymap_config.capslock_to_control) {
-                return KC_LEFT_CTRL | mod;
+                return KC_LEFT_CTRL | keycode_mask;
             } else if (keymap_config.swap_escape_capslock) {
-                return KC_ESCAPE | mod;
+                return KC_ESCAPE | keycode_mask;
             }
             return keycode;
         case KC_LEFT_CTRL:
             if (keymap_config.swap_control_capslock) {
-                return KC_CAPS_LOCK | mod;
+                return KC_CAPS_LOCK | keycode_mask;
             }
             if (keymap_config.swap_lctl_lgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO | mod;
+                    return KC_NO | keycode_mask;
                 }
-                return KC_LEFT_GUI | mod;
+                return KC_LEFT_GUI | keycode_mask;
             }
             return keycode;
         case KC_LEFT_ALT:
             if (keymap_config.swap_lalt_lgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO | mod;
+                    return KC_NO | keycode_mask;
                 }
-                return KC_LEFT_GUI | mod;
+                return KC_LEFT_GUI | keycode_mask;
             }
             return keycode;
         case KC_LEFT_GUI:
             if (keymap_config.swap_lalt_lgui) {
-                return KC_LEFT_ALT | mod;
+                return KC_LEFT_ALT | keycode_mask;
             }
             if (keymap_config.swap_lctl_lgui) {
-                return KC_LEFT_CTRL | mod;
+                return KC_LEFT_CTRL | keycode_mask;
             }
             if (keymap_config.no_gui) {
-                return KC_NO | mod;
+                return KC_NO | keycode_mask;
             }
             return keycode;
         case KC_RIGHT_CTRL:
             if (keymap_config.swap_rctl_rgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO | mod;
+                    return KC_NO | keycode_mask;
                 }
-                return KC_RIGHT_GUI | mod;
+                return KC_RIGHT_GUI | keycode_mask;
             }
             return keycode;
         case KC_RIGHT_ALT:
             if (keymap_config.swap_ralt_rgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO | mod;
+                    return KC_NO | keycode_mask;
                 }
-                return KC_RIGHT_GUI | mod;
+                return KC_RIGHT_GUI | keycode_mask;
             }
             return keycode;
         case KC_RIGHT_GUI:
             if (keymap_config.swap_ralt_rgui) {
-                return KC_RIGHT_ALT | mod;
+                return KC_RIGHT_ALT | keycode_mask;
             }
             if (keymap_config.swap_rctl_rgui) {
-                return KC_RIGHT_CTRL | mod;
+                return KC_RIGHT_CTRL | keycode_mask;
             }
             if (keymap_config.no_gui) {
-                return KC_NO | mod;
+                return KC_NO | keycode_mask;
             }
             return keycode;
         case KC_GRAVE:
             if (keymap_config.swap_grave_esc) {
-                return KC_ESCAPE | mod;
+                return KC_ESCAPE | keycode_mask;
             }
             return keycode;
         case KC_ESCAPE:
             if (keymap_config.swap_grave_esc) {
-                return KC_GRAVE | mod;
+                return KC_GRAVE | keycode_mask;
             } else if (keymap_config.swap_escape_capslock) {
-                return KC_CAPS_LOCK | mod;
+                return KC_CAPS_LOCK | keycode_mask;
             }
             return keycode;
         case KC_BACKSLASH:
             if (keymap_config.swap_backslash_backspace) {
-                return KC_BACKSPACE | mod;
+                return KC_BACKSPACE | keycode_mask;
             }
             return keycode;
         case KC_BACKSPACE:
             if (keymap_config.swap_backslash_backspace) {
-                return KC_BACKSLASH | mod;
+                return KC_BACKSLASH | keycode_mask;
             }
             return keycode;
         default:

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -23,7 +23,7 @@ extern keymap_config_t keymap_config;
  * This function is used to check a specific keycode against the bootmagic config,
  * and will return the corrected keycode, when appropriate.
  */
-uint16_t keycode_config(uint16_t keycode) {
+__attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
     switch (keycode) {
         case QK_BASIC ... QK_MODS_MAX: /* 0x0000 ... 0x1fff*/
             /* basic keycodes and keycodes with extra modifiers */
@@ -138,7 +138,7 @@ uint16_t keycode_config(uint16_t keycode) {
  *  and will remove or replace mods, based on that.
  */
 
-uint8_t mod_config(uint8_t mod) {
+__attribute__((weak)) uint8_t mod_config(uint8_t mod) {
     if (keymap_config.swap_lalt_lgui) {
         if ((mod & MOD_RGUI) == MOD_LGUI) {
             mod &= ~MOD_LGUI;

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -25,93 +25,108 @@ extern keymap_config_t keymap_config;
  */
 uint16_t keycode_config(uint16_t keycode) {
     switch (keycode) {
+        case QK_BASIC ... QK_MODS_MAX: /* 0x0000 ... 0x1fff*/
+            /* basic keycodes and keycodes with extra modifiers */
+        case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:   /* 0x4000 ... 0x4fff */
+        case QK_SWAP_HANDS ... QK_SWAP_HANDS_MAX: /* 0x5600 ... 0x56ff */
+            /* the low byte might also contain some special values, but
+             * these values should not be changed by the magic settings
+             */
+        case QK_MOD_TAP ... QK_MOD_TAP_MAX: /* 0x6000 ... 0x7fff */
+            break;
+        default:
+            return keycode;
+    }
+    /* only the low byte of keycode swapped depending on the magic settings */
+    uint16_t mod = keycode & 0xff00;
+    switch (keycode & 0x00ff) {
         case KC_CAPS_LOCK:
         case KC_LOCKING_CAPS_LOCK:
             if (keymap_config.swap_control_capslock || keymap_config.capslock_to_control) {
-                return KC_LEFT_CTRL;
+                return KC_LEFT_CTRL | mod;
             } else if (keymap_config.swap_escape_capslock) {
-                return KC_ESCAPE;
+                return KC_ESCAPE | mod;
             }
             return keycode;
         case KC_LEFT_CTRL:
             if (keymap_config.swap_control_capslock) {
-                return KC_CAPS_LOCK;
+                return KC_CAPS_LOCK | mod;
             }
             if (keymap_config.swap_lctl_lgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO;
+                    return KC_NO | mod;
                 }
-                return KC_LEFT_GUI;
+                return KC_LEFT_GUI | mod;
             }
-            return KC_LEFT_CTRL;
+            return keycode;
         case KC_LEFT_ALT:
             if (keymap_config.swap_lalt_lgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO;
+                    return KC_NO | mod;
                 }
-                return KC_LEFT_GUI;
+                return KC_LEFT_GUI | mod;
             }
-            return KC_LEFT_ALT;
+            return keycode;
         case KC_LEFT_GUI:
             if (keymap_config.swap_lalt_lgui) {
-                return KC_LEFT_ALT;
+                return KC_LEFT_ALT | mod;
             }
             if (keymap_config.swap_lctl_lgui) {
-                return KC_LEFT_CTRL;
+                return KC_LEFT_CTRL | mod;
             }
             if (keymap_config.no_gui) {
-                return KC_NO;
+                return KC_NO | mod;
             }
-            return KC_LEFT_GUI;
+            return keycode;
         case KC_RIGHT_CTRL:
             if (keymap_config.swap_rctl_rgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO;
+                    return KC_NO | mod;
                 }
-                return KC_RIGHT_GUI;
+                return KC_RIGHT_GUI | mod;
             }
-            return KC_RIGHT_CTRL;
+            return keycode;
         case KC_RIGHT_ALT:
             if (keymap_config.swap_ralt_rgui) {
                 if (keymap_config.no_gui) {
-                    return KC_NO;
+                    return KC_NO | mod;
                 }
-                return KC_RIGHT_GUI;
+                return KC_RIGHT_GUI | mod;
             }
-            return KC_RIGHT_ALT;
+            return keycode;
         case KC_RIGHT_GUI:
             if (keymap_config.swap_ralt_rgui) {
-                return KC_RIGHT_ALT;
+                return KC_RIGHT_ALT | mod;
             }
             if (keymap_config.swap_rctl_rgui) {
-                return KC_RIGHT_CTRL;
+                return KC_RIGHT_CTRL | mod;
             }
             if (keymap_config.no_gui) {
-                return KC_NO;
+                return KC_NO | mod;
             }
-            return KC_RIGHT_GUI;
+            return keycode;
         case KC_GRAVE:
             if (keymap_config.swap_grave_esc) {
-                return KC_ESCAPE;
+                return KC_ESCAPE | mod;
             }
-            return KC_GRAVE;
+            return keycode;
         case KC_ESCAPE:
             if (keymap_config.swap_grave_esc) {
-                return KC_GRAVE;
+                return KC_GRAVE | mod;
             } else if (keymap_config.swap_escape_capslock) {
-                return KC_CAPS_LOCK;
+                return KC_CAPS_LOCK | mod;
             }
-            return KC_ESCAPE;
+            return keycode;
         case KC_BACKSLASH:
             if (keymap_config.swap_backslash_backspace) {
-                return KC_BACKSPACE;
+                return KC_BACKSPACE | mod;
             }
-            return KC_BACKSLASH;
+            return keycode;
         case KC_BACKSPACE:
             if (keymap_config.swap_backslash_backspace) {
-                return KC_BACKSLASH;
+                return KC_BACKSLASH | mod;
             }
-            return KC_BACKSPACE;
+            return keycode;
         default:
             return keycode;
     }

--- a/quantum/keycode_config.h
+++ b/quantum/keycode_config.h
@@ -19,6 +19,7 @@
 #include "eeconfig.h"
 #include "keycode.h"
 #include "action_code.h"
+#include "quantum_keycodes.h"
 
 uint16_t keycode_config(uint16_t keycode);
 uint8_t  mod_config(uint8_t mod);

--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -37,7 +37,7 @@ float cg_swap_song[][2] = CG_SWAP_SONG;
 /**
  * MAGIC actions (BOOTMAGIC without the boot)
  */
-bool process_magic(uint16_t keycode, keyrecord_t *record) {
+__attribute__((weak)) bool process_magic(uint16_t keycode, keyrecord_t *record) {
     // skip anything that isn't a keyup
     if (record->event.pressed) {
         switch (keycode) {


### PR DESCRIPTION
This is for  https://github.com/qmk/qmk_firmware/issues/18349

This worked for my case of combination of
 * mod-tap MT(MOD_LCTL, KC_ESC)
 * MAGIC MAGIC_SWAP_ESCAPE_CAPS

At least some effort is made to avoid applying swap for non-keycode
Other case are included and made to be synmetrical.
Code may need some reformatting.  (/* ...*/ comment)
This is more-or-less proof-of-concept patch.
So there may be shortcomings.

## Description

See issue. https://github.com/qmk/qmk_firmware/issues/18349

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

This solves  https://github.com/qmk/qmk_firmware/issues/18349

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [NO] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage). --- Yes tested but not exhaustive yet. 
