### PR TITLE
Deprecate `SECURE_*` keycodes for `QK_SECURE_*`

### DIFF
--- a/docs/feature_secure.md
+++ b/docs/feature_secure.md
@@ -26,12 +26,12 @@ SECURE_ENABLE = yes
 
 ## Keycodes
 
-| Key              | Description                                                                    |
-|------------------|--------------------------------------------------------------------------------|
-| `SECURE_LOCK`    | Revert back to a locked state                                                  |
-| `SECURE_UNLOCK`  | Forces unlock without performing a unlock sequence                             |
-| `SECURE_TOGGLE`  | Toggle directly between locked and unlock without performing a unlock sequence |
-| `SECURE_REQUEST` | Request that user perform the unlock sequence                                  |
+| Key                 |Aliases  | Description                                                                    |
+|---------------------|---------|--------------------------------------------------------------------------------|
+| `QK_SECURE_LOCK`    |`SE_LOCK`| Revert back to a locked state                                                  |
+| `QK_SECURE_UNLOCK`  |`SE_ULCK`| Forces unlock without performing a unlock sequence                             |
+| `QK_SECURE_TOGGLE`  |`SE_TOGG`| Toggle directly between locked and unlock without performing a unlock sequence |
+| `QK_SECURE_REQUEST` |`SE_REQ` | Request that user perform the unlock sequence                                  |
 
 ## Configuration
 

--- a/docs/feature_secure.md
+++ b/docs/feature_secure.md
@@ -29,7 +29,7 @@ SECURE_ENABLE = yes
 | Key                 |Aliases  | Description                                                                    |
 |---------------------|---------|--------------------------------------------------------------------------------|
 | `QK_SECURE_LOCK`    |`SE_LOCK`| Revert back to a locked state                                                  |
-| `QK_SECURE_UNLOCK`  |`SE_ULCK`| Forces unlock without performing a unlock sequence                             |
+| `QK_SECURE_UNLOCK`  |`SE_UNLK`| Forces unlock without performing a unlock sequence                             |
 | `QK_SECURE_TOGGLE`  |`SE_TOGG`| Toggle directly between locked and unlock without performing a unlock sequence |
 | `QK_SECURE_REQUEST` |`SE_REQ` | Request that user perform the unlock sequence                                  |
 

--- a/quantum/process_keycode/process_secure.c
+++ b/quantum/process_keycode/process_secure.c
@@ -27,7 +27,7 @@ bool process_secure(uint16_t keycode, keyrecord_t *record) {
             secure_lock();
             return false;
         }
-        if (keycode ==QK_ SECURE_UNLOCK) {
+        if (keycode == QK_SECURE_UNLOCK) {
             secure_unlock();
             return false;
         }

--- a/quantum/process_keycode/process_secure.c
+++ b/quantum/process_keycode/process_secure.c
@@ -23,19 +23,19 @@ bool preprocess_secure(uint16_t keycode, keyrecord_t *record) {
 bool process_secure(uint16_t keycode, keyrecord_t *record) {
 #ifndef SECURE_DISABLE_KEYCODES
     if (!record->event.pressed) {
-        if (keycode == SECURE_LOCK) {
+        if (keycode == QK_SECURE_LOCK) {
             secure_lock();
             return false;
         }
-        if (keycode == SECURE_UNLOCK) {
+        if (keycode ==QK_ SECURE_UNLOCK) {
             secure_unlock();
             return false;
         }
-        if (keycode == SECURE_TOGGLE) {
+        if (keycode == QK_SECURE_TOGGLE) {
             secure_is_locked() ? secure_unlock() : secure_lock();
             return false;
         }
-        if (keycode == SECURE_REQUEST) {
+        if (keycode == QK_SECURE_REQUEST) {
             secure_request_unlock();
             return false;
         }

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -598,10 +598,10 @@ enum quantum_keycodes {
     QK_MAKE,
     QK_REBOOT,
 
-    SECURE_LOCK,
-    SECURE_UNLOCK,
-    SECURE_TOGGLE,
-    SECURE_REQUEST,
+    QK_SECURE_LOCK,
+    QK_SECURE_UNLOCK,
+    QK_SECURE_TOGGLE,
+    QK_SECURE_REQUEST,
 
     QK_CAPS_WORD_TOGGLE,
 
@@ -856,6 +856,12 @@ enum quantum_keycodes {
 #define KO_TOGG QK_KEY_OVERRIDE_TOGGLE
 #define KO_ON QK_KEY_OVERRIDE_ON
 #define KO_OFF QK_KEY_OVERRIDE_OFF
+
+// Secure
+#define SE_LOCK QK_SECURE_LOCK
+#define SE_ULCK QK_SECURE_UNLOCK
+#define SE_TOGG QK_SECURE_TOGGLE
+#define SE_REQ QK_SECURE_REQUEST
 
 // Swap Hands
 #define SH_T(kc) (QK_SWAP_HANDS | (kc))

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -859,7 +859,7 @@ enum quantum_keycodes {
 
 // Secure
 #define SE_LOCK QK_SECURE_LOCK
-#define SE_ULCK QK_SECURE_UNLOCK
+#define SE_UNLK QK_SECURE_UNLOCK
 #define SE_TOGG QK_SECURE_TOGGLE
 #define SE_REQ QK_SECURE_REQUEST
 

--- a/quantum/quantum_keycodes_legacy.h
+++ b/quantum/quantum_keycodes_legacy.h
@@ -84,6 +84,11 @@
 #define JS_BUTTON30 QK_JOYSTICK_BUTTON_30
 #define JS_BUTTON31 QK_JOYSTICK_BUTTON_31
 
+#define SECURE_LOCK QK_SECURE_LOCK
+#define SECURE_UNLOCK QK_SECURE_UNLOCK
+#define SECURE_TOGGLE QK_SECURE_TOGGLE
+#define SECURE_REQUEST QK_SECURE_REQUEST
+
 #define TERM_ON _Static_assert(false, "The Terminal feature has been removed from QMK. Please remove use of TERM_ON/TERM_OFF from your keymap.")
 #define TERM_OFF _Static_assert(false, "The Terminal feature has been removed from QMK.. Please remove use of TERM_ON/TERM_OFF from your keymap.")
 // #define RESET _Static_assert(false, "The RESET keycode has been removed from QMK.. Please remove use from your keymap.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Also adds short form aliases.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
