### PR TITLE
Fix compiling for bm40hsrgb

### DIFF
--- a/keyboards/kprepublic/bm40hsrgb/info.json
+++ b/keyboards/kprepublic/bm40hsrgb/info.json
@@ -1,6 +1,6 @@
 {
-    "keyboard_name": "BM40 Hotswap RGB",
-    "manufacturer": "KPRepublic",
+    "keyboard_name": "bm40hsrgb",
+    "manufacturer": "kprepublic",
     "url": "",
     "maintainer": "qmk",
     "usb": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I was looking around on the OpenRGB discord server and heard about the XAP feature that's coming some time in the future. I went to go test that and for some reason my keyboard's firmware wouldn't compile so I did a little bit of looking around and found out that the `info.json` file in my keyboard's directory was the issue
Instead of having the file/directory names, it had a mixed case manufacturer/product names
These changes shouldn't affect anything aside from the output of `lsusb` and allowing it to compile later on when/if the changes from the `xap` branch are merged.
`lsusb` goes from `KPRepublic BM40 Hotswap RGB` to `kprepublic bm40hsrgb`

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixed compiling Kprepublic BM40HSRGB keymaps

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
