### PR TITLE
Extend eeconfig kb/user datablock API

### DIFF
--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -318,7 +318,7 @@ bool eeconfig_is_user_datablock_valid(void) {
  * FIXME: needs doc
  */
 void eeconfig_read_user_datablock(void *data) {
-    if (eeconfig_is_user_datablock_enabled()) {
+    if (eeconfig_is_user_datablock_valid()) {
         eeprom_read_block(data, EECONFIG_USER_DATABLOCK, (EECONFIG_USER_DATA_SIZE));
     } else {
         memset(data, 0, (EECONFIG_USER_DATA_SIZE));

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -71,15 +71,11 @@ void eeconfig_init_quantum(void) {
 #endif
 
 #if (EECONFIG_KB_DATA_SIZE) > 0
-    eeprom_update_dword(EECONFIG_KEYBOARD, (EECONFIG_KB_DATA_VERSION));
-    uint8_t dummy_kb[(EECONFIG_KB_DATA_SIZE)] = {0};
-    eeprom_update_block(EECONFIG_KB_DATABLOCK, dummy_kb, (EECONFIG_KB_DATA_SIZE));
+    eeconfig_init_kb_datablock();
 #endif
 
 #if (EECONFIG_USER_DATA_SIZE) > 0
-    eeprom_update_dword(EECONFIG_USER, (EECONFIG_USER_DATA_VERSION));
-    uint8_t dummy_user[(EECONFIG_USER_DATA_SIZE)] = {0};
-    eeprom_update_block(EECONFIG_USER_DATABLOCK, dummy_user, (EECONFIG_USER_DATA_SIZE));
+    eeconfig_init_user_datablock();
 #endif
 
 #if defined(VIA_ENABLE)
@@ -273,12 +269,19 @@ void eeconfig_update_handedness(bool val) {
 }
 
 #if (EECONFIG_KB_DATA_SIZE) > 0
+/** \brief eeconfig assert keyboard data block version
+ *
+ * FIXME: needs doc
+ */
+bool eeconfig_is_kb_datablock_valid(void) {
+    return eeprom_read_dword(EECONFIG_KEYBOARD) == (EECONFIG_KB_DATA_VERSION);
+}
 /** \brief eeconfig read keyboard data block
  *
  * FIXME: needs doc
  */
 void eeconfig_read_kb_datablock(void *data) {
-    if (eeprom_read_dword(EECONFIG_KEYBOARD) == (EECONFIG_KB_DATA_VERSION)) {
+    if (eeconfig_is_kb_datablock_valid()) {
         eeprom_read_block(data, EECONFIG_KB_DATABLOCK, (EECONFIG_KB_DATA_SIZE));
     } else {
         memset(data, 0, (EECONFIG_KB_DATA_SIZE));
@@ -292,15 +295,30 @@ void eeconfig_update_kb_datablock(const void *data) {
     eeprom_update_dword(EECONFIG_KEYBOARD, (EECONFIG_KB_DATA_VERSION));
     eeprom_update_block(data, EECONFIG_KB_DATABLOCK, (EECONFIG_KB_DATA_SIZE));
 }
+/** \brief eeconfig init keyboard data block
+ *
+ * FIXME: needs doc
+ */
+__attribute__((weak)) void eeconfig_init_kb_datablock(void) {
+    uint8_t dummy_kb[(EECONFIG_KB_DATA_SIZE)] = {0};
+    eeconfig_update_kb_datablock(dummy_kb);
+}
 #endif // (EECONFIG_KB_DATA_SIZE) > 0
 
 #if (EECONFIG_USER_DATA_SIZE) > 0
+/** \brief eeconfig assert user data block version
+ *
+ * FIXME: needs doc
+ */
+bool eeconfig_is_user_datablock_valid(void) {
+    return eeprom_read_dword(EECONFIG_USER) == (EECONFIG_USER_DATA_VERSION);
+}
 /** \brief eeconfig read user data block
  *
  * FIXME: needs doc
  */
 void eeconfig_read_user_datablock(void *data) {
-    if (eeprom_read_dword(EECONFIG_USER) == (EECONFIG_USER_DATA_VERSION)) {
+    if (eeconfig_is_user_datablock_enabled()) {
         eeprom_read_block(data, EECONFIG_USER_DATABLOCK, (EECONFIG_USER_DATA_SIZE));
     } else {
         memset(data, 0, (EECONFIG_USER_DATA_SIZE));
@@ -313,5 +331,13 @@ void eeconfig_read_user_datablock(void *data) {
 void eeconfig_update_user_datablock(const void *data) {
     eeprom_update_dword(EECONFIG_USER, (EECONFIG_USER_DATA_VERSION));
     eeprom_update_block(data, EECONFIG_USER_DATABLOCK, (EECONFIG_USER_DATA_SIZE));
+}
+/** \brief eeconfig init user data block
+ *
+ * FIXME: needs doc
+ */
+__attribute__((weak)) void eeconfig_init_user_datablock(void) {
+    uint8_t dummy_user[(EECONFIG_USER_DATA_SIZE)] = {0};
+    eeconfig_update_user_datablock(dummy_user);
 }
 #endif // (EECONFIG_USER_DATA_SIZE) > 0

--- a/quantum/eeconfig.h
+++ b/quantum/eeconfig.h
@@ -134,13 +134,17 @@ bool eeconfig_read_handedness(void);
 void eeconfig_update_handedness(bool val);
 
 #if (EECONFIG_KB_DATA_SIZE) > 0
+bool eeconfig_is_kb_datablock_valid(void);
 void eeconfig_read_kb_datablock(void *data);
 void eeconfig_update_kb_datablock(const void *data);
+void eeconfig_init_kb_datablock(void);
 #endif // (EECONFIG_KB_DATA_SIZE) > 0
 
 #if (EECONFIG_USER_DATA_SIZE) > 0
+bool eeconfig_is_user_datablock_valid(void);
 void eeconfig_read_user_datablock(void *data);
 void eeconfig_update_user_datablock(const void *data);
+void eeconfig_init_user_datablock(void);
 #endif // (EECONFIG_USER_DATA_SIZE) > 0
 
 // Any "checked" debounce variant used requires implementation of:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Following from #18874, my use case required changes to the introduced functionality to be usable:
* The ability to check version number
  * exposed indirectly to avoid users manually implementing checks
* The ability to init to non zero values
  * `eeconfig_init_kb` _could_ be used however it would write twice

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
