### PR TITLE
Simplify Keymap Config EEPROM

### DIFF
--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -45,10 +45,8 @@ void eeconfig_init_quantum(void) {
     eeprom_update_byte(EECONFIG_DEBUG, 0);
     eeprom_update_byte(EECONFIG_DEFAULT_LAYER, 0);
     default_layer_state = 0;
-    eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, 0);
-    // Enable oneshot and autocorrect by default: 0b0001 0100
-    eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, 0x14);
-    eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
+    // Enable oneshot and autocorrect by default: 0b0001 0100 0000 0000
+    eeprom_update_word(EECONFIG_KEYMAP, 0x1400);
     eeprom_update_byte(EECONFIG_BACKLIGHT, 0);
     eeprom_update_byte(EECONFIG_AUDIO, 0xFF); // On by default
     eeprom_update_dword(EECONFIG_RGBLIGHT, 0);
@@ -167,15 +165,14 @@ void eeconfig_update_default_layer(uint8_t val) {
  * FIXME: needs doc
  */
 uint16_t eeconfig_read_keymap(void) {
-    return (eeprom_read_byte(EECONFIG_KEYMAP_LOWER_BYTE) | (eeprom_read_byte(EECONFIG_KEYMAP_UPPER_BYTE) << 8));
+    return eeprom_read_word(EECONFIG_KEYMAP);
 }
 /** \brief eeconfig update keymap
  *
  * FIXME: needs doc
  */
 void eeconfig_update_keymap(uint16_t val) {
-    eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, val & 0xFF);
-    eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, (val >> 8) & 0xFF);
+    eeprom_update_word(EECONFIG_KEYMAP, val);
 }
 
 /** \brief eeconfig read audio

--- a/quantum/eeconfig.h
+++ b/quantum/eeconfig.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 
 #ifndef EECONFIG_MAGIC_NUMBER
-#    define EECONFIG_MAGIC_NUMBER (uint16_t)0xFEE8 // When changing, decrement this value to avoid future re-init issues
+#    define EECONFIG_MAGIC_NUMBER (uint16_t)0xFEE7 // When changing, decrement this value to avoid future re-init issues
 #endif
 #define EECONFIG_MAGIC_NUMBER_OFF (uint16_t)0xFFFF
 

--- a/quantum/eeconfig.h
+++ b/quantum/eeconfig.h
@@ -29,8 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_MAGIC (uint16_t *)0
 #define EECONFIG_DEBUG (uint8_t *)2
 #define EECONFIG_DEFAULT_LAYER (uint8_t *)3
-#define EECONFIG_KEYMAP (uint8_t *)4
-#define EECONFIG_MOUSEKEY_ACCEL (uint8_t *)5
+#define EECONFIG_KEYMAP (uint16_t *)4
 #define EECONFIG_BACKLIGHT (uint8_t *)6
 #define EECONFIG_AUDIO (uint8_t *)7
 #define EECONFIG_RGBLIGHT (uint32_t *)8
@@ -51,9 +50,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_LED_MATRIX_EXTENDED (uint16_t *)32
 #define EECONFIG_RGB_MATRIX_EXTENDED (uint16_t *)32
 
-// TODO: Combine these into a single word and single block of EEPROM
-#define EECONFIG_KEYMAP_UPPER_BYTE (uint8_t *)34
 // Size of EEPROM being used, other code can refer to this for available EEPROM
+// TODO: Reduce?
 #define EECONFIG_SIZE 35
 /* debug bit */
 #define EECONFIG_DEBUG_ENABLE (1 << 0)
@@ -70,8 +68,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_KEYMAP_SWAP_GRAVE_ESC (1 << 5)
 #define EECONFIG_KEYMAP_SWAP_BACKSLASH_BACKSPACE (1 << 6)
 #define EECONFIG_KEYMAP_NKRO (1 << 7)
-
-#define EECONFIG_KEYMAP_LOWER_BYTE EECONFIG_KEYMAP
 
 bool eeconfig_is_enabled(void);
 bool eeconfig_is_disabled(void);

--- a/quantum/eeconfig.h
+++ b/quantum/eeconfig.h
@@ -51,8 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_RGB_MATRIX_EXTENDED (uint16_t *)32
 
 // Size of EEPROM being used, other code can refer to this for available EEPROM
-// TODO: Reduce?
-#define EECONFIG_SIZE 35
+#define EECONFIG_SIZE 34
 /* debug bit */
 #define EECONFIG_DEBUG_ENABLE (1 << 0)
 #define EECONFIG_DEBUG_MATRIX (1 << 1)


### PR DESCRIPTION
## Description

`EECONFIG_MOUSEKEY_ACCEL` is not actually used anywhere in the repo, so since it's adjacent to `EECONFIG_KEYMAP`, remove it and appropriate it's block for the upper byte of keymap config, so it can use a full, contiguous block.

Also, shift default value to be still correct. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
