### PR TITLE
[Core] ChibiOS: Fix USB bus disconnect handling

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -734,6 +734,7 @@ void init_usb_driver(USBDriver *usbp) {
      * after a reset.
      */
     usbDisconnectBus(usbp);
+    usbStop(usbp);
     wait_ms(50);
     usbStart(usbp, &usbcfg);
     usbConnectBus(usbp);
@@ -742,8 +743,8 @@ void init_usb_driver(USBDriver *usbp) {
 }
 
 __attribute__((weak)) void restart_usb_driver(USBDriver *usbp) {
-    usbStop(usbp);
     usbDisconnectBus(usbp);
+    usbStop(usbp);
 
 #if USB_SUSPEND_WAKEUP_DELAY > 0
     // Some hubs, kvm switches, and monitors do

--- a/tmk_core/protocol/chibios/usb_util.c
+++ b/tmk_core/protocol/chibios/usb_util.c
@@ -17,6 +17,7 @@
 #include "usb_util.h"
 
 void usb_disconnect(void) {
+    usbDisconnectBus(&USBD1);
     usbStop(&USBD1);
 }
 


### PR DESCRIPTION
## Description

`usb_disconnect()` previously only stopped the USB driver but didn't disconnect the device from USB bus. This is a problem with split keyboards that fail to enumerate on bootup but are actually connected to a USB bus. This can happen in the case that a short `SPLIT_USB_TIMEOUT` is used but it takes longer to enumerate with the host system correctly. In this condition the host system would still try to enumerate with the keyboard, as it still recognizes it as a connected device, but never succeed as we already disabled the USB driver. This in turn prevents some systems to boot-up correctly or at least slow down the boot process until the device is finally rejected by the host USB stack.

A drive-by fix is the case for rebooting a keyboard without a physical reconnect and not stopping the USB driver before starting it again - which is a violation of ChibiOS state model for the USB driver.

### Demo: RP2040 split keyboard that fails to enumerate on boot

**With the fix the device is disconnected properly**

![image](https://user-images.githubusercontent.com/13887561/193453914-93c39b87-2193-4766-9fee-209f4249802b.png)

**Without the fix the device is not disconnected and the host tries to enumerate until finally giving up**

![image](https://user-images.githubusercontent.com/13887561/193454011-187694e8-0c28-4cb4-a50d-3417ceaee6d9.png)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/18511

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
