### PR TITLE
[QP] Add RGB565 surface. Docs clarification, cleanup, tabsification, and reordering.

### DIFF
--- a/docs/quantum_painter.md
+++ b/docs/quantum_painter.md
@@ -46,7 +46,9 @@ Drivers have their own set of configurable options, and are described in their r
 
 ## Quantum Painter CLI Commands :id=quantum-painter-cli
 
-### `qmk painter-convert-graphics`
+<!-- tabs:start -->
+
+### ** `qmk painter-convert-graphics` **
 
 This command converts images to a format usable by QMK, i.e. the QGF File Format.
 
@@ -94,7 +96,7 @@ Writing /home/qmk/qmk_firmware/keyboards/my_keeb/generated/my_image.qgf.h...
 Writing /home/qmk/qmk_firmware/keyboards/my_keeb/generated/my_image.qgf.c...
 ```
 
-### `qmk painter-make-font-image`
+### ** `qmk painter-make-font-image` **
 
 This command converts a TTF font to an intermediate format for editing, before converting to the QFF File Format.
 
@@ -127,7 +129,7 @@ The `UNICODE_GLYPHS` argument allows for specifying extra unicode glyphs to gene
 $ qmk painter-make-font-image --font NotoSans-ExtraCondensedBold.ttf --size 11 -o noto11.png --unicode-glyphs "ĄȽɂɻɣɈʣ"
 ```
 
-### `qmk painter-convert-font-image`
+### ** `qmk painter-convert-font-image` **
 
 This command converts an intermediate font image to the QFF File Format.
 
