### PR TITLE
Add unit tests for HOLD_ON_OTHER_KEY_PRESS

### DIFF
--- a/data/mappings/info_config.json
+++ b/data/mappings/info_config.json
@@ -29,6 +29,8 @@
     "DYNAMIC_KEYMAP_LAYER_COUNT": {"info_key": "dynamic_keymap.layer_count", "value_type": "int"},
     "IGNORE_MOD_TAP_INTERRUPT": {"info_key": "tapping.ignore_mod_tap_interrupt", "value_type": "bool"},
     "IGNORE_MOD_TAP_INTERRUPT_PER_KEY": {"info_key": "tapping.ignore_mod_tap_interrupt_per_key", "value_type": "bool"},
+    "HOLD_ON_OTHER_KEY_PRESS": {"info_key": "tapping.hold_on_other_key_press", "value_type": "bool"},
+    "HOLD_ON_OTHER_KEY_PRESS_PER_KEY": {"info_key": "tapping.hold_on_other_key_press_per_key", "value_type": "bool"},
     "LAYOUTS": {"info_key": "layout_aliases", "value_type": "mapping"},
     "LEADER_PER_KEY_TIMING": {"info_key": "leader_key.timing", "value_type": "bool"},
     "LEADER_KEY_STRICT_KEY_PROCESSING": {"info_key": "leader_key.strict_processing", "value_type": "bool"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -535,6 +535,8 @@
                 "force_hold_per_key": {"type": "boolean"},
                 "ignore_mod_tap_interrupt": {"type": "boolean"},
                 "ignore_mod_tap_interrupt_per_key": {"type": "boolean"},
+                "hold_on_other_key_press": {"type": "boolean"},
+                "hold_on_other_key_press_per_key": {"type": "boolean"},
                 "permissive_hold": {"type": "boolean"},
                 "permissive_hold_per_key": {"type": "boolean"},
                 "retro": {"type": "boolean"},

--- a/tests/tap_hold_configurations/hold_on_other_key_press/config.h
+++ b/tests/tap_hold_configurations/hold_on_other_key_press/config.h
@@ -1,0 +1,20 @@
+/* Copyright 2022 Vladislav Kucheriavykh
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "test_common.h"
+#define HOLD_ON_OTHER_KEY_PRESS

--- a/tests/tap_hold_configurations/hold_on_other_key_press/test.mk
+++ b/tests/tap_hold_configurations/hold_on_other_key_press/test.mk
@@ -1,0 +1,18 @@
+# Copyright 2022 Vladislav Kucheriavykh
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# --------------------------------------------------------------------------------
+# Keep this file, even if it is empty, as a marker that this folder contains tests
+# --------------------------------------------------------------------------------

--- a/tests/tap_hold_configurations/hold_on_other_key_press/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/hold_on_other_key_press/test_tap_hold.cpp
@@ -1,0 +1,423 @@
+/* Copyright 2022 Vladislav Kucheriavykh
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.hpp"
+#include "action_tapping.h"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+class HoldOnOtherKeyPress : public TestFixture {};
+
+TEST_F(HoldOnOtherKeyPress, short_distinct_taps_of_mod_tap_key_and_regular_key) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    /* Press mod-tap-hold key. */
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release mod-tap-hold key. */
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key. */
+    EXPECT_REPORT(driver, (KC_A));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key. */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, long_distinct_taps_of_mod_tap_key_and_regular_key) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    /* Press mod-tap-hold key. */
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Idle for tapping term of mod tap hold key. */
+    EXPECT_REPORT(driver, (KC_LSFT));
+    idle_for(TAPPING_TERM + 1);
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release mod-tap-hold key. */
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key. */
+    EXPECT_REPORT(driver, (KC_A));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key. */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, short_distinct_taps_of_layer_tap_key_and_regular_key) {
+    TestDriver driver;
+    InSequence s;
+    auto       layer_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       regular_key        = KeymapKey(0, 2, 0, KC_A);
+    auto       layer_key          = KeymapKey(0, 2, 0, KC_B);
+
+    set_keymap({layer_tap_hold_key, regular_key});
+
+    /* Press layer-tap-hold key. */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release layer-tap-hold key. */
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_EMPTY_REPORT(driver);
+    layer_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key. */
+    EXPECT_REPORT(driver, (KC_A));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key. */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, long_distinct_taps_of_layer_tap_key_and_regular_key) {
+    TestDriver driver;
+    InSequence s;
+    auto       layer_tap_hold_key = KeymapKey(0, 1, 0, LT(1, KC_P));
+    auto       regular_key        = KeymapKey(0, 2, 0, KC_A);
+    auto       layer_key          = KeymapKey(0, 2, 0, KC_B);
+
+    set_keymap({layer_tap_hold_key, regular_key});
+
+    /* Press layer-tap-hold key. */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Idle for tapping term of layer tap hold key. */
+    EXPECT_NO_REPORT(driver);
+    idle_for(TAPPING_TERM + 1);
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release layer-tap-hold key. */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key. */
+    EXPECT_REPORT(driver, (KC_A));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key. */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, tap_regular_key_while_mod_tap_key_is_held) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    /* Press mod-tap-hold key. */
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key. */
+    EXPECT_REPORT(driver, (KC_LSFT));
+    EXPECT_REPORT(driver, (KC_A, KC_LSFT));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key. */
+    EXPECT_REPORT(driver, (KC_LSFT));
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release mod-tap-hold key. */
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Idle for tapping term of mod tap hold key. */
+    idle_for(TAPPING_TERM - 3);
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
+    TestDriver driver;
+    InSequence s;
+    auto       first_mod_tap_hold_key  = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       second_mod_tap_hold_key = KeymapKey(0, 2, 0, RSFT_T(KC_A));
+
+    set_keymap({first_mod_tap_hold_key, second_mod_tap_hold_key});
+
+    /* Press first mod-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    first_mod_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press second tap-hold key */
+    EXPECT_REPORT(driver, (KC_LSFT));
+    second_mod_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release second tap-hold key */
+    EXPECT_REPORT(driver, (KC_A, KC_LSFT));
+    EXPECT_REPORT(driver, (KC_LSFT));
+    second_mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release first mod-tap-hold key */
+    EXPECT_EMPTY_REPORT(driver);
+    first_mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, tap_regular_key_while_layer_tap_key_is_held) {
+    TestDriver driver;
+    InSequence s;
+    auto       layer_tap_hold_key = KeymapKey(0, 1, 0, LT(1, KC_P));
+    auto       regular_key        = KeymapKey(0, 2, 0, KC_A);
+    auto       layer_key          = KeymapKey(1, 2, 0, KC_B);
+
+    set_keymap({layer_tap_hold_key, regular_key, layer_key});
+
+    /* Press layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key */
+    EXPECT_REPORT(driver, (KC_B));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, nested_tap_of_layer_0_layer_tap_keys) {
+    TestDriver driver;
+    InSequence s;
+    /* The keys are layer-taps on layer 0 but regular keys on layer 1 */
+    auto       first_layer_tap_key  = KeymapKey(0, 1, 0, LT(1, KC_A));
+    auto       second_layer_tap_key = KeymapKey(0, 2, 0, LT(1, KC_P));
+    auto       first_key_on_layer   = KeymapKey(1, 1, 0, KC_B);
+    auto       second_key_on_layer  = KeymapKey(1, 2, 0, KC_Q);
+
+    set_keymap({first_layer_tap_key, second_layer_tap_key, first_key_on_layer, second_key_on_layer});
+
+    /* Press first layer-tap key */
+    EXPECT_NO_REPORT(driver);
+    first_layer_tap_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press second layer-tap key */
+    EXPECT_REPORT(driver, (KC_Q));
+    second_layer_tap_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release second layer-tap key */
+    EXPECT_EMPTY_REPORT(driver);
+    second_layer_tap_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release first layer-tap key */
+    EXPECT_NO_REPORT(driver);
+    first_layer_tap_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, nested_tap_of_layer_tap_keys) {
+    TestDriver driver;
+    InSequence s;
+    /* The keys are layer-taps on all layers */
+    auto       first_key_layer_0  = KeymapKey(0, 1, 0, LT(1, KC_A));
+    auto       second_key_layer_0 = KeymapKey(0, 2, 0, LT(1, KC_P));
+    auto       first_key_layer_1  = KeymapKey(1, 1, 0, LT(2, KC_B));
+    auto       second_key_layer_1 = KeymapKey(1, 2, 0, LT(2, KC_Q));
+    auto       first_key_layer_2  = KeymapKey(2, 1, 0, KC_TRNS);
+    auto       second_key_layer_2 = KeymapKey(2, 2, 0, KC_TRNS);
+
+    set_keymap({first_key_layer_0, second_key_layer_0, first_key_layer_1, second_key_layer_1, first_key_layer_2, second_key_layer_2});
+
+    /* Press first layer-tap key */
+    EXPECT_NO_REPORT(driver);
+    first_key_layer_0.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press second layer-tap key */
+    EXPECT_NO_REPORT(driver);
+    second_key_layer_0.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release second layer-tap key */
+    EXPECT_REPORT(driver, (KC_Q));
+    EXPECT_EMPTY_REPORT(driver);
+    second_key_layer_0.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release first layer-tap key */
+    EXPECT_NO_REPORT(driver);
+    first_key_layer_0.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, roll_mod_tap_key_with_regular_key) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    /* Press mod-tap-hold key. */
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key. */
+    EXPECT_REPORT(driver, (KC_LSFT));
+    EXPECT_REPORT(driver, (KC_A, KC_LSFT));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release mod-tap-hold key. */
+    EXPECT_REPORT(driver, (KC_A));
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key. */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+TEST_F(HoldOnOtherKeyPress, roll_layer_tap_key_with_regular_key) {
+    TestDriver driver;
+    InSequence s;
+
+    auto       layer_tap_hold_key = KeymapKey(0, 1, 0, LT(1, KC_P));
+    auto       regular_key        = KeymapKey(0, 2, 0, KC_A);
+    auto       layer_key          = KeymapKey(1, 2, 0, KC_B);
+
+    set_keymap({layer_tap_hold_key, regular_key, layer_key});
+
+    /* Press layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Press regular key */
+    EXPECT_REPORT(driver, (KC_B));
+    regular_key.press();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+
+    /* Release regular key */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add HOLD_ON_OTHER_KEY_PRESS[_PER_KEY] to data-driven files and create a suite of unit tests to verify the behaviour of modtaps, layertaps and regular keys with HOLD_ON_OTHER_KEY_PRESS.

These commits were originally a part of #15741 but that's a breaking change that will take a long time to get merged. The unit tests for HOLD_ON_OTHER_KEY_PRESS aren't particularly tied to the scope and intent of the “make-ignore-mod-tap-interrupt-the-default” PR so they can be reviewed and merged separately.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
