### PR TITLE
Plywrks Ahgase Community Layout Support

### DIFF
--- a/keyboards/plywrks/ahgase/ahgase.h
+++ b/keyboards/plywrks/ahgase/ahgase.h
@@ -46,7 +46,7 @@
 // Full right shift
 // Split left shift
 // 6.25u bottom row
-#define LAYOUT_iso( \
+#define LAYOUT_tkl_f13_iso( \
     k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, k0f, k0g, \
     k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d, k1e, k1f, k1g, \
     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c,      k2e, k2f, k2g, \

--- a/keyboards/plywrks/ahgase/ahgase.h
+++ b/keyboards/plywrks/ahgase/ahgase.h
@@ -25,7 +25,7 @@
 // Full right shift
 // Full left shift
 // 6.25u bottom row
-#define LAYOUT_ansi( \
+#define LAYOUT_tkl_f13_ansi( \
     k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, k0f, k0g, \
     k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d, k1e, k1f, k1g, \
     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c, k2d, k2e, k2f, k2g, \

--- a/keyboards/plywrks/ahgase/info.json
+++ b/keyboards/plywrks/ahgase/info.json
@@ -12,6 +12,10 @@
         "LAYOUT_ansi": "LAYOUT_tkl_f13_ansi",
         "LAYOUT_iso": "LAYOUT_tkl_f13_iso"
     },
+    "community_layouts": [
+        "tkl_f13_ansi",
+        "tkl_f13_iso"
+    ],
     "layouts": {
         "LAYOUT_tkl_f13_ansi": {
             "layout": [

--- a/keyboards/plywrks/ahgase/info.json
+++ b/keyboards/plywrks/ahgase/info.json
@@ -9,7 +9,8 @@
         "device_version": "0.0.1"
     },
     "layout_aliases": {
-        "LAYOUT_ansi": "LAYOUT_tkl_f13_ansi"
+        "LAYOUT_ansi": "LAYOUT_tkl_f13_ansi",
+        "LAYOUT_iso": "LAYOUT_tkl_f13_iso"
     },
     "layouts": {
         "LAYOUT_tkl_f13_ansi": {
@@ -109,7 +110,7 @@
                 {"x":17.25, "y":5.25}
             ]
         },
-        "LAYOUT_iso": {
+        "LAYOUT_tkl_f13_iso": {
             "layout": [
                 {"x":0, "y":0},
                 {"x":1.25, "y":0},

--- a/keyboards/plywrks/ahgase/info.json
+++ b/keyboards/plywrks/ahgase/info.json
@@ -8,8 +8,11 @@
         "pid": "0x7902",
         "device_version": "0.0.1"
     },
+    "layout_aliases": {
+        "LAYOUT_ansi": "LAYOUT_tkl_f13_ansi"
+    },
     "layouts": {
-        "LAYOUT_ansi": {
+        "LAYOUT_tkl_f13_ansi": {
             "layout": [
                 {"x":0, "y":0},
                 {"x":1.25, "y":0},

--- a/keyboards/plywrks/ahgase/keymaps/default/keymap.c
+++ b/keyboards/plywrks/ahgase/keymaps/default/keymap.c
@@ -16,7 +16,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_ansi(
+    [0] = LAYOUT_tkl_f13_ansi(
         KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_F13,  KC_PSCR, KC_SLCK, KC_PAUS,
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,

--- a/keyboards/plywrks/ahgase/keymaps/iso/keymap.c
+++ b/keyboards/plywrks/ahgase/keymaps/iso/keymap.c
@@ -16,7 +16,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_iso(
+    [0] = LAYOUT_tkl_f13_iso(
         KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_F13,  KC_PSCR, KC_SLCK, KC_PAUS,
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_DEL,  KC_END,  KC_PGDN,


### PR DESCRIPTION
## Description

Renames the two non-`LAYOUT_all` macros to be compatible with Community Layouts, and enables support for them.

cc @ramonimbao (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
