### PR TITLE
Remove orphan link in keymap docs (old custom functions)

### DIFF
--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -92,11 +92,10 @@ These keycodes allow the processing to fall through to lower layers in search of
 
 For this example we will walk through an [older version of the default Clueboard 66% keymap](https://github.com/qmk/qmk_firmware/blob/ca01d94005f67ec4fa9528353481faa622d949ae/keyboards/clueboard/keymaps/default/keymap.c). You'll find it helpful to open that file in another browser window so you can look at everything in context.
 
-There are 3 main sections of a `keymap.c` file you'll want to concern yourself with:
+There are 2 main sections of a `keymap.c` file you'll want to concern yourself with:
 
 * [The Definitions](#definitions)
 * [The Layer/Keymap Datastructure](#layers-and-keymaps)
-* [Custom Functions](#custom-functions), if any
 
 ### Definitions
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Removes an anchor link to the "custom functions" section of the keymap docs that was removed in #5281. (This style of custom functions were removed entirely in #16025.)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).


