### PR TITLE
[Keyboard] Minor Aurora Sweep fixes

### DIFF
--- a/keyboards/splitkb/aurora/sweep/keymaps/debug/rules.mk
+++ b/keyboards/splitkb/aurora/sweep/keymaps/debug/rules.mk
@@ -13,6 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-ENCODER_ENABLE = yes
-OLED_ENABLE = yes
+# NOTE: These are already enabled by default at the revision level
+#ENCODER_ENABLE = yes
+#OLED_ENABLE = yes
+
+# RGB Matrix is enabled at the revision level,
+# while we use the regular RGB underglow for testing
+RGB_MATRIX_ENABLE = no
 RGBLIGHT_ENABLE = yes

--- a/keyboards/splitkb/aurora/sweep/keymaps/default/keymap.json
+++ b/keyboards/splitkb/aurora/sweep/keymaps/default/keymap.json
@@ -54,6 +54,9 @@
         ]
     ],
     "config": {
+        // Support for OLED, RGB, and encoders is already enabled
+        // by default on the revision level, but we repeat it here
+        // to make clear that you can disable them to save space.
         "features": {
             "oled": true,
             "rgb_matrix": true,

--- a/keyboards/splitkb/aurora/sweep/keymaps/default/readme.md
+++ b/keyboards/splitkb/aurora/sweep/keymaps/default/readme.md
@@ -100,26 +100,28 @@ Where is the keymap.c?
 
 The keymap.c file is not published to the repository. It is generated from `keymap.json` by the build system.
 
-This avoids duplicating information and allow users to edit their keymap from the qmk configurator web interface.
+This avoids duplicating information and allow users to edit their keymap from the QMK Configurator web interface.
 
 How do I edit and update the keymap?
 ------------------------------------
 
-The `keymap.json` file is generated from the qmk configurator interface and formatted for better readability in the context of the Ferris keyboard.
+The `keymap.json` file is generated from the QMK Configurator interface and formatted for better readability in the context of the Ferris keyboard.
 
 To edit it, you may:
 * Edit it directly from a text editor.
-* Edit it from the qmk configurator.
+* Edit it from the QMK Configurator.
 
 If you decide to use the latter workflow, here are the steps to follow:
 
-* From the qmk configurator, hit the "import QMK keymap json file" button (it has a drawing with an up arrow on it).
+* From the [QMK Configurator](https://config.qmk.fm/#/splitkb/aurora/sweep/rev1/LAYOUT_split_3x5_2), hit the "import QMK keymap json file" button (it has a drawing with an up arrow on it).
 * Browse to the location of your keymap (for example, `<your qmk repo>/keyboards/splitkb/aurora/sweep/keymaps/default/keymap.json`)
 * Perform any modification to the keymap in the web UI
 * Export the keymap to your downloads folder, by hitting the "Export QMK keymap json file" button (it has a drawing with a down arrow on it)
 * Replace your original keymap with the one you just downloaded
 
-I want to do more than the configurator supports!
+_**Note:** At the time of writing (the 24th of October 2022), not every feature used in the default keymap is supported by the QMK Configurator. You cannot yet upload the default `keymap.json` due to a file format mismatch - use the "Load Default" button to load the default keymap instead. Additionally, custom configuration options are still being worked on: if your keymap depends on them, please compile your firmware offline for now._
+
+I want to do more than the JSON format supports!
 -------------------------------------------------
 
 While the `json` format is easy to use, it does lack certain functionality - most notably custom OLED or encoder behaviour.

--- a/keyboards/splitkb/aurora/sweep/rev1/info.json
+++ b/keyboards/splitkb/aurora/sweep/rev1/info.json
@@ -6,7 +6,9 @@
     "features": {
         "mousekey": true,
         "bootmagic": true,
-        "extrakey": true
+        "extrakey": true,
+        "oled": true,
+        "rgb_matrix": true
     },
     "layout_aliases": {
         "LAYOUT": "LAYOUT_split_3x5_2"
@@ -60,6 +62,7 @@
         "cols": ["B6", "D4", "C6", "D7", "E6"]
     },
     "encoder": {
+        "enabled": true,
         "rotary": [
             {
                 "pin_a": "B5",

--- a/keyboards/splitkb/aurora/sweep/rev1/rev1.c
+++ b/keyboards/splitkb/aurora/sweep/rev1/rev1.c
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include QMK_KEYBOARD_H
+
 #ifdef SWAP_HANDS_ENABLE
 // clang-format off
     __attribute__ ((weak)) const keypos_t PROGMEM hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {


### PR DESCRIPTION
## Description

- Fixes compile error with `SWAP_HANDS_ENABLE = yes` due to missing header import
- Enables OLED, RGB Matrix, and encoder when using QMK Configurator

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
