### PR TITLE
fix: ps2_interrupt.c failed to compile

### DIFF
--- a/drivers/ps2/ps2_interrupt.c
+++ b/drivers/ps2/ps2_interrupt.c
@@ -76,14 +76,18 @@ void palCallback(void *arg) {
 }
 
 #    define PS2_INT_INIT()                                 \
-        do { palSetLineMode(PS2_CLOCK_PIN, PAL_MODE_INPUT); } while (0)
+        do {                                               \
+            palSetLineMode(PS2_CLOCK_PIN, PAL_MODE_INPUT); \
+        } while (0)
 #    define PS2_INT_ON()                                                    \
-        do {                                                                   \
+        do {                                                                \
             palEnableLineEvent(PS2_CLOCK_PIN, PAL_EVENT_MODE_FALLING_EDGE); \
             palSetLineCallback(PS2_CLOCK_PIN, palCallback, NULL);           \
         } while (0)
 #    define PS2_INT_OFF()                       \
-        do { palDisableLineEvent(PS2_CLOCK_PIN); } while (0)
+        do {                                    \
+            palDisableLineEvent(PS2_CLOCK_PIN); \
+        } while (0)
 #endif // PROTOCOL_CHIBIOS
 
 void ps2_host_init(void) {

--- a/drivers/ps2/ps2_interrupt.c
+++ b/drivers/ps2/ps2_interrupt.c
@@ -76,17 +76,14 @@ void palCallback(void *arg) {
 }
 
 #    define PS2_INT_INIT()                                 \
-        { palSetLineMode(PS2_CLOCK_PIN, PAL_MODE_INPUT); } \
-        while (0)
+        do { palSetLineMode(PS2_CLOCK_PIN, PAL_MODE_INPUT); } while (0)
 #    define PS2_INT_ON()                                                    \
-        {                                                                   \
+        do {                                                                   \
             palEnableLineEvent(PS2_CLOCK_PIN, PAL_EVENT_MODE_FALLING_EDGE); \
             palSetLineCallback(PS2_CLOCK_PIN, palCallback, NULL);           \
-        }                                                                   \
-        while (0)
+        } while (0)
 #    define PS2_INT_OFF()                       \
-        { palDisableLineEvent(PS2_CLOCK_PIN); } \
-        while (0)
+        do { palDisableLineEvent(PS2_CLOCK_PIN); } while (0)
 #endif // PROTOCOL_CHIBIOS
 
 void ps2_host_init(void) {


### PR DESCRIPTION
## Description

Fix the compilation error for `ps2_interrupt.c`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #18596 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
