### PR TITLE
[Bug] Fix Tap Toggle functionality

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.1.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1.hjson
@@ -33,11 +33,11 @@
         "0x52A0/0x001F": {
             "define": "QK_ONE_SHOT_MOD"
         },
-        "0x52C0/0x001F": {
+        // 0x52C0/0x0040 - UNUSED
+        "0x5300/0x001F": {
             "define": "QK_LAYER_TAP_TOGGLE"
         },
-        // 0x52E0/0x001F - UNUSED
-        // 0x5300/0x02FF - UNUSED
+        // 0x5320/0x02E0 - UNUSED
         "0x5600/0x00FF": {
             "define": "QK_SWAP_HANDS"
         },

--- a/quantum/keycodes.h
+++ b/quantum/keycodes.h
@@ -50,8 +50,8 @@ enum qk_keycode_ranges {
     QK_ONE_SHOT_LAYER_MAX          = 0x529F,
     QK_ONE_SHOT_MOD                = 0x52A0,
     QK_ONE_SHOT_MOD_MAX            = 0x52BF,
-    QK_LAYER_TAP_TOGGLE            = 0x52C0,
-    QK_LAYER_TAP_TOGGLE_MAX        = 0x52DF,
+    QK_LAYER_TAP_TOGGLE            = 0x5300,
+    QK_LAYER_TAP_TOGGLE_MAX        = 0x531F,
     QK_SWAP_HANDS                  = 0x5600,
     QK_SWAP_HANDS_MAX              = 0x56FF,
     QK_TAP_DANCE                   = 0x5700,
@@ -1161,4 +1161,3 @@ enum qk_keycode_defines {
 #define IS_BACKLIGHT_KEYCODE(code) ((code) >= QK_BACKLIGHT_ON && (code) <= QK_BACKLIGHT_TOGGLE_BREATHING)
 #define IS_RGB_KEYCODE(code) ((code) >= RGB_TOG && (code) <= RGB_MODE_TWINKLE)
 #define IS_QUANTUM_KEYCODE(code) ((code) >= QK_BOOTLOADER && (code) <= QK_AUTOCORRECT_TOGGLE)
-

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -115,7 +115,7 @@ action_t action_for_keycode(uint16_t keycode) {
 #endif
 #ifndef NO_ACTION_LAYER
         case QK_LAYER_TAP_TOGGLE ... QK_LAYER_TAP_TOGGLE_MAX:
-            action.code = ACTION_LAYER_TAP_TOGGLE(keycode & 0xFF);
+            action.code = ACTION_LAYER_TAP_TOGGLE(keycode & 0x1F);
             break;
         case QK_LAYER_MOD ... QK_LAYER_MOD_MAX:
             mod          = mod_config(keycode & 0x1F);


### PR DESCRIPTION
## Description

Quick fix of Tap Toggle keycodes due to shifting around. 

If the better solution is found ...

For testing, added debugging.  This does not work:
```
> ACT: Keycode 0x52C7, layer 7, code: 0xA7F0
```
This does:
```
> ACT: Keycode 0x5307, layer 7, code: 0xA7F0
```

Action code appears to be the same (and correct).  But one works, the other doesn't.  prints were placed at the `layer_invert` spot, so ... if it's printing, it should work, but ...

Moving the location works but isn't great.

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
