### PR TITLE
define `oled_write_ln_P` as `oled_write_ln` for non-AVR MCUs

### DIFF
--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -260,7 +260,7 @@ void oled_write_ln_P(const char *data, bool invert);
 void oled_write_raw_P(const char *data, uint16_t size);
 #else
 #    define oled_write_P(data, invert) oled_write(data, invert)
-#    define oled_write_ln_P(data, invert) oled_write(data, invert)
+#    define oled_write_ln_P(data, invert) oled_write_ln(data, invert)
 #    define oled_write_raw_P(data, size) oled_write_raw(data, size)
 #endif // defined(__AVR__)
 


### PR DESCRIPTION
## Description

`oled_write_ln_P` is currently substituted with `oled_write`, losing a line break.
Targeting `master` based on bugfix criteria seen in other PRs. If that's the wrong call, LMK.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
