### PR TITLE
Add supersplit (custom keyboard)

### DIFF
--- a/keyboards/supersplit/config.h
+++ b/keyboards/supersplit/config.h
@@ -1,0 +1,38 @@
+/* Copyright 2022 tarneo (tarneo@tarneo.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT
+//
+
+#define SOFT_SERIAL_PIN D2
+#define MASTER_LEFT
+

--- a/keyboards/supersplit/info.json
+++ b/keyboards/supersplit/info.json
@@ -1,0 +1,112 @@
+{
+    "manufacturer": "tarneaux",
+    "keyboard_name": "supersplit",
+    "maintainer": "tarneaux",
+    "bootloader": "atmel-dfu",
+    "diode_direction": "COL2ROW",
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true
+    },
+    "matrix_pins": {
+        "cols": ["B6", "B2", "B3", "B1", "F7", "F6",
+                 "B6", "B2", "B3", "B1", "F7", "F6"],
+        "rows": ["D1", "D0", "D4", "C6", "D7", "E6"]
+    },
+    "processor": "atmega32u4",
+    "url": "",
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x0000",
+        "vid": "0xFEED"
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                { "matrix": [0, 0], "x": 0, "y": 1.5 },
+                { "matrix": [1, 0], "x": 1, "y": 1.5 },
+                { "matrix": [2, 0], "x": 2, "y": 0.5 },
+                { "matrix": [3, 0], "x": 3, "y": 0 },
+                { "matrix": [4, 0], "x": 4, "y": 0.7 },
+                { "matrix": [5, 0], "x": 5, "y": 1 },
+
+                { "matrix": [0, 1], "x": 0, "y": 2.5 },
+                { "matrix": [1, 1], "x": 1, "y": 2.5 },
+                { "matrix": [2, 1], "x": 2, "y": 1.5 },
+                { "matrix": [3, 1], "x": 3, "y": 1 },
+                { "matrix": [4, 1], "x": 4, "y": 1.7 },
+                { "matrix": [5, 1], "x": 5, "y": 2 },
+
+                { "matrix": [0, 2], "x": 0, "y": 3.5 },
+                { "matrix": [1, 2], "x": 1, "y": 3.5 },
+                { "matrix": [2, 2], "x": 2, "y": 2.5 },
+                { "matrix": [3, 2], "x": 3, "y": 2 },
+                { "matrix": [4, 2], "x": 4, "y": 2.7 },
+                { "matrix": [5, 2], "x": 5, "y": 3 },
+
+                { "matrix": [0, 3], "x": 0, "y": 4.5 },
+                { "matrix": [1, 3], "x": 1, "y": 4.5 },
+                { "matrix": [2, 3], "x": 2, "y": 3.5 },
+                { "matrix": [3, 3], "x": 3, "y": 3 },
+                { "matrix": [4, 3], "x": 4, "y": 3.7 },
+                { "matrix": [5, 3], "x": 5, "y": 4 },
+
+                { "matrix": [3, 4], "x": 6, "y": 5 },
+                { "matrix": [4, 4], "x": 7, "y": 5 },
+                { "matrix": [5, 4], "x": 8, "y": 5 },
+
+                { "matrix": [0, 5], "x": 3, "y": 6 },
+                { "matrix": [1, 5], "x": 4, "y": 6 },
+                { "matrix": [2, 5], "x": 5, "y": 6 },
+                { "matrix": [3, 5], "x": 6, "y": 6 },
+                { "matrix": [4, 5], "x": 7, "y": 6 },
+                { "matrix": [5, 5], "x": 8, "y": 6 },
+
+
+
+                { "matrix": [5, 6], "x": 12, "y": 1 },
+                { "matrix": [4, 6], "x": 13, "y": 0.7 },
+                { "matrix": [3, 6], "x": 14, "y": 0 },
+                { "matrix": [2, 6], "x": 15, "y": 0.5 },
+                { "matrix": [1, 6], "x": 16, "y": 1.5 },
+                { "matrix": [0, 6], "x": 17, "y": 1.5 },
+
+                { "matrix": [5, 7], "x": 12, "y": 2 },
+                { "matrix": [4, 7], "x": 13, "y": 1.7 },
+                { "matrix": [3, 7], "x": 14, "y": 1 },
+                { "matrix": [2, 7], "x": 15, "y": 1.5 },
+                { "matrix": [1, 7], "x": 16, "y": 2.5 },
+                { "matrix": [0, 7], "x": 17, "y": 2.5 },
+
+                { "matrix": [5, 8], "x": 12, "y": 3 },
+                { "matrix": [4, 8], "x": 13, "y": 2.7 },
+                { "matrix": [3, 8], "x": 14, "y": 2 },
+                { "matrix": [2, 8], "x": 15, "y": 2.5 },
+                { "matrix": [1, 8], "x": 16, "y": 3.5 },
+                { "matrix": [0, 8], "x": 17, "y": 3.5 },
+
+                { "matrix": [5, 9], "x": 12, "y": 4 },
+                { "matrix": [4, 9], "x": 13, "y": 3.7 },
+                { "matrix": [3, 9], "x": 14, "y": 3 },
+                { "matrix": [2, 9], "x": 15, "y": 3.5 },
+                { "matrix": [1, 9], "x": 16, "y": 4.5 },
+                { "matrix": [0, 9], "x": 17, "y": 4.5 },
+
+                { "matrix": [0, 10], "x": 9, "y": 5 },
+                { "matrix": [1, 10], "x": 10, "y": 5 },
+                { "matrix": [2, 10], "x": 11, "y": 5 },
+
+                { "matrix": [0, 11], "x": 8, "y": 6 },
+                { "matrix": [1, 11], "x": 9, "y": 6 },
+                { "matrix": [2, 11], "x": 10, "y": 6 },
+                { "matrix": [3, 11], "x": 11, "y": 6 },
+                { "matrix": [4, 11], "x": 12, "y": 6 },
+                { "matrix": [5, 11], "x": 13, "y": 6 }
+            ]
+        }
+    }
+}

--- a/keyboards/supersplit/keymaps/default/keymap.c
+++ b/keyboards/supersplit/keymaps/default/keymap.c
@@ -1,0 +1,34 @@
+/* Copyright 2022 tarneo (tarneo@tarneo.fr)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+            // 6*4 + 9-key thumb cluster = 33 keys
+            // Left side
+            KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5,
+            KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T,
+            KC_CAPS, KC_A, KC_S, KC_D, KC_F, KC_G,
+            KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B,
+            KC_LCTL, KC_LGUI, KC_LALT, KC_SPC, KC_SPC, KC_SPC, KC_SPC, KC_SPC, KC_SPC,
+            // Right side
+            KC_6, KC_7, KC_8, KC_9, KC_0, KC_BSPC,
+            KC_Y, KC_U, KC_I, KC_O, KC_P, KC_BSLS,
+            KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT,
+            KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RSFT,
+            KC_SPC, KC_SPC, KC_SPC, KC_SPC, KC_SPC, KC_SPC, KC_RALT, KC_RGUI, KC_RCTL
+            )
+};

--- a/keyboards/supersplit/readme.md
+++ b/keyboards/supersplit/readme.md
@@ -1,0 +1,25 @@
+# supersplit
+
+*A custom-made keyboard with a 4x6 matrix and a 9-key thumb cluster*
+
+* Keyboard Maintainer: [tarneaux](https://github.com/tarneaux)
+* Hardware Supported: elite-c
+* Hardware Availability: https://github.com/tarneaux/supersplit
+
+Make example for this keyboard (after setting up your build environment):
+
+    make supersplit:default
+
+Flashing example for this keyboard:
+
+    make supersplit:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/supersplit/rules.mk
+++ b/keyboards/supersplit/rules.mk
@@ -1,0 +1,4 @@
+# This file intentionally left blank
+SPLIT_KEYBOARD = yes
+
+SERIAL_DRIVER = bitbang


### PR DESCRIPTION
## Description

I'd like to add my own [keyboard](https://github.com/tarneaux/supersplit) to the upstream so that I can configure it on config.qmk.fm. 

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
