### PR TITLE
[Bug] XAP: Fix unaligned memory access in config blob handler and USB task loop condition

### DIFF
--- a/quantum/xap/xap_handlers.c
+++ b/quantum/xap/xap_handlers.c
@@ -64,7 +64,8 @@ bool xap_respond_get_config_blob_chunk(xap_token_t token, const void *data, size
         return false;
     }
 
-    uint16_t offset = *((uint16_t *)data);
+    uint16_t offset;
+    memcpy(&offset, data, sizeof(uint16_t));
 
     xap_route_qmk_config_blob_chunk_t ret = {0};
 

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -1165,7 +1165,7 @@ void xap_task(void) {
     uint8_t buffer[XAP_EPSIZE];
     size_t  size = 0;
     do {
-        size_t size = chnReadTimeout(&drivers.xap_driver.driver, buffer, sizeof(buffer), TIME_IMMEDIATE);
+        size = chnReadTimeout(&drivers.xap_driver.driver, buffer, sizeof(buffer), TIME_IMMEDIATE);
         if (size > 0) {
             xap_receive_base(buffer);
         }


### PR DESCRIPTION
## Description

This PR fixes two problems:

* Fix unaligned memory access in config blob handler:

`data*` points in the middle of an `u8` array, casting this to an `u16*` and de-referencing it leads to an unaligned memory access - which hardfaults on Cortex M0 mcus e.g. RP2040s.

* Read all incoming data until there is no more data to be read

The while condition did exit after the first loop, regardless if there was more data ready to be read.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* RP2040 hard-faulting with the XAP client

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
