### PR TITLE
Fix jump in mouse_report value when scale changes during cirque get report

### DIFF
--- a/quantum/pointing_device/pointing_device_drivers.c
+++ b/quantum/pointing_device/pointing_device_drivers.c
@@ -123,9 +123,11 @@ bool auto_mouse_activation(report_mouse_t mouse_report) {
 #        endif
 
 report_mouse_t cirque_pinnacle_get_report(report_mouse_t mouse_report) {
+    uint16_t          scale     = cirque_pinnacle_get_scale();
     pinnacle_data_t   touchData = cirque_pinnacle_read_data();
     mouse_xy_report_t report_x = 0, report_y = 0;
-    static uint16_t   x = 0, y = 0;
+    static uint16_t   x = 0, y = 0, last_scale = 0;
+
 #        if defined(CIRQUE_PINNACLE_TAP_ENABLE)
     mouse_report.buttons        = pointing_device_handle_buttons(mouse_report.buttons, false, POINTING_DEVICE_BUTTON1);
 #        endif
@@ -157,15 +159,16 @@ report_mouse_t cirque_pinnacle_get_report(report_mouse_t mouse_report) {
 #        endif
 
     // Scale coordinates to arbitrary X, Y resolution
-    cirque_pinnacle_scale_data(&touchData, cirque_pinnacle_get_scale(), cirque_pinnacle_get_scale());
+    cirque_pinnacle_scale_data(&touchData, scale, scale);
 
     if (!cirque_pinnacle_gestures(&mouse_report, touchData)) {
-        if (x && y && touchData.xValue && touchData.yValue) {
+        if (last_scale && scale == last_scale && x && y && touchData.xValue && touchData.yValue) {
             report_x = CONSTRAIN_HID_XY((int16_t)(touchData.xValue - x));
             report_y = CONSTRAIN_HID_XY((int16_t)(touchData.yValue - y));
         }
-        x = touchData.xValue;
-        y = touchData.yValue;
+        x          = touchData.xValue;
+        y          = touchData.yValue;
+        last_scale = scale;
 
 #        ifdef POINTING_DEVICE_GESTURES_CURSOR_GLIDE_ENABLE
         if (cursor_glide_enable) {


### PR DESCRIPTION

## Description

Avoid sending the report until the scale matches the x,y delta values. Otherwise when adjusting scale while touchpad is active causes a jump in report values due to the touchData and x,y values using different scales, causing the delta calculation to have an erroneous value

I'm happy to adjust the approach as needed. This just seemed the simplest way to ensure the report_x|y delta was using the same scale. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes https://github.com/qmk/qmk_firmware/issues/18980

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
