### PR TITLE
Fix build failures for `bastardkb/tbk` and `jels/boaty`

### DIFF
--- a/keyboards/bastardkb/tbk/tbk.h
+++ b/keyboards/bastardkb/tbk/tbk.h
@@ -15,8 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
+
+#include "quantum.h"
 
 // clang-format off
 #define LAYOUT_split_4x6_5( \

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -773,7 +773,7 @@ def avr_processor_rules(info_data, rules):
     """
     info_data['processor_type'] = 'avr'
     info_data['platform'] = rules['ARCH'] if 'ARCH' in rules else 'unknown'
-    info_data['protocol'] = 'V-USB' if rules.get('MCU') in VUSB_PROCESSORS else 'LUFA'
+    info_data['protocol'] = 'V-USB' if info_data['processor'] in VUSB_PROCESSORS else 'LUFA'
 
     if 'bootloader' not in info_data:
         info_data['bootloader'] = 'atmel-dfu'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`bastardkb/tbk` was missing a `quantum.h` include.
![image](https://user-images.githubusercontent.com/4781841/204016178-d1d698f5-8ed5-4590-9704-87b0059b21f9.png)

`jels/boaty` has nothing wrong with it. The MCU is specified in info.json instead of rules.mk but the CLI is only looking specifically at the latter when trying to determine the protocol, leading to it falling back to `LUFA`. Since info.json `processor` is guaranteed to be present in order to call the appropriate `*_processor_rules()`, let's look at that instead. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
