### PR TITLE
Fix incorrect g_led_config generation

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -621,7 +621,7 @@ def _extract_led_config(info_data, keyboard):
     elif features.get("led_matrix", False):
         feature = "led_matrix"
 
-    if feature is not None:
+    if feature:
         # Process
         for file in find_keyboard_c(keyboard):
             try:

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -613,20 +613,24 @@ def _extract_led_config(info_data, keyboard):
     cols = info_data['matrix_size']['cols']
     rows = info_data['matrix_size']['rows']
 
-    # Assume what feature owns g_led_config
-    feature = "rgb_matrix"
-    if info_data.get("features", {}).get("led_matrix", False):
+    # Determine what feature owns g_led_config
+    features = info_data.get("features", {})
+    feature = None
+    if features.get("rgb_matrix", False):
+        feature = "rgb_matrix"
+    elif features.get("led_matrix", False):
         feature = "led_matrix"
 
-    # Process
-    for file in find_keyboard_c(keyboard):
-        try:
-            ret = find_led_config(file, cols, rows)
-            if ret:
-                info_data[feature] = info_data.get(feature, {})
-                info_data[feature]["layout"] = ret
-        except Exception as e:
-            _log_warning(info_data, f'led_config: {file.name}: {e}')
+    if feature is not None:
+        # Process
+        for file in find_keyboard_c(keyboard):
+            try:
+                ret = find_led_config(file, cols, rows)
+                if ret:
+                    info_data[feature] = info_data.get(feature, {})
+                    info_data[feature]["layout"] = ret
+            except Exception as e:
+                _log_warning(info_data, f'led_config: {file.name}: {e}')
 
     return info_data
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

If neither LED Matrix nor RGB Matrix are enabled, but a `g_led_config` structure exists in the keyboard, this code will parse and re-generate it assuming RGB Matrix. With this change the `g_led_config` is not generated unless one of the two are enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
