### PR TITLE
Fix int8_t overflow in RGB heatmap effect

### DIFF
--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -29,7 +29,7 @@ void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
             if (i_row == row && i_col == col) {
                 g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
             } else {
-#            define LED_DISTANCE(led_a, led_b) sqrt16(((int8_t)(led_a.x - led_b.x) * (int8_t)(led_a.x - led_b.x)) + ((int8_t)(led_a.y - led_b.y) * (int8_t)(led_a.y - led_b.y)))
+#            define LED_DISTANCE(led_a, led_b) sqrt16(((int16_t)(led_a.x - led_b.x) * (int16_t)(led_a.x - led_b.x)) + ((int16_t)(led_a.y - led_b.y) * (int16_t)(led_a.y - led_b.y)))
                 uint8_t distance = LED_DISTANCE(g_led_config.point[g_led_config.matrix_co[row][col]], g_led_config.point[g_led_config.matrix_co[i_row][i_col]]);
 #            undef LED_DISTANCE
                 if (distance <= RGB_MATRIX_TYPING_HEATMAP_SPREAD) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The RGB heatmap effect currently has an issue where pressing the leftmost keys on the keyboard may light up the rightmost keys on the keyboard as well.

This is because the distance calculation for the RGB heatmap effect uses `int8_t` to store the row distance and column distance. However, LED coordinates are stored as `uint8_t`, so it is possible to overflow the `int8_t` when calculating the row distance and column distance.

Changing the row and column distance to `int16_t` fixes this overflow and resolves the issue.

**QUESTION:**
There might still be an issue if any keyboard does not follow the recommendation in https://github.com/samhocevar-forks/qmk-firmware/blob/380e05ad6e1a64d635d723523b7d46ab32423b1c/docs/feature_rgb_matrix.md to define LED coordinates in the inclusive range `{ 0..224, 0..64 }`. That document does suggest that the maximum value for both coordinates is `255`. If anyone does that, intermediate `int16_t` will overflow again.
Ist this a problem that should be addressed? Or is it okay to rely on the keyboards to stay in the recommended range?

I have reproduced the issue on a RP2040-based keyboard (my Lotus58; not in the main QMK repo) as well as an AVR-based keyboard (BM40HSRGB; in the main QMK repo). I have also verified the fix on both of them.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  - **I have tested this change on a RP2040-based keyboard as well as an AVR-based keyboard. It fixes the issue on both of them.**
