### PR TITLE
[Keyboard] Fix config error for Charybdis

### DIFF
--- a/keyboards/bastardkb/charybdis/config.h
+++ b/keyboards/bastardkb/charybdis/config.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "config_common.h"
+
 /* Pointing device configuration. */
 
 // Enable use of pointing device on slave split.


### PR DESCRIPTION
## Description

Missing "config_common.h" Isn't a critical error, but ... sure AF broke my songs. 😅 


## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
