### PR TITLE
Specify `DEFAULT_FOLDER` for `v2/splinky`

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky/rules.mk
@@ -35,3 +35,5 @@ POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor
 WS2812_DRIVER = vendor
+
+DEFAULT_FOLDER = bastardkb/charybdis/3x5/v2/splinky/v3

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky/rules.mk
@@ -35,3 +35,5 @@ POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor
 WS2812_DRIVER = vendor
+
+DEFAULT_FOLDER = bastardkb/charybdis/3x6/v2/splinky/v3

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky/rules.mk
@@ -34,3 +34,5 @@ POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor
 WS2812_DRIVER = vendor
+
+DEFAULT_FOLDER = bastardkb/charybdis/4x6/v2/splinky/v3

--- a/keyboards/bastardkb/scylla/v2/splinky/rules.mk
+++ b/keyboards/bastardkb/scylla/v2/splinky/rules.mk
@@ -31,3 +31,5 @@ SPLIT_KEYBOARD = yes
 
 SERIAL_DRIVER = vendor
 WS2812_DRIVER = vendor
+
+DEFAULT_FOLDER = bastardkb/scylla/v2/splinky/v3

--- a/keyboards/bastardkb/skeletyl/v2/splinky/rules.mk
+++ b/keyboards/bastardkb/skeletyl/v2/splinky/rules.mk
@@ -32,3 +32,5 @@ LAYOUTS = split_3x5_3
 
 SERIAL_DRIVER = vendor
 WS2812_DRIVER = vendor
+
+DEFAULT_FOLDER = bastardkb/skeletyl/v2/splinky/v3

--- a/keyboards/bastardkb/tbkmini/v2/splinky/rules.mk
+++ b/keyboards/bastardkb/tbkmini/v2/splinky/rules.mk
@@ -32,3 +32,5 @@ LAYOUTS = split_3x6_3
 
 SERIAL_DRIVER = vendor
 WS2812_DRIVER = vendor
+
+DEFAULT_FOLDER = bastardkb/tbkmini/v2/splinky/v3


### PR DESCRIPTION
QMK's `list-keyboards` infer a keyboard directory by looking for a `rules.mk` file. Because `v2/splinky/v2` and `v2/splinky/v3` share some `rules.mk` definition in `v2/splinky/rules.mk`, `multibuild` attempts to build them, which fails because `POINTING_DEVICE_CS_PIN` is only defined for the leaf folders.

This commit allows us to default to `v3` by specifying `DEFAULT_FOLDER` in `v2/splinky/rules.mk`

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
