### PR TITLE
Core: Support inverted scan logic for optical switches

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -51,6 +51,7 @@
     "LED_MATRIX_SPD_STEP": {"info_key": "led_matrix.speed_steps", "value_type": "int"},
     "MANUFACTURER": {"info_key": "manufacturer", "value_type": "str"},
     "MATRIX_HAS_GHOST": {"info_key": "matrix_pins.ghost", "value_type": "bool"},
+    "MATRIX_INPUT_PRESSED_STATE": {"info_key": "matrix_pins.input_pressed_state", "value_type": "int"},
     "MATRIX_IO_DELAY": {"info_key": "matrix_pins.io_delay", "value_type": "int"},
     "MOUSEKEY_DELAY": {"info_key": "mousekey.delay", "value_type": "int"},
     "MOUSEKEY_INTERVAL": {"info_key": "mousekey.interval", "value_type": "int"},

--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -61,6 +61,7 @@
     "ONESHOT_TAP_TOGGLE": {"info_key": "oneshot.tap_toggle", "value_type": "int"},
     "PERMISSIVE_HOLD": {"info_key": "tapping.permissive_hold", "value_type": "bool"},
     "PERMISSIVE_HOLD_PER_KEY": {"info_key": "tapping.permissive_hold_per_key", "value_type": "bool"},
+    "PRESSED_KEY_PIN_STATE": {"info_key": "pressed_key.pin_state", "value_type": "int"},
     "PS2_CLOCK_PIN": {"info_key": "ps2.clock_pin"},
     "PS2_DATA_PIN": {"info_key": "ps2.data_pin"},
     "RETRO_TAPPING": {"info_key": "tapping.retro", "value_type": "bool"},

--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -62,7 +62,6 @@
     "ONESHOT_TAP_TOGGLE": {"info_key": "oneshot.tap_toggle", "value_type": "int"},
     "PERMISSIVE_HOLD": {"info_key": "tapping.permissive_hold", "value_type": "bool"},
     "PERMISSIVE_HOLD_PER_KEY": {"info_key": "tapping.permissive_hold_per_key", "value_type": "bool"},
