### PR TITLE
core: make default matrix follow the lite API

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -642,6 +642,9 @@ ifneq ($(strip $(CUSTOM_MATRIX)), yes)
     ifneq ($(strip $(CUSTOM_MATRIX)), lite)
         # Include the standard or split matrix code if needed
         QUANTUM_SRC += $(QUANTUM_DIR)/matrix.c
+    else
+        # Filter out definitions not needed for lite matrix code
+        OPT_DEFS += -DMATRIX_LITE
     endif
 endif
 

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -317,9 +317,8 @@ __attribute__((weak)) bool transport_master_if_connected(matrix_row_t master_mat
 }
 #endif
 
-uint8_t matrix_scan(void) {
+bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     matrix_row_t curr_matrix[MATRIX_ROWS] = {0};
-
 #if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
     // Set row, read cols
     for (uint8_t current_row = 0; current_row < ROWS_PER_HAND; current_row++) {
@@ -332,15 +331,8 @@ uint8_t matrix_scan(void) {
         matrix_read_rows_on_col(curr_matrix, current_col, row_shifter);
     }
 #endif
-
     bool changed = memcmp(raw_matrix, curr_matrix, sizeof(curr_matrix)) != 0;
     if (changed) memcpy(raw_matrix, curr_matrix, sizeof(curr_matrix));
 
-#ifdef SPLIT_KEYBOARD
-    changed = debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, changed) | matrix_post_scan();
-#else
-    changed = debounce(raw_matrix, matrix, ROWS_PER_HAND, changed);
-    matrix_scan_quantum();
-#endif
-    return (uint8_t)changed;
+    return changed;
 }

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -267,7 +267,7 @@ __attribute__((weak)) void matrix_read_rows_on_col(matrix_row_t current_matrix[]
 #    error DIODE_DIRECTION is not defined!
 #endif
 
-void matrix_init_custom(void) {
+__attribute__((weak)) void matrix_init_custom(void) {
 #ifdef SPLIT_KEYBOARD
     // Set pinout for right half if pinout for that half is defined
     if (!isLeftHand) {

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -306,7 +306,7 @@ __attribute__((weak)) bool transport_master_if_connected(matrix_row_t master_mat
 }
 #endif
 
-bool matrix_scan_custom(matrix_row_t current_matrix[]) {
+__attribute__((weak)) bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     matrix_row_t curr_matrix[MATRIX_ROWS] = {0};
 #if defined(DIRECT_PINS) || (DIODE_DIRECTION == COL2ROW)
     // Set row, read cols

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -267,7 +267,7 @@ __attribute__((weak)) void matrix_read_rows_on_col(matrix_row_t current_matrix[]
 #    error DIODE_DIRECTION is not defined!
 #endif
 
-void matrix_init(void) {
+void matrix_init_custom(void) {
 #ifdef SPLIT_KEYBOARD
     // Set pinout for right half if pinout for that half is defined
     if (!isLeftHand) {
@@ -292,21 +292,10 @@ void matrix_init(void) {
         }
 #    endif
     }
-
-    thisHand = isLeftHand ? 0 : (ROWS_PER_HAND);
-    thatHand = ROWS_PER_HAND - thisHand;
 #endif
 
     // initialize key pins
     matrix_init_pins();
-
-    // initialize matrix state: all keys off
-    memset(matrix, 0, sizeof(matrix));
-    memset(raw_matrix, 0, sizeof(raw_matrix));
-
-    debounce_init(ROWS_PER_HAND);
-
-    matrix_init_quantum();
 }
 
 #ifdef SPLIT_KEYBOARD

--- a/quantum/matrix.h
+++ b/quantum/matrix.h
@@ -44,10 +44,12 @@ uint8_t matrix_cols(void);
 void matrix_setup(void);
 /* intialize matrix for scaning. */
 void matrix_init(void);
+#if !defined(MATRIX_LITE)
 /* read matrix rows on col */
 void matrix_read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col, matrix_row_t row_shifter);
 /* read matrix cols on row */
 void matrix_read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row);
+#endif
 /* scan all key states on matrix */
 uint8_t matrix_scan(void);
 /* whether a switch is on */

--- a/quantum/matrix.h
+++ b/quantum/matrix.h
@@ -44,6 +44,10 @@ uint8_t matrix_cols(void);
 void matrix_setup(void);
 /* intialize matrix for scaning. */
 void matrix_init(void);
+/* read matrix rows on col */
+void matrix_read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col, matrix_row_t row_shifter);
+/* read matrix cols on row */
+void matrix_read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row);
 /* scan all key states on matrix */
 uint8_t matrix_scan(void);
 /* whether a switch is on */

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -175,7 +175,7 @@ __attribute__((weak)) uint8_t matrix_scan(void) {
     matrix_scan_quantum();
 #endif
 
-    return changed;
+    return (uint8_t)changed;
 }
 
 __attribute__((weak)) bool peek_matrix(uint8_t row_index, uint8_t col_index, bool raw) {

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -133,9 +133,6 @@ __attribute__((weak)) void matrix_output_unselect_delay(uint8_t line, bool key_p
     matrix_io_delay();
 }
 
-// CUSTOM MATRIX 'LITE'
-__attribute__((weak)) void matrix_init_custom(void) {}
-
 #ifdef SPLIT_KEYBOARD
 __attribute__((weak)) void matrix_slave_scan_kb(void) {
     matrix_slave_scan_user();

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -133,8 +133,8 @@ __attribute__((weak)) void matrix_output_unselect_delay(uint8_t line, bool key_p
     matrix_io_delay();
 }
 
-__attribute__((weak)) void matrix_init_custom(void);
-__attribute__((weak)) bool matrix_scan_custom(matrix_row_t current_matrix[]);
+void matrix_init_custom(void);
+bool matrix_scan_custom(matrix_row_t current_matrix[]);
 
 #ifdef SPLIT_KEYBOARD
 __attribute__((weak)) void matrix_slave_scan_kb(void) {

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -135,9 +135,6 @@ __attribute__((weak)) void matrix_output_unselect_delay(uint8_t line, bool key_p
 
 // CUSTOM MATRIX 'LITE'
 __attribute__((weak)) void matrix_init_custom(void) {}
-__attribute__((weak)) bool matrix_scan_custom(matrix_row_t current_matrix[]) {
-    return true;
-}
 
 #ifdef SPLIT_KEYBOARD
 __attribute__((weak)) void matrix_slave_scan_kb(void) {

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -133,6 +133,9 @@ __attribute__((weak)) void matrix_output_unselect_delay(uint8_t line, bool key_p
     matrix_io_delay();
 }
 
+__attribute__((weak)) void matrix_init_custom(void);
+__attribute__((weak)) bool matrix_scan_custom(matrix_row_t current_matrix[]);
+
 #ifdef SPLIT_KEYBOARD
 __attribute__((weak)) void matrix_slave_scan_kb(void) {
     matrix_slave_scan_user();


### PR DESCRIPTION
stock matrix_scan function is a glorified custom function by default. Time to actually be one
Make init and scan functions to follow the `lite` API. Allow their overriding by user-side code
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
