### PR TITLE
[GMMK Pro][Keymap] Change DEBOUNCE_TYPE to sym_eager_pk to reduce latency

### DIFF
--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/andrebrait/rules.mk
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/andrebrait/rules.mk
@@ -2,3 +2,22 @@
 
 # Disabling MouseKey because it breaks my KVM switch
 MOUSEKEY_ENABLE = no
+
+# Cherry MX-style switches and diodes are not susceptible to noise, no need for noise-resistant algorithms.
+# This significantly reduces latency.
+#
+# The matrix scan frequency seems to be around 1820 Hz, so even sym_defer_g would perform ok,
+# but the "defer" part would mean we would wait DEBOUNCE ms before sending any events.
+# Using "asym_eager_defer_pk" does not seem to benefit us in anything.
+# The GMMK Pro has more then enough system resources for a per-key algorithm.
+# Using an "eager" algorithm leads to extremely low latency while also reducing the chances of chattering
+# due to it's "post-event" debouncing (of sorts).
+#
+# I have observed zero chattering or double-keypress issues on my Gateron Yellow switches.
+# Most chattering issues on the GMMK Pro seem to be related to its proprietary hot-swap sockets anyway.
+DEBOUNCE_TYPE = sym_eager_pk
+
+# Useful for debugging
+# CONSOLE_ENABLE = yes
+# DEBUG_MATRIX_SCAN_RATE_ENABLE = yes
+# DEBUG_MATRIX_SCAN_RATE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Just changing my debounce type on my keymap and adding my reasoning there.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
