### PR TITLE
Corrections to uart driver for Chibios platform

### DIFF
--- a/docs/uart_driver.md
+++ b/docs/uart_driver.md
@@ -35,17 +35,17 @@ Then, modify your board's `mcuconf.h` to enable the peripheral you've chosen, fo
 
 Configuration-wise, you'll need to set up the peripheral as per your MCU's datasheet -- the defaults match the pins for a Proton-C, i.e. STM32F303.
 
-|`config.h` override       |Description                                                    |Default Value|
-|--------------------------|---------------------------------------------------------------|-------------|
-|`#define SERIAL_DRIVER`   |USART peripheral to use - USART1 -> `SD1`, USART2 -> `SD2` etc.|`SD1`        |
-|`#define SD1_TX_PIN`      |The pin to use for TX                                          |`A9`         |
-|`#define SD1_TX_PAL_MODE` |The alternate function mode for TX                             |`7`          |
-|`#define SD1_RX_PIN`      |The pin to use for RX                                          |`A10`        |
-|`#define SD1_RX_PAL_MODE` |The alternate function mode for RX                             |`7`          |
-|`#define SD1_CTS_PIN`     |The pin to use for CTS                                         |`A11`        |
-|`#define SD1_CTS_PAL_MODE`|The alternate function mode for CTS                            |`7`          |
-|`#define SD1_RTS_PIN`     |The pin to use for RTS                                         |`A12`        |
-|`#define SD1_RTS_PAL_MODE`|The alternate function mode for RTS                            |`7`          |
+|`config.h` override      |Description                                                    |Default Value|
+|-------------------------|---------------------------------------------------------------|-------------|
+|`#define SERIAL_DRIVER`  |USART peripheral to use - USART1 -> `SD1`, USART2 -> `SD2` etc.|`SD1`        |
+|`#define SD_TX_PIN`      |The pin to use for TX                                          |`A9`         |
+|`#define SD_TX_PAL_MODE` |The alternate function mode for TX                             |`7`          |
+|`#define SD_RX_PIN`      |The pin to use for RX                                          |`A10`        |
+|`#define SD_RX_PAL_MODE` |The alternate function mode for RX                             |`7`          |
+|`#define SD_CTS_PIN`     |The pin to use for CTS                                         |`A11`        |
+|`#define SD_CTS_PAL_MODE`|The alternate function mode for CTS                            |`7`          |
+|`#define SD_RTS_PIN`     |The pin to use for RTS                                         |`A12`        |
+|`#define SD_RTS_PAL_MODE`|The alternate function mode for RTS                            |`7`          |
 
 ## Functions
 

--- a/docs/uart_driver.md
+++ b/docs/uart_driver.md
@@ -35,17 +35,17 @@ Then, modify your board's `mcuconf.h` to enable the peripheral you've chosen, fo
 
 Configuration-wise, you'll need to set up the peripheral as per your MCU's datasheet -- the defaults match the pins for a Proton-C, i.e. STM32F303.
 