@@ -171,419 +173,205 @@ Writing /home/qmk/qmk_firmware/keyboards/my_keeb/generated/noto11.qff.h...
 Writing /home/qmk/qmk_firmware/keyboards/my_keeb/generated/noto11.qff.c...
 ```
 
-## Quantum Painter Drawing API :id=quantum-painter-api
-
-All APIs require a `painter_device_t` object as their first parameter -- this object comes from the specific device initialisation, and instructions on creating it can be found in each driver's respective section.
-
-To use any of the APIs, you need to include `qp.h`:
-```c
-#include <qp.h>
-```
-
-### General Notes :id=quantum-painter-api-general
-
-The coordinate system used in Quantum Painter generally accepts `left`, `top`, `right`, and `bottom` instead of x/y/width/height, and each coordinate is inclusive of where pixels should be drawn. This is required as some datatypes used by display panels have a maximum value of `255` -- for any value or geometry extent that matches `256`, this would be represented as a `0`, instead.
-
-?> Drawing a horizontal line 8 pixels long, starting from 4 pixels inside the left side of the display, will need `left=4`, `right=11`.
-
-All color data matches the standard QMK HSV triplet definitions:
-
-* Hue is of the range `0...255` and is internally mapped to 0...360 degrees.
-* Saturation is of the range `0...255` and is internally mapped to 0...100% saturation.
-* Value is of the range `0...255` and is internally mapped to 0...100% brightness.
-
-?> Colors used in Quantum Painter are not subject to the RGB lighting CIE curve, if it is enabled.
-
-### Device Control :id=quantum-painter-api-device-control
-
-#### Display Initialisation :id=quantum-painter-api-init
-
-```c
-bool qp_init(painter_device_t device, painter_rotation_t rotation);
-```
-
-The `qp_init` function is used to initialise a display device after it has been created. This accepts a rotation parameter (`QP_ROTATION_0`, `QP_ROTATION_90`, `QP_ROTATION_180`, `QP_ROTATION_270`), which makes sure that the orientation of what's drawn on the display is correct.
-
-```c
-static painter_device_t display;
-void keyboard_post_init_kb(void) {
-    display = qp_make_.......;         // Create the display
-    qp_init(display, QP_ROTATION_0);   // Initialise the display
-}
-```
-
-#### Display Power :id=quantum-painter-api-power
-
-```c
-bool qp_power(painter_device_t device, bool power_on);
-```
-
-The `qp_power` function instructs the display whether or not the display panel should be on or off.
-
-!> If there is a separate backlight controlled through the normal QMK backlight API, this is not controlled by the `qp_power` function and needs to be manually handled elsewhere.
-
-```c
-static uint8_t last_backlight = 255;
-void suspend_power_down_user(void) {
-    if (last_backlight == 255) {
-        last_backlight = get_backlight_level();
-    }
-    backlight_set(0);
-    rgb_matrix_set_suspend_state(true);
-    qp_power(display, false);
-}
-
-void suspend_wakeup_init_user(void) {
-    qp_power(display, true);
-    rgb_matrix_set_suspend_state(false);
-    if (last_backlight != 255) {
-        backlight_set(last_backlight);
-    }
-    last_backlight = 255;
-}
-```
-
-#### Display Clear :id=quantum-painter-api-clear
-
-```c
-bool qp_clear(painter_device_t device);
-```
-
-The `qp_clear` function clears the display's screen.
-
-#### Display Flush :id=quantum-painter-api-flush
-
-```c
-bool qp_flush(painter_device_t device);
-```
-
-The `qp_flush` function ensures that all drawing operations are "pushed" to the display. This should be done as the last operation whenever a sequence of draws occur, and guarantees that any changes are applied.
-
-!> Some display panels may seem to work even without a call to `qp_flush` -- this may be because the driver cannot queue drawing operations and needs to display them immediately when invoked. In general, calling `qp_flush` at the end is still considered "best practice".
-
-```c
-void housekeeping_task_user(void) {
-    static uint32_t last_draw = 0;
-    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
-        last_draw = timer_read32();
-        // Draw a rect based off the current RGB color
-        qp_rect(display, 0, 7, 0, 239, rgb_matrix_get_hue(), 255, 255);
-        qp_flush(display);
-    }
-}
-```
-
-### Drawing Primitives :id=quantum-painter-api-primitives
-
-#### Set Pixel :id=quantum-painter-api-setpixel
-
-```c
-bool qp_setpixel(painter_device_t device, uint16_t x, uint16_t y, uint8_t hue, uint8_t sat, uint8_t val);
-```
-
-The `qp_setpixel` can be used to set a specific pixel on the screen to the supplied color.
-
-?> Using `qp_setpixel` for large amounts of drawing operations is inefficient and should be avoided unless they cannot be achieved with other drawing APIs.
-
-```c
-void housekeeping_task_user(void) {
-    static uint32_t last_draw = 0;
-    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
-        last_draw = timer_read32();
-        // Draw a 240px high vertical rainbow line on X=0:
-        for (int i = 0; i < 239; ++i) {
-            qp_setpixel(display, 0, i, i, 255, 255);
-        }
-        qp_flush(display);
-    }
-}
-```
-
-#### Draw Line :id=quantum-painter-api-line
-
-```c
-bool qp_line(painter_device_t device, uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t hue, uint8_t sat, uint8_t val);
-```
-
-The `qp_line` can be used to draw lines on the screen with the supplied color.
-
-```c
-void housekeeping_task_user(void) {
-    static uint32_t last_draw = 0;
-    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
-        last_draw = timer_read32();
-        // Draw 8px-wide rainbow down the left side of the display
-        for (int i = 0; i < 239; ++i) {
-            qp_line(display, 0, i, 7, i, i, 255, 255);
-        }
-        qp_flush(display);
-    }
-}
-```
-
-#### Draw Rect :id=quantum-painter-api-rect
-
-```c
-bool qp_rect(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint8_t hue, uint8_t sat, uint8_t val, bool filled);
-```
-
-The `qp_rect` can be used to draw rectangles on the screen with the supplied color, with or without a background fill. If not filled, any pixels inside the rectangle will be left as-is.
-
-```c
-void housekeeping_task_user(void) {
-    static uint32_t last_draw = 0;
-    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
-        last_draw = timer_read32();
-        // Draw 8px-wide rainbow filled rectangles down the left side of the display
-        for (int i = 0; i < 239; i+=8) {
-            qp_rect(display, 0, i, 7, i+7, i, 255, 255, true);
-        }
-        qp_flush(display);
-    }
-}
-```
-
-#### Draw Circle :id=quantum-painter-api-circle
-
-```c
-bool qp_circle(painter_device_t device, uint16_t x, uint16_t y, uint16_t radius, uint8_t hue, uint8_t sat, uint8_t val, bool filled);
-```
-
-The `qp_circle` can be used to draw circles on the screen with the supplied color, with or without a background fill. If not filled, any pixels inside the circle will be left as-is.
-
-```c
-void housekeeping_task_user(void) {
-    static uint32_t last_draw = 0;
-    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
-        last_draw = timer_read32();
-        // Draw r=4 filled circles down the left side of the display
-        for (int i = 0; i < 239; i+=8) {
-            qp_circle(display, 4, 4+i, 4, i, 255, 255, true);
-        }
-        qp_flush(display);
-    }
-}
-```
-
-#### Draw Ellipse :id=quantum-painter-api-ellipse
-
-```c
-bool qp_ellipse(painter_device_t device, uint16_t x, uint16_t y, uint16_t sizex, uint16_t sizey, uint8_t hue, uint8_t sat, uint8_t val, bool filled);
-```
-
-The `qp_ellipse` can be used to draw ellipses on the screen with the supplied color, with or without a background fill. If not filled, any pixels inside the ellipses will be left as-is.
-
-```c
-void housekeeping_task_user(void) {
-    static uint32_t last_draw = 0;
-    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
-        last_draw = timer_read32();
-        // Draw 16x8 filled ellipses down the left side of the display
-        for (int i = 0; i < 239; i+=8) {
-            qp_ellipse(display, 8, 4+i, 16, 8, i, 255, 255, true);
-        }
-        qp_flush(display);
-    }
-}
-```
-
-### Image Functions :id=quantum-painter-api-images
-
-#### Load Image :id=quantum-painter-api-load-image
-
-```c
-painter_image_handle_t qp_load_image_mem(const void *buffer);
-```
-
-The `qp_load_image_mem` function loads a QGF image from memory or flash.
-
-`qp_load_image_mem` returns a handle to the loaded image, which can then be used to draw to the screen using `qp_drawimage`, `qp_drawimage_recolor`, `qp_animate`, or `qp_animate_recolor`. If an image is no longer required, it can be unloaded by calling `qp_close_image` below.
-
-See the [CLI Commands](quantum_painter.md?id=quantum-painter-cli) for instructions on how to convert images to [QGF](quantum_painter_qgf.md).
-
-?> The total number of images available to load at any one time is controlled by the configurable option `QUANTUM_PAINTER_NUM_IMAGES` in the table above. If more images are required, the number should be increased in `config.h`.
-
-Image information is available through accessing the handle:
-
-| Property    | Accessor             |
-|-------------|----------------------|
-| Width       | `image->width`       |
-| Height      | `image->height`      |
-| Frame Count | `image->frame_count` |
-
-#### Unload Image :id=quantum-painter-api-close-image
-
-```c
-bool qp_close_image(painter_image_handle_t image);
-```
-
-The `qp_close_image` function releases resources related to the loading of the supplied image.
-
-#### Draw image :id=quantum-painter-api-draw-image
-
-```c
-bool qp_drawimage(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image);
-bool qp_drawimage_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
-```
-
-The `qp_drawimage` and `qp_drawimage_recolor` functions draw the supplied image to the screen at the supplied location, with the latter function allowing for monochrome-based images to be recolored.
-
-```c
-// Draw an image on the bottom-right of the 240x320 display on initialisation
-static painter_image_handle_t my_image;
-void keyboard_post_init_kb(void) {
-    my_image = qp_load_image_mem(gfx_my_image);
-    if (my_image != NULL) {
-        qp_drawimage(display, (239 - my_image->width), (319 - my_image->height), my_image);
-    }
-}
-```
-
-#### Animate Image :id=quantum-painter-api-animate-image
-
-```c
-deferred_token qp_animate(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image);
-deferred_token qp_animate_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
-```
-
-The `qp_animate` and `qp_animate_recolor` functions draw the supplied image to the screen at the supplied location, with the latter function allowing for monochrome-based animations to be recolored. They also set up internal timing such that each frame is rendered at the correct time as per the animated image.
-
-Once an image has been set to animate, it will loop indefinitely until stopped, with no user intervention required.
-
-Both functions return a `deferred_token`, which can then be used to stop the animation, using `qp_stop_animation` below.
-
-```c
-// Animate an image on the bottom-right of the 240x320 display on initialisation
-static painter_image_handle_t my_image;
-static deferred_token my_anim;
-void keyboard_post_init_kb(void) {
-    my_image = qp_load_image_mem(gfx_my_image);
-    if (my_image != NULL) {
-        my_anim = qp_animate(display, (239 - my_image->width), (319 - my_image->height), my_image);
-    }
-}
-```
-
-#### Stop Animation :id=quantum-painter-api-stop-animation
-
-```c
-void qp_stop_animation(deferred_token anim_token);
-```
-
-The `qp_stop_animation` function stops the previously-started animation.
-```c
-void housekeeping_task_user(void) {
-    if (some_random_stop_reason) {
-        qp_stop_animation(my_anim);
-    }
-}
-```
-
-### Font Functions :id=quantum-painter-api-fonts
-
-#### Load Font :id=quantum-painter-api-load-font
-
-```c
-painter_font_handle_t qp_load_font_mem(const void *buffer);
-```
-
-The `qp_load_font_mem` function loads a QFF font from memory or flash.
-
-`qp_load_font_mem` returns a handle to the loaded font, which can then be measured using `qp_textwidth`, or drawn to the screen using `qp_drawtext`, or `qp_drawtext_recolor`. If a font is no longer required, it can be unloaded by calling `qp_close_font` below.
-
-See the [CLI Commands](quantum_painter.md?id=quantum-painter-cli) for instructions on how to convert TTF fonts to [QFF](quantum_painter_qff.md).
-
-?> The total number of fonts available to load at any one time is controlled by the configurable option `QUANTUM_PAINTER_NUM_FONTS` in the table above. If more fonts are required, the number should be increased in `config.h`.
-
-Font information is available through accessing the handle:
-
-| Property    | Accessor             |
-|-------------|----------------------|
-| Line Height | `image->line_height` |
-
-#### Unload Font :id=quantum-painter-api-close-font
-
-```c
-bool qp_close_font(painter_font_handle_t font);
-```
-
-The `qp_close_font` function releases resources related to the loading of the supplied font.
-
-#### Measure Text :id=quantum-painter-api-textwidth
-
-```c
-int16_t qp_textwidth(painter_font_handle_t font, const char *str);
-```
-
-The `qp_textwidth` function allows measurement of how many pixels wide the supplied string would result in, for the given font.
-
-#### Draw Text :id=quantum-painter-api-drawtext
-
-```c
-int16_t qp_drawtext(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str);
-int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
-```
-
-The `qp_drawtext` and `qp_drawtext_recolor` functions draw the supplied string to the screen at the given location using the font supplied, with the latter function allowing for monochrome-based fonts to be recolored.
-
-```c
-// Draw a text message on the bottom-right of the 240x320 display on initialisation
-static painter_font_handle_t my_font;
-void keyboard_post_init_kb(void) {
-    my_font = qp_load_font_mem(font_opensans);
-    if (my_font != NULL) {
-        static const char *text = "Hello from QMK!";
-        int16_t width = qp_textwidth(my_font, text);
-        qp_drawtext(display, (239 - width), (319 - my_font->line_height), my_font, text);
-    }
-}
-```
-
-### Advanced Functions :id=quantum-painter-api-advanced
-
-#### Get Geometry :id=quantum-painter-api-get-geometry
-
-```c
-void qp_get_geometry(painter_device_t device, uint16_t *width, uint16_t *height, painter_rotation_t *rotation, uint16_t *offset_x, uint16_t *offset_y);
-```
-
-The `qp_get_geometry` function allows external code to retrieve the current width, height, rotation, and drawing offsets.
-
-#### Set Viewport Offsets :id=quantum-painter-api-set-viewport
-
-```c
-void qp_set_viewport_offsets(painter_device_t device, uint16_t offset_x, uint16_t offset_y);
-```
-
-The `qp_set_viewport_offsets` function can be used to offset all subsequent drawing operations. For example, if a display controller is internally 240x320, but the display panel is 240x240 and has a Y offset of 80 pixels, you could invoke `qp_set_viewport_offsets(display, 0, 80);` and the drawing positioning would be corrected.
-
-#### Set Viewport :id=quantum-painter-api-viewport
-
-```c
-bool qp_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom);
-```
-
-The `qp_viewport` function controls where raw pixel data is written to.
-
-#### Stream Pixel Data :id=quantum-painter-api-pixdata
-
-```c
-bool qp_pixdata(painter_device_t device, const void *pixel_data, uint32_t native_pixel_count);
-```
-
-The `qp_pixdata` function allows raw pixel data to be streamed to the display. It requires a native pixel count rather than the number of bytes to transfer, to ensure display panel data alignment is respected. E.g. for display panels using RGB565 internal format, sending 10 pixels will result in 20 bytes of transfer.
-
-!> Under normal circumstances, users will not need to manually call either `qp_viewport` or `qp_pixdata`. These allow for writing of raw pixel information, in the display panel's native format, to the area defined by the viewport.
+<!-- tabs:end -->
 
 ## Quantum Painter Display Drivers :id=quantum-painter-drivers
 
-### Common: Surfaces
+<!-- tabs:start -->
+
+### ** Common: Standard TFT (SPI + D/C + RST) **
+
+Most TFT display panels use a 5-pin interface -- SPI SCK, SPI MOSI, SPI CS, D/C, and RST pins.
+
+For these displays, QMK's `spi_master` must already be correctly configured for the platform you're building for.
+
+The pin assignments for SPI CS, D/C, and RST are specified during device construction.
+
+<!-- tabs:start -->
+
+#### ** GC9A01 **
+
+Enabling support for the GC9A01 in Quantum Painter is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PAINTER_ENABLE = yes
+QUANTUM_PAINTER_DRIVERS += gc9a01_spi
+```
+
+Creating a GC9A01 device in firmware can then be done with the following API:
+
+```c
+painter_device_t qp_gc9a01_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+```
+
+The device handle returned from the `qp_gc9a01_make_spi_device` function can be used to perform all other drawing operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 displays:
+#define GC9A01_NUM_DEVICES 3
+```
+
+#### ** ILI9163 **
+
+Enabling support for the ILI9163 in Quantum Painter is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PAINTER_ENABLE = yes
+QUANTUM_PAINTER_DRIVERS += ili9163_spi
+```
+
+Creating a ILI9163 device in firmware can then be done with the following API:
+
+```c
+painter_device_t qp_ili9163_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+```
+
+The device handle returned from the `qp_ili9163_make_spi_device` function can be used to perform all other drawing operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 displays:
+#define ILI9163_NUM_DEVICES 3
+```
+
+#### ** ILI9341 **
+
+Enabling support for the ILI9341 in Quantum Painter is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PAINTER_ENABLE = yes
+QUANTUM_PAINTER_DRIVERS += ili9341_spi
+```
+
+Creating a ILI9341 device in firmware can then be done with the following API:
+
+```c
+painter_device_t qp_ili9341_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+```
+
+The device handle returned from the `qp_ili9341_make_spi_device` function can be used to perform all other drawing operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 displays:
+#define ILI9341_NUM_DEVICES 3
+```
+
+#### ** ILI9488 **
+
+Enabling support for the ILI9488 in Quantum Painter is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PAINTER_ENABLE = yes
+QUANTUM_PAINTER_DRIVERS += ili9488_spi
+```
+
+Creating a ILI9488 device in firmware can then be done with the following API:
+
+```c
+painter_device_t qp_ili9488_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+```
+
+The device handle returned from the `qp_ili9488_make_spi_device` function can be used to perform all other drawing operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 displays:
+#define ILI9488_NUM_DEVICES 3
+```
+
+#### ** SSD1351 **
+
+Enabling support for the SSD1351 in Quantum Painter is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PAINTER_ENABLE = yes
+QUANTUM_PAINTER_DRIVERS += ssd1351_spi
+```
+
+Creating a SSD1351 device in firmware can then be done with the following API:
+
+```c
+painter_device_t qp_ssd1351_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+```
+
+The device handle returned from the `qp_ssd1351_make_spi_device` function can be used to perform all other drawing operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 displays:
+#define SSD1351_NUM_DEVICES 3
+```
+
+#### ** ST7735 **
+
+Enabling support for the ST7735 in Quantum Painter is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PAINTER_ENABLE = yes
+QUANTUM_PAINTER_DRIVERS += st7735_spi
+```
+
+Creating a ST7735 device in firmware can then be done with the following API:
+
+```c
+painter_device_t qp_st7735_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+```
+
+The device handle returned from the `qp_st7735_make_spi_device` function can be used to perform all other drawing operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 displays:
+#define ST7735_NUM_DEVICES 3
+```
+
+!> Some ST7735 devices are known to have different drawing offsets -- despite being a 132x162 pixel display controller internally, some display panels are only 80x160, or smaller. These may require an offset to be applied; see `qp_set_viewport_offsets` above for information on how to override the offsets if they aren't correctly rendered.
+
+#### ** ST7789 **
+
+Enabling support for the ST7789 in Quantum Painter is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PAINTER_ENABLE = yes
+QUANTUM_PAINTER_DRIVERS += st7789_spi
+```
+
+Creating a ST7789 device in firmware can then be done with the following API:
+
+```c
+painter_device_t qp_st7789_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+```
+
+The device handle returned from the `qp_st7789_make_spi_device` function can be used to perform all other drawing operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 displays:
+#define ST7789_NUM_DEVICES 3
+```
+
+!> Some ST7789 devices are known to have different drawing offsets -- despite being a 240x320 pixel display controller internally, some display panels are only 240x240, or smaller. These may require an offset to be applied; see `qp_set_viewport_offsets` above for information on how to override the offsets if they aren't correctly rendered.
+
+<!-- tabs:end -->
+
+### ** Common: Surfaces **
 
 Quantum Painter has surface drivers which are able to target a buffer in RAM. In general, surfaces keep track of the "dirty" region -- the area that has been drawn to since the last flush -- so that when transferring to the display they can transfer the minimal amount of data to achieve the end result.
 
 !> These generally require significant amounts of RAM, so at large sizes and/or higher bit depths, they may not be usable on all MCUs.
 
-### RGB565 Surface :id=qp-driver-rgb565surface
+<!-- tabs:start -->
+
+#### ** RGB565 Surface **
 
 Enabling support for RGB565 surfaces in Quantum Painter is done by adding the following to `rules.mk`:
 
@@ -619,182 +407,434 @@ The `surface` is the surface to copy out from. The `display` is the target displ
 
 ?> Calling `qp_flush()` on the surface resets its dirty region. Copying the surface contents to the display also automatically resets the dirty region.
 
-### Common: Standard TFT (SPI + D/C + RST)
+<!-- tabs:end -->
 
-Most TFT display panels use a 5-pin interface -- SPI SCK, SPI MOSI, SPI CS, D/C, and RST pins.
+<!-- tabs:end -->
 
-For these displays, QMK's `spi_master` must already be correctly configured for the platform you're building for.
+## Quantum Painter Drawing API :id=quantum-painter-api
 
-The pin assignments for SPI CS, D/C, and RST are specified during device construction.
+All APIs require a `painter_device_t` object as their first parameter -- this object comes from the specific device initialisation, and instructions on creating it can be found in each driver's respective section.
 
-### GC9A01 :id=qp-driver-gc9a01
-
-Enabling support for the GC9A01 in Quantum Painter is done by adding the following to `rules.mk`:
-
-```make
-QUANTUM_PAINTER_ENABLE = yes
-QUANTUM_PAINTER_DRIVERS += gc9a01_spi
+To use any of the APIs, you need to include `qp.h`:
+```c
+#include <qp.h>
 ```
 
