### PR TITLE
[Core] Serial-protocol: always clear receive queue on main half of split keyboard

### DIFF
--- a/platforms/chibios/drivers/serial_protocol.c
+++ b/platforms/chibios/drivers/serial_protocol.c
@@ -102,15 +102,11 @@ static inline bool react_to_transaction(void) {
  * @return bool Indicates success of transaction.
  */
 bool soft_serial_transaction(int index) {
-    bool result = initiate_transaction((uint8_t)index);
+    /* Clear the receive queue, to start with a clean slate.
+     * Parts of failed transactions or spurious bytes could still be in it. */
+    serial_transport_driver_clear();
 
-    if (unlikely(!result)) {
-        /* Clear the receive queue, to start with a clean slate.
-         * Parts of failed transactions or spurious bytes could still be in it. */
-        serial_transport_driver_clear();
-    }
-
-    return result;
+    return initiate_transaction((uint8_t)index);
 }
 
 /**


### PR DESCRIPTION
## Description

...in order to flush out any spurious bytes or traffic that belongs to failed transactions send by the secondary half. This is save todo as the main half initiates every transaction and must never receive any data before sending a handshake.

Tested with RP2040 and GD32VF103 splits.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
