### PR TITLE
core: introduce new shared matrix alternative

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -626,7 +626,7 @@ endif
 COMMON_VPATH += $(QUANTUM_DIR)/bootmagic
 QUANTUM_SRC += $(QUANTUM_DIR)/bootmagic/magic.c
 
-VALID_CUSTOM_MATRIX_TYPES:= yes lite no
+VALID_CUSTOM_MATRIX_TYPES:= yes lite shared no
 
 CUSTOM_MATRIX ?= no
 
@@ -642,6 +642,11 @@ ifneq ($(strip $(CUSTOM_MATRIX)), yes)
     ifneq ($(strip $(CUSTOM_MATRIX)), lite)
         # Include the standard or split matrix code if needed
         QUANTUM_SRC += $(QUANTUM_DIR)/matrix.c
+    endif
+    # if 'shared' then skip only the matrix scan implementation
+    ifeq ($(strip $(CUSTOM_MATRIX)), shared)
+        # Exclude only the standard or split matrix code scan
+        OPT_DEFS += -DMATRIX_NO_SCAN
     endif
 endif
 

--- a/docs/custom_matrix.md
+++ b/docs/custom_matrix.md
@@ -49,6 +49,27 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
 }
 ```
 
+## 'shared'
+
+Almost complete default implementation for all scanning functions, removing only the scan routine. This allows flexibility in keyboards with shared matrix wiring, where the scan timing is essential.
+To configure it, add this to your `rules.mk`:
+
+```make
+CUSTOM_MATRIX = shared
+```
+
+And implement the following functions in a `matrix.c` file in your keyboard folder:
+
+```c
+bool matrix_scan_custom(matrix_row_t current_matrix[]) {
+    bool matrix_has_changed = false;
+
+    // TODO: add matrix scanning routine here
+
+    return matrix_has_changed;
+}
+```
+
 
 ## Full Replacement
 

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -322,28 +322,28 @@ __attribute__((weak)) bool transport_master_if_connected(matrix_row_t master_mat
 uint8_t matrix_scan(void) {
     matrix_row_t curr_matrix[MATRIX_ROWS] = {0};
 
-#if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
+#    if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
     // Set row, read cols
     for (uint8_t current_row = 0; current_row < ROWS_PER_HAND; current_row++) {
         matrix_read_cols_on_row(curr_matrix, current_row);
     }
-#elif (DIODE_DIRECTION == ROW2COL)
+#    elif (DIODE_DIRECTION == ROW2COL)
     // Set col, read rows
     matrix_row_t row_shifter = MATRIX_ROW_SHIFTER;
     for (uint8_t current_col = 0; current_col < MATRIX_COLS; current_col++, row_shifter <<= 1) {
         matrix_read_rows_on_col(curr_matrix, current_col, row_shifter);
     }
-#endif
+#    endif
 
     bool changed = memcmp(raw_matrix, curr_matrix, sizeof(curr_matrix)) != 0;
     if (changed) memcpy(raw_matrix, curr_matrix, sizeof(curr_matrix));
 
-#ifdef SPLIT_KEYBOARD
+#    ifdef SPLIT_KEYBOARD
     changed = debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, changed) | matrix_post_scan();
-#else
+#    else
     changed = debounce(raw_matrix, matrix, ROWS_PER_HAND, changed);
     matrix_scan_quantum();
-#endif
+#    endif
     return (uint8_t)changed;
 }
 #endif

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -317,6 +317,8 @@ __attribute__((weak)) bool transport_master_if_connected(matrix_row_t master_mat
 }
 #endif
 
+#ifndef MATRIX_NO_SCAN
+// Some implementations require custom code to time the matrix scan in a very short window. Let them scan it with a custom function
 uint8_t matrix_scan(void) {
     matrix_row_t curr_matrix[MATRIX_ROWS] = {0};
 
@@ -344,3 +346,4 @@ uint8_t matrix_scan(void) {
 #endif
     return (uint8_t)changed;
 }
+#endif

--- a/quantum/matrix.h
+++ b/quantum/matrix.h
@@ -44,6 +44,10 @@ uint8_t matrix_cols(void);
 void matrix_setup(void);
 /* intialize matrix for scaning. */
 void matrix_init(void);
+/* read matrix rows on col */
+void matrix_read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col, matrix_row_t row_shifter);
+/* read matrix cols on row */
+void matrix_read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row);
 /* scan all key states on matrix */
 uint8_t matrix_scan(void);
 /* whether a switch is on */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This custom matrix alternative allows for precise timing control on the matrix scan, as needed with shared matrix keyboards.
The user has to bring his own matrix_scan function, but not rewrite the whole matrix code.

Core qmk code changes have been kept to bare minimum, only exposing some functions of the qmk matrix. It is also introducing a new matrix type: 'shared'. All matrix functions are stock, but the scan function has been disabled. See doc changes for more info

to enable key matrix scanning using the shared driver add in rules.mk:
```
CUSTOM_MATRIX = shared
```


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
