### PR TITLE
Add missing prototype for get_hold_on_other_key_press to resolve #18855

### DIFF
--- a/quantum/action_tapping.h
+++ b/quantum/action_tapping.h
@@ -40,6 +40,7 @@ bool     get_permissive_hold(uint16_t keycode, keyrecord_t *record);
 bool     get_ignore_mod_tap_interrupt(uint16_t keycode, keyrecord_t *record);
 bool     get_tapping_force_hold(uint16_t keycode, keyrecord_t *record);
 bool     get_retro_tapping(uint16_t keycode, keyrecord_t *record);
+bool     get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record);
 
 #ifdef DYNAMIC_TAPPING_TERM_ENABLE
 extern uint16_t g_tapping_term;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Adds the missing function prototype for `get_hold_on_other_key_press` in `/quantum/action_tapping.h`. The missing prototype doesn't cause errors most of the time, but does (at least) if both auto-shift and `HOLD_ON_OTHER_KEY_PRESS_PER_KEY` are enabled, due to use of `get_hold_on_other_key_press` in `quantum/process_keycode/process_auto_shift.c`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #18855

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
