### PR TITLE
docs: add a note about reflashing both halves for encoder resolution

### DIFF
--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -67,6 +67,8 @@ Additionally, if one side does not have an encoder, you can specify `{}` for the
 #define ENCODER_RESOLUTIONS_RIGHT { 4 }
 ```
 
+Keep in mind that whenver you change the encoder resolution, you will need to reflash the half that has the encoder affected by the change.
+
 ## Encoder map :id=encoder-map
 
 Encoder mapping may be added to your `keymap.c`, which replicates the normal keyswitch layer handling functionality, but with encoders. Add this to your keymap's `rules.mk`:

--- a/docs/feature_encoders.md
+++ b/docs/feature_encoders.md
@@ -67,7 +67,7 @@ Additionally, if one side does not have an encoder, you can specify `{}` for the
 #define ENCODER_RESOLUTIONS_RIGHT { 4 }
 ```
 
-Keep in mind that whenver you change the encoder resolution, you will need to reflash the half that has the encoder affected by the change.
+!> Keep in mind that whenver you change the encoder resolution, you will need to reflash the half that has the encoder affected by the change.
 
 ## Encoder map :id=encoder-map
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Documentations do not mention that in order to modify encoder resolution, the half that has the encoder also needs to be reflashed, not only the master half.

In hindsight this is obvious and submitting this PR feels a bit like accepting my own stupidity, but... Well, it might save other dim fellows the couple hours of research and debugging I went through 🤦🏻‍♀️ 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
