### PR TITLE
[Bug] RP2040: only clear RX FIFO for serial pio driver clear

### DIFF
--- a/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/serial_vendor.c
@@ -181,12 +181,13 @@ static inline void leave_rx_state(void) {}
 #endif
 
 /**
- * @brief Clear the RX and TX hardware FIFOs of the state machines.
+ * @brief Clear the FIFO of the RX state machine.
  */
 inline void serial_transport_driver_clear(void) {
     osalSysLock();
-    pio_sm_clear_fifos(pio, rx_state_machine);
-    pio_sm_clear_fifos(pio, tx_state_machine);
+    while (!pio_sm_is_rx_fifo_empty(pio, rx_state_machine)) {
+        pio_sm_clear_fifos(pio, rx_state_machine);
+    }
     osalSysUnlock();
 }
 


### PR DESCRIPTION
 ## Description

Previously the Full-duplex implementation would have it TX FIFO cleared although it was still sending data, as sending data happens asynchronously and we don't wait for all data to be send out before continuing with the execution of the main keyboard loop. Here we would run into a race condition where we cleared all FIFOs before starting a new transaction, while the last one was still in progress. 

This condition can not happen with the RX FIFO as we wait for a reception to be fully completed before continuing the execution, therefore it is save to fully and unconditionally clear the RX FIFO.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* The problem in the driver first surfaced with re-enabling the clearing in #18419

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
