### PR TITLE
ChibiOS USB: Add a dummy IN callback to work around LLD bugs

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -120,6 +120,16 @@ static const USBDescriptor *usb_get_descriptor_cb(USBDriver *usbp, uint8_t dtype
         return &desc;
 }
 
+/*
+ * USB notification callback that does nothing.  Needed to work around bugs in
+ * some USB LLDs that fail to resume the waiting thread when the notification
+ * callback pointer is NULL.
+ */
+static void dummy_usb_cb(USBDriver *usbp, usbep_t ep) {
+    (void)usbp;
+    (void)ep;
+}
+
 #ifndef KEYBOARD_SHARED_EP
 /* keyboard endpoint state structure */
 static USBInEndpointState kbd_ep_state;
@@ -127,7 +137,7 @@ static USBInEndpointState kbd_ep_state;
 static const USBEndpointConfig kbd_ep_config = {
     USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
     NULL,                   /* SETUP packet notification callback */
-    NULL,                   /* IN notification callback */
+    dummy_usb_cb,           /* IN notification callback */
     NULL,                   /* OUT notification callback */
     KEYBOARD_EPSIZE,        /* IN maximum packet size */
     0,                      /* OUT maximum packet size */
@@ -145,7 +155,7 @@ static USBInEndpointState mouse_ep_state;
 static const USBEndpointConfig mouse_ep_config = {
     USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
     NULL,                   /* SETUP packet notification callback */
-    NULL,                   /* IN notification callback */
+    dummy_usb_cb,           /* IN notification callback */
     NULL,                   /* OUT notification callback */
     MOUSE_EPSIZE,           /* IN maximum packet size */
     0,                      /* OUT maximum packet size */
@@ -163,7 +173,7 @@ static USBInEndpointState shared_ep_state;
 static const USBEndpointConfig shared_ep_config = {
     USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
     NULL,                   /* SETUP packet notification callback */
-    NULL,                   /* IN notification callback */
+    dummy_usb_cb,           /* IN notification callback */
     NULL,                   /* OUT notification callback */
     SHARED_EPSIZE,          /* IN maximum packet size */
     0,                      /* OUT maximum packet size */
@@ -181,7 +191,7 @@ static USBInEndpointState joystick_ep_state;
 static const USBEndpointConfig joystick_ep_config = {
     USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
     NULL,                   /* SETUP packet notification callback */
-    NULL,                   /* IN notification callback */
+    dummy_usb_cb,           /* IN notification callback */
     NULL,                   /* OUT notification callback */
     JOYSTICK_EPSIZE,        /* IN maximum packet size */
     0,                      /* OUT maximum packet size */
@@ -199,7 +209,7 @@ static USBInEndpointState digitizer_ep_state;
 static const USBEndpointConfig digitizer_ep_config = {
     USB_EP_MODE_TYPE_INTR,  /* Interrupt EP */
     NULL,                   /* SETUP packet notification callback */
-    NULL,                   /* IN notification callback */
+    dummy_usb_cb,           /* IN notification callback */
     NULL,                   /* OUT notification callback */
     DIGITIZER_EPSIZE,       /* IN maximum packet size */
     0,                      /* OUT maximum packet size */


### PR DESCRIPTION
## Description

In #18631 some IN notification callbacks that were doing nothing were removed, which should be a valid thing to do (ChibiOS HAL checks the `in_cb` and `out_cb` pointers for being non-NULL before invoking those optional callbacks).  However, it turned out that some less popular USB LLDs (KINETIS and MIMXRT1062) have their own checks for those pointers, and (incorrectly) skip the ChibiOS callback handling when those pointers are NULL, which breaks the code for the `USB_USE_WAIT` configuration option (the waiting thread never gets resumed if the corresponding callback pointer is NULL).

Add those dummy callbacks again (but use a single function for all of them instead of individual ones for each endpoint); this restores the KINETIS and MIMXRT1062 boards to the working state while the LLDs are getting fixed.

A more in-depth analysis of what happens in the code is in https://github.com/qmk/qmk_firmware/issues/18805#issuecomment-1287693561.

Tested on a Teensy 3.2 board (`qmk flash -kb handwired/onekey/teensy_32 -km default`).  On that hardware without this fix the lockup happens immediately after pressing a key mapped to `KC_A`; this does not match the MIMXRT1062 behavior described in #18805 (where plain keys still work), but that problem should hopefully be fixed by this change too (given that a revert of #18631 helps there).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #18748
* Fixes #18805

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
