### PR TITLE
Fixup installation procedure for different Fedora versions.

### DIFF
--- a/util/install/fedora.sh
+++ b/util/install/fedora.sh
@@ -8,7 +8,12 @@ _qmk_install() {
         clang diffutils git gcc glibc-headers kernel-devel kernel-headers \
         make unzip wget zip python3 avr-binutils avr-gcc avr-gcc-c++ avr-libc \
         arm-none-eabi-binutils-cs arm-none-eabi-gcc-cs arm-none-eabi-gcc-cs-c++ \
-        arm-none-eabi-newlib avrdude dfu-programmer dfu-util hidapi libusb-devel
+        arm-none-eabi-newlib avrdude dfu-programmer dfu-util hidapi
+
+    # Handle discrepancies between different Fedora versions
+    sudo dnf $SKIP_PROMPT install libusb-devel \
+        || sudo dnf $SKIP_PROMPT install libusb1-devel libusb-compat-0.1-devel \
+        || sudo dnf $SKIP_PROMPT install libusb0-devel
 
     python3 -m pip install --user -r $QMK_FIRMWARE_DIR/requirements.txt
 }


### PR DESCRIPTION
## Description

Fedora 37 has libusb1, with libusb0-compat stuff.
This just pulls out the install script deps to try both cases.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
