### PR TITLE
made it possible to debounce Keyboardio Model01, sort of

### DIFF
--- a/keyboards/keyboardio/model01/config.h
+++ b/keyboards/keyboardio/model01/config.h
@@ -23,8 +23,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 8
 #define MATRIX_COLS 8
 
-/* The scanners already debounce for us */
-#define DEBOUNCE 0
+/*
+ * The scanners debounce for us
+ * but they can still be pretty bouncy, so make it configurable.
+ * NOTE: This does NOT use QMK's debounce algorithms.
+ * This only sets the i2c scanning interval...
+ * ... which is a primitive but mostly effective form of debouncing.
+ */
+#ifndef DEBOUNCE
+#define DEBOUNCE 2
+#endif
 
 /* RGB matrix constants */
 #define RGB_MATRIX_LED_COUNT 64

--- a/keyboards/keyboardio/model01/matrix.c
+++ b/keyboards/keyboardio/model01/matrix.c
@@ -73,8 +73,8 @@ void matrix_init(void) {
   PORTC |= _BV(7);
 
   i2c_init();
-  i2c_set_keyscan_interval(LEFT, 2);
-  i2c_set_keyscan_interval(RIGHT, 2);
+  i2c_set_keyscan_interval(LEFT, DEBOUNCE);
+  i2c_set_keyscan_interval(RIGHT, DEBOUNCE);
   memset(rows, 0, sizeof(rows));
 
   matrix_init_quantum();


### PR DESCRIPTION
## Description

I tried QMK on my old Model01, and it bounced so much it was unusable.  When I tried to type, it came out as: "III rrerallly nnened  to get  debouuunncnciiinngn to worrrk..  Thiisi thiinnig iisi uuunnnuusuable.."

Unfortunately, it has custom matrix scanning code which override's QMK's debouncing code, so the usual debouncing options didn't work.  However, I found a value which could be tweaked to achieve a similar effect, and it made the board usable again.  I'm typing this on that same board.

This solution isn't ideal, but it's the most effective solution I could find without rewriting the matrix scanner.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
