### PR TITLE
fix elite_c_to_ converters

### DIFF
--- a/platforms/chibios/converters/elite_c_to_elite_pi/_pin_defs.h
+++ b/platforms/chibios/converters/elite_c_to_elite_pi/_pin_defs.h
@@ -18,7 +18,7 @@
 #define B5 9U
 
 // Right side (front)
-//      RAW
+#define B0 11U // back pad
 //      GND
 //      RESET
 //      VCC

--- a/platforms/chibios/converters/elite_c_to_stemcell/_pin_defs.h
+++ b/platforms/chibios/converters/elite_c_to_stemcell/_pin_defs.h
@@ -32,7 +32,7 @@
 #define B5 PAL_LINE(GPIOB, 9)
 
 // Right side (front)
-//      RAW
+#define B0 PAL_LINE(GPIOA, 9) // unconnected pin
 //      GND
 //      RESET
 //      VCC

--- a/platforms/chibios/converters/promicro_to_elite_pi/_pin_defs.h
+++ b/platforms/chibios/converters/promicro_to_elite_pi/_pin_defs.h
@@ -32,5 +32,5 @@
 #define B6 21U
 
 // LEDs
-#define D5 12U
-#define B0 13U
+#define D5 10U // back pad
+#define B0 11U // back pad


### PR DESCRIPTION
## Description

Update elite_c_to_ converters to map B0, which is a pin on the Elite-C

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
