### PR TITLE
Keymap config ram

### DIFF
--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -47,7 +47,9 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
             case MAGIC_TOGGLE_CONTROL_CAPSLOCK:
             case MAGIC_SWAP_ESCAPE_CAPSLOCK ... MAGIC_TOGGLE_ESCAPE_CAPSLOCK:
                 /* keymap config */
+#ifndef KEYMAP_CONFIG_RAM
                 keymap_config.raw = eeconfig_read_keymap();
+#endif
                 switch (keycode) {
                     case MAGIC_SWAP_CONTROL_CAPSLOCK:
                         keymap_config.swap_control_capslock = true;
@@ -184,7 +186,9 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
                         break;
                 }
 
+#ifndef KEYMAP_CONFIG_RAM
                 eeconfig_update_keymap(keymap_config.raw);
+#endif
                 clear_keyboard(); // clear to prevent stuck keys
 
                 return false;


### PR DESCRIPTION
Provide an optional feature to keymap_config data to be non-persistent.

This means keyboard always turn on to its default map without surprize of swapped keys but you still retain capability to swap via quantum keycode.

## Description

This is an implementation of my comment posted as
https://github.com/qmk/qmk_firmware/pull/18353#issuecomment-1247516071

Instead of storing the keymap_config struct in eeprom, this enables user to select storing it in RAM if KEYMAP_CONFIG_RAM is defined.

The QMK behavior doesn't change for existing keyboards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

No more surprise for some swapped keys.  At least, power-on reset them all.
 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
