### PR TITLE
[Core] Copy RP2040 vector table to RAM on startup

### DIFF
--- a/platforms/chibios/vendors/RP/RP2040.mk
+++ b/platforms/chibios/vendors/RP/RP2040.mk
@@ -11,7 +11,8 @@ endif
 # Raspberry Pi Pico SDK Support
 ##############################################################################
 ADEFS  += -DCRT0_VTOR_INIT=1 \
-		  -DCRT0_EXTRA_CORES_NUMBER=0
+		  -DCRT0_EXTRA_CORES_NUMBER=0 \
+          -DCRT0_INIT_VECTORS=1
 
 CFLAGS += -DPICO_NO_FPGA_CHECK \
           -DNDEBUG


### PR DESCRIPTION
## Description

~~Depends on https://github.com/ChibiOS/ChibiOS-Contrib/pull/336 being merged first.~~ merged, also to QMK develop.

...this reduces possible latency when invoking interrupt handlers by mitigating XIP cache misses which are not existent when running code from RAM.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
