### PR TITLE
onekey: disable NKRO and mousekeys by default

### DIFF
--- a/keyboards/handwired/onekey/bluepill_f103c6/rules.mk
+++ b/keyboards/handwired/onekey/bluepill_f103c6/rules.mk
@@ -13,10 +13,6 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # LTO is required to fit the firmware into the available 24K of flash
 LTO_ENABLE = yes
 
-# Disable some features which still don't fit into flash even with LTO
-MOUSEKEY_ENABLE = no
-NKRO_ENABLE = no
-
 # EEPROM emulation not supported yet (need to implement a proper firmware size
 # check first, otherwise the chance of the EEPROM backing store overwriting
 # some part of the firmware code is really high).

--- a/keyboards/handwired/onekey/info.json
+++ b/keyboards/handwired/onekey/info.json
@@ -10,11 +10,11 @@
     "diode_direction": "COL2ROW",
     "features": {
         "bootmagic": false,
-        "mousekey": true,
+        "mousekey": false,
         "extrakey": true,
         "console": true,
         "command": false,
-        "nkro": true,
+        "nkro": false,
         "backlight": false,
         "rgblight": false,
         "audio": false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
⚠ handwired/onekey/bluepill_f103c6: Feature mousekey is specified in both info.json and rules.mk, the rules.mk value wins.
⚠ handwired/onekey/bluepill_f103c6: Feature nkro is specified in both info.json and rules.mk, the rules.mk value wins.
```

These features are hard to properly test with only a single key, and with CI in place checking that it at least compiles is already done.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
