### PR TITLE
Use `get_u16_str` instead of `snprintf` in `autoshift_timer_report`

### DIFF
--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -17,7 +17,6 @@
 #ifdef AUTO_SHIFT_ENABLE
 
 #    include <stdbool.h>
-#    include <stdio.h>
 #    include "process_auto_shift.h"
 
 #    ifndef AUTO_SHIFT_DISABLED_AT_STARTUP
@@ -331,11 +330,12 @@ void autoshift_disable(void) {
 #    ifndef AUTO_SHIFT_NO_SETUP
 void autoshift_timer_report(void) {
 #        ifdef SEND_STRING_ENABLE
-    char display[8];
-
-    snprintf(display, 8, "\n%d\n", autoshift_timeout);
-
-    send_string((const char *)display);
+    const char *autoshift_timeout_str = get_u16_str(autoshift_timeout, ' ');
+    // Skip padding spaces
+    while (*autoshift_timeout_str == ' ') {
+        autoshift_timeout_str++;
+    }
+    send_string(autoshift_timeout_str);
 #        endif
 }
 #    endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Including `<string.h>` for `snprintf` takes a considerable amount of firmware space. Using the newly added `get_u16_str` function lets us save some firmware size.

To assess the results, I measured the size regression using `./util/size_regression.sh` on multiple keymaps that enable AUTO_SHIFT:

- atreus62/scheiklp delta:   -802
- nacly/splitreus62/scheiklp delta:  -1212
- dz60/LEdiodes delta: -1212
- handwired/dactyl_manuform/4x6/scheiklp delta:  -1082
- unikeyboard/diverge3/iso_uk delta:  -1150
- lily58/yshrsmz delta:   +200
- massdrop/ctrl/xanimos delta:     +0
- keyboardio/atreus/kkokdae delta:   -766
- kprepublic/jj50/archetype delta:  -1232
- crkbd/nimishgautam delta:     +0
- xiudi/xd75/raoeus delta: -1210
- splitkb/kyria/jhelvy delta:  -1214
- crkbd/rmeli delta:  -1106
- xiudi/xd75/scheiklp delta:  -1062
- handwired/dactyl/manuform/5x6/scheiklp delta:  -1062

As we can see, about 1 kilobyte is saved in average. Lily58/yshrsmz is the only keymap whose size actually increases after applying this patch but I'm not sure why; perhaps `snprintf` is already used elsewhere in his keymap and this patch forces him to compile the `get_u16_str` function he previously didn't need.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
