### PR TITLE
core: allow locking the matrix state

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -252,6 +252,14 @@ __attribute__((weak)) void keyboard_post_init_kb(void) {
     keyboard_post_init_user();
 }
 
+/** \brief is_matrix_locked
+ *
+ * FIXME: needs doc
+ */
+__attribute__((weak)) bool is_matrix_locked(void) {
+    return false;
+}
+
 /** \brief keyboard_setup
  *
  * FIXME: needs doc
@@ -449,54 +457,57 @@ static inline void generate_tick_event(void) {
  * @return false Matrix didn't change
  */
 static bool matrix_task(void) {
-    static matrix_row_t matrix_previous[MATRIX_ROWS];
+    if (!is_matrix_locked()) {
+        static matrix_row_t matrix_previous[MATRIX_ROWS];
 
-    matrix_scan();
+        matrix_scan();
 
-    bool matrix_changed = false;
-    for (uint8_t row = 0; row < MATRIX_ROWS && !matrix_changed; row++) {
-        matrix_changed |= matrix_previous[row] ^ matrix_get_row(row);
-    }
-
-    matrix_scan_perf_task();
-
-    // Short-circuit the complete matrix processing if it is not necessary
-    if (!matrix_changed) {
-        generate_tick_event();
-        return matrix_changed;
-    }
-
-    if (debug_config.matrix) {
-        matrix_print();
-    }
-
-    const bool process_keypress = should_process_keypress();
-
-    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-        const matrix_row_t current_row = matrix_get_row(row);
-        const matrix_row_t row_changes = current_row ^ matrix_previous[row];
-
-        if (!row_changes || has_ghost_in_row(row, current_row)) {
-            continue;
+        bool matrix_changed = false;
+        for (uint8_t row = 0; row < MATRIX_ROWS && !matrix_changed; row++) {
+            matrix_changed |= matrix_previous[row] ^ matrix_get_row(row);
         }
 
-        matrix_row_t col_mask = 1;
-        for (uint8_t col = 0; col < MATRIX_COLS; col++, col_mask <<= 1) {
-            if (row_changes & col_mask) {
-                const bool key_pressed = current_row & col_mask;
+        matrix_scan_perf_task();
 
-                if (process_keypress) {
-                    action_exec(MAKE_KEYEVENT(row, col, key_pressed));
-                }
+        // Short-circuit the complete matrix processing if it is not necessary
+        if (!matrix_changed) {
+            generate_tick_event();
+            return matrix_changed;
+        }
 
-                switch_events(row, col, key_pressed);
+        if (debug_config.matrix) {
+            matrix_print();
+        }
+
+        const bool process_keypress = should_process_keypress();
+
+        for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+            const matrix_row_t current_row = matrix_get_row(row);
+            const matrix_row_t row_changes = current_row ^ matrix_previous[row];
+
+            if (!row_changes || has_ghost_in_row(row, current_row)) {
+                continue;
             }
+
+            matrix_row_t col_mask = 1;
+            for (uint8_t col = 0; col < MATRIX_COLS; col++, col_mask <<= 1) {
+                if (row_changes & col_mask) {
+                    const bool key_pressed = current_row & col_mask;
+
+                    if (process_keypress) {
+                        action_exec(MAKE_KEYEVENT(row, col, key_pressed));
+                    }
+
+                    switch_events(row, col, key_pressed);
+                }
+            }
+
+            matrix_previous[row] = current_row;
         }
 
-        matrix_previous[row] = current_row;
-    }
-
-    return matrix_changed;
+        return matrix_changed;
+    } else
+        return false;
 }
 
 /** \brief Tasks previously located in matrix_scan_quantum

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -111,7 +111,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 static uint32_t last_input_modification_time = 0;
 uint32_t        last_input_activity_time(void) {
-           return last_input_modification_time;
+    return last_input_modification_time;
 }
 uint32_t last_input_activity_elapsed(void) {
     return timer_elapsed32(last_input_modification_time);

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -462,55 +462,55 @@ static bool matrix_task(void) {
     if (!matrix_available()) {
         generate_tick_event();
         return matrix_changed;
-    } else {
-        static matrix_row_t matrix_previous[MATRIX_ROWS];
+    }
 
-        matrix_scan();
+    static matrix_row_t matrix_previous[MATRIX_ROWS];
 
-        for (uint8_t row = 0; row < MATRIX_ROWS && !matrix_changed; row++) {
-            matrix_changed |= matrix_previous[row] ^ matrix_get_row(row);
-        }
+    matrix_scan();
 
-        matrix_scan_perf_task();
+    for (uint8_t row = 0; row < MATRIX_ROWS && !matrix_changed; row++) {
+        matrix_changed |= matrix_previous[row] ^ matrix_get_row(row);
+    }
 
-        // Short-circuit the complete matrix processing if it is not necessary
-        if (!matrix_changed) {
-            generate_tick_event();
-            return matrix_changed;
-        }
+    matrix_scan_perf_task();
 
-        if (debug_config.matrix) {
-            matrix_print();
-        }
-
-        const bool process_keypress = should_process_keypress();
-
-        for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-            const matrix_row_t current_row = matrix_get_row(row);
-            const matrix_row_t row_changes = current_row ^ matrix_previous[row];
-
-            if (!row_changes || has_ghost_in_row(row, current_row)) {
-                continue;
-            }
-
-            matrix_row_t col_mask = 1;
-            for (uint8_t col = 0; col < MATRIX_COLS; col++, col_mask <<= 1) {
-                if (row_changes & col_mask) {
-                    const bool key_pressed = current_row & col_mask;
-
-                    if (process_keypress) {
-                        action_exec(MAKE_KEYEVENT(row, col, key_pressed));
-                    }
-
-                    switch_events(row, col, key_pressed);
-                }
-            }
-
-            matrix_previous[row] = current_row;
-        }
-
+    // Short-circuit the complete matrix processing if it is not necessary
+    if (!matrix_changed) {
+        generate_tick_event();
         return matrix_changed;
     }
+
+    if (debug_config.matrix) {
+        matrix_print();
+    }
+
+    const bool process_keypress = should_process_keypress();
+
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        const matrix_row_t current_row = matrix_get_row(row);
+        const matrix_row_t row_changes = current_row ^ matrix_previous[row];
+
+        if (!row_changes || has_ghost_in_row(row, current_row)) {
+            continue;
+        }
+
+        matrix_row_t col_mask = 1;
+        for (uint8_t col = 0; col < MATRIX_COLS; col++, col_mask <<= 1) {
+            if (row_changes & col_mask) {
+                const bool key_pressed = current_row & col_mask;
+
+                if (process_keypress) {
+                    action_exec(MAKE_KEYEVENT(row, col, key_pressed));
+                }
+
+                switch_events(row, col, key_pressed);
+            }
+        }
+
+        matrix_previous[row] = current_row;
+    }
+
+    return matrix_changed;
 }
 
 /** \brief Tasks previously located in matrix_scan_quantum

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -130,7 +130,7 @@ void last_matrix_activity_trigger(void) {
 
 static uint32_t last_encoder_modification_time = 0;
 uint32_t        last_encoder_activity_time(void) {
-           return last_encoder_modification_time;
+    return last_encoder_modification_time;
 }
 uint32_t last_encoder_activity_elapsed(void) {
     return timer_elapsed32(last_encoder_modification_time);

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -252,12 +252,12 @@ __attribute__((weak)) void keyboard_post_init_kb(void) {
     keyboard_post_init_user();
 }
 
-/** \brief is_matrix_locked
+/** \brief matrix_available
  *
- * FIXME: needs doc
+ * Override this function if you have a condition where matrix tasks should not be available
  */
-__attribute__((weak)) bool is_matrix_locked(void) {
-    return false;
+__attribute__((weak)) bool matrix_available(void) {
+    return true;
 }
 
 /** \brief keyboard_setup
@@ -459,7 +459,7 @@ static inline void generate_tick_event(void) {
 static bool matrix_task(void) {
     bool matrix_changed = false;
 
-    if (is_matrix_locked()) {
+    if (!matrix_available()) {
         generate_tick_event();
         return matrix_changed;
     } else {

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -111,7 +111,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 static uint32_t last_input_modification_time = 0;
 uint32_t        last_input_activity_time(void) {
-    return last_input_modification_time;
+           return last_input_modification_time;
 }
 uint32_t last_input_activity_elapsed(void) {
     return timer_elapsed32(last_input_modification_time);
@@ -119,7 +119,7 @@ uint32_t last_input_activity_elapsed(void) {
 
 static uint32_t last_matrix_modification_time = 0;
 uint32_t        last_matrix_activity_time(void) {
-    return last_matrix_modification_time;
+           return last_matrix_modification_time;
 }
 uint32_t last_matrix_activity_elapsed(void) {
     return timer_elapsed32(last_matrix_modification_time);
@@ -130,7 +130,7 @@ void last_matrix_activity_trigger(void) {
 
 static uint32_t last_encoder_modification_time = 0;
 uint32_t        last_encoder_activity_time(void) {
-    return last_encoder_modification_time;
+           return last_encoder_modification_time;
 }
 uint32_t last_encoder_activity_elapsed(void) {
     return timer_elapsed32(last_encoder_modification_time);
@@ -457,12 +457,16 @@ static inline void generate_tick_event(void) {
  * @return false Matrix didn't change
  */
 static bool matrix_task(void) {
-    if (!is_matrix_locked()) {
+    bool matrix_changed = false;
+
+    if (is_matrix_locked()) {
+        generate_tick_event();
+        return matrix_changed;
+    } else {
         static matrix_row_t matrix_previous[MATRIX_ROWS];
 
         matrix_scan();
 
-        bool matrix_changed = false;
         for (uint8_t row = 0; row < MATRIX_ROWS && !matrix_changed; row++) {
             matrix_changed |= matrix_previous[row] ^ matrix_get_row(row);
         }
@@ -506,8 +510,7 @@ static bool matrix_task(void) {
         }
 
         return matrix_changed;
-    } else
-        return false;
+    }
 }
 
 /** \brief Tasks previously located in matrix_scan_quantum

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -119,7 +119,7 @@ uint32_t last_input_activity_elapsed(void) {
 
 static uint32_t last_matrix_modification_time = 0;
 uint32_t        last_matrix_activity_time(void) {
-           return last_matrix_modification_time;
+    return last_matrix_modification_time;
 }
 uint32_t last_matrix_activity_elapsed(void) {
     return timer_elapsed32(last_matrix_modification_time);

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -457,17 +457,15 @@ static inline void generate_tick_event(void) {
  * @return false Matrix didn't change
  */
 static bool matrix_task(void) {
-    bool matrix_changed = false;
-
     if (!matrix_available()) {
         generate_tick_event();
-        return matrix_changed;
+        return false;
     }
 
     static matrix_row_t matrix_previous[MATRIX_ROWS];
 
     matrix_scan();
-
+    bool matrix_changed = false;
     for (uint8_t row = 0; row < MATRIX_ROWS && !matrix_changed; row++) {
         matrix_changed |= matrix_previous[row] ^ matrix_get_row(row);
     }

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -252,11 +252,11 @@ __attribute__((weak)) void keyboard_post_init_kb(void) {
     keyboard_post_init_user();
 }
 
-/** \brief matrix_available
+/** \brief matrix_can_read
  *
- * Override this function if you have a condition where matrix tasks should not be available
+ * Allows overriding when matrix scanning operations should be executed.
  */
-__attribute__((weak)) bool matrix_available(void) {
+__attribute__((weak)) bool matrix_can_read(void) {
     return true;
 }
 
@@ -457,7 +457,7 @@ static inline void generate_tick_event(void) {
  * @return false Matrix didn't change
  */
 static bool matrix_task(void) {
-    if (!matrix_available()) {
+    if (!matrix_can_read()) {
         generate_tick_event();
         return false;
     }

--- a/quantum/matrix.h
+++ b/quantum/matrix.h
@@ -46,6 +46,8 @@ void matrix_setup(void);
 void matrix_init(void);
 /* scan all key states on matrix */
 uint8_t matrix_scan(void);
+/* whether matrix tasks are available */
+bool matrix_available(void);
 /* whether a switch is on */
 bool matrix_is_on(uint8_t row, uint8_t col);
 /* matrix state on row */

--- a/quantum/matrix.h
+++ b/quantum/matrix.h
@@ -46,8 +46,8 @@ void matrix_setup(void);
 void matrix_init(void);
 /* scan all key states on matrix */
 uint8_t matrix_scan(void);
-/* whether matrix tasks are available */
-bool matrix_available(void);
+/* whether matrix scanning operations should be executed */
+bool matrix_can_read(void);
 /* whether a switch is on */
 bool matrix_is_on(uint8_t row, uint8_t col);
 /* matrix state on row */


### PR DESCRIPTION
introducing flexibility on matrix tasks timing. matrix state can now be locked when we don't need a matrix scan

Followup on #18732 , specifically [this comment](https://github.com/qmk/qmk_firmware/pull/18732#pullrequestreview-1143212426). This takes care of matrix tasks running when they should not and also rectifies the matrix report rates on sn32. Might also be useful in the future for implementing timer controlled scans in other boards.
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
