### PR TITLE
led_update_kb -> led_update_ports where appropriate

### DIFF
--- a/keyboards/dk60/dk60.c
+++ b/keyboards/dk60/dk60.c
@@ -44,14 +44,10 @@ void led_init_ports(void) {
     setPinOutput(F0);
 }
 
-bool led_update_kb(led_t led_state) {
-    if (led_update_user(led_state)) {
-        if (led_state.caps_lock) {
-            dk60_caps_led_on();
-        } else {
-            dk60_caps_led_off();
-        }
+void led_update_ports(led_t led_state) {
+    if (led_state.caps_lock) {
+        dk60_caps_led_on();
+    } else {
+        dk60_caps_led_off();
     }
-
-    return true;
 }

--- a/keyboards/dp60/keymaps/indicator/indicator.c
+++ b/keyboards/dp60/keymaps/indicator/indicator.c
@@ -80,14 +80,10 @@ void rgblight_call_driver(LED_TYPE *start_led, uint8_t num_leds)
     indicator_write(start_led + (RGBLED_NUM - RGB_INDICATOR_NUM), RGB_INDICATOR_NUM);
 }
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if (res) {
-        rgblight_set_layer_state(0, led_state.caps_lock);
-        rgblight_set_layer_state(1, led_state.scroll_lock);
-        rgblight_set_layer_state(2, led_state.num_lock);
-    }
-    return res;
+void led_update_ports(led_t led_state) {
+    rgblight_set_layer_state(0, led_state.caps_lock);
+    rgblight_set_layer_state(1, led_state.scroll_lock);
+    rgblight_set_layer_state(2, led_state.num_lock);
 }
 
 layer_state_t layer_state_set_kb(layer_state_t state) {

--- a/keyboards/fallacy/fallacy.c
+++ b/keyboards/fallacy/fallacy.c
@@ -29,12 +29,8 @@ void matrix_scan_kb(void) {
  
 /* update LED driver with usb led_state
  */
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if(res) {
-        set_fallacy_led(2, led_state.caps_lock);    /* caps */
-        set_fallacy_led(1, led_state.num_lock);     /* num lock */
-        set_fallacy_led(0, led_state.scroll_lock);  /* scroll lock */
-    }
-    return res;
+void led_update_ports(led_t led_state) {
+    set_fallacy_led(2, led_state.caps_lock);    /* caps */
+    set_fallacy_led(1, led_state.num_lock);     /* num lock */
+    set_fallacy_led(0, led_state.scroll_lock);  /* scroll lock */
 }

--- a/keyboards/iron180/iron180.c
+++ b/keyboards/iron180/iron180.c
@@ -18,8 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "iron180.h"
 
 #ifdef CAPSLOCK_BACKLIGHT
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
+void led_update_ports(led_t led_state) {
     if (!led_state.caps_lock){
         if (is_backlight_breathing()) breathing_disable();
         backlight_disable();
@@ -28,6 +27,5 @@ bool led_update_kb(led_t led_state) {
 	if (is_backlight_breathing()) breathing_enable();
         backlight_enable();
     }
-    return res;
 }
 #endif

--- a/keyboards/kc60/kc60.c
+++ b/keyboards/kc60/kc60.c
@@ -1,13 +1,9 @@
 #include "kc60.h"
 
-bool led_update_kb(led_t led_state) {
-    if (led_update_user(led_state)) {
-        if (led_state.caps_lock) {
-            setPinOutput(B2);
-        } else {
-            setPinInput(B2);
-        }
+void led_update_ports(led_t led_state) {
+    if (led_state.caps_lock) {
+        setPinOutput(B2);
+    } else {
+        setPinInput(B2);
     }
-
-    return true;
 }

--- a/keyboards/metamechs/timberwolf/timberwolf.c
+++ b/keyboards/metamechs/timberwolf/timberwolf.c
@@ -16,16 +16,12 @@
 
 #include "timberwolf.h"
 
-bool led_update_kb(led_t led_state) {
-    bool runDefault = led_update_user(led_state);
-    if(runDefault) {
-        if (led_state.caps_lock) {
-            backlight_level_noeeprom(get_backlight_level());
-        } else {
-            backlight_set(0);
-        }
+void led_update_ports(led_t led_state) {
+    if (led_state.caps_lock) {
+        backlight_level_noeeprom(get_backlight_level());
+    } else {
+        backlight_set(0);
     }
-    return runDefault;
 }
 
 bool encoder_update_kb(uint8_t index, bool clockwise) {

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -370,12 +370,8 @@ const uint8_t music_map[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_moonlander(
 #endif
 
 #ifdef CAPS_LOCK_STATUS
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if(res) {
-        ML_LED_6(led_state.caps_lock);
-    }
-    return res;
+void led_update_ports(led_t led_state) {
+    ML_LED_6(led_state.caps_lock);
 }
 #endif
 

--- a/keyboards/novelkeys/nk65/nk65.c
+++ b/keyboards/novelkeys/nk65/nk65.c
@@ -25,16 +25,12 @@
  * Middle LED is blue and red. LED driver 2 RGB 6 Red and Blue channel
  * Bottom LED is red only LED driver 2 RGB 6 Green channel.
  */
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if(res) {
-        if (led_state.caps_lock) {
-            IS31FL3733_set_color( 7+64-1, 0, 255, 0 );
-        } else {
-            IS31FL3733_set_color( 7+64-1, 0, 0, 0 );
-        }
+void led_update_ports(led_t led_state) {
+    if (led_state.caps_lock) {
+        IS31FL3733_set_color( 7+64-1, 0, 255, 0 );
+    } else {
+        IS31FL3733_set_color( 7+64-1, 0, 0, 0 );
     }
-    return res;
 }
 
 __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {

--- a/keyboards/nullbitsco/nibble/nibble.c
+++ b/keyboards/nullbitsco/nibble/nibble.c
@@ -16,10 +16,6 @@
 #include QMK_KEYBOARD_H
 
 // Use Bit-C LED to show CAPS LOCK status
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if (res) {
-        set_bitc_LED(led_state.caps_lock ? LED_DIM : LED_OFF);
-    }
-    return res;
+void led_update_ports(led_t led_state) {
+    set_bitc_LED(led_state.caps_lock ? LED_DIM : LED_OFF);
 }

--- a/keyboards/nullbitsco/tidbit/tidbit.c
+++ b/keyboards/nullbitsco/tidbit/tidbit.c
@@ -103,12 +103,8 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
 }
 
 // Use Bit-C LED to show NUM LOCK status
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if (res) {
-        set_bitc_LED(led_state.num_lock ? LED_DIM : LED_OFF);
-    }
-    return res;
+void led_update_ports(led_t led_state) {
+    set_bitc_LED(led_state.num_lock ? LED_DIM : LED_OFF);
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/viendi8l/viendi8l.c
+++ b/keyboards/viendi8l/viendi8l.c
@@ -23,13 +23,9 @@ uint8_t caps_color[3] = {0xFF,0xFF,0xFF};
 uint8_t num_color[3] = {0xFF,0xFF,0xFF};
 uint8_t layer_color[3] = {0xFF,0xFF,0xFF};
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if(res) {
-        led_state.caps_lock ? rgblight_setrgb_at(caps_color[0], caps_color[1], caps_color[2], 2) : rgblight_setrgb_at(0x00,0x00,0x00,2);
-        led_state.num_lock ? rgblight_setrgb_at(num_color[0], num_color[1], num_color[2], 3) : rgblight_setrgb_at(0x00,0x00,0x00,3);
-    }
-    return res;
+void led_update_ports(led_t led_state) {
+    led_state.caps_lock ? rgblight_setrgb_at(caps_color[0], caps_color[1], caps_color[2], 2) : rgblight_setrgb_at(0x00,0x00,0x00,2);
+    led_state.num_lock ? rgblight_setrgb_at(num_color[0], num_color[1], num_color[2], 3) : rgblight_setrgb_at(0x00,0x00,0x00,3);
 }
 
 layer_state_t layer_state_set_kb(layer_state_t state) {

--- a/keyboards/weirdo/ls_60/ls_60.c
+++ b/keyboards/weirdo/ls_60/ls_60.c
@@ -16,16 +16,10 @@
 #include "ls_60.h"
 
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-
-    if (res) {
-        if(led_state.caps_lock){
-            rgblight_setrgb_at(192, 192, 192, 0);
-        } else {
-            rgblight_setrgb_at(0, 0, 0, 0);
-        }
+void led_update_ports(led_t led_state) {
+    if(led_state.caps_lock){
+        rgblight_setrgb_at(192, 192, 192, 0);
+    } else {
+        rgblight_setrgb_at(0, 0, 0, 0);
     }
-
-    return res;
 }

--- a/keyboards/yiancardesigns/seigaiha/seigaiha.c
+++ b/keyboards/yiancardesigns/seigaiha/seigaiha.c
@@ -20,17 +20,13 @@
 
 uint8_t send_data = 0x00;
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if(res) {
-        if (led_state.caps_lock){
-            send_data |= 1 << 5;
-        } else {
-            send_data &= ~(1 << 5);
-        }
-        i2c_writeReg((PORT_EXPANDER_ADDRESS << 1), 0x0A, &send_data, 1, 20);
+void led_update_ports(led_t led_state) {
+    if (led_state.caps_lock){
+        send_data |= 1 << 5;
+    } else {
+        send_data &= ~(1 << 5);
     }
-    return res;
+    i2c_writeReg((PORT_EXPANDER_ADDRESS << 1), 0x0A, &send_data, 1, 20);
 }
 
 __attribute__((weak)) layer_state_t layer_state_set_user(layer_state_t state) {


### PR DESCRIPTION
## Description

Following #14452, less boilerplate is needed to customize indicator led control.

I went through the keyboard .c files and updated those instances where the change was straightforward. I did not touch instances where the implementation consisted solely of `writePin` invocations, because I believe nearly all of those functions could go and be replaced by the desired LED pin `define`s.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python) - _No style changes introduced._
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
