### PR TITLE
Fixing PMW3389.c so it can compile

### DIFF
--- a/drivers/sensors/pmw3389.c
+++ b/drivers/sensors/pmw3389.c
@@ -8,8 +8,6 @@
 #include "pmw33xx_common.h"
 #include "progmem.h"
 
-extern const size_t pmw33xx_number_of_sensors;
-
 uint16_t pmw33xx_get_cpi(uint8_t sensor) {
     if (sensor >= pmw33xx_number_of_sensors) {
         return 0;


### PR DESCRIPTION
Just removing the `extern constant pmw33xx_number_of_sensors` definition as it is not needed anymore as `pmw33xx_number_of_sensors`  is now a macro defined in `pmw33xx_common.h`  This was done for the PMW3360 sensor but the PMW3389 sensor was missed.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  PMW3389 based pointing devices would fail to compile

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
