### PR TITLE
Remove TERM_ON/TERM_OFF from my keymap

### DIFF
--- a/layouts/community/ortho_5x12/riblee/keymap.c
+++ b/layouts/community/ortho_5x12/riblee/keymap.c
@@ -196,7 +196,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 [_ADJUST] = LAYOUT_ortho_5x12(
     KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,    KC_F10,  KC_F11,    KC_F12,
-    _______, QK_BOOT, DEBUG,   _______, _______, _______, _______, TERM_ON, TERM_OFF, KC_INS,  KC_PSCR,   KC_DEL,
+    _______, QK_BOOT, DEBUG,   _______, _______, _______, _______, _______, _______,  KC_INS,  KC_PSCR,   KC_DEL,
     _______, _______, MU_MOD,  AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK,  DVORAK,  HUNGARIAN, WORKMAN,
     _______, _______, _______, _______, UC_MOD,  UC_RMOD, NK_TOGG, CG_NORM, CG_SWAP,  _______, _______,   _______,
     _______, _______, _______, _______, _______, _______, _______, _______, _______,  _______, _______,   _______


### PR DESCRIPTION
## Description

Remove terminal related keycodes from my keymap.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
