### PR TITLE
Sync velocikey config for split keybords

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -286,6 +286,14 @@ This enables transmitting the pointing device status to the master side of the s
 
 !> There is additional required configuration for `SPLIT_POINTING_ENABLE` outlined in the [pointing device documentation](feature_pointing_device.md?id=split-keyboard-configuration).
 
+
+```c
+#define SPLIT_VELOCIKEY_ENABLE
+```
+
+This enables transmitting the current [velocikey](feature_velocikey.md) on/off status and speed to the slave side of the split keyboard. The purpose of this feature is to match the effect speed between the split sides.
+
+
 ### Custom data sync between sides :id=custom-data-sync
 
 QMK's split transport allows for arbitrary data transactions at both the keyboard and user levels. This is modelled on a remote procedure call, with the master invoking a function on the slave side, with the ability to send data from master to slave, process it slave side, and send data back from slave to master.

--- a/docs/feature_velocikey.md
+++ b/docs/feature_velocikey.md
@@ -27,3 +27,5 @@ Support for LED breathing effects is planned but not available yet.
 
  ## Configuration
  Velocikey doesn't currently support any configuration via keyboard settings. If you want to adjust something like the speed increase or decay rate, you would need to edit `velocikey.c` and adjust the values there to achieve the kinds of speeds that you like.
+
+!> In order to synchronize the velocikey status and speed between split keyboard sides, define `SPLIT_VELOCIKEY_ENABLE` as described in [the split keyboard documentation](feature_split_keyboard.md).

--- a/quantum/split_common/transaction_id_define.h
+++ b/quantum/split_common/transaction_id_define.h
@@ -88,6 +88,10 @@ enum serial_transaction_id {
     PUT_WATCHDOG,
 #endif // defined(SPLIT_WATCHDOG_ENABLE)
 
+#if defined(SPLIT_VELOCIKEY_ENABLE)
+    PUT_VELOCIKEY,
+#endif // defined(SPLIT_VELOCIKEY_ENABLE)
+
 #if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
     PUT_RPC_INFO,
     PUT_RPC_REQ_DATA,

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -125,6 +125,13 @@ typedef struct _rpc_sync_info_t {
 } rpc_sync_info_t;
 #endif // defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
 
+#if defined(SPLIT_VELOCIKEY_ENABLE)
+typedef struct _velocikey_sync_t {
+    bool    enabled;
+    uint8_t speed;
+} velocikey_sync_t;
+#endif // defined(SPLIT_VELOCIKEY_ENABLE)
+
 typedef struct _split_shared_memory_t {
 #ifdef USE_I2C
     int8_t transaction_id;
@@ -191,6 +198,10 @@ typedef struct _split_shared_memory_t {
 #if defined(SPLIT_WATCHDOG_ENABLE)
     bool watchdog_pinged;
 #endif // defined(SPLIT_WATCHDOG_ENABLE)
+
+#if defined(SPLIT_VELOCIKEY_ENABLE)
+    velocikey_sync_t velocikey;
+#endif // defined(SPLIT_VELOCIKEY_ENABLE)
 
 #if defined(SPLIT_TRANSACTION_IDS_KB) || defined(SPLIT_TRANSACTION_IDS_USER)
     rpc_sync_info_t rpc_info;

--- a/quantum/velocikey.c
+++ b/quantum/velocikey.c
@@ -17,6 +17,10 @@ bool velocikey_enabled(void) {
     return eeprom_read_byte(EECONFIG_VELOCIKEY) == 1;
 }
 
+void velocikey_set_enabled(bool value) {
+    eeprom_update_byte(EECONFIG_VELOCIKEY, value ? 1 : 0);
+}
+
 void velocikey_toggle(void) {
     if (velocikey_enabled())
         eeprom_update_byte(EECONFIG_VELOCIKEY, 0);
@@ -43,4 +47,12 @@ void velocikey_decelerate(void) {
 
 uint8_t velocikey_match_speed(uint8_t minValue, uint8_t maxValue) {
     return MAX(minValue, maxValue - (maxValue - minValue) * ((float)typing_speed / TYPING_SPEED_MAX_VALUE));
+}
+
+uint8_t velocikey_get_speed(void) {
+    return typing_speed;
+}
+
+void velocikey_set_speed(uint8_t speed) {
+    typing_speed = speed;
 }

--- a/quantum/velocikey.c
+++ b/quantum/velocikey.c
@@ -18,7 +18,7 @@ bool velocikey_enabled(void) {
 }
 
 void velocikey_set_enabled(bool value) {
-    eeprom_update_byte(EECONFIG_VELOCIKEY, value ? 1 : 0);
+    if (value != velocikey_enabled()) eeprom_update_byte(EECONFIG_VELOCIKEY, value ? 1 : 0);
 }
 
 void velocikey_toggle(void) {

--- a/quantum/velocikey.h
+++ b/quantum/velocikey.h
@@ -5,6 +5,9 @@
 
 bool    velocikey_enabled(void);
 void    velocikey_toggle(void);
+void    velocikey_set_enabled(bool);
 void    velocikey_accelerate(void);
 void    velocikey_decelerate(void);
 uint8_t velocikey_match_speed(uint8_t minValue, uint8_t maxValue);
+uint8_t velocikey_get_speed(void);
+void    velocikey_set_speed(uint8_t);


### PR DESCRIPTION
Add synchronization of velocikey status and speed between split sides. Without this, the effect speed of the slave side is just the predefined speed while the master side speed is properly adjusted by velocikey. Syncing the rgb state doesn't help in that case as the velocikey speed overrides the rgb speed if it's enabled.

The behavior is enabled using the new option `SPLIT_VELOCIKEY_ENABLE`. 

## Description

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/5916

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage). ( tested on a kyria rev 2 )
