### PR TITLE
Invert pointing device motion pin for cirque touchpads

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -289,6 +289,7 @@ void           pointing_device_driver_set_cpi(uint16_t cpi) {}
 | `POINTING_DEVICE_INVERT_X`                     | (Optional) Inverts the X axis report.                                                                                            | _not defined_ |
 | `POINTING_DEVICE_INVERT_Y`                     | (Optional) Inverts the Y axis report.                                                                                            | _not defined_ |
 | `POINTING_DEVICE_MOTION_PIN`                   | (Optional) If supported, will only read from sensor if pin is active.                                                            | _not defined_ |
+| `POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW`        | (Optional) If defined then the motion pin is active-low.                                                                         | _varies_      |
 | `POINTING_DEVICE_TASK_THROTTLE_MS`             | (Optional) Limits the frequency that the sensor is polled for motion.                                                            | _not defined_ |
 | `POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE` | (Optional) Enable inertial cursor. Cursor continues moving after a flick gesture and slows down by kinetic friction.             | _not defined_ |
 | `POINTING_DEVICE_GESTURES_SCROLL_ENABLE`       | (Optional) Enable scroll gesture. The gesture that activates the scroll is device dependent.                                     | _not defined_ |

--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -144,7 +144,11 @@ __attribute__((weak)) void pointing_device_init(void) {
     {
         pointing_device_driver.init();
 #ifdef POINTING_DEVICE_MOTION_PIN
+#    ifdef POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
         setPinInputHigh(POINTING_DEVICE_MOTION_PIN);
+#    else
+        setPinInput(POINTING_DEVICE_MOTION_PIN);
+#    endif
 #endif
     }
 
@@ -236,7 +240,11 @@ __attribute__((weak)) void pointing_device_task(void) {
 #    if defined(SPLIT_POINTING_ENABLE)
 #        error POINTING_DEVICE_MOTION_PIN not supported when sharing the pointing device report between sides.
 #    endif
+#    ifdef POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
     if (!readPin(POINTING_DEVICE_MOTION_PIN))
+#    else
+    if (readPin(POINTING_DEVICE_MOTION_PIN))
+#    endif
 #endif
 
 #if defined(SPLIT_POINTING_ENABLE)

--- a/quantum/pointing_device/pointing_device.h
+++ b/quantum/pointing_device/pointing_device.h
@@ -23,18 +23,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if defined(POINTING_DEVICE_DRIVER_adns5050)
 #    include "drivers/sensors/adns5050.h"
+#    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
 #elif defined(POINTING_DEVICE_DRIVER_adns9800)
 #    include "spi_master.h"
 #    include "drivers/sensors/adns9800.h"
+#    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
 #elif defined(POINTING_DEVICE_DRIVER_analog_joystick)
 #    include "analog.h"
 #    include "drivers/sensors/analog_joystick.h"
+#    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
 #elif defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_i2c) || defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_spi)
 #    include "drivers/sensors/cirque_pinnacle.h"
 #    include "drivers/sensors/cirque_pinnacle_gestures.h"
 #    include "pointing_device_gestures.h"
 #elif defined(POINTING_DEVICE_DRIVER_paw3204)
 #    include "drivers/sensors/paw3204.h"
+#    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
 #elif defined(POINTING_DEVICE_DRIVER_pimoroni_trackball)
 #    include "i2c_master.h"
 #    include "drivers/sensors/pimoroni_trackball.h"
@@ -48,9 +52,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    ifdef PIMORONI_TRACKBALL_ROTATE
 #        define POINTING_DEVICE_ROTATION_90
 #    endif
+#    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
 #elif defined(POINTING_DEVICE_DRIVER_pmw3360) || defined(POINTING_DEVICE_DRIVER_pmw3389)
 #    include "spi_master.h"
 #    include "drivers/sensors/pmw33xx_common.h"
+#    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
 #else
 void           pointing_device_driver_init(void);
 report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report);


### PR DESCRIPTION
## Description

Cirque touchpads 'data ready'-pin implements active-high logic in contrast to most other pointing devices which use an active-low logic. Therefore, this commit implements both a configurable inversion of the motion pin logic and sets the the default for the cirque touchpad driver accordingly.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR
This issue came up yesterday in the #help-firmware discord channel and was pointed out by @daskygit after Kuromitsu#5783 tried to use the motion pin.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
