### PR TITLE
`mechlovin/adelais/standard_led/avr/rev1`: fix layout

### DIFF
--- a/keyboards/mechlovin/adelais/standard_led/avr/rev1/rev1.h
+++ b/keyboards/mechlovin/adelais/standard_led/avr/rev1/rev1.h
@@ -64,7 +64,7 @@
     K1E, K00, K01, K02, K03, K04, K05, K06,         K07, K08, K09, K0A, K0B, K0C, K0D,      \
     K2E, K10, K11, K12, K13, K14, K15,              K16, K17, K18, K19, K1A, K1B, K1C, K1D, \
     K3E, K20, K21, K22, K23, K24, K25,              K26, K27, K28, K29, K2A, K2B, K2D,      \
-         K30,      K32, K33, K34, K35, K36,         K37, K38, K39, K3A, K3B, K4C, K3C, K3D, \
+         K30,      K32, K33, K34, K35, K36,         K37, K38, K39, K3A, K3B, K4C, K3C,      \
          K40,      K42,      K44,      K46,              K48,      K4A,                K4D  \
 ) { \
     { K00,   K01,   K02,   K03,   K04,   K05,   K06,   K07,   K08,   K09,   K0A,   K0B,   K0C,   K0D,   KC_NO }, \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
☒ mechlovin/adelais/standard_led/avr/rev1: Number of keys for LAYOUT_alice_full_rshift does not match! info.json specifies 64 keys, C macro specifies 65
```

Extra key in this layout macro which wasn't mapped anywhere.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
