### PR TITLE
added BS_TOGG so BS_SWAP and BS_NORM can be on a single key

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -404,6 +404,7 @@ See also: [Magic Keycodes](keycodes_magic.md)
 |`MAGIC_UNSWAP_GRAVE_ESC`          |`GE_NORM`|Unswap <code>&#96;</code> and Escape                                      |
 |`MAGIC_SWAP_BACKSLASH_BACKSPACE`  |`BS_SWAP`|Swap `\` and Backspace                                                    |
 |`MAGIC_UNSWAP_BACKSLASH_BACKSPACE`|`BS_NORM`|Unswap `\` and Backspace                                                  |
+|`MAGIC_TOGGLE_BACKSLASH_BACKSPACE`|`BS_TOGG`|Toggle `\` and Backspace swap state                                       |
 |`MAGIC_HOST_NKRO`                 |`NK_ON`  |Enable N-key rollover                                                     |
 |`MAGIC_UNHOST_NKRO`               |`NK_OFF` |Disable N-key rollover                                                    |
 |`MAGIC_TOGGLE_NKRO`               |`NK_TOGG`|Toggle N-key rollover                                                     |

--- a/quantum/process_keycode/process_magic.c
+++ b/quantum/process_keycode/process_magic.c
@@ -45,6 +45,7 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
             case MAGIC_SWAP_LCTL_LGUI ... MAGIC_EE_HANDS_RIGHT:
             case MAGIC_TOGGLE_GUI:
             case MAGIC_TOGGLE_CONTROL_CAPSLOCK:
+            case MAGIC_TOGGLE_BACKSLASH_BACKSPACE:
             case MAGIC_SWAP_ESCAPE_CAPSLOCK ... MAGIC_TOGGLE_ESCAPE_CAPSLOCK:
                 /* keymap config */
                 keymap_config.raw = eeconfig_read_keymap();
@@ -162,6 +163,9 @@ bool process_magic(uint16_t keycode, keyrecord_t *record) {
                             PLAY_SONG(cg_norm_song);
                         }
 #endif
+                        break;
+                    case MAGIC_TOGGLE_BACKSLASH_BACKSPACE:
+                        keymap_config.swap_backslash_backspace = !keymap_config.swap_backslash_backspace;
                         break;
                     case MAGIC_TOGGLE_NKRO:
                         clear_keyboard(); // clear first buffer to prevent stuck keys

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -615,6 +615,8 @@ enum quantum_keycodes {
     AUTOCORRECT_OFF,
     AUTOCORRECT_TOGGLE,
 
+    MAGIC_TOGGLE_BACKSLASH_BACKSPACE,
+
     // Start of custom keycode range for keyboards and keymaps - always leave at the end
     SAFE_RANGE
 };
@@ -731,6 +733,7 @@ enum quantum_keycodes {
 
 #define BS_SWAP MAGIC_SWAP_BACKSLASH_BACKSPACE
 #define BS_NORM MAGIC_UNSWAP_BACKSLASH_BACKSPACE
+#define BS_TOGG MAGIC_TOGGLE_BACKSLASH_BACKSPACE
 
 #define NK_ON MAGIC_HOST_NKRO
 #define NK_OFF MAGIC_UNHOST_NKRO


### PR DESCRIPTION
## Description

Most of the magic swap keys have a toggle, but backspace/backslash didn't.  So I added one.

This lets me have one key to toggle that behavior, instead of needing to dedicate two keys.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
