### PR TITLE
Expose coef and interval config in Cirque Pinnacle cursor glide 

### DIFF
--- a/drivers/sensors/cirque_pinnacle_gestures.h
+++ b/drivers/sensors/cirque_pinnacle_gestures.h
@@ -102,8 +102,10 @@ void cirque_pinnacle_enable_cursor_glide(bool enable);
 /*
  * Configure inertial cursor.
  * @param trigger_px Movement required to trigger cursor glide, set this to non-zero if you have some amount of hover.
+ * @param coef Coefficient of friction used to calculate how quickly glide decays
+ * @param interval Glide report interval, in milliseconds to determine if glide is valid
  */
-void cirque_pinnacle_configure_cursor_glide(float trigger_px);
+void cirque_pinnacle_configure_cursor_glide(float trigger_px, float coef, float interval);
 #endif
 
 /* Process available gestures */

--- a/quantum/pointing_device/pointing_device_drivers.c
+++ b/quantum/pointing_device/pointing_device_drivers.c
@@ -107,8 +107,10 @@ void cirque_pinnacle_enable_cursor_glide(bool enable) {
     cursor_glide_enable = enable;
 }
 
-void cirque_pinnacle_configure_cursor_glide(float trigger_px) {
+void cirque_pinnacle_configure_cursor_glide(float trigger_px, float coef, float interval) {
     glide.config.trigger_px = trigger_px;
+    glide.config.coef       = coef;
+    glide.config.interval   = interval;
 }
 #    endif
 


### PR DESCRIPTION
## Description

While working on the firmware for a custom keyboard featuring a Cirque trackpad I found myself needing to change the coefficient of friction configuration value. This was not exposed like `trigger_px` - however I borrowed the pattern from `cirque_pinnacle_configure_circular_scroll` where multiple options could be configured from the same fiction call.  

I exposed both `coef` and `interval` options as well as the existing `trigger_pix` option in `cirque_pinnacle_configure_cursor_glide`.

`cirque_pinnacle_configure_cursor_glide` nor `cirque_pinnacle_configure_circular_scroll` are exposed in documentation - should these be? I would be happy to update the `feature_pointing_device.md` documentation to mention these. 


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
