### PR TITLE
Revert RESET-> QK_BOOT in Read Me files where applicable

### DIFF
--- a/keyboards/bioi/f60/readme.md
+++ b/keyboards/bioi/f60/readme.md
@@ -21,5 +21,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 ## Bootloader
 
 * **Bootmagic reset**: Hold down the top left key (ESC) and plug in the keyboard
-* **Physical reset button**: Short the two small pads labeled "QK_BOOT" the back of the PCB
+* **Physical reset button**: Short the two small pads labeled `RESET` the back of the PCB
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/bobpad/readme.md
+++ b/keyboards/bobpad/readme.md
@@ -19,7 +19,7 @@ Flashing example for this keyboard:
 ## Bootloader
 
 Enter the bootloader in 3 ways:
-* **Physical reset button**: Briefly short the pad connected to QK_BOOT and GND on the back
+* **Physical reset button**: Briefly short the pad connected to *RESET* and *GND* on the back
 * **Keycode in layout**: Press the key mapped to `QK_BOOT`, this is the recommened method
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/creatkeebs/glacier/readme.md
+++ b/keyboards/creatkeebs/glacier/readme.md
@@ -16,7 +16,7 @@ A 80% keyboard
 
 Enter the bootloader in 2 ways:
 
-* Physical reset button: Press the `QK_BOOT` button on the back of the PCB.
+* Physical reset button: Press the `RESET` button on the back of the PCB.
 * Keycode in layout: Press the key mapped to `QK_BOOT` if it is available.
 
 ### Building the Firmware

--- a/keyboards/creatkeebs/thera/readme.md
+++ b/keyboards/creatkeebs/thera/readme.md
@@ -18,7 +18,7 @@ A 75% keyboard
 
 Enter the bootloader in 2 ways:
 
-* Physical reset button: Press the `QK_BOOT` button on the back of the PCB.
+* Physical reset button: Press the `RESET` button on the back of the PCB.
 * Keycode in layout: Press the key mapped to `QK_BOOT` if it is available.
 
 ### Building the Firmware

--- a/keyboards/handwired/axon/readme.md
+++ b/keyboards/handwired/axon/readme.md
@@ -15,8 +15,8 @@ Make example for this keyboard (after setting up your build environment):
 ## To reset into bootloader mode:
 
 1. While plugged in, press and hold `BOOT` switch
-2. While holding `BOOT`, press `QK_BOOT` and hold it for a second or two
-3. Release `QK_BOOT`
+2. While holding `BOOT`, press `RESET` and hold it for a second or two
+3. Release `RESET`
 4. Release `BOOT`
 5. The keyboard should now be recognized as a USBasp programmer device.
 

--- a/keyboards/handwired/swiftrax/digicarp65/readme.md
+++ b/keyboards/handwired/swiftrax/digicarp65/readme.md
@@ -17,5 +17,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 Enter the bootloader in 3 ways:
 
 * **Bootmagic reset**: Hold down the key at (0,0) in the matrix (top left key)and plug in the keyboard
-* **Physical reset button**: Briefly short the pad on the back of the PCB labeled QK_BOOT
+* **Physical reset button**: Briefly short the pad on the back of the PCB labeled `RESET`
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/late9/readme.md
+++ b/keyboards/late9/readme.md
@@ -20,7 +20,7 @@ Flashing example for this keyboard:
     make late9/rev1:default:flash
 
 
-When asked by the terminal, short with a metal wire the pins on the backside of the board highlighted as `RST` (one is the `QK_BOOT` and the other one is `GROUND`) to enter the bootloader and let the OS detects the device.
+When asked by the terminal, short with a metal wire the pins on the backside of the board highlighted as `RST` (one is the `RESET` and the other one is `GROUND`) to enter the bootloader and let the OS detects the device.
 After installing this firmware you can use Bootmagic to enter the bootloader while plugging in your LATE-9. By default it's the button on the upper-left of the keyboard.
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/linworks/fave65h/readme.md
+++ b/keyboards/linworks/fave65h/readme.md
@@ -17,7 +17,7 @@ Make example for this keyboard (after setting up your build environment):
 
 ## Bootloader Enter the bootloader in 3 ways: 
 * **Bootmagic reset**: Hold down the key ESC key and plug in the keyboard (Top Left most switch)