-|`config.h` override      |Description                                                    |Default Value|
-|-------------------------|---------------------------------------------------------------|-------------|
-|`#define SERIAL_DRIVER`  |USART peripheral to use - USART1 -> `SD1`, USART2 -> `SD2` etc.|`SD1`        |
-|`#define SD_TX_PIN`      |The pin to use for TX                                          |`A9`         |
-|`#define SD_TX_PAL_MODE` |The alternate function mode for TX                             |`7`          |
-|`#define SD_RX_PIN`      |The pin to use for RX                                          |`A10`        |
-|`#define SD_RX_PAL_MODE` |The alternate function mode for RX                             |`7`          |
-|`#define SD_CTS_PIN`     |The pin to use for CTS                                         |`A11`        |
-|`#define SD_CTS_PAL_MODE`|The alternate function mode for CTS                            |`7`          |
-|`#define SD_RTS_PIN`     |The pin to use for RTS                                         |`A12`        |
-|`#define SD_RTS_PAL_MODE`|The alternate function mode for RTS                            |`7`          |
+|`config.h` override       |Description                                                    |Default Value|
+|--------------------------|---------------------------------------------------------------|-------------|
+|`#define SERIAL_DRIVER`   |USART peripheral to use - USART1 -> `SD1`, USART2 -> `SD2` etc.|`SD1`        |
+|`#define SD1_TX_PIN`      |The pin to use for TX                                          |`A9`         |
+|`#define SD1_TX_PAL_MODE` |The alternate function mode for TX                             |`7`          |
+|`#define SD1_RX_PIN`      |The pin to use for RX                                          |`A10`        |
+|`#define SD1_RX_PAL_MODE` |The alternate function mode for RX                             |`7`          |
+|`#define SD1_CTS_PIN`     |The pin to use for CTS                                         |`A11`        |
+|`#define SD1_CTS_PAL_MODE`|The alternate function mode for CTS                            |`7`          |
+|`#define SD1_RTS_PIN`     |The pin to use for RTS                                         |`A12`        |
+|`#define SD1_RTS_PAL_MODE`|The alternate function mode for RTS                            |`7`          |
 
 ## Functions
 

--- a/platforms/chibios/drivers/uart.c
+++ b/platforms/chibios/drivers/uart.c
@@ -21,9 +21,9 @@
 #if defined(MCU_KINETIS)
 static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE};
 #elif defined(WB32F3G71xx) || defined(WB32FQ95xx)
-static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD_WRDLEN, SD_STPBIT, SD_PARITY, SD_ATFLCT};
+static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD1_WRDLEN, SD1_STPBIT, SD1_PARITY, SD1_ATFLCT};
 #else
