### PR TITLE
Enabling Pointing Device support in register code functions

### DIFF
--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -303,16 +303,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
             break;
     }
 #        endif // !NO_CHARYBDIS_KEYCODES
-#        ifndef MOUSEKEY_ENABLE
-    // Simulate mouse keys if full support is not enabled (reduces firmware size
-    // while maintaining support for mouse keys).
-    if (IS_MOUSEKEY_BUTTON(keycode)) {
-        report_mouse_t mouse_report = pointing_device_get_report();
-        mouse_report.buttons        = pointing_device_handle_buttons(mouse_report.buttons, record->event.pressed, keycode - KC_MS_BTN1);
-        pointing_device_set_report(mouse_report);
-        pointing_device_send();
-    }
-#        endif // !MOUSEKEY_ENABLE
 #    endif     // POINTING_DEVICE_ENABLE
     if ((keycode >= POINTER_DEFAULT_DPI_FORWARD && keycode < CHARYBDIS_SAFE_RANGE) || IS_MOUSEKEY(keycode)) {
         debug_charybdis_config_to_console(&g_charybdis_config);

--- a/keyboards/handwired/tractyl_manuform/tractyl_manuform.c
+++ b/keyboards/handwired/tractyl_manuform/tractyl_manuform.c
@@ -308,16 +308,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
             break;
     }
 #    endif  // !NO_CHARYBDIS_KEYCODES
-#    ifndef MOUSEKEY_ENABLE
-    // Simulate mouse keys if full support is not enabled (reduces firmware size
-    // while maintaining support for mouse keys).
-    if (IS_MOUSEKEY_BUTTON(keycode)) {
-        report_mouse_t mouse_report = pointing_device_get_report();
-        mouse_report.buttons        = pointing_device_handle_buttons(mouse_report.buttons, record->event.pressed, keycode - KC_MS_BTN1);
-        pointing_device_set_report(mouse_report);
-        pointing_device_send();
-    }
-#    endif  // !MOUSEKEY_ENABLE
     return true;
 }
 

--- a/keyboards/ploopyco/mouse/mouse.c
+++ b/keyboards/ploopyco/mouse/mouse.c
@@ -167,21 +167,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
 #endif
     }
 
-/* If Mousekeys is disabled, then use handle the mouse button
- * keycodes.  This makes things simpler, and allows usage of
- * the keycodes in a consistent manner.  But only do this if
- * Mousekeys is not enable, so it's not handled twice.
- */
-#ifndef MOUSEKEY_ENABLE
-    if (IS_MOUSEKEY_BUTTON(keycode)) {
-        report_mouse_t currentReport = pointing_device_get_report();
-        currentReport.buttons        = pointing_device_handle_buttons(currentReport.buttons, record->event.pressed, keycode - KC_MS_BTN1);
-        pointing_device_set_report(currentReport);
-        pointing_device_send();
-    }
-
-#endif
-
     return true;
 }
 

--- a/keyboards/ploopyco/trackball/trackball.c
+++ b/keyboards/ploopyco/trackball/trackball.c
@@ -178,14 +178,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
  * the keycodes in a consistent manner.  But only do this if
  * Mousekeys is not enable, so it's not handled twice.
  */
-#ifndef MOUSEKEY_ENABLE
-    if (IS_MOUSEKEY_BUTTON(keycode)) {
-        report_mouse_t currentReport = pointing_device_get_report();
-        currentReport.buttons        = pointing_device_handle_buttons(currentReport.buttons, record->event.pressed, keycode - KC_MS_BTN1);
-        pointing_device_set_report(currentReport);
-        pointing_device_send();
-    }
-#endif
 
     return true;
 }

--- a/keyboards/ploopyco/trackball_mini/trackball_mini.c
+++ b/keyboards/ploopyco/trackball_mini/trackball_mini.c
@@ -169,20 +169,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
         pointing_device_set_cpi(is_drag_scroll ? PLOOPY_DRAGSCROLL_DPI : dpi_array[keyboard_config.dpi_config]);
     }
 
-/* If Mousekeys is disabled, then use handle the mouse button
- * keycodes.  This makes things simpler, and allows usage of
- * the keycodes in a consistent manner.  But only do this if
- * Mousekeys is not enable, so it's not handled twice.
- */
-#ifndef MOUSEKEY_ENABLE
-    if (IS_MOUSEKEY_BUTTON(keycode)) {
-        report_mouse_t currentReport = pointing_device_get_report();
-        currentReport.buttons        = pointing_device_handle_buttons(currentReport.buttons, record->event.pressed, keycode - KC_MS_BTN1);
-        pointing_device_set_report(currentReport);
-        pointing_device_send();
-    }
-#endif
-
     return true;
 }
 

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -918,6 +918,10 @@ __attribute__((weak)) void register_code(uint8_t code) {
         mousekey_on(code);
         mousekey_send();
     }
+#elif defined(POINTING_DEVICE_ENABLE)
+    else if IS_MOUSEKEY(code) {
+        pointing_device_keycode_handler(code, true);
+    }
 #endif
 }
 
@@ -977,6 +981,10 @@ __attribute__((weak)) void unregister_code(uint8_t code) {
     else if IS_MOUSEKEY (code) {
         mousekey_off(code);
         mousekey_send();
+    }
+#elif defined(POINTING_DEVICE_ENABLE)
+    else if IS_MOUSEKEY(code) {
+        pointing_device_keycode_handler(code, false);
     }
 #endif
 }

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -919,7 +919,7 @@ __attribute__((weak)) void register_code(uint8_t code) {
         mousekey_send();
     }
 #elif defined(POINTING_DEVICE_ENABLE)
