### PR TITLE
Tests that caps word stays active after use of OSL

### DIFF
--- a/tests/caps_word/test_caps_word.cpp
+++ b/tests/caps_word/test_caps_word.cpp
@@ -591,6 +591,57 @@ INSTANTIATE_TEST_CASE_P(
         ),
     CapsWordDoubleTapShiftParams::GetName
     );
-// clang-format on
 
+// Tests that holding a OSL keeps caps word active and shifts keys on the layer that need to be shifted.
+TEST_F(CapsWord, IgnoresOSLHold) {
+    TestDriver driver;
+    KeymapKey key_a(0, 0, 0, KC_A);
+    KeymapKey key_osl(0, 1, 0, OSL(1));
+    KeymapKey key_b(1, 0, 0, KC_B);
+    set_keymap({key_a, key_osl, key_b});
+
+    // Allow any number of reports with no keys or only modifiers.
+    // clang-format off
+    EXPECT_CALL(driver, send_keyboard_mock(AnyOf(
+                KeyboardReport(),
+                KeyboardReport(KC_LSFT))))
+        .Times(AnyNumber());
+
+    EXPECT_REPORT(driver, (KC_LSFT, KC_B));
+    caps_word_on();
+
+    key_osl.press();
+    run_one_scan_loop();
+    tap_key(key_b);
+    key_osl.release();
+    run_one_scan_loop();
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+
+// Tests that tapping a OSL keeps caps word active and shifts keys on the layer that need to be shifted.
+TEST_F(CapsWord, IgnoresOSLTap) {
+    TestDriver driver;
+    KeymapKey key_a(0, 0, 0, KC_A);
+    KeymapKey key_osl(0, 1, 0, OSL(1));
+    KeymapKey key_b(1, 0, 0, KC_B);
+    set_keymap({key_a, key_osl, key_b});
+
+    // Allow any number of reports with no keys or only modifiers.
+    // clang-format off
+    EXPECT_CALL(driver, send_keyboard_mock(AnyOf(
+                KeyboardReport(),
+                KeyboardReport(KC_LSFT))))
+        .Times(AnyNumber());
+
+    EXPECT_REPORT(driver, (KC_LSFT, KC_B));
+    caps_word_on();
+
+    tap_key(key_osl);
+    tap_key(key_b);
+    run_one_scan_loop();
+
+    testing::Mock::VerifyAndClearExpectations(&driver);
+}
+// clang-format on
 } // namespace


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add tests that tapping or holding a OSL keeps caps word active and shifts keys on the layer that need to be shifted.
These tests address issue #18136.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
