### PR TITLE
keyboards/anavi: Add ANAVI Macro Pad 10

### DIFF
--- a/keyboards/anavi/macropad10/config.h
+++ b/keyboards/anavi/macropad10/config.h
@@ -1,0 +1,11 @@
+// Copyright 2022 Leon Anavi <leon@anavi.org>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "config_common.h"
+
+/* Double tap reset button to enter bootloader */
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP17
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500U

--- a/keyboards/anavi/macropad10/info.json
+++ b/keyboards/anavi/macropad10/info.json
@@ -1,0 +1,72 @@
+{
+    "keyboard_name": "Macro Pad 10",
+    "manufacturer": "ANAVI",
+    "url": "https://github.com/AnaviTechnology/anavi-macro-pad-10",
+    "maintainer": "leon-anavi",
+    "processor": "RP2040",
+    "bootloader": "rp2040",
+    "diode_direction": "COL2ROW",
+    "matrix_pins": {
+        "cols": ["GP6", "GP7", "GP0"],
+        "rows": ["GP29", "GP28", "GP27"]
+    },
+    "features": {
+        "bootmagic": false,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": false,
+        "nkro": true,
+	"rgblight": true
+    },
+    "rgblight": {
+        "pin": "GP3",
+        "led_count": 4,
+	"hue_steps": 10,
+	"saturation_steps": 17,
+        "brightness_steps": 17,
+	"max_brightness": 255,
+	"animations": {
+		"alternating": true,
+		"breathing": true,
+		"christmas": true,
+		"knight": true,
+		"rainbow_mood": true,
+		"rainbow_swirl": true,
+		"rgb_test": true,
+		"snake": true,
+		"static_gradient": true,
+		"twinkle": true
+        }
+    },
+    "encoder": {
+	"enabled": true,
+        "rotary": [
+            {
+		    "pin_a": "GP1",
+		    "pin_b": "GP2",
+		    "resolution": 2
+	    }
+        ]
+    },
+    "layouts": {
+        "LAYOUT_mp10": {
+            "layout": [
+                { "matrix": [0, 0], "x": 0, "y": 0 },
+                { "matrix": [0, 1], "x": 1, "y": 0 },
+                { "matrix": [0, 2], "x": 2, "y": 0 },
+                { "matrix": [1, 0], "x": 0, "y": 1 },
+                { "matrix": [1, 1], "x": 1, "y": 1 },
+                { "matrix": [1, 2], "x": 2, "y": 1 },
+                { "matrix": [2, 0], "x": 0, "y": 2 },
+                { "matrix": [2, 1], "x": 1, "y": 2 },
+                { "matrix": [2, 2], "x": 2, "y": 2 }
+            ]
+        }
+    },
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x9A25",
+        "vid": "0xFEED"
+    }
+}

--- a/keyboards/anavi/macropad10/keymaps/default/keymap.c
+++ b/keyboards/anavi/macropad10/keymaps/default/keymap.c
@@ -1,0 +1,16 @@
+// Copyright 2022 Leon Anavi <leon@anavi.org>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+enum layer_names {
+    _BASE
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_BASE] = LAYOUT_mp10(
+        KC_A   , KC_B   , KC_C   ,
+	KC_D   , KC_E   , KC_F   ,
+	RGB_M_R , RGB_MOD , RGB_TOG
+    )
+};

--- a/keyboards/anavi/macropad10/macropad10.c
+++ b/keyboards/anavi/macropad10/macropad10.c
@@ -1,0 +1,16 @@
+// Copyright 2022 Leon Anavi <leon@anavi.org>
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "encoder.h"
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) { return false; }
+    if (clockwise) {
+        tap_code(KC_VOLU);
+    } else {
+        tap_code(KC_VOLD);
+    }
+    return true;
+}
+#endif
+

--- a/keyboards/anavi/macropad10/readme.md
+++ b/keyboards/anavi/macropad10/readme.md
@@ -1,0 +1,21 @@
+# ANAVI Macro Pad 10
+
+Mini hot-swappable mechanical keyboard with a clickable rotary encoder, 9 Cherry MX compatible switches, translucent key caps, USB-C, RP2040 microcontroller, backlighting and under lighting.
+
+* Keyboard Maintainer: [Leon Anavi](https://github.com/leon-anavi)
+* Hardware Supported: ANAVI Macro Pad 10
+* Hardware Availability: [Crowd Supply](https://www.crowdsupply.com/anavi-technology/anavi-macro-pad-10), [GitHub repository](https://github.com/AnaviTechnology/anavi-macro-pad-10)
+
+Make example for this keyboard (after setting up your build environment):
+
+    qmk compile -kb anavi/macropad10 -km default
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the top left key on the left half, or top right key on the right half, and then plug in the USB cable on that keyboard half.
+* **Physical reset button**: Double tap the reset button on the XIAO RP2040.
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available.

--- a/keyboards/anavi/macropad10/rules.mk
+++ b/keyboards/anavi/macropad10/rules.mk
@@ -1,0 +1,1 @@
+WS2812_DRIVER = vendor


### PR DESCRIPTION
ANAVI Macro Pad 10 is a mini hot-swappable mechanical keyboard with a clickable rotary encoder, 9 Cherry MX compatible switches, translucent key caps, USB-C, RP2040 microcontroller, backlighting and under lighting.

This commits adds initial QMK support for ANAVI Macro Pad 10 with:
- Default keymap
- Rotary encoder for controlling the volume
- WS2812B RGB underlighting

Several hardware features of ANAVI Macro Pad 10 are not supported yet: backlighting, neopixel on the XIAO RP2040 module and the click of the encoder (aka to use the encoder as a key).

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add a new keyboard: ANAVI Macro Pad 10 with Raspberry Pi RP2040 MCU, This is a mini hot-swappable mechanical keyboard with a clickable rotary encoder, 9 Cherry MX compatible switches, translucent key caps, USB-C, backlighting and under lighting.

This commits adds initial QMK support for ANAVI Macro Pad 10 with:
- Default keymap
- Rotary encoder for controlling the volume
- WS2812B RGB underlighting

Several hardware features of ANAVI Macro Pad 10 are not supported yet: backlighting, neopixel on the XIAO RP2040 module and the click of the encoder (aka to use the encoder as a key).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
