### PR TITLE
ploopyco/trackball_mini: always update encoder

### DIFF
--- a/keyboards/ploopyco/trackball_mini/trackball_mini.c
+++ b/keyboards/ploopyco/trackball_mini/trackball_mini.c
@@ -92,6 +92,13 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
 }
 
 void process_wheel(void) {
+    uint16_t p1 = adc_read(OPT_ENC1_MUX);
+    uint16_t p2 = adc_read(OPT_ENC2_MUX);
+
+    if (debug_encoder) dprintf("OPT1: %d, OPT2: %d\n", p1, p2);
+
+    int8_t dir = opt_encoder_handler(p1, p2);
+
     // If the mouse wheel was just released, do not scroll.
     if (timer_elapsed(lastMidClick) < SCROLL_BUTT_DEBOUNCE) return;
 
@@ -105,16 +112,10 @@ void process_wheel(void) {
 #endif
     }
 
-    lastScroll  = timer_read();
-    uint16_t p1 = adc_read(OPT_ENC1_MUX);
-    uint16_t p2 = adc_read(OPT_ENC2_MUX);
-
-    if (debug_encoder) dprintf("OPT1: %d, OPT2: %d\n", p1, p2);
-
-    int8_t dir = opt_encoder_handler(p1, p2);
-
     if (dir == 0) return;
     encoder_update_kb(0, dir > 0);
+
+    lastScroll = timer_read();
 }
 
 void pointing_device_init_kb(void) {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The encoder derives scroll direction based on the last known wheel position, as such it needs up-to-date wheel state at all times to compute the right direction.

When using `opt_encoder_simple.c` as the implementation, the default delay may cause the encoder to see "impossible" states (which requires recalibration) or states that imply an opposite direction to the actual scrolling direction. This is very evident when the wheel is free-spinning.

This commit reorders the code to make sure the optical encoder state is always updated, but only apply scrolling when specified conditions are met (ie. after debounce period, middle mouse released, etc.).

Tested with `opt_encoder_simple.c`, where a free-spinning wheel now generates very smooth scrolling with no apparent glitches. This has not been tested with the default encoder, but similar benefits should be found there.

Since all Ploopy devices share the same encoder glue, this change can potentially be replicated to other devices for similar benefits.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
