### PR TITLE
Start moving towards introspection-based data retrieval

### DIFF
--- a/builddefs/build_full_test.mk
+++ b/builddefs/build_full_test.mk
@@ -20,7 +20,6 @@ $(TEST)_SRC := \
 	$(TMK_COMMON_SRC) \
 	$(QUANTUM_SRC) \
 	$(SRC) \
-	tests/test_common/keymap.c \
 	tests/test_common/matrix.c \
 	tests/test_common/test_driver.cpp \
 	tests/test_common/keyboard_report_util.cpp \
@@ -29,7 +28,7 @@ $(TEST)_SRC := \
 	tests/test_common/test_logger.cpp \
 	$(patsubst $(ROOTDIR)/%,%,$(wildcard $(TEST_PATH)/*.cpp))
 
-$(TEST)_DEFS := $(TMK_COMMON_DEFS) $(OPT_DEFS)
+$(TEST)_DEFS := $(TMK_COMMON_DEFS) $(OPT_DEFS) "-DKEYMAP_C=\"keymap.c\""
 
 $(TEST)_CONFIG := $(TEST_PATH)/config.h
 

--- a/builddefs/build_full_test.mk
+++ b/builddefs/build_full_test.mk
@@ -20,6 +20,7 @@ $(TEST)_SRC := \
 	$(TMK_COMMON_SRC) \
 	$(QUANTUM_SRC) \
 	$(SRC) \
+	$(QUANTUM_PATH)/keymap_introspection.c \
 	tests/test_common/matrix.c \
 	tests/test_common/test_driver.cpp \
 	tests/test_common/keyboard_report_util.cpp \

--- a/builddefs/build_test.mk
+++ b/builddefs/build_test.mk
@@ -72,6 +72,7 @@ endif
 
 $(TEST)_SRC += \
 	tests/test_common/main.c \
+	$(QUANTUM_PATH)/keymap_introspection.c \
 	$(QUANTUM_PATH)/logging/print.c
 
 $(TEST_OBJ)/$(TEST)_SRC := $($(TEST)_SRC)

--- a/builddefs/build_test.mk
+++ b/builddefs/build_test.mk
@@ -72,7 +72,6 @@ endif
 
 $(TEST)_SRC += \
 	tests/test_common/main.c \
-	$(QUANTUM_PATH)/keymap_introspection.c \
 	$(QUANTUM_PATH)/logging/print.c
 
 $(TEST_OBJ)/$(TEST)_SRC := $($(TEST)_SRC)

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -153,7 +153,7 @@ void dynamic_keymap_reset(void) {
         for (int row = 0; row < MATRIX_ROWS; row++) {
             for (int column = 0; column < MATRIX_COLS; column++) {
                 if (layer < keymap_layer_count()) {
-                    dynamic_keymap_set_keycode(layer, row, column, pgm_read_word(&keymaps[layer][row][column]));
+                    dynamic_keymap_set_keycode(layer, row, column, keycode_at_keymap_location_raw(layer, row, column));
                 } else {
                     dynamic_keymap_set_keycode(layer, row, column, KC_TRANSPARENT);
                 }
@@ -162,8 +162,8 @@ void dynamic_keymap_reset(void) {
 #ifdef ENCODER_MAP_ENABLE
         for (int encoder = 0; encoder < NUM_ENCODERS; encoder++) {
             if (layer < encodermap_layer_count()) {
-                dynamic_keymap_set_encoder(layer, encoder, true, pgm_read_word(&encoder_map[layer][encoder][0]));
-                dynamic_keymap_set_encoder(layer, encoder, false, pgm_read_word(&encoder_map[layer][encoder][1]));
+                dynamic_keymap_set_encoder(layer, encoder, true, keycode_at_encodermap_location_raw(layer, encoder, true));
+                dynamic_keymap_set_encoder(layer, encoder, false, keycode_at_encodermap_location_raw(layer, encoder, false));
             } else {
                 dynamic_keymap_set_encoder(layer, encoder, true, KC_TRANSPARENT);
                 dynamic_keymap_set_encoder(layer, encoder, false, KC_TRANSPARENT);
@@ -201,20 +201,21 @@ void dynamic_keymap_set_buffer(uint16_t offset, uint16_t size, uint8_t *data) {
     }
 }
 
-// This overrides the one in quantum/keymap_common.c
-uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key) {
-    if (layer < DYNAMIC_KEYMAP_LAYER_COUNT && key.row < MATRIX_ROWS && key.col < MATRIX_COLS) {
-        return dynamic_keymap_get_keycode(layer, key.row, key.col);
+uint16_t keycode_at_keymap_location(uint8_t layer_num, uint8_t row, uint8_t column) {
+    if (layer_num < DYNAMIC_KEYMAP_LAYER_COUNT && row < MATRIX_ROWS && column < MATRIX_COLS) {
+        return dynamic_keymap_get_keycode(layer_num, row, column);
     }
-#ifdef ENCODER_MAP_ENABLE
-    else if (layer < DYNAMIC_KEYMAP_LAYER_COUNT && key.row == KEYLOC_ENCODER_CW && key.col < NUM_ENCODERS) {
-        return dynamic_keymap_get_encoder(layer, key.col, true);
-    } else if (layer < DYNAMIC_KEYMAP_LAYER_COUNT && key.row == KEYLOC_ENCODER_CCW && key.col < NUM_ENCODERS) {
-        return dynamic_keymap_get_encoder(layer, key.col, false);
-    }
-#endif // ENCODER_MAP_ENABLE
     return KC_NO;
 }
+
+#ifdef ENCODER_MAP_ENABLE
+uint16_t keycode_at_encodermap_location(uint8_t layer_num, uint8_t encoder_idx, bool clockwise) {
+    if (layer_num < DYNAMIC_KEYMAP_LAYER_COUNT && encoder_idx < NUM_ENCODERS) {
+        return dynamic_keymap_get_encoder(layer_num, encoder_idx, clockwise);
+    }
+    return KC_NO;
+}
+#endif // ENCODER_MAP_ENABLE
 
 uint8_t dynamic_keymap_macro_get_count(void) {
     return DYNAMIC_KEYMAP_MACRO_COUNT;

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -175,12 +175,11 @@ uint32_t get_matrix_scan_rate(void) {
 #endif
 
 #ifdef MATRIX_HAS_GHOST
-extern const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS];
-static matrix_row_t   get_real_keys(uint8_t row, matrix_row_t rowdata) {
+static matrix_row_t get_real_keys(uint8_t row, matrix_row_t rowdata) {
     matrix_row_t out = 0;
     for (uint8_t col = 0; col < MATRIX_COLS; col++) {
         // read each key in the row data and check if the keymap defines it as a real key
-        if (pgm_read_byte(&keymaps[0][row][col]) && (rowdata & (1 << col))) {
+        if (keycode_at_keymap_location(0, row, col) && (rowdata & (1 << col))) {
             // this creates new row data, if a key is defined in the keymap, it will be set here
             out |= 1 << col;
         }

--- a/quantum/keymap.h
+++ b/quantum/keymap.h
@@ -33,8 +33,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // translates key to keycode
 uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key);
 
-extern const uint16_t keymaps[][MATRIX_ROWS][MATRIX_COLS];
-
 #ifdef ENCODER_MAP_ENABLE
 // Ensure we have a forward declaration for the encoder map
 #    include "encoder.h"

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -147,13 +147,13 @@ action_t action_for_keycode(uint16_t keycode) {
 // translates key to keycode
 __attribute__((weak)) uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key) {
     if (key.row < MATRIX_ROWS && key.col < MATRIX_COLS) {
-        return pgm_read_word(&keymaps[layer][key.row][key.col]);
+        return keycode_at_keymap_location(layer, key.row, key.col);
     }
 #ifdef ENCODER_MAP_ENABLE
     else if (key.row == KEYLOC_ENCODER_CW && key.col < NUM_ENCODERS) {
-        return pgm_read_word(&encoder_map[layer][key.col][0]);
+        return keycode_at_encodermap_location(layer, key.col, true);
     } else if (key.row == KEYLOC_ENCODER_CCW && key.col < NUM_ENCODERS) {
-        return pgm_read_word(&encoder_map[layer][key.col][1]);
+        return keycode_at_encodermap_location(layer, key.col, false);
     }
 #endif // ENCODER_MAP_ENABLE
     return KC_NO;

--- a/quantum/keymap_introspection.c
+++ b/quantum/keymap_introspection.c
@@ -19,6 +19,17 @@ uint8_t keymap_layer_count(void) {
 
 _Static_assert(NUM_KEYMAP_LAYERS <= MAX_LAYER, "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT");
 
+uint16_t keycode_at_keymap_location_raw(uint8_t layer_num, uint8_t row, uint8_t column) {
+    if (layer_num < NUM_KEYMAP_LAYERS && row < MATRIX_ROWS && column < MATRIX_COLS) {
+        return pgm_read_word(&keymaps[layer_num][row][column]);
+    }
+    return KC_NO;
+}
+
+__attribute__((weak)) uint16_t keycode_at_keymap_location(uint8_t layer_num, uint8_t row, uint8_t column) {
+    return keycode_at_keymap_location_raw(layer_num, row, column);
+}
+
 #if defined(ENCODER_ENABLE) && defined(ENCODER_MAP_ENABLE)
 
 #    define NUM_ENCODERMAP_LAYERS ((uint8_t)(sizeof(encoder_map) / ((NUM_ENCODERS) * (2) * sizeof(uint16_t))))
@@ -28,5 +39,16 @@ uint8_t encodermap_layer_count(void) {
 }
 
 _Static_assert(NUM_KEYMAP_LAYERS == NUM_ENCODERMAP_LAYERS, "Number of encoder_map layers doesn't match the number of keymap layers");
+
+uint16_t keycode_at_encodermap_location_raw(uint8_t layer_num, uint8_t encoder_idx, bool clockwise) {
+    if (layer_num < NUM_ENCODERMAP_LAYERS && encoder_idx < NUM_ENCODERS) {
+        return pgm_read_word(&encoder_map[layer_num][encoder_idx][clockwise ? 0 : 1]);
+    }
+    return KC_NO;
+}
+
+__attribute__((weak)) uint16_t keycode_at_encodermap_location(uint8_t layer_num, uint8_t encoder_idx, bool clockwise) {
+    return keycode_at_encodermap_location_raw(layer_num, encoder_idx, clockwise);
+}
 
 #endif // defined(ENCODER_ENABLE) && defined(ENCODER_MAP_ENABLE)

--- a/quantum/keymap_introspection.h
+++ b/quantum/keymap_introspection.h
@@ -7,9 +7,19 @@
 // Get the number of layers defined in the keymap
 uint8_t keymap_layer_count(void);
 
+// Get the keycode for the keymap location, stored in firmware rather than any other persistent storage
+uint16_t keycode_at_keymap_location_raw(uint8_t layer_num, uint8_t row, uint8_t column);
+// Get the keycode for the keymap location, potentially stored dynamically
+uint16_t keycode_at_keymap_location(uint8_t layer_num, uint8_t row, uint8_t column);
+
 #if defined(ENCODER_ENABLE) && defined(ENCODER_MAP_ENABLE)
 
 // Get the number of layers defined in the encoder map
 uint8_t encodermap_layer_count(void);
+
+// Get the keycode for the encoder mapping location, stored in firmware rather than any other persistent storage
+uint16_t keycode_at_encodermap_location_raw(uint8_t layer_num, uint8_t encoder_idx, bool clockwise);
+// Get the keycode for the encoder mapping location, potentially stored dynamically
+uint16_t keycode_at_encodermap_location(uint8_t layer_num, uint8_t encoder_idx, bool clockwise);
 
 #endif // defined(ENCODER_ENABLE) && defined(ENCODER_MAP_ENABLE)


### PR DESCRIPTION
## Description

Starts preparation for decoupling dynamic keymap from being so intertwined with EEPROM as its specific backend.
Adds overridable functions for retrieval of keymap and encodermap data.
Modified `dynamic_keymap.c` to implement those overrides, allowing normal use of `keymap_key_to_keycode`.

Combos, key overrides, etc. to come in followup PRs.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