-Creating a GC9A01 device in firmware can then be done with the following API:
+<!-- tabs:start -->
+
+### ** General Notes **
+
+The coordinate system used in Quantum Painter generally accepts `left`, `top`, `right`, and `bottom` instead of x/y/width/height, and each coordinate is inclusive of where pixels should be drawn. This is required as some datatypes used by display panels have a maximum value of `255` -- for any value or geometry extent that matches `256`, this would be represented as a `0`, instead.
+
+?> Drawing a horizontal line 8 pixels long, starting from 4 pixels inside the left side of the display, will need `left=4`, `right=11`.
+
+All color data matches the standard QMK HSV triplet definitions:
+
+* Hue is of the range `0...255` and is internally mapped to 0...360 degrees.
+* Saturation is of the range `0...255` and is internally mapped to 0...100% saturation.
+* Value is of the range `0...255` and is internally mapped to 0...100% brightness.
+
+?> Colors used in Quantum Painter are not subject to the RGB lighting CIE curve, if it is enabled.
+
+### ** Device Control **
+
+<!-- tabs:start -->
+
+#### ** Display Initialisation **
 
 ```c
-painter_device_t qp_gc9a01_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+bool qp_init(painter_device_t device, painter_rotation_t rotation);
 ```
 
-The device handle returned from the `qp_gc9a01_make_spi_device` function can be used to perform all other drawing operations.
-
-The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+The `qp_init` function is used to initialise a display device after it has been created. This accepts a rotation parameter (`QP_ROTATION_0`, `QP_ROTATION_90`, `QP_ROTATION_180`, `QP_ROTATION_270`), which makes sure that the orientation of what's drawn on the display is correct.
 
 ```c
-// 3 displays:
-#define GC9A01_NUM_DEVICES 3
+static painter_device_t display;
+void keyboard_post_init_kb(void) {
+    display = qp_make_.......;         // Create the display
+    qp_init(display, QP_ROTATION_0);   // Initialise the display
+}
 ```
 
-### ILI9163 :id=qp-driver-ili9163
-
-Enabling support for the ILI9163 in Quantum Painter is done by adding the following to `rules.mk`:
-
-```make
-QUANTUM_PAINTER_ENABLE = yes
-QUANTUM_PAINTER_DRIVERS += ili9163_spi
-```
-
-Creating a ILI9163 device in firmware can then be done with the following API:
+#### ** Display Power **
 
 ```c
-painter_device_t qp_ili9163_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+bool qp_power(painter_device_t device, bool power_on);
 ```
 
-The device handle returned from the `qp_ili9163_make_spi_device` function can be used to perform all other drawing operations.
+The `qp_power` function instructs the display whether or not the display panel should be on or off.
 
-The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+!> If there is a separate backlight controlled through the normal QMK backlight API, this is not controlled by the `qp_power` function and needs to be manually handled elsewhere.
 
 ```c
-// 3 displays:
-#define ILI9163_NUM_DEVICES 3
+static uint8_t last_backlight = 255;
+void suspend_power_down_user(void) {
+    if (last_backlight == 255) {
+        last_backlight = get_backlight_level();
+    }
+    backlight_set(0);
+    rgb_matrix_set_suspend_state(true);
+    qp_power(display, false);
+}
+
+void suspend_wakeup_init_user(void) {
+    qp_power(display, true);
+    rgb_matrix_set_suspend_state(false);
+    if (last_backlight != 255) {
+        backlight_set(last_backlight);
+    }
+    last_backlight = 255;
+}
 ```
 
-### ILI9341 :id=qp-driver-ili9341
-
-Enabling support for the ILI9341 in Quantum Painter is done by adding the following to `rules.mk`:
-
-```make
-QUANTUM_PAINTER_ENABLE = yes
-QUANTUM_PAINTER_DRIVERS += ili9341_spi
-```
-
-Creating a ILI9341 device in firmware can then be done with the following API:
+#### ** Display Clear **
 
 ```c
-painter_device_t qp_ili9341_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+bool qp_clear(painter_device_t device);
 ```
 
-The device handle returned from the `qp_ili9341_make_spi_device` function can be used to perform all other drawing operations.
+The `qp_clear` function clears the display's screen.
 
-The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+#### ** Display Flush **
 
 ```c
-// 3 displays:
-#define ILI9341_NUM_DEVICES 3
+bool qp_flush(painter_device_t device);
 ```
 
-### ILI9488 :id=qp-driver-ili9488
+The `qp_flush` function ensures that all drawing operations are "pushed" to the display. This should be done as the last operation whenever a sequence of draws occur, and guarantees that any changes are applied.
 
-Enabling support for the ILI9488 in Quantum Painter is done by adding the following to `rules.mk`:
-
-```make
-QUANTUM_PAINTER_ENABLE = yes
-QUANTUM_PAINTER_DRIVERS += ili9488_spi
-```
-
-Creating a ILI9488 device in firmware can then be done with the following API:
+!> Some display panels may seem to work even without a call to `qp_flush` -- this may be because the driver cannot queue drawing operations and needs to display them immediately when invoked. In general, calling `qp_flush` at the end is still considered "best practice".
 
 ```c
-painter_device_t qp_ili9488_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+void housekeeping_task_user(void) {
+    static uint32_t last_draw = 0;
+    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
+        last_draw = timer_read32();
+        // Draw a rect based off the current RGB color
+        qp_rect(display, 0, 7, 0, 239, rgb_matrix_get_hue(), 255, 255);
+        qp_flush(display);
+    }
+}
 ```
 
-The device handle returned from the `qp_ili9488_make_spi_device` function can be used to perform all other drawing operations.
+<!-- tabs:end -->
 
-The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+### ** Drawing Primitives **
+
+<!-- tabs:start -->
+
+#### ** Set Pixel **
 
 ```c
-// 3 displays:
-#define ILI9488_NUM_DEVICES 3
+bool qp_setpixel(painter_device_t device, uint16_t x, uint16_t y, uint8_t hue, uint8_t sat, uint8_t val);
 ```
 
-### SSD1351 :id=qp-driver-ssd1351
+The `qp_setpixel` can be used to set a specific pixel on the screen to the supplied color.
 
