### PR TITLE
Use `keyboard_pre_init_kb(void)` at keyboard level

### DIFF
--- a/keyboards/bastardkb/dilemma/dilemma.c
+++ b/keyboards/bastardkb/dilemma/dilemma.c
@@ -331,7 +331,7 @@ void matrix_init_kb(void) {
 // Forward declare RP2040 SDK declaration.
 void gpio_init(uint gpio);
 
-void keyboard_pre_init_user(void) {
+void keyboard_pre_init_kb(void) {
     // Ensures that GP26 through GP29 are initialized as digital inputs (as
     // opposed to analog inputs).  These GPIOs are shared with A0 through A3,
     // respectively.  On RP2040-B2 and later, the digital inputs are disabled by
@@ -340,4 +340,6 @@ void keyboard_pre_init_user(void) {
     gpio_init(GP27);
     gpio_init(GP28);
     gpio_init(GP29);
+
+    keyboard_pre_init_user();
 }


### PR DESCRIPTION
Instead of  the `_user(void)` variant that should be used at the keymap level.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
