### PR TITLE
Keyquest Enclave-1: rename LAYOUT to LAYOUT_ortho_3x3

### DIFF
--- a/keyboards/keyquest/enclave/info.json
+++ b/keyboards/keyquest/enclave/info.json
@@ -7,8 +7,11 @@
         "pid": "0x0E0E",
         "device_version": "0.0.1"
     },
+    "layout_aliases": {
+        "LAYOUT": "LAYOUT_ortho_3x3"
+    },
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_ortho_3x3": {
             "layout": [
                 { "matrix": [0, 0], "x": 0, "y": 0 },
                 { "matrix": [0, 1], "x": 1, "y": 0 },

--- a/keyboards/keyquest/enclave/info.json
+++ b/keyboards/keyquest/enclave/info.json
@@ -1,7 +1,7 @@
 {
     "manufacturer": "keyquest",
     "keyboard_name": "Enclave-1",
-    "maintainer": "the keyquest team",
+    "maintainer": "keyquesttech",
     "usb": {
         "vid": "0x1117",
         "pid": "0x0E0E",

--- a/keyboards/keyquest/enclave/keymaps/default/keymap.c
+++ b/keyboards/keyquest/enclave/keymaps/default/keymap.c
@@ -25,25 +25,25 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * │ M7 │ M8 │ M9 │
      * └────┴────┴────┘
      */
-    [0] = LAYOUT(
+    [0] = LAYOUT_ortho_3x3(
         KC_MEDIA_PREV_TRACK, KC_MEDIA_PLAY_PAUSE, KC_MEDIA_NEXT_TRACK,
         C(KC_C), C(KC_V), G(KC_V),
         KC_AUDIO_VOL_UP, KC_AUDIO_VOL_DOWN, MO(1)
     ),
 
-    [1] = LAYOUT(
+    [1] = LAYOUT_ortho_3x3(
         _______, _______, _______,
         _______, _______, _______,
         _______, MO(2), _______
     ),
 
-    [2] = LAYOUT(
+    [2] = LAYOUT_ortho_3x3(
         _______, _______, _______,
         _______, _______, _______,
         MO(3), _______, _______
     ),
 
-    [3] = LAYOUT(
+    [3] = LAYOUT_ortho_3x3(
         RGB_TOG, RGB_MODE_PLAIN, RGB_MODE_BREATHE,
         RGB_MODE_RAINBOW, RGB_MODE_SWIRL, RGB_MODE_GRADIENT,
         _______, _______, _______

--- a/keyboards/keyquest/enclave/keymaps/via/keymap.c
+++ b/keyboards/keyquest/enclave/keymaps/via/keymap.c
@@ -24,25 +24,25 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * │ M7 │ M8 │ M9 │
      * └────┴────┴────┘
      */
-    [0] = LAYOUT(
+    [0] = LAYOUT_ortho_3x3(
         KC_MEDIA_PREV_TRACK, KC_MEDIA_PLAY_PAUSE, KC_MEDIA_NEXT_TRACK,
         KC_AUDIO_VOL_UP, KC_AUDIO_MUTE, KC_AUDIO_VOL_DOWN,
         _______, _______, _______
     ),
 
-    [1] = LAYOUT(
+    [1] = LAYOUT_ortho_3x3(
         _______, _______, _______,
         _______, _______, _______,
         _______, _______, _______
     ),
 
-    [2] = LAYOUT(
+    [2] = LAYOUT_ortho_3x3(
         _______, _______, _______,
         _______, _______, _______,
         _______, _______, _______
     ),
 
-    [3] = LAYOUT(
+    [3] = LAYOUT_ortho_3x3(
         _______, _______, _______,
         _______, _______, _______,
         _______, _______, _______


### PR DESCRIPTION
## Description

Also corrects the `maintainer` field in `info.json` to reference the maintainer's GitHub username.

cc @keyquesttech (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
