### PR TITLE
Make QP driver init functions weak.

### DIFF
--- a/drivers/painter/gc9a01/qp_gc9a01.c
+++ b/drivers/painter/gc9a01/qp_gc9a01.c
@@ -17,7 +17,7 @@ tft_panel_dc_reset_painter_device_t gc9a01_drivers[GC9A01_NUM_DEVICES] = {0};
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-bool qp_gc9a01_init(painter_device_t device, painter_rotation_t rotation) {
+__attribute__((weak)) bool qp_gc9a01_init(painter_device_t device, painter_rotation_t rotation) {
     // A lot of these "unknown" opcodes are sourced from other OSS projects and are seemingly required for this display to function.
     // clang-format off
     const uint8_t gc9a01_init_sequence[] = {

--- a/drivers/painter/ili9xxx/qp_ili9163.c
+++ b/drivers/painter/ili9xxx/qp_ili9163.c
@@ -20,7 +20,7 @@ tft_panel_dc_reset_painter_device_t ili9163_drivers[ILI9163_NUM_DEVICES] = {0};
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 
-bool qp_ili9163_init(painter_device_t device, painter_rotation_t rotation) {
+__attribute__((weak)) bool qp_ili9163_init(painter_device_t device, painter_rotation_t rotation) {
     // clang-format off
     const uint8_t ili9163_init_sequence[] = {
         // Command,                 Delay,  N, Data[N]

--- a/drivers/painter/ili9xxx/qp_ili9341.c
+++ b/drivers/painter/ili9xxx/qp_ili9341.c
@@ -20,7 +20,7 @@ tft_panel_dc_reset_painter_device_t ili9341_drivers[ILI9341_NUM_DEVICES] = {0};
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 
-bool qp_ili9341_init(painter_device_t device, painter_rotation_t rotation) {
+__attribute__((weak)) bool qp_ili9341_init(painter_device_t device, painter_rotation_t rotation) {
     // clang-format off
     const uint8_t ili9341_init_sequence[] = {
         // Command,                 Delay,  N, Data[N]

--- a/drivers/painter/ili9xxx/qp_ili9488.c
+++ b/drivers/painter/ili9xxx/qp_ili9488.c
@@ -20,7 +20,7 @@ tft_panel_dc_reset_painter_device_t ili9488_drivers[ILI9488_NUM_DEVICES] = {0};
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 
-bool qp_ili9488_init(painter_device_t device, painter_rotation_t rotation) {
+__attribute__((weak)) bool qp_ili9488_init(painter_device_t device, painter_rotation_t rotation) {
     // clang-format off
     const uint8_t ili9488_init_sequence[] = {
         // Command,                 Delay,  N, Data[N]

--- a/drivers/painter/ssd1351/qp_ssd1351.c
+++ b/drivers/painter/ssd1351/qp_ssd1351.c
@@ -20,7 +20,7 @@ tft_panel_dc_reset_painter_device_t ssd1351_drivers[SSD1351_NUM_DEVICES] = {0};
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 
-bool qp_ssd1351_init(painter_device_t device, painter_rotation_t rotation) {
+__attribute__((weak)) bool qp_ssd1351_init(painter_device_t device, painter_rotation_t rotation) {
     tft_panel_dc_reset_painter_device_t *driver = (tft_panel_dc_reset_painter_device_t *)device;
 
     // clang-format off

--- a/drivers/painter/st77xx/qp_st7735.c
+++ b/drivers/painter/st77xx/qp_st7735.c
@@ -49,7 +49,7 @@ static inline void st7735_automatic_viewport_offsets(painter_device_t device, pa
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 
-bool qp_st7735_init(painter_device_t device, painter_rotation_t rotation) {
+__attribute__((weak)) bool qp_st7735_init(painter_device_t device, painter_rotation_t rotation) {
     // clang-format off
     const uint8_t st7735_init_sequence[] = {
         // Command,                 Delay, N, Data[N]

--- a/drivers/painter/st77xx/qp_st7789.c
+++ b/drivers/painter/st77xx/qp_st7789.c
@@ -48,7 +48,7 @@ static inline void st7789_automatic_viewport_offsets(painter_device_t device, pa
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 
-bool qp_st7789_init(painter_device_t device, painter_rotation_t rotation) {
+__attribute__((weak)) bool qp_st7789_init(painter_device_t device, painter_rotation_t rotation) {
     // clang-format off
     const uint8_t st7789_init_sequence[] = {
         // Command,                 Delay, N, Data[N]


### PR DESCRIPTION
## Description

Allows keyboards to override the init sequence for each driver, potentially opening up support for slightly different panels.
Will need to be on top of custom implementations to check that they don't get copypasta'd everywhere -- in that case we should formalise the process by punting the sequence into core.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
