### PR TITLE
Update keyboards readme

### DIFF
--- a/keyboards/readme.md
+++ b/keyboards/readme.md
@@ -14,16 +14,17 @@ What makes OLKB keyboards shine is a combo of lean aesthetics, compact size, and
 
 ### Clueboard - Zach White
 
-Designed and built in Felton, CA, Clueboards keyboard emphasize quality and locally sourced components, available on [clueboard.co](http://clueboard.co)
+Designed and built in Felton, CA, Clueboards keyboard emphasize quality and locally sourced components.
 
 * [Clueboard](/keyboards/clueboard/66/) &mdash; The 66% custom keyboard.
 * [Cluecard](/keyboards/clueboard/card/) &mdash; A small board to help you hack on QMK.
 * [Cluepad](/keyboards/clueboard/17/) &mdash; A mechanical numpad with QMK superpowers.
 
-### ErgoDox EZ and Planck EZ - ZSA Technology Labs
+### Moonlander, ErgoDox EZ and Planck EZ - ZSA Technology Labs
 
-[ZSA Technology Labs](https://ergodox-ez.com) maintains its own [fork of QMK](https://github.com/zsa/qmk_firmware) which feeds its [configurator](https://configure.ergodox-ez.com), for stability and legal purposes. The ZSA boards are:
+[ZSA Technology Labs](https://zsa.io) maintains its own [fork of QMK](https://github.com/zsa/qmk_firmware) which feeds its [configurator](https://configure.zsa.io), for stability and legal purposes. The ZSA boards are:
 
+* [Moonlander Mark I](/keyboards/moonlander/) &mdash; A next-gen split, ergonomic keyboard with an active left side, USB type C, integrated wrist rest, and a thumb cluster that can move.
 * [ErgoDox EZ](/keyboards/ergodox_ez/) &mdash; A powerful split mechanical keyboard.
 * [Planck EZ](/keyboards/planck/ez) &mdash; A 40% DIY powerhouse of customizability and modification capability. It's a lean, mean, typing machine, which ships fully assembled with a two-year warranty.
 


### PR DESCRIPTION
## Description

Clueboard keyboards are no longer commercially available and ZSA has expanded its offering.

The top-level project readme also suggests the Atreus keyboard as being 'official'. That keyboard is also no longer commercially available (in its original form; keyboardio sells a new variant). I wonder whether it would be good to either include Atreus in the list of official keyboards in the keyboards readme, or drop Clueboard from that list. The fate of both lines of keyboards appears to be similar.

@skullydazed @technomancy 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation
