### PR TITLE
[Docs] Remove broken link

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -356,8 +356,6 @@ qk_tap_dance_action_t tap_dance_actions[] = {
 
 And then simply use `TD(X_CTL)` anywhere in your keymap.
 
-If you want to implement this in your userspace, then you may want to check out how [DanielGGordon](https://github.com/qmk/qmk_firmware/tree/master/users/gordon) has implemented this in their userspace.
-
 > In this configuration "hold" takes place **after** tap dance timeout. To achieve instant hold, remove `state->interrupted` checks in conditions. As a result you may use comfortable longer tapping periods to have more time for taps and not to wait too long for holds (try starting with doubled `TAPPING_TERM`).
 
 #### Example 5: Using tap dance for advanced mod-tap and layer-tap keys :id=example-5

--- a/docs/ja/feature_tap_dance.md
+++ b/docs/ja/feature_tap_dance.md
@@ -340,8 +340,6 @@ qk_tap_dance_action_t tap_dance_actions[] = {
 
 これで、キーマップのどこでも簡単に `TD(X_CTL)` マクロが使えます。
 
-もし、この機能をユーザスペースで実現したい場合、 [DanielGGordon](https://github.com/qmk/qmk_firmware/tree/master/users/gordon) がユーザスペースでどのように実装しているか確認してください。
-
 > この設定の "hold" は、タップダンスのタイムアウト（`ACTION_TAP_DANCE_FN_ADVANCED_TIME` 参照）の **後** に起こります。即座に "hold" を得るためには、条件から `state->interrupted` の確認を除きます。結果として、複数回のタップのための時間をより多く持つことで快適な長いタップの期限を使うことができ、そして、"hold" のために長く待たないようにすることができます(2倍の `TAPPING TERM` で開始してみてください)。
 
 #### 例5: タップダンスを高度なモッドタップとレイヤータップキーに使う :id=example-5


### PR DESCRIPTION
## Description
Just noticed a broken link while reading Tap Dance's documentation. Removed it
I don't speak japanese, so i may have do it wrong on that translation, chinese didn't have a Tap Dance file.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
