### PR TITLE
Macro3: rename LAYOUT to LAYOUT_ortho_2x4

### DIFF
--- a/keyboards/macro3/info.json
+++ b/keyboards/macro3/info.json
@@ -8,8 +8,11 @@
         "pid": "0x3388",
         "device_version": "0.0.3"
     },
+    "layout_aliases": {
+        "LAYOUT": "LAYOUT_ortho_2x4"
+    },
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_ortho_2x4": {
             "layout": [
                 {"x": 0, "y": 0},
                 {"x": 1, "y": 0},

--- a/keyboards/macro3/keymaps/default/keymap.c
+++ b/keyboards/macro3/keymaps/default/keymap.c
@@ -6,11 +6,11 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
+    [0] = LAYOUT_ortho_2x4(
         KC_MUTE, KC_MPLY, KC_MRWD, LT(1,KC_MFFD),
         C(KC_Z), C(KC_X), C(KC_C), C(KC_V)
     ),
-    [1] = LAYOUT(
+    [1] = LAYOUT_ortho_2x4(
         _______, _______, _______, _______,
         QK_BOOT, _______, _______, _______
     )

--- a/keyboards/macro3/macro3.h
+++ b/keyboards/macro3/macro3.h
@@ -5,7 +5,7 @@
 
 #include "quantum.h"
 
-#define LAYOUT( \
+#define LAYOUT_ortho_2x4( \
     K00, K01, K02, K03, \
     K10, K11, K12, K13  \
 ) \


### PR DESCRIPTION
## Description

[title]

cc @filterpaper (keyboard maintainer, sort of)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
