### PR TITLE
Update platformdev_blackpill_f411.md

### DIFF
--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -171,7 +171,7 @@
       * [Early initialization](platformdev_chibios_earlyinit.md)
       * [Raspberry Pi RP2040](platformdev_rp2040.md)
       * [Proton C](platformdev_proton_c.md)
-      * [WeAct Blackpill F411](platformdev_blackpill_f411.md)
+      * [WeAct Blackpill F4x1](platformdev_blackpill_f4x1.md)
 
   * QMK Reference
     * [Contributing to QMK](contributing.md)

--- a/docs/platformdev_blackpill_f411.md
+++ b/docs/platformdev_blackpill_f411.md
@@ -1,4 +1,4 @@
-# WeAct Blackpill (STM32F411)
+# WeAct Blackpill (STM32F411 & STM32F401)
 
 The WeAct Blackpill is a popular choice for handwired boards, as it offers a powerful micro controller, USB Type C, a good number of pins to use, and a large amount of firmware space.  All for a ~$6 USD price tag. 
 

--- a/docs/platformdev_blackpill_f4x1.md
+++ b/docs/platformdev_blackpill_f4x1.md
@@ -1,8 +1,10 @@
-# WeAct Blackpill (STM32F411 & STM32F401)
+# WeAct Blackpill (STM32F4x1)
+
+This document applies to the F411 and F401 based blackpills.
 
 The WeAct Blackpill is a popular choice for handwired boards, as it offers a powerful micro controller, USB Type C, a good number of pins to use, and a large amount of firmware space.  All for a ~$6 USD price tag. 
 
-* [WeAct GitHub for F411 Blackpill](https://github.com/WeActTC/MiniSTM32F4x1)
+* [WeAct GitHub for F4x1 Blackpill](https://github.com/WeActTC/MiniSTM32F4x1)
   * Unfortunately, due to supply issues official WeAct F411 based blackpills may not be available.
 
 ![Blackpill F411](https://i.imgur.com/nCgeolTh.png)

--- a/docs/platformdev_blackpill_f4x1.md
+++ b/docs/platformdev_blackpill_f4x1.md
@@ -1,6 +1,6 @@
 # WeAct Blackpill (STM32F4x1)
 
-This document applies to the F411 and F401 based blackpills.
+This document applies to the F401- and F411-based Blackpills.
 
 The WeAct Blackpill is a popular choice for handwired boards, as it offers a powerful micro controller, USB Type C, a good number of pins to use, and a large amount of firmware space.  All for a ~$6 USD price tag. 
 


### PR DESCRIPTION
Add STM32F401 to headline to help future googlers not getting to the bootloader on those boards

## Description

Add the F401 type for "seo".
