### PR TITLE
wilba_tech: allow keymaps to override backlight_effect_indicators()

### DIFF
--- a/keyboards/wilba_tech/wt_rgb_backlight.c
+++ b/keyboards/wilba_tech/wt_rgb_backlight.c
@@ -2417,7 +2417,7 @@ void backlight_effect_indicators_set_colors( uint8_t index, HS color )
 
 // This runs after another backlight effect and replaces
 // colors already set
-void backlight_effect_indicators(void)
+__attribute__ ((weak)) void backlight_effect_indicators(void)
 {
     if ( g_config.caps_lock_indicator.index != 255 && host_keyboard_led_state().caps_lock )
     {


### PR DESCRIPTION
## Description

As the title says, this allows user keymaps to override backlight_effect_indicators() for keyboards which use Wilba Tech RGB.

I wanted to light things up in a custom way to show each key defined in each active non-base layer, plus extra lighting for modifier keys.  With this one-line change, now I can.

The Wilba Tech code doesn't have a _kb() / _user() abstraction for customizing this, and I don't want to break anyone's keymaps by changing the API, so I just made the function weak.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
