### PR TITLE
Sabre Fix LEDs being inverted

### DIFF
--- a/keyboards/wolf/sabre/config.h
+++ b/keyboards/wolf/sabre/config.h
@@ -47,5 +47,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #define BACKLIGHT_PIN B7
 
+#define LED_PIN_ON_STATE 0
 #define LED_CAPS_LOCK_PIN B3
 #define LED_SCROLL_LOCK_PIN B0


### PR DESCRIPTION
## Description

The caps lock and scroll lock LEDs were inverted

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