-static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD_CR1, SD_CR2, SD_CR3};
+static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD1_CR1, SD1_CR2, SD1_CR3};
 #endif
 
 void uart_init(uint32_t baud) {
@@ -39,11 +39,11 @@ void uart_init(uint32_t baud) {
 #endif
 
 #if defined(USE_GPIOV1)
-        palSetLineMode(SD_TX_PIN, PAL_MODE_ALTERNATE_PUSHPULL);
-        palSetLineMode(SD_RX_PIN, PAL_MODE_INPUT);
+        palSetLineMode(SD1_TX_PIN, PAL_MODE_ALTERNATE_PUSHPULL);
+        palSetLineMode(SD1_RX_PIN, PAL_MODE_INPUT);
 #else
-        palSetLineMode(SD_TX_PIN, PAL_MODE_ALTERNATE(SD_TX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
-        palSetLineMode(SD_RX_PIN, PAL_MODE_ALTERNATE(SD_RX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+        palSetLineMode(SD1_TX_PIN, PAL_MODE_ALTERNATE(SD1_TX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+        palSetLineMode(SD1_RX_PIN, PAL_MODE_ALTERNATE(SD1_RX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
 #endif
         sdStart(&SERIAL_DRIVER, &serialConfig);
     }

--- a/platforms/chibios/drivers/uart.c
+++ b/platforms/chibios/drivers/uart.c
@@ -39,8 +39,8 @@ void uart_init(uint32_t baud) {
 #endif
 
 #if defined(USE_GPIOV1)
-        palSetLineMode(SD1_TX_PIN, PAL_MODE_ALTERNATE_PUSHPULL);
-        palSetLineMode(SD1_RX_PIN, PAL_MODE_INPUT);
+        palSetLineMode(SD1_TX_PIN, SD1_TX_PAL_MODE);
+        palSetLineMode(SD1_RX_PIN, SD1_RX_PAL_MODE);
 #else
         palSetLineMode(SD1_TX_PIN, PAL_MODE_ALTERNATE(SD1_TX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
         palSetLineMode(SD1_RX_PIN, PAL_MODE_ALTERNATE(SD1_RX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);

--- a/platforms/chibios/drivers/uart.c
+++ b/platforms/chibios/drivers/uart.c
@@ -21,9 +21,9 @@
 #if defined(MCU_KINETIS)
 static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE};
 #elif defined(WB32F3G71xx) || defined(WB32FQ95xx)
-static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD1_WRDLEN, SD1_STPBIT, SD1_PARITY, SD1_ATFLCT};
+static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD_WRDLEN, SD_STPBIT, SD_PARITY, SD_ATFLCT};
 #else
-static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD1_CR1, SD1_CR2, SD1_CR3};
+static SerialConfig serialConfig = {SERIAL_DEFAULT_BITRATE, SD_CR1, SD_CR2, SD_CR3};
 #endif
 
 void uart_init(uint32_t baud) {
@@ -39,11 +39,11 @@ void uart_init(uint32_t baud) {
 #endif
 
 #if defined(USE_GPIOV1)
-        palSetLineMode(SD1_TX_PIN, SD1_TX_PAL_MODE);
-        palSetLineMode(SD1_RX_PIN, SD1_RX_PAL_MODE);
+        palSetLineMode(SD_TX_PIN, PAL_MODE_ALTERNATE_PUSHPULL);
+        palSetLineMode(SD_RX_PIN, PAL_MODE_INPUT);
 #else
-        palSetLineMode(SD1_TX_PIN, PAL_MODE_ALTERNATE(SD1_TX_PAL_MODE) | PAL_OUTPUT_TYPE_OPENDRAIN);
-        palSetLineMode(SD1_RX_PIN, PAL_MODE_ALTERNATE(SD1_RX_PAL_MODE) | PAL_OUTPUT_TYPE_OPENDRAIN);
+        palSetLineMode(SD_TX_PIN, PAL_MODE_ALTERNATE(SD_TX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+        palSetLineMode(SD_RX_PIN, PAL_MODE_ALTERNATE(SD_RX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
 #endif
         sdStart(&SERIAL_DRIVER, &serialConfig);
     }

--- a/platforms/chibios/drivers/uart.h
+++ b/platforms/chibios/drivers/uart.h
@@ -24,82 +24,68 @@
 #    define SERIAL_DRIVER SD1
 #endif
 
-#ifndef SD1_TX_PIN
-#    define SD1_TX_PIN A9
+#ifndef SD_TX_PIN
+#    define SD_TX_PIN A9
 #endif
 
-#ifndef SD1_RX_PIN
-#    define SD1_RX_PIN A10
+#ifndef SD_RX_PIN
+#    define SD_RX_PIN A10
 #endif
 
-#ifndef SD1_CTS_PIN
-#    define SD1_CTS_PIN A11
+//CTS currently not implemented
+#ifndef SD_CTS_PIN
+#    define SD_CTS_PIN A11
 #endif
 
-#ifndef SD1_RTS_PIN
-#    define SD1_RTS_PIN A12
+//RTS currently not implemented
+#ifndef SD_RTS_PIN
+#    define SD_RTS_PIN A12
 #endif
 
-#ifdef USE_GPIOV1
-#    ifndef SD1_TX_PAL_MODE
-#        define SD1_TX_PAL_MODE PAL_MODE_ALTERNATE_OPENDRAIN
+#if !defined(USE_GPIOV1)
+#    ifndef SD_TX_PAL_MODE
+#        define SD_TX_PAL_MODE 7
 #    endif
 
-#    ifndef SD1_RX_PAL_MODE
-#        define SD1_RX_PAL_MODE PAL_MODE_ALTERNATE_OPENDRAIN
+#    ifndef SD_RX_PAL_MODE
+#        define SD_RX_PAL_MODE 7
 #    endif
 
-#    ifndef SD1_CTS_PAL_MODE
-#        define SD1_CTS_PAL_MODE PAL_MODE_ALTERNATE_OPENDRAIN
+#    ifndef SD_CTS_PAL_MODE
+#        define SD_CTS_PAL_MODE 7
 #    endif
 
-#    ifndef SD1_RTS_PAL_MODE
-#        define SD1_RTS_PAL_MODE PAL_MODE_ALTERNATE_OPENDRAIN
-#    endif
-#else
-#    ifndef SD1_TX_PAL_MODE
-#        define SD1_TX_PAL_MODE 7
-#    endif
-
-#    ifndef SD1_RX_PAL_MODE
-#        define SD1_RX_PAL_MODE 7
-#    endif
-
-#    ifndef SD1_CTS_PAL_MODE
-#        define SD1_CTS_PAL_MODE 7
-#    endif
-
-#    ifndef SD1_RTS_PAL_MODE
-#        define SD1_RTS_PAL_MODE 7
+#    ifndef SD_RTS_PAL_MODE
+#        define SD_RTS_PAL_MODE 7
 #    endif
 #endif
 
-#ifndef SD1_CR1
-#    define SD1_CR1 0
+#ifndef SD_CR1
+#    define SD_CR1 0
 #endif
 
-#ifndef SD1_CR2
+#ifndef SD_CR2
 #    define SD1_CR2 0
 #endif
 
-#ifndef SD1_CR3
-#    define SD1_CR3 0
+#ifndef SD_CR3
+#    define SD_CR3 0
 #endif
 
-#ifndef SD1_WRDLEN
-#    define SD1_WRDLEN 3
+#ifndef SD_WRDLEN
+#    define SD_WRDLEN 3
 #endif
 
-#ifndef SD1_STPBIT
-#    define SD1_STPBIT 0
+#ifndef SD_STPBIT
+#    define SD_STPBIT 0
 #endif
 
-#ifndef SD1_PARITY
-#    define SD1_PARITY 0
+#ifndef SD_PARITY
+#    define SD_PARITY 0
 #endif
 
-#ifndef SD1_ATFLCT
-#    define SD1_ATFLCT 0
+#ifndef SD_ATFLCT
+#    define SD_ATFLCT 0
 #endif
 
 void uart_init(uint32_t baud);

--- a/platforms/chibios/drivers/uart.h
+++ b/platforms/chibios/drivers/uart.h
@@ -32,12 +32,12 @@
 #    define SD_RX_PIN A10
 #endif
 
-//CTS currently not implemented
+// CTS currently not implemented
 #ifndef SD_CTS_PIN
 #    define SD_CTS_PIN A11
 #endif
 
-//RTS currently not implemented
+// RTS currently not implemented
 #ifndef SD_RTS_PIN
 #    define SD_RTS_PIN A12
 #endif

--- a/platforms/chibios/drivers/uart.h
+++ b/platforms/chibios/drivers/uart.h
@@ -24,68 +24,66 @@
 #    define SERIAL_DRIVER SD1
 #endif
 
-#ifndef SD_TX_PIN
-#    define SD_TX_PIN A9
+#ifndef SD1_TX_PIN
+#    define SD1_TX_PIN A9
 #endif
 
-#ifndef SD_RX_PIN
-#    define SD_RX_PIN A10
+#ifndef SD1_RX_PIN
+#    define SD1_RX_PIN A10
 #endif
 
-// CTS currently not implemented
-#ifndef SD_CTS_PIN
-#    define SD_CTS_PIN A11
+#ifndef SD1_CTS_PIN
+#    define SD1_CTS_PIN A11
 #endif
 
-// RTS currently not implemented
-#ifndef SD_RTS_PIN
-#    define SD_RTS_PIN A12
+#ifndef SD1_RTS_PIN
+#    define SD1_RTS_PIN A12
 #endif
 
 #if !defined(USE_GPIOV1)
-#    ifndef SD_TX_PAL_MODE
-#        define SD_TX_PAL_MODE 7
+#    ifndef SD1_TX_PAL_MODE
+#        define SD1_TX_PAL_MODE 7
 #    endif
 
-#    ifndef SD_RX_PAL_MODE
-#        define SD_RX_PAL_MODE 7
+#    ifndef SD1_RX_PAL_MODE
+#        define SD1_RX_PAL_MODE 7
 #    endif
 
-#    ifndef SD_CTS_PAL_MODE
-#        define SD_CTS_PAL_MODE 7
+#    ifndef SD1_CTS_PAL_MODE
+#        define SD1_CTS_PAL_MODE 7
 #    endif
 
-#    ifndef SD_RTS_PAL_MODE
-#        define SD_RTS_PAL_MODE 7
+#    ifndef SD1_RTS_PAL_MODE
+#        define SD1_RTS_PAL_MODE 7
 #    endif
 #endif
 
-#ifndef SD_CR1
-#    define SD_CR1 0
+#ifndef SD1_CR1
+#    define SD1_CR1 0
 #endif
 
-#ifndef SD_CR2
-#    define SD_CR2 0
+#ifndef SD1_CR2
+#    define SD1_CR2 0
 #endif
 
-#ifndef SD_CR3
-#    define SD_CR3 0
+#ifndef SD1_CR3
+#    define SD1_CR3 0
 #endif
 
-#ifndef SD_WRDLEN
-#    define SD_WRDLEN 3
+#ifndef SD1_WRDLEN
+#    define SD1_WRDLEN 3
 #endif
 
-#ifndef SD_STPBIT
-#    define SD_STPBIT 0
+#ifndef SD1_STPBIT
+#    define SD1_STPBIT 0
 #endif
 
-#ifndef SD_PARITY
-#    define SD_PARITY 0
+#ifndef SD1_PARITY
+#    define SD1_PARITY 0
 #endif
 
-#ifndef SD_ATFLCT
-#    define SD_ATFLCT 0
+#ifndef SD1_ATFLCT
+#    define SD1_ATFLCT 0
 #endif
 
 void uart_init(uint32_t baud);

--- a/platforms/chibios/drivers/uart.h
+++ b/platforms/chibios/drivers/uart.h
@@ -40,7 +40,20 @@
 #    define SD1_RTS_PIN A12
 #endif
 
-#if !defined(USE_GPIOV1)
+#ifdef USE_GPIOV1
+#    ifndef SD1_TX_PAL_MODE
+#        define SD1_TX_PAL_MODE PAL_MODE_ALTERNATE_PUSHPULL
+#    endif
+#    ifndef SD1_RX_PAL_MODE
+#        define SD1_RX_PAL_MODE PAL_MODE_INPUT
+#    endif
+#    ifndef SD1_CTS_PAL_MODE
+#        define SD1_CTS_PAL_MODE PAL_MODE_INPUT
+#    endif
+#    ifndef SD1_RTS_PAL_MODE
+#        define SD1_RTS_PAL_MODE PAL_MODE_ALTERNATE_PUSHPULL
+#    endif
+#else
 #    ifndef SD1_TX_PAL_MODE
 #        define SD1_TX_PAL_MODE 7
 #    endif

--- a/platforms/chibios/drivers/uart.h
+++ b/platforms/chibios/drivers/uart.h
@@ -65,7 +65,7 @@
 #endif
 
 #ifndef SD_CR2
-#    define SD1_CR2 0
+#    define SD_CR2 0
 #endif
 
 #ifndef SD_CR3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
UART driver for ChibiOS was not working on ARM (testing using STM32F411), it looks like it just didn't follow along with changes in the serial driver as far as how to correctly assign pin modes with palSetLineMode. With these changes, it now works as expected.

I also took the opportunity to refactor some naming to make it more generic (SD instead of SD1) and updated documentation accordingly. A search of the repo showed that no one was actually using the original SD1 naming yet.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
