### PR TITLE
Fix retain brightness when val is changed while a layer is active

### DIFF
--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -580,6 +580,10 @@ void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool w
                     dprintf("rgblight rainbow set hsv: %d,%d,%d,%u\n", i, _hue, direction, range);
                     sethsv(_hue, sat, val, (LED_TYPE *)&led[i + rgblight_ranges.effect_start_pos]);
                 }
+#ifdef RGBLIGHT_LAYERS_RETAIN_VAL
+                // needed for rgblight_layers_write() to get the new val, since it reads rgblight_config.val
+                rgblight_config.val = val;
+#endif
                 rgblight_set();
             }
 #endif

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -580,10 +580,10 @@ void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool w
                     dprintf("rgblight rainbow set hsv: %d,%d,%d,%u\n", i, _hue, direction, range);
                     sethsv(_hue, sat, val, (LED_TYPE *)&led[i + rgblight_ranges.effect_start_pos]);
                 }
-#ifdef RGBLIGHT_LAYERS_RETAIN_VAL
+#    ifdef RGBLIGHT_LAYERS_RETAIN_VAL
                 // needed for rgblight_layers_write() to get the new val, since it reads rgblight_config.val
                 rgblight_config.val = val;
-#endif
+#    endif
                 rgblight_set();
             }
 #endif

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -526,10 +526,19 @@ void rgblight_sethsv_noeeprom_old(uint8_t hue, uint8_t sat, uint8_t val) {
 
 void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool write_to_eeprom) {
     if (rgblight_config.enable) {
+#ifdef RGBLIGHT_SPLIT
+        if (rgblight_config.hue != hue || rgblight_config.sat != sat || rgblight_config.val != val) {
+            RGBLIGHT_SPLIT_SET_CHANGE_HSVS;
+        }
+#endif
         rgblight_status.base_mode = mode_base_table[rgblight_config.mode];
         if (rgblight_config.mode == RGBLIGHT_MODE_STATIC_LIGHT) {
             // same static color
             LED_TYPE tmp_led;
+#ifdef RGBLIGHT_LAYERS_RETAIN_VAL
+            // needed for rgblight_layers_write() to get the new val, since it reads rgblight_config.val
+            rgblight_config.val = val;
+#endif
             sethsv(hue, sat, val, &tmp_led);
             rgblight_setrgb(tmp_led.r, tmp_led.g, tmp_led.b);
         } else {
@@ -575,11 +584,6 @@ void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool w
             }
 #endif
         }
-#ifdef RGBLIGHT_SPLIT
-        if (rgblight_config.hue != hue || rgblight_config.sat != sat || rgblight_config.val != val) {
-            RGBLIGHT_SPLIT_SET_CHANGE_HSVS;
-        }
-#endif
         rgblight_config.hue = hue;
         rgblight_config.sat = sat;
         rgblight_config.val = val;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!---If `RGBLIGHT_LAYERS_RETAIN_VAL` is defined and the HSV val is changed while a layer is active, the brightness doesn't update. This should fix that. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
If `RGBLIGHT_LAYERS_RETAIN_VAL` is defined while lighting layers are used, `rgblight_layers_write()` checks `rgblight_config.val` for the currently set brightness. However, `rgblight_sethsv_eeprom_helper()` updates `rgblight_config.val` with the new `val` _after_ it calls `rgblight_setrgb()`, which ultimately calls `rgblight_layers_write()`. This means that if the brightness is changed while a lighting layer is active, the LEDs won't change to the new brightness until the lighting layer changes, or the HSV is changed again.

Tested with Iris Rev. 3

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
