### PR TITLE
[Core] use `IS_EVENT` macro instead of `!IS_NOEVENT`

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -70,7 +70,7 @@ __attribute__((weak)) bool pre_process_record_quantum(keyrecord_t *record) {
  * FIXME: Needs documentation.
  */
 void action_exec(keyevent_t event) {
-    if (!IS_NOEVENT(event)) {
+    if (IS_EVENT(event)) {
         ac_dprintf("\n---- action_exec: start -----\n");
         ac_dprintf("EVENT: ");
         debug_event(event);
@@ -87,7 +87,7 @@ void action_exec(keyevent_t event) {
 
 #ifdef SWAP_HANDS_ENABLE
     // Swap hands handles both keys and encoders, if ENCODER_MAP_ENABLE is defined.
-    if (!IS_NOEVENT(event)) {
+    if (IS_EVENT(event)) {
         process_hand_swap(&event);
     }
 #endif
@@ -125,7 +125,7 @@ void action_exec(keyevent_t event) {
     if (IS_NOEVENT(record.event) || pre_process_record_quantum(&record)) {
         process_record(&record);
     }
-    if (!IS_NOEVENT(record.event)) {
+    if (IS_EVENT(record.event)) {
         ac_dprintf("processed: ");
         debug_record(record);
         dprintln();

--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -17,7 +17,7 @@
 #        endif
 #    endif
 
-#    define IS_TAPPING() !IS_NOEVENT(tapping_key.event)
+#    define IS_TAPPING() IS_EVENT(tapping_key.event)
 #    define IS_TAPPING_PRESSED() (IS_TAPPING() && tapping_key.event.pressed)
 #    define IS_TAPPING_RELEASED() (IS_TAPPING() && !tapping_key.event.pressed)
 #    define IS_TAPPING_KEY(k) (IS_TAPPING() && KEYEQ(tapping_key.event.key, (k)))
@@ -85,7 +85,7 @@ static void debug_waiting_buffer(void);
  */
 void action_tapping_process(keyrecord_t record) {
     if (process_tapping(&record)) {
-        if (!IS_NOEVENT(record.event)) {
+        if (IS_EVENT(record.event)) {
             ac_dprintf("processed: ");
             debug_record(record);
             ac_dprintf("\n");
@@ -101,7 +101,7 @@ void action_tapping_process(keyrecord_t record) {
     }
 
     // process waiting_buffer
-    if (!IS_NOEVENT(record.event) && waiting_buffer_head != waiting_buffer_tail) {
+    if (IS_EVENT(record.event) && waiting_buffer_head != waiting_buffer_tail) {
         ac_dprintf("---- action_exec: process waiting_buffer -----\n");
     }
     for (; waiting_buffer_tail != waiting_buffer_head; waiting_buffer_tail = (waiting_buffer_tail + 1) % WAITING_BUFFER_SIZE) {
@@ -113,7 +113,7 @@ void action_tapping_process(keyrecord_t record) {
             break;
         }
     }
-    if (!IS_NOEVENT(record.event)) {
+    if (IS_EVENT(record.event)) {
         ac_dprintf("\n");
     }
 }
@@ -316,7 +316,7 @@ bool process_tapping(keyrecord_t *keyp) {
                     debug_tapping_key();
                     return true;
                 } else {
-                    if (!IS_NOEVENT(event)) {
+                    if (IS_EVENT(event)) {
                         ac_dprintf("Tapping: key event while last tap(>0).\n");
                     }
                     process_record(keyp);
@@ -362,7 +362,7 @@ bool process_tapping(keyrecord_t *keyp) {
                     debug_tapping_key();
                     return true;
                 } else {
-                    if (!IS_NOEVENT(event)) {
+                    if (IS_EVENT(event)) {
                         ac_dprintf("Tapping: key event while last timeout tap(>0).\n");
                     }
                     process_record(keyp);
@@ -402,7 +402,7 @@ bool process_tapping(keyrecord_t *keyp) {
                     return true;
                 }
             } else {
-                if (!IS_NOEVENT(event)) ac_dprintf("Tapping: other key just after tap.\n");
+                if (IS_EVENT(event)) ac_dprintf("Tapping: other key just after tap.\n");
                 process_record(keyp);
                 return true;
             }

--- a/quantum/keyboard.h
+++ b/quantum/keyboard.h
@@ -53,6 +53,9 @@ typedef struct {
 static inline bool IS_NOEVENT(keyevent_t event) {
     return event.time == 0 || (event.key.row == KEYLOC_TICK && event.key.col == KEYLOC_TICK);
 }
+static inline bool IS_EVENT(keyevent_t event) {
+    return !IS_NOEVENT(event);
+}
 static inline bool IS_KEYEVENT(keyevent_t event) {
     return event.key.row < MATRIX_ROWS && event.key.col < MATRIX_COLS;
 }
@@ -63,10 +66,10 @@ static inline bool IS_ENCODEREVENT(keyevent_t event) {
     return event.key.row == KEYLOC_ENCODER_CW || event.key.row == KEYLOC_ENCODER_CCW;
 }
 static inline bool IS_PRESSED(keyevent_t event) {
-    return !IS_NOEVENT(event) && event.pressed;
+    return IS_EVENT(event) && event.pressed;
 }
 static inline bool IS_RELEASED(keyevent_t event) {
-    return !IS_NOEVENT(event) && !event.pressed;
+    return IS_EVENT(event) && !event.pressed;
 }
 
 /* Common keyevent object factory */


### PR DESCRIPTION
## Description

Just a small readability improvement.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