-* **Physical reset short**: Briefly short the 2 pads labelled QK_BOOT on the back of the PCB
+* **Physical reset short**: Briefly short the 2 pads labelled `RESET` on the back of the PCB
 * **Keycode in layout**: Press the B key on layer 1 which is mapped to `QK_BOOT`
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/linworks/fave84h/readme.md
+++ b/keyboards/linworks/fave84h/readme.md
@@ -19,5 +19,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 ## Bootloader Enter the bootloader in 3 ways: 
 * **Bootmagic reset**: Hold down the key ESC key and plug in the keyboard (Top Left most switch)
-* **Physical reset short**: Briefly short the 2 pads labelled QK_BOOT on the back of the PCB
+* **Physical reset short**: Briefly short the 2 pads labelled `RESET` on the back of the PCB
 * **Keycode in layout**: Press the B key on layer 1 which is mapped to `QK_BOOT`

--- a/keyboards/linworks/fave87h/readme.md
+++ b/keyboards/linworks/fave87h/readme.md
@@ -19,5 +19,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 ## Bootloader Enter the bootloader in 3 ways: 
 * **Bootmagic reset**: Hold down the key ESC key and plug in the keyboard (Top Left most switch)
-* **Physical reset short**: Briefly short the 2 pads labelled QK_BOOT on the back of the PCB
+* **Physical reset short**: Briefly short the 2 pads labelled `RESET` on the back of the PCB
 * **Keycode in layout**: Press the B key on layer 1 which is mapped to `QK_BOOT`

--- a/keyboards/mechanickeys/miniashen40/readme.md
+++ b/keyboards/mechanickeys/miniashen40/readme.md
@@ -32,7 +32,7 @@ Enter the bootloader in 3 ways:
 * **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
 * **Physical**: 
   1. Press and hold `BOOT` switch
-  2. Tap `QK_BOOT` switch
+  2. Tap `RESET` switch
   3. Release `BOOT` switch
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available
 

--- a/keyboards/neopad/readme.md
+++ b/keyboards/neopad/readme.md
@@ -19,7 +19,7 @@ Flashing example for this keyboard:
 
     make neopad/rev1:default:flash
 
-When asked by the terminal, press the dedicated `QK_BOOT` button (the one above the 2 LEDs) to enter the bootloader and let the OS detects the device.
+When asked by the terminal, press the dedicated `RESET` button (the one above the 2 LEDs) to enter the bootloader and let the OS detects the device.
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 

--- a/keyboards/pearlboards/atlas/readme.md
+++ b/keyboards/pearlboards/atlas/readme.md
@@ -18,5 +18,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 Enter the bootloader in 2 ways:
 
-* **Physical reset button**: Briefly press the button on the back of the PCB labeled "QK_BOOT"
+* **Physical reset button**: Briefly press the button on the back of the PCB labeled `RESET`
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` in conjunction with the key mapped to `MO(1))` 

--- a/keyboards/pearlboards/pandora/readme.md
+++ b/keyboards/pearlboards/pandora/readme.md
@@ -15,3 +15,10 @@ Make example for this keyboard (after setting up your build environment):
     make pearlboards/pandora:default
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 2 ways:
+
+* **Physical reset button**: Briefly press the button on the back of the PCB labeled `RESET`
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` in conjunction with the key mapped to `MO(1))` 

--- a/keyboards/pearlboards/pearl/readme.md
+++ b/keyboards/pearlboards/pearl/readme.md
@@ -18,5 +18,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 Enter the bootloader in 2 ways:
 
