### PR TITLE
Replication of the oled_write_char, oled_write, and oled_write_ln function using uint16 instead of char

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -281,6 +281,23 @@ void oled_write(const char *data, bool invert);
 // Advances the cursor to the next page, wiring ' ' to the remainder of the current page
 void oled_write_ln(const char *data, bool invert);
 
+// Writes a singe bitmap glyph by index to the buffer at current cursor position
+// Advances the cursor while writing, inverts the pixels if true
+// Main handler that writes character data to the display buffer
+// Allows for accessing glyphs with index larger than 256
+void oled_write_index(const uint16_t data, bool invert)
+
+// Writes bitmap glyphs according to indices to the buffer at current cursor position
+// Advances the cursor while writing, inverts the pixels if true
+// Allows for accessing glyphs with index larger than 256
+void oled_index(const uint16_t *data, bool invert)
+
+// Writes bitmap glyphs according to indices to the buffer at current cursor position
+// Advances the cursor while writing, inverts the pixels if true
+// Advances the cursor to the next page, wiring ' ' to the remainder of the current page
+// Allows for accessing glyphs with index larger than 256
+void oled_write_index_ln(const uint16_t *data, bool invert)
+
 // Pans the buffer to the right (or left by passing true) by moving contents of the buffer
 // Useful for moving the screen in preparation for new drawing
 // oled_scroll_left or oled_scroll_right should be preferred for all cases of moving a static

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -226,6 +226,18 @@ void oled_write(const char *data, bool invert);
 // Advances the cursor to the next page, wiring ' ' to the remainder of the current page
 void oled_write_ln(const char *data, bool invert);
 
+
+void oled_write_index(const uint16_t data, bool invert);
+
+// Writes a string to the buffer at current cursor position
+// Advances the cursor while writing, inverts the pixels if true
+void oled_index(const uint16_t *data, uint16_t size, bool invert);
+
+// Writes a string to the buffer at current cursor position
+// Advances the cursor while writing, inverts the pixels if true
+// Advances the cursor to the next page, wiring ' ' to the remainder of the current page
+void oled_write_index_ln(const uint16_t *data, const uint16_t size, bool invert);
+
 // Pans the buffer to the right (or left by passing true) by moving contents of the buffer
 // Useful for moving the screen in preparation for new drawing
 void oled_pan(bool left);


### PR DESCRIPTION
## Description
To allow for bitmaps with more than 254 glyphs i replicated the the oled_write_char, oled_write, and oled_write_ln function using uint16 instead of char.

The functions can be used exactly like the char / string ones using uint16 values / arrays instead.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [!] I have added tests to cover my changes. ------ Am i required to write tests for my changes?
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
