### PR TITLE
[XAP] prevent OOB reads in config blob handler

### DIFF
--- a/quantum/xap/xap.c
+++ b/quantum/xap/xap.c
@@ -21,8 +21,12 @@
 #include "lighting_map.h"
 #include "config_blob_gz.h"
 bool get_config_blob_chunk(uint16_t offset, uint8_t *data, uint8_t data_len) {
-    if (offset + data_len > CONFIG_BLOB_GZ_LEN) {
-        data_len = CONFIG_BLOB_GZ_LEN - offset;
+    if (offset >= CONFIG_BLOB_GZ_LEN) {
+        return false;
+    }
+
+    if (offset + data_len >= CONFIG_BLOB_GZ_LEN) {
+        data_len = (CONFIG_BLOB_GZ_LEN - 1) - offset;
     }
 
     memcpy_P(data, &config_blob_gz[offset], data_len);

--- a/quantum/xap/xap_handlers.c
+++ b/quantum/xap/xap_handlers.c
@@ -71,7 +71,9 @@ bool xap_respond_get_config_blob_chunk(xap_token_t token, const void *data, size
     xap_route_qmk_config_blob_chunk_t ret = {0};
 
     bool get_config_blob_chunk(uint16_t offset, uint8_t * data, uint8_t data_len);
-    get_config_blob_chunk(offset, (uint8_t *)&ret, sizeof(ret));
+    if (!get_config_blob_chunk(offset, (uint8_t *)&ret, sizeof(ret))) {
+        return false;
+    }
 
     return xap_respond_data(token, &ret, sizeof(ret));
 }


### PR DESCRIPTION
## Description

This fixes two bugs:

1. An invalid `offset` could be specified which wasn't checked to be in the bounds of the config blob.
2. The `data_len` check was incorrect as it would allow reading one byte past the config blob lenght.

Before the changes the following operation wouldn't fail:

Assuming we have blob of 64 bytes size and attempt a read with an `offset` of 32 and `data_len` of 32, we actually try to read 32 bytes starting from the 33. byte in the config blob. This reads exactly one byte past array (33 + 32 > 64). Therefore we have to subtract one byte the get the correct length.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