-    "PRESSED_KEY_PIN_STATE": {"info_key": "pressed_key.pin_state", "value_type": "int"},
     "PS2_CLOCK_PIN": {"info_key": "ps2.clock_pin"},
     "PS2_DATA_PIN": {"info_key": "ps2.data_pin"},
     "RETRO_TAPPING": {"info_key": "tapping.retro", "value_type": "bool"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -285,6 +285,7 @@
                 "custom": {"type": "boolean"},
                 "custom_lite": {"type": "boolean"},
                 "ghost": {"type": "boolean"},
+                "input_pressed_state": {"$ref": "qmk.definitions.v1#/unsigned_int"},
                 "io_delay": {"$ref": "qmk.definitions.v1#/unsigned_int"},
                 "direct": {
                     "type": "array",

--- a/docs/porting_your_keyboard_to_qmk.md
+++ b/docs/porting_your_keyboard_to_qmk.md
@@ -100,6 +100,16 @@ Finally, you can specify the direction your diodes point. This can be `COL2ROW` 
     "diode_direction": "ROW2COL",
 ```
 
+## Configuration Options
+
+To invert the keypress logic, configure `pressed_key.pin_state`:
+
+```json
+    "pressed_key.pin_state": 1,
+```
+
+This configures state of the GPIO pins when the key is pressed - `1` for high, `0` for low. Default value is `0`.
+
 #### Direct Pin Matrix
 To configure a keyboard where each switch is connected to a separate pin and ground instead of sharing row and column pins, use `matrix_pins.direct`. The mapping defines the pins of each switch in rows and columns, from left to right. The size of the `matrix_pins.direct` array infers the size of the matrix. Use `NO_PIN` to fill in blank spaces. Overrides the behaviour of `diode_direction`, `matrix_pins.cols` and `matrix_pins.rows`.
 

--- a/docs/porting_your_keyboard_to_qmk.md
+++ b/docs/porting_your_keyboard_to_qmk.md
@@ -94,21 +94,23 @@ The next section of the `info` file deals with your keyboard's matrix. The first
 
 The size of the `matrix_pins.cols` and `matrix_pins.rows` arrays infer the size of the matrix (previously `MATRIX_ROWS` and `MATRIX_COLS`). 
 
+## Configuration Options
+
+To invert the keypress logic, configure `input_pressed_state`:
+
+```json
+    "matrix_pins": {
+        "input_pressed_state": 1,
+},
+```
+
+This configures state of the GPIO pins when the key is pressed - `1` for high, `0` for low. Default value is `0`.
+
 Finally, you can specify the direction your diodes point. This can be `COL2ROW` or `ROW2COL`.
 
 ```json
     "diode_direction": "ROW2COL",
 ```
-
-## Configuration Options
-
-To invert the keypress logic, configure `pressed_key.pin_state`:
-
-```json
-    "pressed_key.pin_state": 1,
-```
-
-This configures state of the GPIO pins when the key is pressed - `1` for high, `0` for low. Default value is `0`.
 
 #### Direct Pin Matrix
 To configure a keyboard where each switch is connected to a separate pin and ground instead of sharing row and column pins, use `matrix_pins.direct`. The mapping defines the pins of each switch in rows and columns, from left to right. The size of the `matrix_pins.direct` array infers the size of the matrix. Use `NO_PIN` to fill in blank spaces. Overrides the behaviour of `diode_direction`, `matrix_pins.cols` and `matrix_pins.rows`.

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -96,8 +96,11 @@ static inline void setPinInputHigh_atomic(pin_t pin) {
 }
 
 static inline uint8_t readMatrixPin(pin_t pin) {
-    if ((pin == NO_PIN) || (readPin(pin) != PRESSED_KEY_PIN_STATE)) return 1;
-    if (readPin(pin) == PRESSED_KEY_PIN_STATE) return 0;
+    if (pin != NO_PIN) {
+        return (readPin(pin) == PRESSED_KEY_PIN_STATE) ? 0 : 1;
+    } else {
+        return 1;
+    }
 }
 
 // matrix code
@@ -122,9 +125,7 @@ __attribute__((weak)) void matrix_read_cols_on_row(matrix_row_t current_matrix[]
     matrix_row_t row_shifter = MATRIX_ROW_SHIFTER;
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++, row_shifter <<= 1) {
         pin_t pin = direct_pins[current_row][col_index];
-        if (pin != NO_PIN) {
             current_row_value |= readMatrixPin(pin) ? 0 : row_shifter;
-        }
     }
 
     // Update the matrix

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -125,7 +125,7 @@ __attribute__((weak)) void matrix_read_cols_on_row(matrix_row_t current_matrix[]
     matrix_row_t row_shifter = MATRIX_ROW_SHIFTER;
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++, row_shifter <<= 1) {
         pin_t pin = direct_pins[current_row][col_index];
-            current_row_value |= readMatrixPin(pin) ? 0 : row_shifter;
+        current_row_value |= readMatrixPin(pin) ? 0 : row_shifter;
     }
 
     // Update the matrix

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -46,8 +46,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define SPLIT_MUTABLE_COL const
 #endif
 
-#ifndef PRESSED_KEY_PIN_STATE
-#    define PRESSED_KEY_PIN_STATE 0
+#ifndef MATRIX_INPUT_PRESSED_STATE
+#    define MATRIX_INPUT_PRESSED_STATE 0
 #endif
 
 #ifdef DIRECT_PINS
@@ -97,7 +97,7 @@ static inline void setPinInputHigh_atomic(pin_t pin) {
 
 static inline uint8_t readMatrixPin(pin_t pin) {
     if (pin != NO_PIN) {
-        return (readPin(pin) == PRESSED_KEY_PIN_STATE) ? 0 : 1;
+        return (readPin(pin) == MATRIX_INPUT_PRESSED_STATE) ? 0 : 1;
     } else {
         return 1;
     }

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -46,6 +46,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define SPLIT_MUTABLE_COL const
 #endif
 
+#ifndef PRESSED_KEY_PIN_STATE
+#    define PRESSED_KEY_PIN_STATE 0
+#endif
+
 #ifdef DIRECT_PINS
 static SPLIT_MUTABLE pin_t direct_pins[ROWS_PER_HAND][MATRIX_COLS] = DIRECT_PINS;
 #elif (DIODE_DIRECTION == ROW2COL) || (DIODE_DIRECTION == COL2ROW)
@@ -93,7 +97,9 @@ static inline void setPinInputHigh_atomic(pin_t pin) {
 
 static inline uint8_t readMatrixPin(pin_t pin) {
     if (pin != NO_PIN) {
-        return readPin(pin);
+        if (readPin(pin) == PRESSED_KEY_PIN_STATE) {
+            return 0;
+        }
     } else {
         return 1;
     }
@@ -122,7 +128,7 @@ __attribute__((weak)) void matrix_read_cols_on_row(matrix_row_t current_matrix[]
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++, row_shifter <<= 1) {
         pin_t pin = direct_pins[current_row][col_index];
         if (pin != NO_PIN) {
-            current_row_value |= readPin(pin) ? 0 : row_shifter;
+            current_row_value |= readMatrixPin(pin) ? 0 : row_shifter;
         }
     }
 

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -96,13 +96,8 @@ static inline void setPinInputHigh_atomic(pin_t pin) {
 }
 
 static inline uint8_t readMatrixPin(pin_t pin) {
-    if (pin != NO_PIN) {
-        if (readPin(pin) == PRESSED_KEY_PIN_STATE) {
-            return 0;
-        }
-    } else {
-        return 1;
-    }
+    if ((pin == NO_PIN) || (readPin(pin) != PRESSED_KEY_PIN_STATE)) return 1;
+    if (readPin(pin) == PRESSED_KEY_PIN_STATE) return 0;
 }
 
 // matrix code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Some optical switch designs use inverted logic for pressed state.

To invert the keypress logic, configure `matrix_pins.input_pressed_state` in info.json:

```json
    "matrix_pins": {
        "input_pressed_state": 1,
},
```
or, define `MATRIX_INPUT_PRESSED_STATE 1`  in config.h
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
