### PR TITLE
Fix oled_render for ssd1306/sh1106 driver

### DIFF
--- a/drivers/oled/ssd1306_sh1106.c
+++ b/drivers/oled/ssd1306_sh1106.c
@@ -291,65 +291,63 @@ static void rotate_90(const uint8_t *src, uint8_t *dest) {
 }
 
 void oled_render(void) {
-    if (!oled_initialized) {
-        return;
-    }
-
     // Do we have work to do?
     oled_dirty &= OLED_ALL_BLOCKS_MASK;
-    if (!oled_dirty || oled_scrolling) {
+    if (!oled_dirty || !oled_initialized || oled_scrolling) {
         return;
-    }
-
-    // Find first dirty block
-    uint8_t update_start = 0;
-    while (!(oled_dirty & ((OLED_BLOCK_TYPE)1 << update_start))) {
-        ++update_start;
-    }
-
-    // Set column & page position
-    static uint8_t display_start[] = {I2C_CMD, COLUMN_ADDR, 0, OLED_DISPLAY_WIDTH - 1, PAGE_ADDR, 0, OLED_DISPLAY_HEIGHT / 8 - 1};
-    if (!HAS_FLAGS(oled_rotation, OLED_ROTATION_90)) {
-        calc_bounds(update_start, &display_start[1]); // Offset from I2C_CMD byte at the start
-    } else {
-        calc_bounds_90(update_start, &display_start[1]); // Offset from I2C_CMD byte at the start
-    }
-
-    // Send column & page position
-    if (I2C_TRANSMIT(display_start) != I2C_STATUS_SUCCESS) {
-        print("oled_render offset command failed\n");
-        return;
-    }
-
-    if (!HAS_FLAGS(oled_rotation, OLED_ROTATION_90)) {
-        // Send render data chunk as is
-        if (I2C_WRITE_REG(I2C_DATA, &oled_buffer[OLED_BLOCK_SIZE * update_start], OLED_BLOCK_SIZE) != I2C_STATUS_SUCCESS) {
-            print("oled_render data failed\n");
-            return;
-        }
-    } else {
-        // Rotate the render chunks
-        const static uint8_t source_map[] = OLED_SOURCE_MAP;
-        const static uint8_t target_map[] = OLED_TARGET_MAP;
-
-        static uint8_t temp_buffer[OLED_BLOCK_SIZE];
-        memset(temp_buffer, 0, sizeof(temp_buffer));
-        for (uint8_t i = 0; i < sizeof(source_map); ++i) {
-            rotate_90(&oled_buffer[OLED_BLOCK_SIZE * update_start + source_map[i]], &temp_buffer[target_map[i]]);
-        }
-
-        // Send render data chunk after rotating
-        if (I2C_WRITE_REG(I2C_DATA, &temp_buffer[0], OLED_BLOCK_SIZE) != I2C_STATUS_SUCCESS) {
-            print("oled_render90 data failed\n");
-            return;
-        }
     }
 
     // Turn on display if it is off
     oled_on();
 
-    // Clear dirty flag
-    oled_dirty &= ~((OLED_BLOCK_TYPE)1 << update_start);
+    uint8_t update_start = 0;
+    while (oled_dirty) { // render all dirty blocks
+        // Find next dirty block
+        while (!(oled_dirty & ((OLED_BLOCK_TYPE)1 << update_start))) {
+            ++update_start;
+        }
+
+        // Set column & page position
+        static uint8_t display_start[] = {I2C_CMD, COLUMN_ADDR, 0, OLED_DISPLAY_WIDTH - 1, PAGE_ADDR, 0, OLED_DISPLAY_HEIGHT / 8 - 1};
+        if (!HAS_FLAGS(oled_rotation, OLED_ROTATION_90)) {
+            calc_bounds(update_start, &display_start[1]); // Offset from I2C_CMD byte at the start
+        } else {
+            calc_bounds_90(update_start, &display_start[1]); // Offset from I2C_CMD byte at the start
+        }
+
+        // Send column & page position
+        if (I2C_TRANSMIT(display_start) != I2C_STATUS_SUCCESS) {
+            print("oled_render offset command failed\n");
+            return;
+        }
+
+        if (!HAS_FLAGS(oled_rotation, OLED_ROTATION_90)) {
+            // Send render data chunk as is
+            if (I2C_WRITE_REG(I2C_DATA, &oled_buffer[OLED_BLOCK_SIZE * update_start], OLED_BLOCK_SIZE) != I2C_STATUS_SUCCESS) {
+                print("oled_render data failed\n");
+                return;
+            }
+        } else {
+            // Rotate the render chunks
+            const static uint8_t source_map[] = OLED_SOURCE_MAP;
+            const static uint8_t target_map[] = OLED_TARGET_MAP;
+
+            static uint8_t temp_buffer[OLED_BLOCK_SIZE];
+            memset(temp_buffer, 0, sizeof(temp_buffer));
+            for (uint8_t i = 0; i < sizeof(source_map); ++i) {
+                rotate_90(&oled_buffer[OLED_BLOCK_SIZE * update_start + source_map[i]], &temp_buffer[target_map[i]]);
+            }
+
+            // Send render data chunk after rotating
+            if (I2C_WRITE_REG(I2C_DATA, &temp_buffer[0], OLED_BLOCK_SIZE) != I2C_STATUS_SUCCESS) {
+                print("oled_render90 data failed\n");
+                return;
+            }
+        }
+
+        // Clear dirty flag of just rendered block
+        oled_dirty &= ~((OLED_BLOCK_TYPE)1 << update_start);
+    }
 }
 
 void oled_set_cursor(uint8_t col, uint8_t line) {


### PR DESCRIPTION
`oled_render` only rendered the first dirty block. Changed to loop over all dirty blocks.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`oled_render` is meant to render all dirty changes to the device, but it only renders the first dirty block it finds. In practice this does not usually cause much of a problem because it is called repeatedly from `oled_task`, and eventually all dirty blocks get rendered.

However, if you intend to update the oled very fast, like in an animation, the first blocks get dirty before the `oled_task` loop can catch up w/ rendering the later blocks. This causes the later blocks to not get rendered.

This change fixes that problem by rendering all dirty blocks in `oled_render` which is what I believe users of that function would expect it to do. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* none

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
