### PR TITLE
Revert to legacy wear-leveling driver by default for F401.

### DIFF
--- a/builddefs/mcu_selection.mk
+++ b/builddefs/mcu_selection.mk
@@ -367,6 +367,10 @@ ifneq ($(findstring STM32F401, $(MCU)),)
 
   # Bootloader address for STM32 DFU
   STM32_BOOTLOADER_ADDRESS ?= 0x1FFF0000
+
+  # Revert to legacy wear-leveling driver until ChibiOS's EFL driver is fixed with 128kB and 384kB variants.
+  EEPROM_DRIVER ?= wear_leveling
+  WEAR_LEVELING_DRIVER ?= legacy
 endif
 
 ifneq ($(findstring STM32F405, $(MCU)),)


### PR DESCRIPTION
## Description

Should hopefully alleviate Configurator until next cycle when we pick up the fixed ChibiOS.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* [qmk/qmk_configurator#1228](https://github.com/qmk/qmk_configurator/issues/1228)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