-Enabling support for the SSD1351 in Quantum Painter is done by adding the following to `rules.mk`:
-
-```make
-QUANTUM_PAINTER_ENABLE = yes
-QUANTUM_PAINTER_DRIVERS += ssd1351_spi
-```
-
-Creating a SSD1351 device in firmware can then be done with the following API:
+?> Using `qp_setpixel` for large amounts of drawing operations is inefficient and should be avoided unless they cannot be achieved with other drawing APIs.
 
 ```c
-painter_device_t qp_ssd1351_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+void housekeeping_task_user(void) {
+    static uint32_t last_draw = 0;
+    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
+        last_draw = timer_read32();
+        // Draw a 240px high vertical rainbow line on X=0:
+        for (int i = 0; i < 239; ++i) {
+            qp_setpixel(display, 0, i, i, 255, 255);
+        }
+        qp_flush(display);
+    }
+}
 ```
 
-The device handle returned from the `qp_ssd1351_make_spi_device` function can be used to perform all other drawing operations.
-
-The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+#### ** Draw Line **
 
 ```c
-// 3 displays:
-#define SSD1351_NUM_DEVICES 3
+bool qp_line(painter_device_t device, uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t hue, uint8_t sat, uint8_t val);
 ```
 
-### ST7789 :id=qp-driver-st7789
-
-Enabling support for the ST7789 in Quantum Painter is done by adding the following to `rules.mk`:
-
-```make
-QUANTUM_PAINTER_ENABLE = yes
-QUANTUM_PAINTER_DRIVERS += st7789_spi
-```
-
-Creating a ST7789 device in firmware can then be done with the following API:
+The `qp_line` can be used to draw lines on the screen with the supplied color.
 
 ```c
-painter_device_t qp_st7789_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+void housekeeping_task_user(void) {
+    static uint32_t last_draw = 0;
+    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
+        last_draw = timer_read32();
+        // Draw 8px-wide rainbow down the left side of the display
+        for (int i = 0; i < 239; ++i) {
+            qp_line(display, 0, i, 7, i, i, 255, 255);
+        }
+        qp_flush(display);
+    }
+}
 ```
 
-The device handle returned from the `qp_st7789_make_spi_device` function can be used to perform all other drawing operations.
-
-The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+#### ** Draw Rect **
 
 ```c
-// 3 displays:
-#define ST7789_NUM_DEVICES 3
+bool qp_rect(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint8_t hue, uint8_t sat, uint8_t val, bool filled);
 ```
 
-!> Some ST7789 devices are known to have different drawing offsets -- despite being a 240x320 pixel display controller internally, some display panels are only 240x240, or smaller. These may require an offset to be applied; see `qp_set_viewport_offsets` above for information on how to override the offsets if they aren't correctly rendered.
-
-### ST7735 :id=qp-driver-st7735
-
-Enabling support for the ST7735 in Quantum Painter is done by adding the following to `rules.mk`:
-
-```make
-QUANTUM_PAINTER_ENABLE = yes
-QUANTUM_PAINTER_DRIVERS += st7735_spi
-```
-
-Creating a ST7735 device in firmware can then be done with the following API:
+The `qp_rect` can be used to draw rectangles on the screen with the supplied color, with or without a background fill. If not filled, any pixels inside the rectangle will be left as-is.
 
 ```c
-painter_device_t qp_st7735_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
+void housekeeping_task_user(void) {
+    static uint32_t last_draw = 0;
+    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
+        last_draw = timer_read32();
+        // Draw 8px-wide rainbow filled rectangles down the left side of the display
+        for (int i = 0; i < 239; i+=8) {
+            qp_rect(display, 0, i, 7, i+7, i, 255, 255, true);
+        }
+        qp_flush(display);
+    }
+}
 ```
 
-The device handle returned from the `qp_st7735_make_spi_device` function can be used to perform all other drawing operations.
-
-The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+#### ** Draw Circle **
 
 ```c
-// 3 displays:
-#define ST7735_NUM_DEVICES 3
+bool qp_circle(painter_device_t device, uint16_t x, uint16_t y, uint16_t radius, uint8_t hue, uint8_t sat, uint8_t val, bool filled);
 ```
 
-!> Some ST7735 devices are known to have different drawing offsets -- despite being a 132x162 pixel display controller internally, some display panels are only 80x160, or smaller. These may require an offset to be applied; see `qp_set_viewport_offsets` above for information on how to override the offsets if they aren't correctly rendered.
+The `qp_circle` can be used to draw circles on the screen with the supplied color, with or without a background fill. If not filled, any pixels inside the circle will be left as-is.
+
+```c
+void housekeeping_task_user(void) {
+    static uint32_t last_draw = 0;
+    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
+        last_draw = timer_read32();
+        // Draw r=4 filled circles down the left side of the display
+        for (int i = 0; i < 239; i+=8) {
+            qp_circle(display, 4, 4+i, 4, i, 255, 255, true);
+        }
+        qp_flush(display);
+    }
+}
+```
+
+#### ** Draw Ellipse **
+
+```c
+bool qp_ellipse(painter_device_t device, uint16_t x, uint16_t y, uint16_t sizex, uint16_t sizey, uint8_t hue, uint8_t sat, uint8_t val, bool filled);
+```
+
+The `qp_ellipse` can be used to draw ellipses on the screen with the supplied color, with or without a background fill. If not filled, any pixels inside the ellipses will be left as-is.
+
+```c
+void housekeeping_task_user(void) {
+    static uint32_t last_draw = 0;
+    if (timer_elapsed32(last_draw) > 33) { // Throttle to 30fps
+        last_draw = timer_read32();
+        // Draw 16x8 filled ellipses down the left side of the display
+        for (int i = 0; i < 239; i+=8) {
+            qp_ellipse(display, 8, 4+i, 16, 8, i, 255, 255, true);
+        }
+        qp_flush(display);
+    }
+}
+```
+
+<!-- tabs:end -->
+
+### ** Image Functions **
+
+<!-- tabs:start -->
+
+#### ** Load Image **
+
+```c
+painter_image_handle_t qp_load_image_mem(const void *buffer);
+```
+
+The `qp_load_image_mem` function loads a QGF image from memory or flash.
+
+`qp_load_image_mem` returns a handle to the loaded image, which can then be used to draw to the screen using `qp_drawimage`, `qp_drawimage_recolor`, `qp_animate`, or `qp_animate_recolor`. If an image is no longer required, it can be unloaded by calling `qp_close_image` below.
+
+See the [CLI Commands](quantum_painter.md?id=quantum-painter-cli) for instructions on how to convert images to [QGF](quantum_painter_qgf.md).
+
+?> The total number of images available to load at any one time is controlled by the configurable option `QUANTUM_PAINTER_NUM_IMAGES` in the table above. If more images are required, the number should be increased in `config.h`.
+
+Image information is available through accessing the handle:
+
+| Property    | Accessor             |
+|-------------|----------------------|
+| Width       | `image->width`       |
+| Height      | `image->height`      |
+| Frame Count | `image->frame_count` |
+
+#### ** Unload Image **
+
+```c
+bool qp_close_image(painter_image_handle_t image);
+```
+
+The `qp_close_image` function releases resources related to the loading of the supplied image.
+
+#### ** Draw image **
+
+```c
+bool qp_drawimage(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image);
+bool qp_drawimage_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+```
+
+The `qp_drawimage` and `qp_drawimage_recolor` functions draw the supplied image to the screen at the supplied location, with the latter function allowing for monochrome-based images to be recolored.
+
+```c
+// Draw an image on the bottom-right of the 240x320 display on initialisation
+static painter_image_handle_t my_image;
+void keyboard_post_init_kb(void) {
+    my_image = qp_load_image_mem(gfx_my_image);
+    if (my_image != NULL) {
+        qp_drawimage(display, (239 - my_image->width), (319 - my_image->height), my_image);
+    }
+}
+```
+
+#### ** Animate Image **
+
+```c
+deferred_token qp_animate(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image);
+deferred_token qp_animate_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+```
+
+The `qp_animate` and `qp_animate_recolor` functions draw the supplied image to the screen at the supplied location, with the latter function allowing for monochrome-based animations to be recolored. They also set up internal timing such that each frame is rendered at the correct time as per the animated image.
+
+Once an image has been set to animate, it will loop indefinitely until stopped, with no user intervention required.
+
+Both functions return a `deferred_token`, which can then be used to stop the animation, using `qp_stop_animation` below.
+
+```c
+// Animate an image on the bottom-right of the 240x320 display on initialisation
+static painter_image_handle_t my_image;
+static deferred_token my_anim;
+void keyboard_post_init_kb(void) {
+    my_image = qp_load_image_mem(gfx_my_image);
+    if (my_image != NULL) {
+        my_anim = qp_animate(display, (239 - my_image->width), (319 - my_image->height), my_image);
+    }
+}
+```
+
+#### ** Stop Animation **
+
+```c
+void qp_stop_animation(deferred_token anim_token);
+```
+
+The `qp_stop_animation` function stops the previously-started animation.
+```c
+void housekeeping_task_user(void) {
+    if (some_random_stop_reason) {
+        qp_stop_animation(my_anim);
+    }
+}
+```
+
+<!-- tabs:end -->
+
+### ** Font Functions **
+
+<!-- tabs: start -->
+
+#### ** Load Font **
+
+```c
+painter_font_handle_t qp_load_font_mem(const void *buffer);
+```
+
+The `qp_load_font_mem` function loads a QFF font from memory or flash.
+
+`qp_load_font_mem` returns a handle to the loaded font, which can then be measured using `qp_textwidth`, or drawn to the screen using `qp_drawtext`, or `qp_drawtext_recolor`. If a font is no longer required, it can be unloaded by calling `qp_close_font` below.
+
+See the [CLI Commands](quantum_painter.md?id=quantum-painter-cli) for instructions on how to convert TTF fonts to [QFF](quantum_painter_qff.md).
+
+?> The total number of fonts available to load at any one time is controlled by the configurable option `QUANTUM_PAINTER_NUM_FONTS` in the table above. If more fonts are required, the number should be increased in `config.h`.
+
+Font information is available through accessing the handle:
+
+| Property    | Accessor             |
+|-------------|----------------------|
+| Line Height | `image->line_height` |
+
+#### ** Unload Font **
+
+```c
+bool qp_close_font(painter_font_handle_t font);
+```
+
+The `qp_close_font` function releases resources related to the loading of the supplied font.
+
+#### ** Measure Text **
+
+```c
+int16_t qp_textwidth(painter_font_handle_t font, const char *str);
+```
+
+The `qp_textwidth` function allows measurement of how many pixels wide the supplied string would result in, for the given font.
+
+#### ** Draw Text **
+
+```c
+int16_t qp_drawtext(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str);
+int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+```
+
+The `qp_drawtext` and `qp_drawtext_recolor` functions draw the supplied string to the screen at the given location using the font supplied, with the latter function allowing for monochrome-based fonts to be recolored.
+
+```c
+// Draw a text message on the bottom-right of the 240x320 display on initialisation
+static painter_font_handle_t my_font;
+void keyboard_post_init_kb(void) {
+    my_font = qp_load_font_mem(font_opensans);
+    if (my_font != NULL) {
+        static const char *text = "Hello from QMK!";
+        int16_t width = qp_textwidth(my_font, text);
+        qp_drawtext(display, (239 - width), (319 - my_font->line_height), my_font, text);
+    }
+}
+```
+
+<!-- tabs:end -->
+
+### ** Advanced Functions **
+
+<!-- tabs:start -->
+
+#### ** Get Geometry **
+
+```c
+void qp_get_geometry(painter_device_t device, uint16_t *width, uint16_t *height, painter_rotation_t *rotation, uint16_t *offset_x, uint16_t *offset_y);
+```
+
+The `qp_get_geometry` function allows external code to retrieve the current width, height, rotation, and drawing offsets.
+
+#### ** Set Viewport Offsets **
+
+```c
+void qp_set_viewport_offsets(painter_device_t device, uint16_t offset_x, uint16_t offset_y);
+```
+
+The `qp_set_viewport_offsets` function can be used to offset all subsequent drawing operations. For example, if a display controller is internally 240x320, but the display panel is 240x240 and has a Y offset of 80 pixels, you could invoke `qp_set_viewport_offsets(display, 0, 80);` and the drawing positioning would be corrected.
+
+#### ** Set Viewport **
+
+```c
+bool qp_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom);
+```
+
+The `qp_viewport` function controls where raw pixel data is written to.
+
+#### ** Stream Pixel Data **
+
+```c
+bool qp_pixdata(painter_device_t device, const void *pixel_data, uint32_t native_pixel_count);
+```
+
+The `qp_pixdata` function allows raw pixel data to be streamed to the display. It requires a native pixel count rather than the number of bytes to transfer, to ensure display panel data alignment is respected. E.g. for display panels using RGB565 internal format, sending 10 pixels will result in 20 bytes of transfer.
+
+!> Under normal circumstances, users will not need to manually call either `qp_viewport` or `qp_pixdata`. These allow for writing of raw pixel information, in the display panel's native format, to the area defined by the viewport.
+
+<!-- tabs:end -->
+
+<!-- tabs:end -->

