### PR TITLE
ps2 busywait driver for pico (remote mode only)

### DIFF
--- a/platforms/chibios/drivers/ps2/ps2_io.c
+++ b/platforms/chibios/drivers/ps2/ps2_io.c
@@ -14,6 +14,7 @@
 #    error "PS/2 data setting is required in config.h"
 #endif
 
+#ifdef PAL_MODE_OUTPUT_OPENDRAIN
 /*
  * Clock
  */
@@ -53,3 +54,42 @@ bool data_in(void) {
     palSetLineMode(PS2_DATA_PIN, PAL_MODE_INPUT);
     return palReadLine(PS2_DATA_PIN);
 }
+#else
+/*
+ * Clock
+ */
+void clock_init(void) {}
+
+void clock_lo(void) {
+    palSetLineMode(PS2_CLOCK_PIN, PAL_MODE_OUTPUT_PUSHPULL);
+    palWriteLine(PS2_CLOCK_PIN, PAL_LOW);
+}
+
+void clock_hi(void) {
+    palSetLineMode(PS2_CLOCK_PIN, PAL_MODE_INPUT);
+}
+
+bool clock_in(void) {
+    palSetLineMode(PS2_CLOCK_PIN, PAL_MODE_INPUT);
+    return palReadLine(PS2_CLOCK_PIN);
+}
+
+/*
+ * Data
+ */
+void data_init(void) {}
+
+void data_lo(void) {
+    palSetLineMode(PS2_DATA_PIN, PAL_MODE_OUTPUT_PUSHPULL);
+    palWriteLine(PS2_DATA_PIN, PAL_LOW);
+}
+
+void data_hi(void) {
+    palSetLineMode(PS2_DATA_PIN, PAL_MODE_INPUT);
+}
+
+bool data_in(void) {
+    palSetLineMode(PS2_DATA_PIN, PAL_MODE_INPUT);
+    return palReadLine(PS2_DATA_PIN);
+}
+#endif


### PR DESCRIPTION
the pi pico doesn't support PAL_MODE_OUTPUT_OPENDRAIN

this sort of emulates that output mode using OUTPUT_PUSHPULL and INPUT

for some reason this doesn't compile when remote mode is turned off, idk.

this should also work for other platforms that don't support PAL_MODE_OUTPUT_OPENDRAIN but *do* support PAL_MODE_OUTPUT_PUSHPULL and PAL_MODE_INPUT, idk what those platforms are but if one exists it'll work with this.

## Description

I modified the clock/data hi/lo/in functions for cases where the OPENDRAIN output mode isn't available (like on the pico)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
