### PR TITLE
[Core] Stabilize RP2040 Half-duplex PIO split comms take 2

### DIFF
--- a/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
@@ -140,9 +140,8 @@ void pio_serve_interrupt(void) {
 // strength is chosen because the transmitting side must still be able to drive
 // the signal low. With this configuration the rise times are fast enough and
 // the generated low level with 360mV will generate a logical zero.
-static inline void enter_rx_state(void) {
+static void __no_inline_not_in_flash_func(enter_rx_state)(void) {
     osalSysLock();
-    nvicEnableVector(RP_USBCTRL_IRQ_NUMBER, RP_IRQ_USB0_PRIORITY);
     // Wait for the transmitting state machines FIFO to run empty. At this point
     // the last byte has been pulled from the transmitting state machines FIFO
     // into the output shift register. We have to wait a tiny bit more until
@@ -162,11 +161,8 @@ static inline void enter_rx_state(void) {
     osalSysUnlock();
 }
 
-static inline void leave_rx_state(void) {
+static void __no_inline_not_in_flash_func(leave_rx_state)(void) {
     osalSysLock();
-    // We don't want to be interrupted by frequent (1KHz) USB interrupts while
-    // doing our timing critical sending operation.
-    nvicDisableVector(RP_USBCTRL_IRQ_NUMBER);
     // In Half-duplex operation the tx pin dual-functions as sender and
     // receiver. To not receive the data we will send, we disable the receiving
     // state machine.
@@ -198,11 +194,6 @@ static inline msg_t sync_tx(sysinterval_t timeout) {
     msg_t msg = MSG_OK;
     osalSysLock();
     while (pio_sm_is_tx_fifo_full(pio, tx_state_machine)) {
-#if !defined(SERIAL_USART_FULL_DUPLEX)
-        // Enable USB interrupts again, because we might sleep for a long time
-        // here and don't want to be disconnected from the host.
-        nvicEnableVector(RP_USBCTRL_IRQ_NUMBER, RP_IRQ_USB0_PRIORITY);
-#endif
         pio_set_irq0_source_enabled(pio, pis_sm0_tx_fifo_not_full + tx_state_machine, true);
         msg = osalThreadSuspendTimeoutS(&tx_thread, timeout);
         if (msg < MSG_OK) {
@@ -210,10 +201,6 @@ static inline msg_t sync_tx(sysinterval_t timeout) {
             break;
         }
     }
-#if !defined(SERIAL_USART_FULL_DUPLEX)
-    // Entering timing critical territory again.
-    nvicDisableVector(RP_USBCTRL_IRQ_NUMBER);
-#endif
     osalSysUnlock();
     return msg;
 }


### PR DESCRIPTION
## Description

...by moving the actually timing critical `enter_rx_state()` and `leave_rx_state()` functions to RAM in order to not be affected by XIP cache spikes. This commit also reverts the hacky USB interrupt disabling that was done in 293c53d774

Tested successfully with RP2040 BastardKB half-duplex split.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
