### PR TITLE
Some optimizations for the Keychron Q3

### DIFF
--- a/keyboards/keychron/q3/config.h
+++ b/keyboards/keychron/q3/config.h
@@ -54,6 +54,9 @@
 #define WEAR_LEVELING_LOGICAL_SIZE 2048
 #define WEAR_LEVELING_BACKING_SIZE (WEAR_LEVELING_LOGICAL_SIZE * 2)
 
+/* Ignore atomic blocks as they are unnecessary on this MCU */
+#define IGNORE_ATOMIC_BLOCK
+
 // RGB Matrix Animation modes. Explicitly enabled
 // For full list of effects, see:
 // https://docs.qmk.fm/#/feature_rgb_matrix?id=rgb-matrix-effects

--- a/keyboards/keychron/q3/config.h
+++ b/keyboards/keychron/q3/config.h
@@ -57,6 +57,9 @@
 /* Ignore atomic blocks as they are unnecessary on this MCU */
 #define IGNORE_ATOMIC_BLOCK
 
+/* Drive high instead of pull high to unselect */
+#define MATRIX_UNSELECT_DRIVE_HIGH
+
 // RGB Matrix Animation modes. Explicitly enabled
 // For full list of effects, see:
 // https://docs.qmk.fm/#/feature_rgb_matrix?id=rgb-matrix-effects

--- a/keyboards/keychron/q3/config.h
+++ b/keyboards/keychron/q3/config.h
@@ -19,6 +19,7 @@
 /* key matrix size */
 #define MATRIX_ROWS 6
 #define MATRIX_COLS 16
+#define MATRIX_IO_DELAY 2
 
 /* COL2ROW or ROW2COL */
 #define DIODE_DIRECTION ROW2COL

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -185,6 +185,7 @@ static void matrix_init_pins(void) {
 
 static void matrix_read_rows_on_col(matrix_row_t current_matrix[], uint8_t current_col, matrix_row_t row_shifter) {
     bool key_pressed = false;
+    bool pins[ROWS_PER_HAND];
 
     // Select col
     if (!select_col(current_col)) { // select col
@@ -192,18 +193,24 @@ static void matrix_read_rows_on_col(matrix_row_t current_matrix[], uint8_t curre
     }
     matrix_output_select_delay();
 
+    // Read all required pins
+    for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {
+        pins[row_index] = readMatrixPin(row_pins[row_index]) == 0;
+    }
+
+    // Unselect col
+    unselect_col(current_col);
+
     // For each row...
     for (uint8_t row_index = 0; row_index < ROWS_PER_HAND; row_index++) {
         // Check row pin state
-        if (readMatrixPin(row_pins[row_index]) == 0) {
+        if (pins[row_index]) {
             // Pin LO, set col bit
             current_matrix[row_index] |= row_shifter;
             key_pressed = true;
         }
     }
 
-    // Unselect col
-    unselect_col(current_col);
     matrix_output_unselect_delay(current_col, key_pressed); // wait for all Row signals to go HIGH
 }
 

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -126,8 +126,6 @@ static bool select_col(uint8_t col) {
     } else {
         if (col == 8) {
             shiftout_single(0x00);
-        } else {
-            shiftout_single(0x01);
         }
         return true;
     }
@@ -144,8 +142,7 @@ static void unselect_col(uint8_t col) {
         setPinInputHigh_atomic(pin);
 #endif
     } else {
-        if (col == (MATRIX_COLS - 1))
-            shiftout_single(0x01);
+        shiftout_single(0x01);
     }
 }
 

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -165,9 +165,6 @@ static void matrix_read_rows_on_col(matrix_row_t current_matrix[], uint8_t curre
             // Pin LO, set col bit
             current_matrix[row_index] |= row_shifter;
             key_pressed = true;
-        } else {
-            // Pin HI, clear col bit
-            current_matrix[row_index] &= ~row_shifter;
         }
     }
 

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -183,6 +183,7 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
 
     // Set col, read rows
     matrix_row_t row_shifter = MATRIX_ROW_SHIFTER;
+#pragma GCC unroll 65534
     for (uint8_t current_col = 0; current_col < MATRIX_COLS; current_col++, row_shifter <<= 1) {
         matrix_read_rows_on_col(curr_matrix, current_col, row_shifter);
     }

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -187,8 +187,19 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
         matrix_read_rows_on_col(curr_matrix, current_col, row_shifter);
     }
 
-    bool changed = memcmp(current_matrix, curr_matrix, sizeof(curr_matrix)) != 0;
-    if (changed) memcpy(current_matrix, curr_matrix, sizeof(curr_matrix));
+    matrix_row_t changed = 0;
+#pragma GCC unroll 65534
+    for (uint8_t current_row = 0; current_row < MATRIX_ROWS; current_row++) {
+        matrix_row_t i = curr_matrix[current_row];
+        i ^= current_matrix[current_row];
+        changed |= i;
+    }
 
+    if (changed) {
+#pragma GCC unroll 65534
+        for (uint8_t current_row = 0; current_row < MATRIX_ROWS; current_row++) {
+            current_matrix[current_row] = curr_matrix[current_row];
+        }
+    }
     return changed;
 }


### PR DESCRIPTION
## Description

Some optimizations for the Keychron Q3 matrix scan code.
These changes bring the scan rate from about 1000 to about 9000.

Specifics:
- The MCU of this keyboard has a lot of flash so loops can be force-unrolled generously.
- Atomic blocks are of unnecessary on this MCU.
- `setPinOutput` is pretty slow so doing those calls only in the initialization function helps quite a bit too.
- By splitting up the reading of the pin states and the processing of those states, we can use the processing as part of the unselect delay, reducing the time between pin select and unselect, and allowing us to lower the unselect delay.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
