### PR TITLE
Fix encoder_init call order in keyboard_init

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -354,6 +354,9 @@ void keyboard_init(void) {
 #ifdef SPLIT_KEYBOARD
     split_pre_init();
 #endif
+#ifdef ENCODER_ENABLE
+    encoder_init();
+#endif
     matrix_init();
     quantum_init();
 #if defined(CRC_ENABLE)
@@ -373,9 +376,6 @@ void keyboard_init(void) {
 #endif
 #ifdef RGBLIGHT_ENABLE
     rgblight_init();
-#endif
-#ifdef ENCODER_ENABLE
-    encoder_init();
 #endif
 #ifdef STENO_ENABLE_ALL
     steno_init();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

From the [insight of sigprof](https://github.com/qmk/qmk_firmware/pull/19140#issuecomment-1326155380) it was discovered that `encoder_init` initializes `thisCount` which is used in `encoder_state_raw` `memcpy`. `quantum_init` was calling `encoder_state_raw` though the initialization of `bootmatgic` calling `matrix_scan`. This caused undefined behavior resulting in bad values being sent over transport. Adjusting
the call order of `encoder_init` allows for correct behavior of `encoder_state_raw`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/19139

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
