### PR TITLE
[Bug] Fix compilation issue with WPM

### DIFF
--- a/quantum/wpm.c
+++ b/quantum/wpm.c
@@ -19,6 +19,7 @@
 #include "timer.h"
 #include "keycode.h"
 #include "quantum_keycodes.h"
+#include "action_util.h"
 #include <math.h>
 
 // WPM Stuff


### PR DESCRIPTION
## Description

`WPM_ALLOW_COUNT_REGRESSION` uses mods and keycodes, and the recent changes break the chain of includes. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
