### PR TITLE
Keeb.io Sinc: Enable Split LED state

### DIFF
--- a/keyboards/keebio/sinc/rev1/config.h
+++ b/keyboards/keebio/sinc/rev1/config.h
@@ -23,6 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
+/* Synchronize Caps Lock LED across halves */
+#define SPLIT_LED_STATE_ENABLE
 
 /* ws2812 RGB LED */
 #define RGBLIGHT_LED_MAP { 1, 2, 3, 12, 13, 14, 15, 0, 7, 6, 5, 4, 11, 10, 9, 8 }

--- a/keyboards/keebio/sinc/rev2/config.h
+++ b/keyboards/keebio/sinc/rev2/config.h
@@ -23,6 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
+/* Synchronize Caps Lock LED across halves */
+#define SPLIT_LED_STATE_ENABLE
 
 /* ws2812 RGB LED */
 #define RGBLIGHT_LED_MAP { 1, 2, 3, 12, 13, 14, 15, 0, 7, 6, 5, 4, 11, 10, 9, 8 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Enable `SPLIT_LED_STATE_ENABLE` for Sinc Revs 1 & 2

## Description

<!--- Describe your changes in detail here. -->
This should fix the caps-lock LED state when the keyboard is connected via the "right" half.
The keyboard pre-dates the existence of that macro; prior to that point, it apparently used to be the default.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
