### PR TITLE
Keychron Q3 I2C & CKLED2001 transfer speedup

### DIFF
--- a/drivers/led/ckled2001.c
+++ b/drivers/led/ckled2001.c
@@ -36,7 +36,7 @@
 #endif
 
 // Transfer buffer for TWITransmitData()
-uint8_t g_twi_transfer_buffer[20];
+uint8_t g_twi_transfer_buffer[65];
 
 // These buffers match the CKLED2001 PWM registers.
 // The control buffers match the PG0 LED On/Off registers.
@@ -72,27 +72,26 @@ bool CKLED2001_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 bool CKLED2001_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes PG1 is already selected.
     // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // g_twi_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 3 transfers of 64 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < 192; i += 16) {
+    // Iterate over the pwm_buffer contents at 64 byte intervals.
+    for (uint8_t i = 0; i < 192; i += 64) {
         g_twi_transfer_buffer[0] = i;
-        // Copy the data from i to i+15.
+        // Copy the data from i to i+63.
         // Device will auto-increment register for data after the first byte
         // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        for (int j = 0; j < 16; j++) {
+        for (uint8_t j = 0; j < 64; j++) {
             g_twi_transfer_buffer[1 + j] = pwm_buffer[i + j];
         }
 
 #if CKLED2001_PERSISTENCE > 0
         for (uint8_t i = 0; i < CKLED2001_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, CKLED2001_TIMEOUT) != 0) {
+            if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 65, CKLED2001_TIMEOUT) != 0) {
                 return false;
             }
         }
 #else
-        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 17, CKLED2001_TIMEOUT) != 0) {
+        if (i2c_transmit(addr << 1, g_twi_transfer_buffer, 65, CKLED2001_TIMEOUT) != 0) {
             return false;
         }
 #endif

--- a/keyboards/keychron/q3/config.h
+++ b/keyboards/keychron/q3/config.h
@@ -31,6 +31,13 @@
 #define DRIVER_ADDR_1 0b1110111
 #define DRIVER_ADDR_2 0b1110100
 
+/* Increase I2C speed to 1000 KHz */
+#define I2C1_TIMINGR_PRESC 0U
+#define I2C1_TIMINGR_SCLDEL 3U
+#define I2C1_TIMINGR_SDADEL 0U
+#define I2C1_TIMINGR_SCLH 15U
+#define I2C1_TIMINGR_SCLL 51U
+
 /* Scan phase of led driver set as MSKPHASE_9CHANNEL(defined as 0x03 in CKLED2001.h) */
 #define PHASE_CHANNEL MSKPHASE_9CHANNEL
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
This PR focuses on indirectly increasing the keyboard matrix scan frequency which is held back by sending the latest pwm buffers over to the 2 CKLED2001 LED drivers.

<!--- Describe your changes in detail here. -->
Prior to this PR the keeb is doing ~**640** matrix scans/sec with RGB enabled.
The increase in I2C speed to 1000 KHz (from the default of 400 KHz) gets this up to ~1100 matrix scans/sec with RGB enabled.
The increased g_twi_transfer_buffer gets the amount of transmissions from 12 per driver (24 total) to 3 per driver (6 total), getting it to ~**1150** matrix scans/sec with RGB enabled.

The 1000 KHz is within the spec of  the `STM32L432` and technically can be pushed even further (but CUBE-MX won't let me generate those :( ) .
I should note that the "official doc" for `CKLED2001` only advertises 400 KHz support (from my past experience most I2C slave devices can be ran well over the spec without adverse effects, which is also the case here).

I have tested the above changes on `Keychron Q3 ANSI (no knob)` over the past couple of days & haven't noticed any issues.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