-    else if IS_MOUSEKEY(code) {
+    else if IS_MOUSEKEY (code) {
         pointing_device_keycode_handler(code, true);
     }
 #endif
@@ -983,7 +983,7 @@ __attribute__((weak)) void unregister_code(uint8_t code) {
         mousekey_send();
     }
 #elif defined(POINTING_DEVICE_ENABLE)
-    else if IS_MOUSEKEY(code) {
+    else if IS_MOUSEKEY (code) {
         pointing_device_keycode_handler(code, false);
     }
 #endif

--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -469,7 +469,7 @@ __attribute__((weak)) report_mouse_t pointing_device_task_combined_user(report_m
 }
 #endif
 
-void pointing_device_keycode_handler(uint16_t keycode, bool pressed) {
+__attribute__((weak)) void pointing_device_keycode_handler(uint16_t keycode, bool pressed) {
     if IS_MOUSEKEY_BUTTON (keycode) {
         local_mouse_report.buttons = pointing_device_handle_buttons(local_mouse_report.buttons, pressed, keycode - KC_MS_BTN1);
         pointing_device_set_report(local_mouse_report);

--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -471,7 +471,7 @@ __attribute__((weak)) report_mouse_t pointing_device_task_combined_user(report_m
 
 void pointing_device_keycode_handler(uint16_t keycode, bool pressed) {
     if IS_MOUSEKEY_BUTTON (keycode) {
-        local_mouse_report.buttons = pointing_device_handle_buttons(local_mouse_report.buttons, true, keycode - KC_MS_BTN1);
+        local_mouse_report.buttons = pointing_device_handle_buttons(local_mouse_report.buttons, pressed, keycode - KC_MS_BTN1);
         pointing_device_set_report(local_mouse_report);
         pointing_device_send();
     // } else if IS_MOUSEKEY_WHEEL (code) {

--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -472,17 +472,6 @@ __attribute__((weak)) report_mouse_t pointing_device_task_combined_user(report_m
 __attribute__((weak)) void pointing_device_keycode_handler(uint16_t keycode, bool pressed) {
     if IS_MOUSEKEY_BUTTON (keycode) {
         local_mouse_report.buttons = pointing_device_handle_buttons(local_mouse_report.buttons, pressed, keycode - KC_MS_BTN1);
-        pointing_device_set_report(local_mouse_report);
         pointing_device_send();
-    // } else if IS_MOUSEKEY_WHEEL (code) {
-    //     if (code == KC_MS_WH_UP) {
-    //         local_mouse_report.h = 1;
-    //     } else if (code == KC_MS_WH_DOWN) {
-    //         local_mouse_report.h = -1;
-    //     } else if (code == KC_MS_WH_LEFT) {
-    //         local_mouse_report.v = -1;
-    //     } else if (code == KC_MS_WH_RIGHT) {
-    //         local_mouse_report.v = 1;
-    //     }
     }
 }

--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -22,6 +22,7 @@
 #ifdef MOUSEKEY_ENABLE
 #    include "mousekey.h"
 #endif
+
 #if (defined(POINTING_DEVICE_ROTATION_90) + defined(POINTING_DEVICE_ROTATION_180) + defined(POINTING_DEVICE_ROTATION_270)) > 1
 #    error More than one rotation selected.  This is not supported.
 #endif
@@ -467,3 +468,21 @@ __attribute__((weak)) report_mouse_t pointing_device_task_combined_user(report_m
     return pointing_device_combine_reports(left_report, right_report);
 }
 #endif
+
+void pointing_device_keycode_handler(uint16_t keycode, bool pressed) {
+    if IS_MOUSEKEY_BUTTON (keycode) {
+        local_mouse_report.buttons = pointing_device_handle_buttons(local_mouse_report.buttons, true, keycode - KC_MS_BTN1);
+        pointing_device_set_report(local_mouse_report);
+        pointing_device_send();
+    // } else if IS_MOUSEKEY_WHEEL (code) {
+    //     if (code == KC_MS_WH_UP) {
+    //         local_mouse_report.h = 1;
+    //     } else if (code == KC_MS_WH_DOWN) {
+    //         local_mouse_report.h = -1;
+    //     } else if (code == KC_MS_WH_LEFT) {
+    //         local_mouse_report.v = -1;
+    //     } else if (code == KC_MS_WH_RIGHT) {
+    //         local_mouse_report.v = 1;
+    //     }
+    }
+}

--- a/quantum/pointing_device/pointing_device.h
+++ b/quantum/pointing_device/pointing_device.h
@@ -100,6 +100,7 @@ report_mouse_t pointing_device_task_kb(report_mouse_t mouse_report);
 report_mouse_t pointing_device_task_user(report_mouse_t mouse_report);
 uint8_t        pointing_device_handle_buttons(uint8_t buttons, bool pressed, pointing_device_buttons_t button);
 report_mouse_t pointing_device_adjust_by_defines(report_mouse_t mouse_report);
+void           pointing_device_keycode_handler(uint16_t keycode, bool pressed);
 
 #if defined(SPLIT_POINTING_ENABLE)
 void     pointing_device_set_shared_report(report_mouse_t report);


### PR DESCRIPTION
## Description

Removes custom keycode handling for pointing device keyboards, and allows for register_code to properly handle mouse buttons when mousekeys is off. 

## Types of Changes

- [x] Core
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
