### PR TITLE
fixed MOUSEKEY_INERTIA on AVR

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -129,7 +129,7 @@ static int8_t move_unit(uint8_t axis) {
 
         // x**2 acceleration (quadratic, more precise for short movements)
         int16_t percent = (inertia << 8) / mk_time_to_max;
-        percent         = (percent * percent) >> 8;
+        percent         = ((int32_t)percent * percent) >> 8;
         if (inertia < 0) percent = -percent;
 
         // unit = sign(inertia) + (percent of max speed)


### PR DESCRIPTION
## Description

MouseKey "inertia" mode wasn't working on AVR.  This one-word change fixes it.

The AVR compiler seems to need an explicit cast during fixed-point multiply, or it'll overflow and cause some strange behavior.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* MouseKey "inertia" mode didn't work correctly on AVR.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