--- a/docs/quantum_painter.md
+++ b/docs/quantum_painter.md
@@ -639,6 +639,17 @@ void housekeeping_task_user(void) {
 
 ### ** Image Functions **
 
+Making an image available for use requires compiling it into your firmware. To do so, assuming you've created `my_image.qgf.c` and `my_image.qgf.h` as per the CLI examples above, you'd add the following to your `rules.mk`:
+
+```make
+SRC += my_image.qgf.c
+```
+
+...and in your `keymap.c`, you'd add to the top of the file:
+```c
+#include "my_image.qgf.h"
+```
+
 <!-- tabs:start -->
 
 #### ** Load Image **
@@ -735,6 +746,17 @@ void housekeeping_task_user(void) {
 
 ### ** Font Functions **
 
+Making a font available for use requires compiling it into your firmware. To do so, assuming you've created `my_font.qff.c` and `my_font.qff.h` as per the CLI examples above, you'd add the following to your `rules.mk`:
+
+```make
+SRC += noto11.qff.c
+```
+
+...and in your `keymap.c`, you'd add to the top of the file:
+```c
+#include "noto11.qff.h"
+```
+
 <!-- tabs: start -->
 
 #### ** Load Font **
@@ -786,7 +808,7 @@ The `qp_drawtext` and `qp_drawtext_recolor` functions draw the supplied string t
 // Draw a text message on the bottom-right of the 240x320 display on initialisation
 static painter_font_handle_t my_font;
 void keyboard_post_init_kb(void) {
-    my_font = qp_load_font_mem(font_opensans);
+    my_font = qp_load_font_mem(font_noto11);
     if (my_font != NULL) {
         static const char *text = "Hello from QMK!";
         int16_t width = qp_textwidth(my_font, text);

--- a/docs/quantum_painter.md
+++ b/docs/quantum_painter.md
@@ -383,12 +383,23 @@ QUANTUM_PAINTER_DRIVERS += rgb565_surface
 Creating a RGB565 surface in firmware can then be done with the following API:
 
 ```c
-painter_device_t qp_make_rgb565_surface(uint16_t panel_width, uint16_t panel_height, void *buffer);
+painter_device_t qp_rgb565_make_surface(uint16_t panel_width, uint16_t panel_height, void *buffer);
 ```
 
 The `buffer` is a user-supplied area of memory, and is assumed to be of the size `sizeof(uint16_t) * panel_width * panel_height`.
 
-The device handle returned from the `qp_make_rgb565_surface` function can be used to perform all other drawing operations.
+The device handle returned from the `qp_rgb565_make_surface` function can be used to perform all other drawing operations.
+
+Example:
+
+```c
+static painter_device_t my_surface;
+static uint16_t my_framebuffer[320 * 240]; // Allocate a buffer for a 320x240 RGB565 display
+void keyboard_post_init_kb(void) {
+    my_surface = qp_rgb565_make_surface(320, 240, my_framebuffer);
+    qp_init(my_surface, QP_ROTATION_0);
+}
+```
 
 The maximum number of RGB565 surfaces can be configured by changing the following in your `config.h` (default is 1):
 

--- a/drivers/painter/generic/qp_rgb565_surface.c
+++ b/drivers/painter/generic/qp_rgb565_surface.c
@@ -181,13 +181,18 @@ const struct painter_driver_vtable_t rgb565_surface_driver_vtable = {
 // Comms vtable
 
 static bool qp_rgb565_surface_comms_init(painter_device_t device) {
+    // No-op.
     return true;
 }
 static bool qp_rgb565_surface_comms_start(painter_device_t device) {
+    // No-op.
     return true;
 }
-static void qp_rgb565_surface_comms_stop(painter_device_t device) {}
-uint32_t    qp_rgb565_surface_comms_send(painter_device_t device, const void *data, uint32_t byte_count) {
+static void qp_rgb565_surface_comms_stop(painter_device_t device) {
+    // No-op.
+}
+uint32_t qp_rgb565_surface_comms_send(painter_device_t device, const void *data, uint32_t byte_count) {
+    // No-op.
     return byte_count;
 }
 

--- a/drivers/painter/generic/qp_rgb565_surface.c
+++ b/drivers/painter/generic/qp_rgb565_surface.c
@@ -1,0 +1,274 @@
+// Copyright 2022 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "color.h"
+#include "qp_rgb565_surface.h"
+#include "qp_draw.h"
+
+#define BYTE_SWAP(x) (((((uint16_t)(x)) >> 8) & 0x00FF) | ((((uint16_t)(x)) << 8) & 0xFF00))
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Common
+
+// Device definition
+typedef struct rgb565_surface_painter_device_t {
+    struct painter_driver_t base; // must be first, so it can be cast to/from the painter_device_t* type
+
+    // The target buffer
+    uint16_t *buffer;
+
+    // Manually manage the viewport for streaming pixel data to the display
+    uint16_t viewport_l;
+    uint16_t viewport_t;
+    uint16_t viewport_r;
+    uint16_t viewport_b;
+
+    // Current write location to the display when streaming pixel data
+    uint16_t pixdata_x;
+    uint16_t pixdata_y;
+
+    // Maintain a dirty region so we can stream only what we need
+    bool     is_dirty;
+    uint16_t dirty_l;
+    uint16_t dirty_t;
+    uint16_t dirty_r;
+    uint16_t dirty_b;
+
+} rgb565_surface_painter_device_t;
+
+// Driver storage
+rgb565_surface_painter_device_t surface_drivers[RGB565_SURFACE_NUM_DEVICES] = {0};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Helpers
+
+static inline void increment_pixdata_location(rgb565_surface_painter_device_t *surface) {
+    // Increment the X-position
+    surface->pixdata_x++;
+
+    // If the x-coord has gone past the right-side edge, loop it back around and increment the y-coord
+    if (surface->pixdata_x > surface->viewport_r) {
+        surface->pixdata_x = surface->viewport_l;
+        surface->pixdata_y++;
+    }
+
+    // If the y-coord has gone past the bottom, loop it back to the top
+    if (surface->pixdata_y > surface->viewport_b) {
+        surface->pixdata_y = surface->viewport_t;
+    }
+}
+
+static inline void setpixel(rgb565_surface_painter_device_t *surface, uint16_t x, uint16_t y, uint16_t rgb565) {
+    // Skip messing with the dirty info if the original value already matches
+    if (surface->buffer[y * surface->base.panel_width + x] != rgb565) {
+        // Maintain dirty region
+        if (surface->dirty_l > x) {
+            surface->dirty_l = x;
+        }
+        if (surface->dirty_r < x) {
+            surface->dirty_r = x;
+        }
+        if (surface->dirty_t > y) {
+            surface->dirty_t = y;
+        }
+        if (surface->dirty_b < y) {
+            surface->dirty_b = y;
+        }
+
+        // Always dirty after a setpixel
+        surface->is_dirty = true;
+
+        // Update the pixel data in the buffer
+        surface->buffer[y * surface->base.panel_width + x] = rgb565;
+    }
+}
+
+static inline void append_pixel(rgb565_surface_painter_device_t *surface, uint16_t rgb565) {
+    setpixel(surface, surface->pixdata_x, surface->pixdata_y, rgb565);
+    increment_pixdata_location(surface);
+}
+
+static inline void stream_pixdata(rgb565_surface_painter_device_t *surface, const uint16_t *data, uint32_t native_pixel_count) {
+    for (uint32_t pixel_counter = 0; pixel_counter < native_pixel_count; ++pixel_counter) {
+        append_pixel(surface, data[pixel_counter]);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Driver vtable
+
+static bool qp_rgb565_surface_init(painter_device_t device, painter_rotation_t rotation) {
+    struct painter_driver_t *        driver  = (struct painter_driver_t *)device;
+    rgb565_surface_painter_device_t *surface = (rgb565_surface_painter_device_t *)driver;
+    memset(surface->buffer, 0, driver->panel_width * driver->panel_height * driver->native_bits_per_pixel / 8);
+    return true;
+}
+
+static bool qp_rgb565_surface_power(painter_device_t device, bool power_on) {
+    // No-op.
+    return true;
+}
+
+static bool qp_rgb565_surface_clear(painter_device_t device) {
+    struct painter_driver_t *driver = (struct painter_driver_t *)device;
+    driver->driver_vtable->init(device, driver->rotation); // Re-init the surface
+    return true;
+}
+
+static bool qp_rgb565_surface_flush(painter_device_t device) {
+    struct painter_driver_t *        driver  = (struct painter_driver_t *)device;
+    rgb565_surface_painter_device_t *surface = (rgb565_surface_painter_device_t *)driver;
+    surface->dirty_l = surface->dirty_t = 0xFFFF;
+    surface->dirty_r = surface->dirty_b = 0;
+    surface->is_dirty                   = false;
+    return true;
+}
+
+static bool qp_rgb565_surface_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom) {
+    struct painter_driver_t *        driver  = (struct painter_driver_t *)device;
+    rgb565_surface_painter_device_t *surface = (rgb565_surface_painter_device_t *)driver;
+
+    // Set the viewport locations
+    surface->viewport_l = left;
+    surface->viewport_t = top;
+    surface->viewport_r = right;
+    surface->viewport_b = bottom;
+
+    // Reset the write location to the top left
+    surface->pixdata_x = left;
+    surface->pixdata_y = top;
+    return true;
+}
+
+// Stream pixel data to the current write position in GRAM
+static bool qp_rgb565_surface_pixdata(painter_device_t device, const void *pixel_data, uint32_t native_pixel_count) {
+    struct painter_driver_t *        driver  = (struct painter_driver_t *)device;
+    rgb565_surface_painter_device_t *surface = (rgb565_surface_painter_device_t *)driver;
+    stream_pixdata(surface, (const uint16_t *)pixel_data, native_pixel_count);
+    return true;
+}
+
+// Pixel colour conversion
+static bool qp_rgb565_surface_palette_convert_rgb565_swapped(painter_device_t device, int16_t palette_size, qp_pixel_t *palette) {
+    for (int16_t i = 0; i < palette_size; ++i) {
+        RGB      rgb      = hsv_to_rgb_nocie((HSV){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
+        uint16_t rgb565   = (((uint16_t)rgb.r) >> 3) << 11 | (((uint16_t)rgb.g) >> 2) << 5 | (((uint16_t)rgb.b) >> 3);
+        palette[i].rgb565 = BYTE_SWAP(rgb565);
+    }
+    return true;
+}
+
+// Append pixels to the target location, keyed by the pixel index
+static bool qp_rgb565_surface_append_pixels_rgb565(painter_device_t device, uint8_t *target_buffer, qp_pixel_t *palette, uint32_t pixel_offset, uint32_t pixel_count, uint8_t *palette_indices) {
+    uint16_t *buf = (uint16_t *)target_buffer;
+    for (uint32_t i = 0; i < pixel_count; ++i) {
+        buf[pixel_offset + i] = palette[palette_indices[i]].rgb565;
+    }
+    return true;
+}
+
+const struct painter_driver_vtable_t rgb565_surface_driver_vtable = {
+    .init            = qp_rgb565_surface_init,
+    .power           = qp_rgb565_surface_power,
+    .clear           = qp_rgb565_surface_clear,
+    .flush           = qp_rgb565_surface_flush,
+    .pixdata         = qp_rgb565_surface_pixdata,
+    .viewport        = qp_rgb565_surface_viewport,
+    .palette_convert = qp_rgb565_surface_palette_convert_rgb565_swapped,
+    .append_pixels   = qp_rgb565_surface_append_pixels_rgb565,
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Comms vtable
+
+static bool qp_rgb565_surface_comms_init(painter_device_t device) {
+    return true;
+}
+static bool qp_rgb565_surface_comms_start(painter_device_t device) {
+    return true;
+}
+static void qp_rgb565_surface_comms_stop(painter_device_t device) {}
+uint32_t    qp_rgb565_surface_comms_send(painter_device_t device, const void *data, uint32_t byte_count) {
+    return byte_count;
+}
+
+struct painter_comms_vtable_t rgb565_surface_driver_comms_vtable = {
+    // These are all effective no-op's because they're not actually needed.
+    .comms_init  = qp_rgb565_surface_comms_init,
+    .comms_start = qp_rgb565_surface_comms_start,
+    .comms_stop  = qp_rgb565_surface_comms_stop,
+    .comms_send  = qp_rgb565_surface_comms_send};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Factory function for creating a handle to an rgb565 surface
+
+painter_device_t qp_make_rgb565_surface(uint16_t panel_width, uint16_t panel_height, void *buffer) {
+    for (uint32_t i = 0; i < RGB565_SURFACE_NUM_DEVICES; ++i) {
+        rgb565_surface_painter_device_t *driver = &surface_drivers[i];
+        if (!driver->base.driver_vtable) {
+            driver->base.driver_vtable         = &rgb565_surface_driver_vtable;
+            driver->base.comms_vtable          = &rgb565_surface_driver_comms_vtable;
+            driver->base.native_bits_per_pixel = 16; // RGB565
+            driver->base.panel_width           = panel_width;
+            driver->base.panel_height          = panel_height;
+            driver->base.rotation              = QP_ROTATION_0;
+            driver->base.offset_x              = 0;
+            driver->base.offset_y              = 0;
+            driver->buffer                     = (uint16_t *)buffer;
+            return (painter_device_t)driver;
+        }
+    }
+    return NULL;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Drawing routine to copy out the dirty region and send it to another device
+
+bool qp_rgb565_surface_draw(painter_device_t surface, painter_device_t display, uint16_t x, uint16_t y) {
+    struct painter_driver_t *        surface_driver = (struct painter_driver_t *)surface;
+    rgb565_surface_painter_device_t *surface_handle = (rgb565_surface_painter_device_t *)surface_driver;
+
+    // If we're not dirty... we're done.
+    if (!surface_handle->is_dirty) {
+        return true;
+    }
+
+    // Set the target drawing area
+    bool ok = qp_viewport(display, x + surface_handle->dirty_l, y + surface_handle->dirty_t, x + surface_handle->dirty_r, y + surface_handle->dirty_b);
+    if (!ok) {
+        return false;
+    }
+
+    // Housekeeping of the amount of pixels to transfer
+    uint32_t  total_pixel_count = QUANTUM_PAINTER_PIXDATA_BUFFER_SIZE / sizeof(uint16_t);
+    uint32_t  pixel_counter     = 0;
+    uint16_t *target_buffer     = (uint16_t *)qp_internal_global_pixdata_buffer;
+
+    // Fill the global pixdata area so that we can start transferring to the panel
+    for (uint16_t y = surface_handle->dirty_t; y <= surface_handle->dirty_b; ++y) {
+        for (uint16_t x = surface_handle->dirty_l; x <= surface_handle->dirty_r; ++x) {
+            // Update the target buffer
+            target_buffer[pixel_counter++] = surface_handle->buffer[y * surface_handle->base.panel_width + x];
+
+            // If we've accumulated enough data, send it
+            if (pixel_counter == total_pixel_count) {
+                ok = qp_pixdata(display, qp_internal_global_pixdata_buffer, pixel_counter);
+                if (!ok) {
+                    return false;
+                }
+                // Reset the counter
+                pixel_counter = 0;
+            }
+        }
+    }
+
+    // If there's any leftover data, send it
+    if (pixel_counter > 0) {
+        ok = qp_pixdata(display, qp_internal_global_pixdata_buffer, pixel_counter);
+        if (!ok) {
+            return false;
+        }
+    }
+
+    // Clear the dirty info for the surface
+    return qp_flush(surface);
+}

--- a/drivers/painter/generic/qp_rgb565_surface.c
+++ b/drivers/painter/generic/qp_rgb565_surface.c
@@ -4,8 +4,6 @@
 #include "qp_rgb565_surface.h"
 #include "qp_draw.h"
 
-#define BYTE_SWAP(x) (((((uint16_t)(x)) >> 8) & 0x00FF) | ((((uint16_t)(x)) << 8) & 0xFF00))
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Common
 
@@ -117,7 +115,7 @@ static bool qp_rgb565_surface_clear(painter_device_t device) {
 static bool qp_rgb565_surface_flush(painter_device_t device) {
     struct painter_driver_t *        driver  = (struct painter_driver_t *)device;
     rgb565_surface_painter_device_t *surface = (rgb565_surface_painter_device_t *)driver;
-    surface->dirty_l = surface->dirty_t = 0xFFFF;
+    surface->dirty_l = surface->dirty_t = UINT16_MAX;
     surface->dirty_r = surface->dirty_b = 0;
     surface->is_dirty                   = false;
     return true;
@@ -152,7 +150,7 @@ static bool qp_rgb565_surface_palette_convert_rgb565_swapped(painter_device_t de
     for (int16_t i = 0; i < palette_size; ++i) {
         RGB      rgb      = hsv_to_rgb_nocie((HSV){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
         uint16_t rgb565   = (((uint16_t)rgb.r) >> 3) << 11 | (((uint16_t)rgb.g) >> 2) << 5 | (((uint16_t)rgb.b) >> 3);
-        palette[i].rgb565 = BYTE_SWAP(rgb565);
+        palette[i].rgb565 = __builtin_bswap16(rgb565);
     }
     return true;
 }

--- a/drivers/painter/generic/qp_rgb565_surface.c
+++ b/drivers/painter/generic/qp_rgb565_surface.c
@@ -206,7 +206,7 @@ struct painter_comms_vtable_t rgb565_surface_driver_comms_vtable = {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Factory function for creating a handle to an rgb565 surface
 
-painter_device_t qp_make_rgb565_surface(uint16_t panel_width, uint16_t panel_height, void *buffer) {
+painter_device_t qp_rgb565_make_surface(uint16_t panel_width, uint16_t panel_height, void *buffer) {
     for (uint32_t i = 0; i < RGB565_SURFACE_NUM_DEVICES; ++i) {
         rgb565_surface_painter_device_t *driver = &surface_drivers[i];
         if (!driver->base.driver_vtable) {

--- a/drivers/painter/generic/qp_rgb565_surface.h
+++ b/drivers/painter/generic/qp_rgb565_surface.h
@@ -25,7 +25,7 @@
  * @param buffer[in] pointer to a preallocated buffer of size `(sizeof(uint16_t) * panel_width * panel_height)`
  * @return the device handle used with all drawing routines in Quantum Painter
  */
-painter_device_t qp_make_rgb565_surface(uint16_t panel_width, uint16_t panel_height, void *buffer);
+painter_device_t qp_rgb565_make_surface(uint16_t panel_width, uint16_t panel_height, void *buffer);
 
 /**
  * Helper method to draw the dirty contents of the framebuffer to the target device.

--- a/drivers/painter/generic/qp_rgb565_surface.h
+++ b/drivers/painter/generic/qp_rgb565_surface.h
@@ -35,7 +35,7 @@ painter_device_t qp_make_rgb565_surface(uint16_t panel_width, uint16_t panel_hei
  * @param surface[in] the surface to copy from
  * @param display[in] the display to copy into
  * @param x[in] the x-location of the original position of the framebuffer
- * @param y[in] the x-location of the original position of the framebuffer
+ * @param y[in] the y-location of the original position of the framebuffer
  * @return whether the draw operation completed successfully
  */
 bool qp_rgb565_surface_draw(painter_device_t surface, painter_device_t display, uint16_t x, uint16_t y);

--- a/drivers/painter/generic/qp_rgb565_surface.h
+++ b/drivers/painter/generic/qp_rgb565_surface.h
@@ -17,6 +17,26 @@
 // Forward declarations
 
 #ifdef QUANTUM_PAINTER_RGB565_SURFACE_ENABLE
+/**
+ * Factory method for an RGB565 surface (aka framebuffer).
+ *
+ * @param panel_width[in] the width of the display panel
+ * @param panel_height[in] the height of the display panel
+ * @param buffer[in] pointer to a preallocated buffer of size `(sizeof(uint16_t) * panel_width * panel_height)`
+ * @return the device handle used with all drawing routines in Quantum Painter
+ */
 painter_device_t qp_make_rgb565_surface(uint16_t panel_width, uint16_t panel_height, void *buffer);
-bool             qp_rgb565_surface_draw(painter_device_t surface, painter_device_t display, uint16_t x, uint16_t y);
+
+/**
+ * Helper method to draw the dirty contents of the framebuffer to the target device.
+ *
+ * After successful completion, the dirty area is reset.
+ *
+ * @param surface[in] the surface to copy from
+ * @param display[in] the display to copy into
+ * @param x[in] the x-location of the original position of the framebuffer
+ * @param y[in] the x-location of the original position of the framebuffer
+ * @return whether the draw operation completed successfully
+ */
+bool qp_rgb565_surface_draw(painter_device_t surface, painter_device_t display, uint16_t x, uint16_t y);
 #endif // QUANTUM_PAINTER_RGB565_SURFACE_ENABLE

--- a/drivers/painter/generic/qp_rgb565_surface.h
+++ b/drivers/painter/generic/qp_rgb565_surface.h
@@ -1,0 +1,22 @@
+// Copyright 2022 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "qp_internal.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter RGB565 surface configurables (add to your keyboard's config.h)
+
+#ifndef RGB565_SURFACE_NUM_DEVICES
+/**
+ * @def This controls the maximum number of surface devices that Quantum Painter can use at any one time.
+ *      Increasing this number allows for multiple framebuffers to be used. Each requires its own RAM allocation.
+ */
+#    define RGB565_SURFACE_NUM_DEVICES 1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Forward declarations
+
+#ifdef QUANTUM_PAINTER_RGB565_SURFACE_ENABLE
+painter_device_t qp_make_rgb565_surface(uint16_t panel_width, uint16_t panel_height, void *buffer);
+bool             qp_rgb565_surface_draw(painter_device_t surface, painter_device_t display, uint16_t x, uint16_t y);
+#endif // QUANTUM_PAINTER_RGB565_SURFACE_ENABLE

--- a/drivers/painter/tft_panel/qp_tft_panel.c
+++ b/drivers/painter/tft_panel/qp_tft_panel.c
@@ -7,8 +7,6 @@
 #include "qp_draw.h"
 #include "qp_tft_panel.h"
 
-#define BYTE_SWAP(x) (((((uint16_t)(x)) >> 8) & 0x00FF) | ((((uint16_t)(x)) << 8) & 0xFF00))
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum Painter API implementations
 
@@ -94,7 +92,7 @@ bool qp_tft_panel_palette_convert_rgb565_swapped(painter_device_t device, int16_
     for (int16_t i = 0; i < palette_size; ++i) {
         RGB      rgb      = hsv_to_rgb_nocie((HSV){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
         uint16_t rgb565   = (((uint16_t)rgb.r) >> 3) << 11 | (((uint16_t)rgb.g) >> 2) << 5 | (((uint16_t)rgb.b) >> 3);
-        palette[i].rgb565 = BYTE_SWAP(rgb565);
+        palette[i].rgb565 = __builtin_bswap16(rgb565);
     }
     return true;
 }

--- a/quantum/painter/qp.h
+++ b/quantum/painter/qp.h
@@ -432,6 +432,10 @@ int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, pai
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum Painter Drivers
 
+#ifdef QUANTUM_PAINTER_RGB565_SURFACE_ENABLE
+#    include "qp_rgb565_surface.h"
+#endif // QUANTUM_PAINTER_RGB565_SURFACE_ENABLE
+
 #ifdef QUANTUM_PAINTER_ILI9163_ENABLE
 #    include "qp_ili9163.h"
 #endif // QUANTUM_PAINTER_ILI9163_ENABLE

--- a/quantum/painter/qp_draw_image.c
+++ b/quantum/painter/qp_draw_image.c
@@ -25,10 +25,10 @@ typedef struct qgf_image_handle_t {
 static qgf_image_handle_t image_descriptors[QUANTUM_PAINTER_NUM_IMAGES] = {0};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Quantum Painter External API: qp_load_image_mem
+// Helper: load image from stream
 
-painter_image_handle_t qp_load_image_mem(const void *buffer) {
-    qp_dprintf("qp_load_image_mem: entry\n");
+static painter_image_handle_t qp_load_image_internal(bool (*stream_factory)(qgf_image_handle_t *image, void *arg), void *arg) {
+    qp_dprintf("qp_load_image: entry\n");
     qgf_image_handle_t *image = NULL;
 
     // Find a free slot
@@ -41,20 +41,18 @@ painter_image_handle_t qp_load_image_mem(const void *buffer) {
 
     // Drop out if not found
     if (!image) {
-        qp_dprintf("qp_load_image_mem: fail (no free slot)\n");
+        qp_dprintf("qp_load_image: fail (no free slot)\n");
         return NULL;
     }
 
-    // Assume we can read the graphics descriptor
-    image->mem_stream = qp_make_memory_stream((void *)buffer, sizeof(qgf_graphics_descriptor_v1_t));
-
-    // Update the length of the stream to match, and rewind to the start
-    image->mem_stream.length   = qgf_get_total_size(&image->stream);
-    image->mem_stream.position = 0;
+    if (!stream_factory(image, arg)) {
+        qp_dprintf("qp_load_image: fail (could not create stream)\n");
+        return NULL;
+    }
 
     // Now that we know the length, validate the input data
     if (!qgf_validate_stream(&image->stream)) {
-        qp_dprintf("qp_load_image_mem: fail (failed validation)\n");
+        qp_dprintf("qp_load_image: fail (failed validation)\n");
         return NULL;
     }
 
@@ -63,8 +61,28 @@ painter_image_handle_t qp_load_image_mem(const void *buffer) {
 
     // Validation success, we can return the handle
     image->validate_ok = true;
-    qp_dprintf("qp_load_image_mem: ok\n");
+    qp_dprintf("qp_load_image: ok\n");
     return (painter_image_handle_t)image;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter External API: qp_load_image_mem
+
+static inline bool image_mem_stream_factory(qgf_image_handle_t *image, void *arg) {
+    void *buffer = arg;
+
+    // Assume we can read the graphics descriptor
+    image->mem_stream = qp_make_memory_stream((void *)buffer, sizeof(qgf_graphics_descriptor_v1_t));
+
+    // Update the length of the stream to match, and rewind to the start
+    image->mem_stream.length   = qgf_get_total_size(&image->stream);
+    image->mem_stream.position = 0;
+
+    return true;
+}
+
+painter_image_handle_t qp_load_image_mem(const void *buffer) {
+    return qp_load_image_internal(image_mem_stream_factory, (void *)buffer);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -79,6 +97,7 @@ bool qp_close_image(painter_image_handle_t image) {
 
     // Free up this image for use elsewhere.
     qgf_image->validate_ok = false;
+    qp_stream_close(&qgf_image->stream);
     return true;
 }
 

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -36,10 +36,10 @@ typedef struct qff_font_handle_t {
 static qff_font_handle_t font_descriptors[QUANTUM_PAINTER_NUM_FONTS] = {0};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Quantum Painter External API: qp_load_font_mem
+// Helper: load font from stream
 
-painter_font_handle_t qp_load_font_mem(const void *buffer) {
-    qp_dprintf("qp_load_font_mem: entry\n");
+static painter_font_handle_t qp_load_font_internal(bool (*stream_factory)(qff_font_handle_t *font, void *arg), void *arg) {
+    qp_dprintf("qp_load_font: entry\n");
     qff_font_handle_t *font = NULL;
 
     // Find a free slot
@@ -52,20 +52,18 @@ painter_font_handle_t qp_load_font_mem(const void *buffer) {
 
     // Drop out if not found
     if (!font) {
-        qp_dprintf("qp_load_font_mem: fail (no free slot)\n");
+        qp_dprintf("qp_load_font: fail (no free slot)\n");
         return NULL;
     }
 
-    // Assume we can read the graphics descriptor
-    font->mem_stream = qp_make_memory_stream((void *)buffer, sizeof(qff_font_descriptor_v1_t));
-
-    // Update the length of the stream to match, and rewind to the start
-    font->mem_stream.length   = qff_get_total_size(&font->stream);
-    font->mem_stream.position = 0;
+    if (!stream_factory(font, arg)) {
+        qp_dprintf("qp_load_font: fail (could not create stream)\n");
+        return NULL;
+    }
 
     // Now that we know the length, validate the input data
     if (!qff_validate_stream(&font->stream)) {
-        qp_dprintf("qp_load_font_mem: fail (failed validation)\n");
+        qp_dprintf("qp_load_font: fail (failed validation)\n");
         return NULL;
     }
 
@@ -76,12 +74,12 @@ painter_font_handle_t qp_load_font_mem(const void *buffer) {
 
     void *ram_buffer = malloc(font->mem_stream.length);
     if (ram_buffer == NULL) {
-        qp_dprintf("qp_load_font_mem: could not allocate enough RAM for font, falling back to original\n");
+        qp_dprintf("qp_load_font: could not allocate enough RAM for font, falling back to original\n");
     } else {
         do {
             // Copy the data into RAM
             if (qp_stream_read(ram_buffer, 1, font->mem_stream.length, &font->mem_stream) != font->mem_stream.length) {
-                qp_dprintf("qp_load_font_mem: could not copy from flash to RAM, falling back to original\n");
+                qp_dprintf("qp_load_font: could not copy from flash to RAM, falling back to original\n");
                 break;
             }
 
@@ -102,15 +100,35 @@ painter_font_handle_t qp_load_font_mem(const void *buffer) {
     qff_read_font_descriptor(&font->stream, &font->base.line_height, &font->has_ascii_table, &font->num_unicode_glyphs, &font->bpp, &font->has_palette, &font->compression_scheme, NULL);
 
     if (!qp_internal_bpp_capable(font->bpp)) {
-        qp_dprintf("qp_load_font_mem: fail (image bpp too high (%d), check QUANTUM_PAINTER_SUPPORTS_256_PALETTE)\n", (int)font->bpp);
+        qp_dprintf("qp_load_font: fail (image bpp too high (%d), check QUANTUM_PAINTER_SUPPORTS_256_PALETTE)\n", (int)font->bpp);
         qp_close_font((painter_font_handle_t)font);
         return NULL;
     }
 
     // Validation success, we can return the handle
     font->validate_ok = true;
-    qp_dprintf("qp_load_font_mem: ok\n");
+    qp_dprintf("qp_load_font: ok\n");
     return (painter_font_handle_t)font;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter External API: qp_load_font_mem
+
+static inline bool font_mem_stream_factory(qff_font_handle_t *font, void *arg) {
+    void *buffer = arg;
+
+    // Assume we can read the graphics descriptor
+    font->mem_stream = qp_make_memory_stream(buffer, sizeof(qff_font_descriptor_v1_t));
+
+    // Update the length of the stream to match, and rewind to the start
+    font->mem_stream.length   = qff_get_total_size(&font->stream);
+    font->mem_stream.position = 0;
+
+    return true;
+}
+
+painter_font_handle_t qp_load_font_mem(const void *buffer) {
+    return qp_load_font_internal(font_mem_stream_factory, (void *)buffer);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -133,6 +151,7 @@ bool qp_close_font(painter_font_handle_t font) {
 #endif // QUANTUM_PAINTER_LOAD_FONTS_TO_RAM
 
     // Free up this font for use elsewhere.
+    qp_stream_close(&qff_font->stream);
     qff_font->validate_ok = false;
     return true;
 }

--- a/quantum/painter/qp_stream.h
+++ b/quantum/painter/qp_stream.h
@@ -41,6 +41,8 @@ typedef struct qp_stream_t qp_stream_t;
 uint32_t qp_stream_read_impl(void *output_buf, uint32_t member_size, uint32_t num_members, qp_stream_t *stream);
 uint32_t qp_stream_write_impl(const void *input_buf, uint32_t member_size, uint32_t num_members, qp_stream_t *stream);
 
+#define qp_stream_close(stream_ptr) (((qp_stream_t *)(stream_ptr))->close((qp_stream_t *)(stream_ptr)))
+
 #define STREAM_EOF ((int16_t)(-1))
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -52,6 +54,7 @@ struct qp_stream_t {
     int (*seek)(qp_stream_t *stream, int32_t offset, int origin);
     int32_t (*tell)(qp_stream_t *stream);
     bool (*is_eof)(qp_stream_t *stream);
+    void (*close)(qp_stream_t *stream);
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -77,6 +80,6 @@ typedef struct qp_file_stream_t {
     FILE *      file;
 } qp_file_stream_t;
 
-qp_file_stream_t qo_make_file_stream(FILE *f);
+qp_file_stream_t qp_make_file_stream(FILE *f);
 
 #endif // QP_STREAM_HAS_FILE_IO

--- a/quantum/painter/rules.mk
+++ b/quantum/painter/rules.mk
@@ -8,8 +8,8 @@ VALID_QUANTUM_PAINTER_DRIVERS := \
 	ili9163_spi \
 	ili9341_spi \
 	ili9488_spi \
-	st7789_spi \
 	st7735_spi \
+	st7789_spi \
 	gc9a01_spi \
 	ssd1351_spi
 
@@ -88,17 +88,6 @@ define handle_quantum_painter_driver
             $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
             $(DRIVER_PATH)/painter/ili9xxx/qp_ili9488.c \
 
-    else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),st7789_spi)
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
-        OPT_DEFS += -DQUANTUM_PAINTER_ST7789_ENABLE -DQUANTUM_PAINTER_ST7789_SPI_ENABLE
-        COMMON_VPATH += \
-            $(DRIVER_PATH)/painter/tft_panel \
-            $(DRIVER_PATH)/painter/st77xx
-        SRC += \
-            $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
-            $(DRIVER_PATH)/painter/st77xx/qp_st7789.c
-
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),st7735_spi)
         QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
         QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
@@ -109,6 +98,17 @@ define handle_quantum_painter_driver
         SRC += \
             $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
             $(DRIVER_PATH)/painter/st77xx/qp_st7735.c
+
+    else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),st7789_spi)
+        QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
+        QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+        OPT_DEFS += -DQUANTUM_PAINTER_ST7789_ENABLE -DQUANTUM_PAINTER_ST7789_SPI_ENABLE
+        COMMON_VPATH += \
+            $(DRIVER_PATH)/painter/tft_panel \
+            $(DRIVER_PATH)/painter/st77xx
+        SRC += \
+            $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
+            $(DRIVER_PATH)/painter/st77xx/qp_st7789.c
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),gc9a01_spi)
         QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes

--- a/quantum/painter/rules.mk
+++ b/quantum/painter/rules.mk
@@ -3,7 +3,15 @@ QUANTUM_PAINTER_DRIVERS ?=
 QUANTUM_PAINTER_ANIMATIONS_ENABLE ?= yes
 
 # The list of permissible drivers that can be listed in QUANTUM_PAINTER_DRIVERS
-VALID_QUANTUM_PAINTER_DRIVERS := rgb565_surface ili9163_spi ili9341_spi ili9488_spi st7789_spi st7735_spi gc9a01_spi ssd1351_spi
+VALID_QUANTUM_PAINTER_DRIVERS := \
+	rgb565_surface \
+	ili9163_spi \
+	ili9341_spi \
+	ili9488_spi \
+	st7789_spi \
+	st7735_spi \
+	gc9a01_spi \
+	ssd1351_spi
 
 #-------------------------------------------------------------------------------
 

--- a/quantum/painter/rules.mk
+++ b/quantum/painter/rules.mk
@@ -3,7 +3,7 @@ QUANTUM_PAINTER_DRIVERS ?=
 QUANTUM_PAINTER_ANIMATIONS_ENABLE ?= yes
 
 # The list of permissible drivers that can be listed in QUANTUM_PAINTER_DRIVERS
-VALID_QUANTUM_PAINTER_DRIVERS := ili9163_spi ili9341_spi ili9488_spi st7789_spi st7735_spi gc9a01_spi ssd1351_spi
+VALID_QUANTUM_PAINTER_DRIVERS := rgb565_surface ili9163_spi ili9341_spi ili9488_spi st7789_spi st7735_spi gc9a01_spi ssd1351_spi
 
 #-------------------------------------------------------------------------------
 
@@ -39,6 +39,13 @@ define handle_quantum_painter_driver
 
     ifeq ($$(filter $$(strip $$(CURRENT_PAINTER_DRIVER)),$$(VALID_QUANTUM_PAINTER_DRIVERS)),)
         $$(error "$$(CURRENT_PAINTER_DRIVER)" is not a valid Quantum Painter driver)
+
+    else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),rgb565_surface)
+        OPT_DEFS += -DQUANTUM_PAINTER_RGB565_SURFACE_ENABLE
+        COMMON_VPATH += \
+            $(DRIVER_PATH)/painter/generic
+        SRC += \
+            $(DRIVER_PATH)/painter/generic/qp_rgb565_surface.c \
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),ili9163_spi)
         QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes


### PR DESCRIPTION
## Description

Adds support for an RGB565 surface, aka framebuffer. Allows for drawing to RAM, then copying just the dirty region to another display.

Slight tweak to the image/font loader functions to allow for alternate methods of loading assets, with the filesystem stuff in the pipeline.

Also did documentation cleanup requested by Dasky.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).