### PR TITLE
Relocate US ANSI shifted keycode aliases

### DIFF
--- a/quantum/keymap_extras/keymap_us.h
+++ b/quantum/keymap_extras/keymap_us.h
@@ -1,18 +1,5 @@
-/* Copyright 2020
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright 2022 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
 

--- a/quantum/keymap_extras/keymap_us.h
+++ b/quantum/keymap_extras/keymap_us.h
@@ -1,0 +1,85 @@
+/* Copyright 2020
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "keymap.h"
+
+// clang-format off
+
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ~ │ ! │ @ │ # │ $ │ % │ ^ │ & │ * │ ( │ ) │ _ │ + │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │   │ { │ } │  |  │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴─────┤
+ * │      │   │   │   │   │   │   │   │   │   │ : │ " │        │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────────┤
+ * │        │   │   │   │   │   │   │   │ < │ > │ ? │          │
+ * ├────┬───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define KC_TILD S(KC_GRAVE) // ~
+#define KC_EXLM S(KC_1)     // !
+#define KC_AT   S(KC_2)     // @
+#define KC_HASH S(KC_3)     // #
+#define KC_DLR  S(KC_4)     // $
+#define KC_PERC S(KC_5)     // %
+#define KC_CIRC S(KC_6)     // ^
+#define KC_AMPR S(KC_7)     // &
+#define KC_ASTR S(KC_8)     // *
+#define KC_LPRN S(KC_9)     // (
+#define KC_RPRN S(KC_0)     // )
+#define KC_UNDS S(KC_MINUS) // _
+#define KC_PLUS S(KC_EQUAL) // +
+// Row 2
+#define KC_LCBR S(KC_LEFT_BRACKET)  // {
+#define KC_RCBR S(KC_RIGHT_BRACKET) // }
+#define KC_PIPE S(KC_BACKSLASH)     // |
+// Row 3
+#define KC_COLN S(KC_SEMICOLON) // :
+#define KC_DQUO S(KC_QUOTE)     // "
+// Row 4
+#define KC_LABK S(KC_COMMA) // <
+#define KC_RABK S(KC_DOT)   // >
+#define KC_QUES S(KC_SLASH) // ?
+
+// alias stuff
+#define KC_TILDE KC_TILD
+#define KC_EXCLAIM KC_EXLM
+#define KC_DOLLAR KC_DLR
+#define KC_PERCENT KC_PERC
+#define KC_CIRCUMFLEX KC_CIRC
+#define KC_AMPERSAND KC_AMPR
+#define KC_ASTERISK KC_ASTR
+#define KC_LEFT_PAREN KC_LPRN
+#define KC_RIGHT_PAREN KC_RPRN
+#define KC_UNDERSCORE KC_UNDS
+
+#define KC_LEFT_CURLY_BRACE KC_LCBR
+#define KC_RIGHT_CURLY_BRACE KC_RCBR
+
+#define KC_COLON KC_COLN
+#define KC_DOUBLE_QUOTE KC_DQUO
+#define KC_DQT KC_DQUO
+
+#define KC_LEFT_ANGLE_BRACKET KC_LABK
+#define KC_LT KC_LABK
+#define KC_RIGHT_ANGLE_BRACKET KC_RABK
+#define KC_GT KC_RABK
+#define KC_QUESTION KC_QUES

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -656,67 +656,7 @@ enum quantum_keycodes {
 #define MOD_MEH 0x7
 
 // US ANSI shifted keycode aliases
-#define KC_TILDE LSFT(KC_GRAVE) // ~
-#define KC_TILD KC_TILDE
-
-#define KC_EXCLAIM LSFT(KC_1) // !
-#define KC_EXLM KC_EXCLAIM
-
-#define KC_AT LSFT(KC_2) // @
-
-#define KC_HASH LSFT(KC_3) // #
-
-#define KC_DOLLAR LSFT(KC_4) // $
-#define KC_DLR KC_DOLLAR
-
-#define KC_PERCENT LSFT(KC_5) // %
-#define KC_PERC KC_PERCENT
-
-#define KC_CIRCUMFLEX LSFT(KC_6) // ^
-#define KC_CIRC KC_CIRCUMFLEX
-
-#define KC_AMPERSAND LSFT(KC_7) // &
-#define KC_AMPR KC_AMPERSAND
-
-#define KC_ASTERISK LSFT(KC_8) // *
-#define KC_ASTR KC_ASTERISK
-
-#define KC_LEFT_PAREN LSFT(KC_9) // (
-#define KC_LPRN KC_LEFT_PAREN
-
-#define KC_RIGHT_PAREN LSFT(KC_0) // )
-#define KC_RPRN KC_RIGHT_PAREN
-
-#define KC_UNDERSCORE LSFT(KC_MINUS) // _
-#define KC_UNDS KC_UNDERSCORE
-
-#define KC_PLUS LSFT(KC_EQUAL) // +
-
-#define KC_LEFT_CURLY_BRACE LSFT(KC_LEFT_BRACKET) // {
-#define KC_LCBR KC_LEFT_CURLY_BRACE
-
-#define KC_RIGHT_CURLY_BRACE LSFT(KC_RIGHT_BRACKET) // }
-#define KC_RCBR KC_RIGHT_CURLY_BRACE
-
-#define KC_LEFT_ANGLE_BRACKET LSFT(KC_COMMA) // <
-#define KC_LABK KC_LEFT_ANGLE_BRACKET
-#define KC_LT KC_LEFT_ANGLE_BRACKET
-
-#define KC_RIGHT_ANGLE_BRACKET LSFT(KC_DOT) // >
-#define KC_RABK KC_RIGHT_ANGLE_BRACKET
-#define KC_GT KC_RIGHT_ANGLE_BRACKET
-
-#define KC_COLON LSFT(KC_SEMICOLON) // :
-#define KC_COLN KC_COLON
-
-#define KC_PIPE LSFT(KC_BACKSLASH) // |
-
-#define KC_QUESTION LSFT(KC_SLASH) // ?
-#define KC_QUES KC_QUESTION
-
-#define KC_DOUBLE_QUOTE LSFT(KC_QUOTE) // "
-#define KC_DQUO KC_DOUBLE_QUOTE
-#define KC_DQT KC_DOUBLE_QUOTE
+#include "keymap_us.h"
 
 #define KC_DELT KC_DELETE // Del key (four letter code)
 

--- a/quantum/sequencer/tests/rules.mk
+++ b/quantum/sequencer/tests/rules.mk
@@ -2,7 +2,7 @@
 # - it is consistent with the example that is used as a reference in the Unit Testing article (https://docs.qmk.fm/#/unit_testing?id=adding-tests-for-new-or-existing-features)
 # - Neither `make test:sequencer` or `make test:SEQUENCER` work when using SCREAMING_SNAKE_CASE
 
-sequencer_DEFS := -DNO_DEBUG -DMIDI_MOCKED
+sequencer_DEFS := -DMATRIX_ROWS=1 -DMATRIX_COLS=1 -DNO_DEBUG -DMIDI_MOCKED
 
 sequencer_SRC := \
 	$(QUANTUM_PATH)/sequencer/tests/midi_mock.c \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As part of DD keycodes, the US ANSI shifted keycode aliases can be generated from the same process.

This PR moves the block so that the parsing/generation can take place as well as making quantum keycodes easier to generate.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
