### PR TITLE
kint36: do not restart USB stack after wakeup

### DIFF
--- a/platforms/chibios/boards/PJRC_TEENSY_3_6/board/board.mk
+++ b/platforms/chibios/boards/PJRC_TEENSY_3_6/board/board.mk
@@ -1,0 +1,11 @@
+include $(CHIBIOS_CONTRIB)/os/hal/boards/PJRC_TEENSY_3_6/board.mk
+
+# List of all the board related files.
+BOARDSRC += $(BOARD_PATH)/board/extra.c
+
+# Required include directories
+BOARDINC += $(BOARD_PATH)/board
+
+# Shared variables
+ALLCSRC += $(BOARDSRC)
+ALLINC  += $(BOARDINC)

--- a/platforms/chibios/boards/PJRC_TEENSY_3_6/board/extra.c
+++ b/platforms/chibios/boards/PJRC_TEENSY_3_6/board/extra.c
@@ -1,0 +1,7 @@
+#include <hal.h>
+
+void restart_usb_driver(USBDriver *usbp) {
+    // Do nothing. Restarting the USB driver on the Teensy 3.6 breaks it,
+    // resulting in a keyboard which can wake up a PC from Suspend-to-RAM, but
+    // does not actually produce any keypresses until you un-plug and re-plug.
+}


### PR DESCRIPTION
Without this change, the Teensy 3.6 kinT variant can wake a computer from Suspend-to-RAM, but the keyboard does not actually produce any keypresses until you un-plug and re-plug it.

related to https://github.com/kinx-project/kint/issues/59

related to https://github.com/qmk/qmk_firmware/issues/16934

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/16934

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
