### PR TITLE
Fix Caps Lock indicators on Wilba Tech PCBs

### DIFF
--- a/keyboards/wilba_tech/wt_main.c
+++ b/keyboards/wilba_tech/wt_main.c
@@ -115,14 +115,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record)
     return process_record_user(keycode, record);
 }
 
-void led_set_kb(uint8_t usb_led)
-{
-#if RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
-    backlight_set_indicator_state(usb_led);
-#endif // RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
-    led_set_user(usb_led);
-}
-
 void suspend_power_down_kb(void)
 {
 #if RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED

--- a/keyboards/wilba_tech/wt_mono_backlight.c
+++ b/keyboards/wilba_tech/wt_mono_backlight.c
@@ -53,7 +53,6 @@ backlight_config g_config = {
 };
 
 bool g_suspend_state = false;
-uint8_t g_indicator_state = 0;
 
 // Global tick at 20 Hz
 uint32_t g_tick = 0;
@@ -118,11 +117,6 @@ void backlight_set_suspend_state(bool state)
 	g_suspend_state = state;
 }
 
-void backlight_set_indicator_state(uint8_t state)
-{
-    g_indicator_state = state;
-}
-
 void backlight_set_brightness_all( uint8_t value )
 {
 	IS31FL3736_mono_set_brightness_all( value );
@@ -168,7 +162,9 @@ void backlight_effect_indicators(void)
 #if defined(MONO_BACKLIGHT_WT75_A)
     HSV hsv = { .h = g_config.color_1.h, .s = g_config.color_1.s, .v = g_config.brightness };
     RGB rgb = hsv_to_rgb( hsv );
-    // G8, H8, I8 -> (6*8+7) (7*8+7), (8*8+7)
+    // SW7,CS8 = (6*8+7) = 55
+    // SW8,CS8 = (7*8+7) = 63
+    // SW9,CS8 = (8*8+7) = 71
     IS31FL3736_mono_set_brightness(55, rgb.r);
     IS31FL3736_mono_set_brightness(63, rgb.g);
     IS31FL3736_mono_set_brightness(71, rgb.b);
@@ -183,20 +179,20 @@ defined(MONO_BACKLIGHT_WT75_A) || \
 defined(MONO_BACKLIGHT_WT75_B) || \
 defined(MONO_BACKLIGHT_WT75_C) || \
 defined(MONO_BACKLIGHT_WT80_A)
-    if ( g_indicator_state & (1<<USB_LED_CAPS_LOCK) ) {
-        // Caps Lock: D1 -> (4*8+0)
-        IS31FL3736_mono_set_brightness(32, 255);
+    if ( host_keyboard_led_state().caps_lock ) {
+        // SW3,CS1 = (2*8+0) = 16
+        IS31FL3736_mono_set_brightness(16, 255);
     }
 #endif
 #if defined(MONO_BACKLIGHT_WT80_A) 
-    if ( g_indicator_state & (1<<USB_LED_SCROLL_LOCK) ) {
-        // Scroll Lock: G7 -> (6*8+6)
+    if ( host_keyboard_led_state().scroll_lock ) {
+        // SW7,CS7 = (6*8+6) = 54
         IS31FL3736_mono_set_brightness(54, 255);
     }
 #endif
 #if defined(MONO_BACKLIGHT_WT75_C) 
-    if ( g_indicator_state & (1<<USB_LED_SCROLL_LOCK) ) {
-        // Scroll Lock: G8 -> (6*8+7)
+    if ( host_keyboard_led_state().scroll_lock ) {
+        // SW7,CS8 = (6*8+7) = 55
         IS31FL3736_mono_set_brightness(55, 255);
     }
 #endif

--- a/keyboards/wilba_tech/wt_mono_backlight.h
+++ b/keyboards/wilba_tech/wt_mono_backlight.h
@@ -56,7 +56,6 @@ void backlight_timer_enable(void);
 void backlight_timer_disable(void);
 
 void backlight_set_suspend_state(bool state);
-void backlight_set_indicator_state(uint8_t state);
 
 // This should not be called from an interrupt
 // (eg. from a timer interrupt).

--- a/keyboards/wilba_tech/wt_rgb_backlight.c
+++ b/keyboards/wilba_tech/wt_rgb_backlight.c
@@ -144,7 +144,6 @@ backlight_config g_config = {
 };
 
 bool g_suspend_state = false;
-uint8_t g_indicator_state = 0;
 
 // Global tick at 20 Hz
 uint32_t g_tick = 0;
@@ -1982,11 +1981,6 @@ void backlight_set_suspend_state(bool state)
     g_suspend_state = state;
 }
 
-void backlight_set_indicator_state(uint8_t state)
-{
-    g_indicator_state = state;
-}
-
 void backlight_effect_rgb_test(void)
 {
     // Mask out bits 4 and 5
@@ -2425,8 +2419,7 @@ void backlight_effect_indicators_set_colors( uint8_t index, HS color )
 // colors already set
 void backlight_effect_indicators(void)
 {
-    if ( g_config.caps_lock_indicator.index != 255 &&
-            ( g_indicator_state & (1<<USB_LED_CAPS_LOCK) ) )
+    if ( g_config.caps_lock_indicator.index != 255 && host_keyboard_led_state().caps_lock )
     {
         backlight_effect_indicators_set_colors( g_config.caps_lock_indicator.index, g_config.caps_lock_indicator.color );
     }

--- a/keyboards/wilba_tech/wt_rgb_backlight.h
+++ b/keyboards/wilba_tech/wt_rgb_backlight.h
@@ -81,7 +81,6 @@ void backlight_timer_enable(void);
 void backlight_timer_disable(void);
 
 void backlight_set_suspend_state(bool state);
-void backlight_set_indicator_state(uint8_t state);
 
 // This should not be called from an interrupt
 // (eg. from a timer interrupt).


### PR DESCRIPTION
## Description

I got the LED address wrong on the last commit. Whoops.
Also did a minor refactor since caching the indicator state was redundant.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