-* **Physical reset button**: Briefly press the button on the front left of the PCB labeled "QK_BOOT"
+* **Physical reset button**: Briefly press the button on the front left of the PCB labeled `RESET`
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` in conjunction with the key mapped to `MO(1))` 

--- a/keyboards/pearlboards/zeus/readme.md
+++ b/keyboards/pearlboards/zeus/readme.md
@@ -18,5 +18,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 Enter the bootloader in 2 ways:
 
-* **Physical reset button**: Briefly press the button on the back of the PCB labeled "QK_BOOT"
+* **Physical reset button**: Briefly press the button on the back of the PCB labeled `RESET`
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` in conjunction with the key mapped to `MO(1))` 

--- a/keyboards/pearlboards/zeuspad/readme.md
+++ b/keyboards/pearlboards/zeuspad/readme.md
@@ -18,5 +18,5 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 Enter the bootloader in 2 ways:
 
-* **Physical reset button**: Briefly press the button on the front of the PCB labeled "QK_BOOT"
+* **Physical reset button**: Briefly press the button on the front of the PCB labeled `RESET`
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` in conjunction with the key mapped to `MO(1))` 

--- a/keyboards/polycarbdiet/s20/readme.md
+++ b/keyboards/polycarbdiet/s20/readme.md
@@ -17,7 +17,7 @@ Flashing example for this keyboard:
     make polycarbdiet/s20:default:flash
 
 **Reset Method:** 
-- Press the `QK_BOOT` button on the under side of the PCB  
+- Press the `RESET` button on the under side of the PCB  
 
 **Bootloader Method:** 
 - Hold down the key located at `K00`, commonly programmed as `ESC`, while plugging in the keyboard.

--- a/keyboards/ramonimbao/mona/v1_1/readme.md
+++ b/keyboards/ramonimbao/mona/v1_1/readme.md
@@ -7,7 +7,7 @@ A gummy-worm o-ring mount 60% marble keyboard. Now with ALPS/MX, Caps Lock LED, 
 * Keyboard Maintainer: [Ramon Imbao](https://github.com/ramonimbao)
 * Hardware Supported: ATmega32u4
 
-To get to the bootloader, with the USB cable plugged in, press the `QK_BOOT` button on the back of the PCB.
+To get to the bootloader, with the USB cable plugged in, press the `RESET` button on the back of the PCB.
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/keyboards/ramonimbao/mona/v32a/readme.md
+++ b/keyboards/ramonimbao/mona/v32a/readme.md
@@ -7,7 +7,7 @@ A gummy-worm o-ring mount 60% marble keyboard. Now with ALPS/MX, Caps Lock LED, 
 * Keyboard Maintainer: [Ramon Imbao](https://github.com/ramonimbao)
 * Hardware Supported: ATmega32A
 
-To get to the bootloader, with the USB cable plugged in, press the `QK_BOOT` button on the back of the PCB.
+To get to the bootloader, with the USB cable plugged in, press the `RESET` button on the back of the PCB.
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/keyboards/ryanskidmore/rskeys100/readme.md
+++ b/keyboards/ryanskidmore/rskeys100/readme.md
@@ -19,4 +19,4 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 ## Bootloader
 
-To enter the bootloader, press the `QK_BOOT` button on your daughterboard PCB while it's plugged in.
+To enter the bootloader, press the `RESET` button on your daughterboard PCB while it's plugged in.

--- a/keyboards/ryloo_studio/m0110/readme.md
+++ b/keyboards/ryloo_studio/m0110/readme.md
@@ -16,9 +16,9 @@ Flashing example for this keyboard:
 
 Putting the Keyboard in Bootloader Mode:
 
-The shipped PCB did not come with a reset button.  To put the PCB in bootloader mode: locate the 2 `QK_BOOT` pins in the back of the PCB and short them with a conductive wire or tweezer.
+The shipped PCB did not come with a reset button.  To put the PCB in bootloader mode: locate the 2 `RESET` pins in the back of the PCB and short them with a conductive wire or tweezer.
 
-![Ryloo Studio M0110 PCB QK_BOOT pins location](https://i.imgur.com/QJWmpqF.jpeg)
+![Ryloo Studio M0110 PCB RESET pins location](https://i.imgur.com/QJWmpqF.jpeg)
 
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).

--- a/keyboards/studiokestra/bourgeau/readme.md
+++ b/keyboards/studiokestra/bourgeau/readme.md
@@ -11,7 +11,7 @@ Compact 75% universal hotswap PCB with USB-C that supports a fixed 6.25U bottom 
 There are 3 ways to put the board in bootloader mode:
 
 - Hold the top-left key (typically `Esc`) while plugging in the USB cable, OR
-- While the PCB is plugged into the PC, press the physical `QK_BOOT` button on the back of the board, OR
+- While the PCB is plugged into the PC, press the physical `RESET` button on the back of the board, OR
 - With the default layout, toggle Layer 1 and press the `ESC` key.
 
 ## Compiling Firmware

--- a/keyboards/studiokestra/cascade/readme.md
+++ b/keyboards/studiokestra/cascade/readme.md
@@ -11,7 +11,7 @@
 There are 3 ways to put the board in bootloader mode:
 
 - Hold the top-left key (typically `Esc`) while plugging in the USB cable, OR
-- While the PCB is plugged into the PC, press the physical `QK_BOOT` button on the back of the board, OR
+- While the PCB is plugged into the PC, press the physical `RESET` button on the back of the board, OR
 - With the default layout, toggle Layer 1 and press the `ESC` key.
 
 ## Compiling Firmware

--- a/keyboards/studiokestra/galatea/readme.md
+++ b/keyboards/studiokestra/galatea/readme.md
@@ -13,7 +13,7 @@ TKL H87/88c compatible PCB with support for the most common layouts.
 There are 3 ways to put the board in bootloader mode:
 
 - Hold the top-left key (typically `Esc`) while plugging in the USB cable, OR
-- While the PCB is plugged into the PC, press the physical `QK_BOOT` button on the back of the board, OR
+- While the PCB is plugged into the PC, press the physical `RESET` button on the back of the board, OR
 - With the default layout, toggle Layer 1 and press the `R` key. 
 
 ## Compiling Firmware

--- a/keyboards/studiokestra/nue/readme.md
+++ b/keyboards/studiokestra/nue/readme.md
@@ -11,7 +11,7 @@
 There are 3 ways to put the board in bootloader mode:
 
 - Hold the top-left key (typically `Esc`) while plugging in the USB cable, OR
-- While the PCB is plugged into the PC, press the physical `QK_BOOT` button on the back of the board, OR
+- While the PCB is plugged into the PC, press the physical `RESET` button on the back of the board, OR
 - With the default layout, toggle Layer 1 and press the `R` key. 
 
 ## Compiling Firmware

--- a/keyboards/ydkb/just60/readme.md
+++ b/keyboards/ydkb/just60/readme.md
@@ -2,7 +2,7 @@
 
 Just60 keyboard produced by Yang. The keyboard comes with a custom Mass Storage Device bootloader and a TMK based firmware from ydkb.io.
 
-To use a QMK based firmware, you might want to install a QMK bootloader. The PCB exposes 6 pins for ISP(In-System Programming), and they are located just under the ATMega32U4 chip. From left to right, the pins are `VCC`, `SCLK`, `MOSI`, `MISO`, `QK_BOOT`, `GND`. The `GND` is the square one. You could program the flash with any AVR programmer, or a Raspberry Pi with `avrdude`.
+To use a QMK based firmware, you might want to install a QMK bootloader. The PCB exposes 6 pins for ISP(In-System Programming), and they are located just under the ATMega32U4 chip. From left to right, the pins are `VCC`, `SCLK`, `MOSI`, `MISO`, `RESET`, `GND`. The `GND` is the square one. You could program the flash with any AVR programmer, or a Raspberry Pi with `avrdude`.
 
 Backlight LEDs and Bluetooth are not working yet.
 


### PR DESCRIPTION
## Description

During the rename of RESET to QK_BOOT (#18110) some Read Me files were changed while describing labels or function rather than keycode. This PR reverts the changes where needed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
