### PR TITLE
[Test] Introduce VERIFY_AND_CLEAR shorthand

### DIFF
--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -37,14 +37,14 @@ TEST_F(AutoShift, key_release_before_timeout) {
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_REPORT(driver, (KC_A));
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(AutoShift, key_release_after_timeout) {
@@ -58,7 +58,7 @@ TEST_F(AutoShift, key_release_after_timeout) {
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     idle_for(AUTO_SHIFT_TIMEOUT);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_REPORT(driver, (KC_LSFT, KC_A));
@@ -66,5 +66,5 @@ TEST_F(AutoShift, key_release_after_timeout) {
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/autocorrect/test_autocorrect.cpp
+++ b/tests/autocorrect/test_autocorrect.cpp
@@ -51,7 +51,7 @@ TEST_F(AutoCorrect, OnOffToggle) {
     autocorrect_toggle();
     EXPECT_EQ(autocorrect_is_enabled(), true);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test that typing "fales" autocorrects to "false"
@@ -80,7 +80,7 @@ TEST_F(AutoCorrect, fales_to_false_autocorrection) {
 
     TapKeys(key_f, key_a, key_l, key_e, key_s);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test that typing "fales" doesn't autocorrect if disabled
@@ -109,7 +109,7 @@ TEST_F(AutoCorrect, fales_disabled_autocorrect) {
     TapKeys(key_f, key_a, key_l, key_e, key_s);
     autocorrect_enable();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test that typing "falsify" doesn't autocorrect if disabled
@@ -139,7 +139,7 @@ TEST_F(AutoCorrect, falsify_should_not_autocorrect) {
 
     TapKeys(key_f, key_a, key_l, key_s, key_i, key_f, key_y);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test that  typing "ture" autocorrect to "true"
@@ -169,7 +169,7 @@ TEST_F(AutoCorrect, ture_to_true_autocorrect) {
 
     TapKeys(key_space, key_t_code, key_u, key_r, key_e);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test that  typing "overture" does not autocorrect
@@ -200,5 +200,5 @@ TEST_F(AutoCorrect, overture_should_not_autocorrect) {
 
     TapKeys(key_o, key_v, key_e, key_r, key_t_code, key_u, key_r, key_e);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/basic/test_action_layer.cpp
+++ b/tests/basic/test_action_layer.cpp
@@ -28,7 +28,7 @@ TEST_F(ActionLayer, LayerStateDBG) {
 
     layer_state_set(0);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerStateSet) {
@@ -39,7 +39,7 @@ TEST_F(ActionLayer, LayerStateSet) {
     layer_state_set(0b001100);
     EXPECT_EQ(layer_state, 0b001100);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerStateIs) {
@@ -56,7 +56,7 @@ TEST_F(ActionLayer, LayerStateIs) {
     EXPECT_EQ(layer_state_is(1), true);
     EXPECT_EQ(layer_state_is(2), false);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerStateCmp) {
@@ -76,7 +76,7 @@ TEST_F(ActionLayer, LayerStateCmp) {
     EXPECT_EQ(layer_state_cmp(prev_layer, 1), true);
     EXPECT_EQ(layer_state_cmp(prev_layer, 2), false);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerClear) {
@@ -85,7 +85,7 @@ TEST_F(ActionLayer, LayerClear) {
     layer_clear();
     EXPECT_EQ(layer_state, 0);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerMove) {
@@ -96,7 +96,7 @@ TEST_F(ActionLayer, LayerMove) {
     layer_move(3);
     EXPECT_EQ(layer_state, 0b1000);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerOn) {
@@ -108,7 +108,7 @@ TEST_F(ActionLayer, LayerOn) {
     layer_on(3);
     EXPECT_EQ(layer_state, 0b1010);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerOff) {
@@ -121,7 +121,7 @@ TEST_F(ActionLayer, LayerOff) {
     layer_off(2);
     EXPECT_EQ(layer_state, 0b0010);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, MomentaryLayerDoesNothing) {
@@ -134,12 +134,12 @@ TEST_F(ActionLayer, MomentaryLayerDoesNothing) {
     EXPECT_NO_REPORT(driver);
     layer_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_NO_REPORT(driver);
     layer_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, MomentaryLayerWithKeypress) {
@@ -155,28 +155,28 @@ TEST_F(ActionLayer, MomentaryLayerWithKeypress) {
     layer_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press key on layer 1 */
     EXPECT_REPORT(driver, (KC_B)).Times(1);
     regular_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release key on layer 1 */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release MO */
     EXPECT_NO_REPORT(driver);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, ToggleLayerDoesNothing) {
@@ -192,14 +192,14 @@ TEST_F(ActionLayer, ToggleLayerDoesNothing) {
     layer_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release TG. */
     EXPECT_NO_REPORT(driver);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, ToggleLayerUpAndDown) {
@@ -216,26 +216,26 @@ TEST_F(ActionLayer, ToggleLayerUpAndDown) {
     toggle_layer_1_on_layer_0.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_NO_REPORT(driver);
     toggle_layer_1_on_layer_0.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Toggle Layer 0. */
     EXPECT_NO_REPORT(driver);
     toggle_layer_0_on_layer_1.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_NO_REPORT(driver);
     toggle_layer_0_on_layer_1.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerTapToggleDoesNothing) {
@@ -251,13 +251,13 @@ TEST_F(ActionLayer, LayerTapToggleDoesNothing) {
     layer_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_NO_REPORT(driver);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerTapToggleWithKeypress) {
@@ -275,25 +275,25 @@ TEST_F(ActionLayer, LayerTapToggleWithKeypress) {
     layer_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_B)).Times(1);
     regular_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_NO_REPORT(driver);
     layer_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerTapToggleWithToggleWithKeypress) {
@@ -344,19 +344,19 @@ TEST_F(ActionLayer, LayerTapToggleWithToggleWithKeypress) {
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_B)).Times(1);
     regular_key.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(ActionLayer, LayerTapReleasedBeforeKeypressReleaseWithModifiers) {
@@ -373,7 +373,7 @@ TEST_F(ActionLayer, LayerTapReleasedBeforeKeypressReleaseWithModifiers) {
     layer_0_key_0.press();
     idle_for(TAPPING_TERM);
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press key with layer 1 mapping, result basically expected
      * altough more reports are send then necessary. */
@@ -382,14 +382,14 @@ TEST_F(ActionLayer, LayerTapReleasedBeforeKeypressReleaseWithModifiers) {
     layer_1_key_1.press();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(1));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer tap key, no report is send because key is still held. */
     EXPECT_NO_REPORT(driver);
     layer_0_key_0.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Unregister keycode and modifier. */
     EXPECT_REPORT(driver, (KC_RALT)).Times(1);
@@ -397,5 +397,5 @@ TEST_F(ActionLayer, LayerTapReleasedBeforeKeypressReleaseWithModifiers) {
     layer_1_key_1.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/basic/test_keypress.cpp
+++ b/tests/basic/test_keypress.cpp
@@ -175,23 +175,23 @@ TEST_F(KeyPress, PressPlusEqualReleaseBeforePress) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_EQUAL));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_plus.release();
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_eql.press();
     EXPECT_REPORT(driver, (key_eql.report_code));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_eql.release();
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(KeyPress, PressPlusEqualDontReleaseBeforePress) {
@@ -206,24 +206,24 @@ TEST_F(KeyPress, PressPlusEqualDontReleaseBeforePress) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_EQUAL));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_eql.press();
     EXPECT_EMPTY_REPORT(driver);
     EXPECT_REPORT(driver, (KC_EQUAL));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_plus.release();
     // BUG: Should really still return KC_EQUAL, but this is fine too
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_eql.release();
     EXPECT_NO_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(KeyPress, PressEqualPlusReleaseBeforePress) {
@@ -237,24 +237,24 @@ TEST_F(KeyPress, PressEqualPlusReleaseBeforePress) {
     key_eql.press();
     EXPECT_REPORT(driver, (KC_EQUAL));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_eql.release();
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_plus.press();
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_EQUAL));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_plus.release();
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(KeyPress, PressEqualPlusDontReleaseBeforePress) {
@@ -268,7 +268,7 @@ TEST_F(KeyPress, PressEqualPlusDontReleaseBeforePress) {
     key_eql.press();
     EXPECT_REPORT(driver, (KC_EQUAL));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_plus.press();
     // BUG: The sequence is a bit strange, but it works, the end result is that
@@ -277,16 +277,16 @@ TEST_F(KeyPress, PressEqualPlusDontReleaseBeforePress) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_EQUAL));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_eql.release();
     // I guess it's fine to still report shift here
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     key_plus.release();
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -36,12 +36,12 @@ TEST_F(OneShot, OSMWithoutAdditionalKeypressDoesNothing) {
     run_one_scan_loop();
     osm_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* OSM are added when an actual report is send */
     EXPECT_REPORT(driver, (osm_key.report_code));
     send_keyboard_report();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Make unit-test pass */
     clear_oneshot_mods();
@@ -62,19 +62,19 @@ TEST_P(OneShotParametrizedTestFixture, OSMExpiredDoesNothing) {
     run_one_scan_loop();
     osm_key.release();
     idle_for(ONESHOT_TIMEOUT);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 #endif
@@ -92,19 +92,19 @@ TEST_P(OneShotParametrizedTestFixture, OSMWithAdditionalKeypress) {
     run_one_scan_loop();
     osm_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_REPORT(driver, (osm_key.report_code, regular_key.report_code)).Times(1);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_P(OneShotParametrizedTestFixture, OSMAsRegularModifierWithAdditionalKeypress) {
@@ -120,26 +120,26 @@ TEST_P(OneShotParametrizedTestFixture, OSMAsRegularModifierWithAdditionalKeypres
     EXPECT_NO_REPORT(driver);
     osm_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release OSM */
     EXPECT_REPORT(driver, (regular_key.report_code, osm_key.report_code)).Times(1);
     EXPECT_EMPTY_REPORT(driver);
     osm_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // clang-format off
@@ -172,24 +172,24 @@ TEST_F(OneShot, OSLWithAdditionalKeypress) {
     EXPECT_NO_REPORT(driver);
     osl_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release OSL key */
     EXPECT_NO_REPORT(driver);
     osl_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
     EXPECT_EMPTY_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/basic/test_tapping.cpp
+++ b/tests/basic/test_tapping.cpp
@@ -134,7 +134,7 @@ TEST_F(Tapping, TapA_CTL_T_KeyWhileReleasingShift) {
     // Shift is reported
     EXPECT_REPORT(driver, (KC_LSFT));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     mod_tap_hold_key.press();
     // Tapping keys does nothing on press
@@ -145,7 +145,7 @@ TEST_F(Tapping, TapA_CTL_T_KeyWhileReleasingShift) {
     // Releasing shift is delayed while tapping is in progress
     EXPECT_NO_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     mod_tap_hold_key.release();
     // Releasing mod-tap key reports the tap and releases shift
@@ -153,7 +153,7 @@ TEST_F(Tapping, TapA_CTL_T_KeyWhileReleasingShift) {
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Tapping, TapA_CTL_T_KeyWhileReleasingLayer) {
@@ -180,7 +180,7 @@ TEST_F(Tapping, TapA_CTL_T_KeyWhileReleasingLayer) {
     // Releasing layer is delayed while tapping is in progress
     EXPECT_NO_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     mod_tap_hold_key1.release();
     // Releasing mod-tap key reports the tap of the layer 1 key
@@ -188,5 +188,5 @@ TEST_F(Tapping, TapA_CTL_T_KeyWhileReleasingLayer) {
     EXPECT_REPORT(driver, (KC_Q));
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/caps_word/caps_word_autoshift/test_caps_word_autoshift.cpp
+++ b/tests/caps_word/caps_word_autoshift/test_caps_word_autoshift.cpp
@@ -64,7 +64,7 @@ TEST_F(CapsWord, AutoShiftKeys) {
     tap_key(key_spc);
     tap_key(key_a);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test Caps Word + Auto Shift where keys A and B are rolled.
@@ -104,7 +104,7 @@ TEST_F(CapsWord, AutoShiftRolledShiftedKeys) {
     run_one_scan_loop();
 
     caps_word_off();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests that with tap-hold keys with Retro Shift, letter keys are shifted by
@@ -133,5 +133,5 @@ TEST_F(CapsWord, RetroShiftKeys) {
     tap_key(key_modtap_a);                     // Tap A quickly.
 
     EXPECT_EQ(is_caps_word_on(), true);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/caps_word/caps_word_combo/test_caps_word_combo.cpp
+++ b/tests/caps_word/caps_word_combo/test_caps_word_combo.cpp
@@ -102,7 +102,7 @@ TEST_P(CapsWord, SingleCombo) {
     EXPECT_TRUE(is_caps_word_on());
     caps_word_off();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test a longer 4-key combo.
@@ -123,7 +123,7 @@ TEST_P(CapsWord, LongerCombo) {
     EXPECT_TRUE(is_caps_word_on());
     caps_word_off();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test with two overlapping combos on regular keys:
@@ -161,7 +161,7 @@ TEST_P(CapsWord, ComboRegularKeys) {
     tap_key(key_a);
 
     EXPECT_FALSE(is_caps_word_on());
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Test where combo chords involve tap-hold keys:
@@ -194,7 +194,7 @@ TEST_P(CapsWord, ComboModTapKey) {
     EXPECT_TRUE(is_caps_word_on());
     caps_word_off();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // clang-format off

--- a/tests/caps_word/caps_word_unicodemap/test_caps_word_unicodemap.cpp
+++ b/tests/caps_word/caps_word_unicodemap/test_caps_word_unicodemap.cpp
@@ -93,7 +93,7 @@ TEST_F(CapsWord, ShiftedUnicodeMapKey) {
     tap_keys(key_delta, key_spc, key_delta);
 
     EXPECT_EQ(is_caps_word_on(), false);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests typing U_ENDASH while Caps Word is on.
@@ -117,5 +117,5 @@ TEST_F(CapsWord, UnshiftedUnicodeMapKey) {
     tap_key(key_dash);
 
     EXPECT_EQ(is_caps_word_on(), true);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/caps_word/test_caps_word.cpp
+++ b/tests/caps_word/test_caps_word.cpp
@@ -90,7 +90,7 @@ TEST_F(CapsWord, OnOffToggleFuns) {
     caps_word_toggle();
     EXPECT_EQ(is_caps_word_on(), false);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests the default `caps_word_press_user()` function.
@@ -133,7 +133,7 @@ TEST_F(CapsWord, CapswrdKey) {
     tap_key(key_capswrd); // Tap the QK_CAPS_WORD_TOGGLE key again.
     EXPECT_EQ(is_caps_word_on(), false);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests that being idle for CAPS_WORD_IDLE_TIMEOUT turns off Caps Word.
@@ -157,7 +157,7 @@ TEST_F(CapsWord, IdleTimeout) {
     caps_word_on();
     tap_key(key_a);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     idle_for(CAPS_WORD_IDLE_TIMEOUT);
     run_one_scan_loop();
@@ -171,7 +171,7 @@ TEST_F(CapsWord, IdleTimeout) {
     EXPECT_REPORT(driver, (KC_A));
     tap_key(key_a);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests that typing "A, 4, A, 4" produces "Shift+A, 4, Shift+A, 4".
@@ -201,7 +201,7 @@ TEST_F(CapsWord, ShiftsLettersButNotDigits) {
     caps_word_on();
     tap_keys(key_a, key_4, key_a, key_4);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests that typing "A, Space, A" produces "Shift+A, Space, A".
@@ -230,7 +230,7 @@ TEST_F(CapsWord, SpaceTurnsOffCapsWord) {
     caps_word_on();
     tap_keys(key_a, key_spc, key_a);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests that typing "AltGr + A" produces "Shift + AltGr + A".
@@ -260,7 +260,7 @@ TEST_F(CapsWord, ShiftsAltGrSymbols) {
     run_one_scan_loop();
     key_altgr.release();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests typing "AltGr + A" using a mod-tap key.
@@ -291,7 +291,7 @@ TEST_F(CapsWord, ShiftsModTapAltGrSymbols) {
     key_altgr_t.release();
 
     EXPECT_TRUE(is_caps_word_on());
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 struct CapsWordPressUserParams {
@@ -326,7 +326,7 @@ TEST_P(CapsWordPressUser, KeyCode) {
     EXPECT_EQ(passed_keycode, GetParam().expected_passed_keycode);
     EXPECT_EQ(is_caps_word_on(), GetParam().continues_caps_word);
     clear_oneshot_mods();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 const uint16_t LT_1_KC_A = LT(1, KC_A);
@@ -431,7 +431,7 @@ TEST_P(CapsWordBothShifts, PressLRLR) {
 
     EXPECT_EQ(is_caps_word_on(), true);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Pressing shifts as "Left down, Right down, Right up, Left up".
@@ -468,7 +468,7 @@ TEST_P(CapsWordBothShifts, PressLRRL) {
 
     EXPECT_EQ(is_caps_word_on(), true);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // clang-format off
@@ -524,7 +524,7 @@ TEST_P(CapsWordDoubleTapShift, Activation) {
 
     EXPECT_EQ(is_caps_word_on(), true);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     // We have to manually reset the internal state of the caps word state
     // machine at this point. This due to imperfect test isolation which can't
@@ -562,7 +562,7 @@ TEST_P(CapsWordDoubleTapShift, Interrupted) {
     EXPECT_EQ(is_caps_word_on(), false); // Caps Word is still off.
     clear_oneshot_mods();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Double tap doesn't count if taps are more than tapping term apart.
@@ -585,7 +585,7 @@ TEST_P(CapsWordDoubleTapShift, SlowTaps) {
     EXPECT_EQ(is_caps_word_on(), false); // Caps Word is still off.
     clear_oneshot_mods();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // clang-format off
@@ -623,7 +623,7 @@ TEST_F(CapsWord, IgnoresOSLHold) {
     key_osl.release();
     run_one_scan_loop();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // Tests that tapping a OSL keeps caps word active and shifts keys on the layer that need to be shifted.
@@ -648,7 +648,7 @@ TEST_F(CapsWord, IgnoresOSLTap) {
     tap_key(key_b);
     run_one_scan_loop();
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 // clang-format on
 } // namespace

--- a/tests/secure/test_secure.cpp
+++ b/tests/secure/test_secure.cpp
@@ -43,7 +43,7 @@ TEST_F(Secure, test_lock) {
     secure_lock();
     EXPECT_FALSE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_timeout) {
@@ -58,7 +58,7 @@ TEST_F(Secure, test_unlock_timeout) {
     idle_for(SECURE_IDLE_TIMEOUT + 1);
     EXPECT_FALSE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request) {
@@ -80,7 +80,7 @@ TEST_F(Secure, test_unlock_request) {
     tap_keys(key_a, key_b, key_c, key_d);
     EXPECT_TRUE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request_fail) {
@@ -108,7 +108,7 @@ TEST_F(Secure, test_unlock_request_fail) {
     tap_keys(key_e, key_a, key_b, key_c, key_d);
     EXPECT_FALSE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request_timeout) {
@@ -124,7 +124,7 @@ TEST_F(Secure, test_unlock_request_timeout) {
     EXPECT_FALSE(secure_is_unlocking());
     EXPECT_FALSE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request_fail_mid) {
@@ -151,7 +151,7 @@ TEST_F(Secure, test_unlock_request_fail_mid) {
     EXPECT_FALSE(secure_is_unlocking());
     EXPECT_FALSE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request_fail_out_of_order) {
@@ -179,7 +179,7 @@ TEST_F(Secure, test_unlock_request_fail_out_of_order) {
     EXPECT_FALSE(secure_is_unlocking());
     EXPECT_FALSE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request_on_layer) {
@@ -206,7 +206,7 @@ TEST_F(Secure, test_unlock_request_on_layer) {
     EXPECT_TRUE(secure_is_unlocked());
     EXPECT_FALSE(layer_state_is(1));
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request_mid_stroke) {
@@ -231,7 +231,7 @@ TEST_F(Secure, test_unlock_request_mid_stroke) {
     tap_keys(key_a, key_b, key_c, key_d);
     EXPECT_TRUE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Secure, test_unlock_request_mods) {
@@ -256,5 +256,5 @@ TEST_F(Secure, test_unlock_request_mods) {
     tap_keys(key_a, key_b, key_c, key_d);
     EXPECT_TRUE(secure_is_unlocked());
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/default_mod_tap/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/default_mod_tap/test_tap_hold.cpp
@@ -38,19 +38,19 @@ TEST_F(DefaultTapHold, tap_regular_key_while_mod_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_NO_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_REPORT(driver, (KC_P));
@@ -59,11 +59,11 @@ TEST_F(DefaultTapHold, tap_regular_key_while_mod_tap_key_is_held) {
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Idle for tapping term of mod tap hold key. */
     idle_for(TAPPING_TERM - 3);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(DefaultTapHold, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
@@ -78,19 +78,19 @@ TEST_F(DefaultTapHold, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     first_mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press second tap-hold key */
     EXPECT_NO_REPORT(driver);
     second_mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release second tap-hold key */
     EXPECT_NO_REPORT(driver);
     second_mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release first mod-tap-hold key */
     EXPECT_REPORT(driver, (KC_P));
@@ -99,7 +99,7 @@ TEST_F(DefaultTapHold, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
     EXPECT_EMPTY_REPORT(driver);
     first_mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(DefaultTapHold, tap_regular_key_while_layer_tap_key_is_held) {
@@ -115,19 +115,19 @@ TEST_F(DefaultTapHold, tap_regular_key_while_layer_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer-tap-hold key */
     EXPECT_REPORT(driver, (KC_P));
@@ -136,7 +136,7 @@ TEST_F(DefaultTapHold, tap_regular_key_while_layer_tap_key_is_held) {
     EXPECT_EMPTY_REPORT(driver);
     layer_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(DefaultTapHold, tap_mod_tap_hold_key_two_times) {
@@ -150,26 +150,26 @@ TEST_F(DefaultTapHold, tap_mod_tap_hold_key_two_times) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press mod-tap-hold key again. */
     EXPECT_REPORT(driver, (KC_P));
     mod_tap_hold_key.press();
     idle_for(TAPPING_TERM);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(DefaultTapHold, tap_mod_tap_hold_key_twice_and_hold_on_second_time) {
@@ -183,26 +183,26 @@ TEST_F(DefaultTapHold, tap_mod_tap_hold_key_twice_and_hold_on_second_time) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press mod-tap-hold key again. */
     EXPECT_REPORT(driver, (KC_P));
     mod_tap_hold_key.press();
     idle_for(TAPPING_TERM);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(DefaultTapHold, tap_and_hold_mod_tap_hold_key) {
@@ -216,11 +216,11 @@ TEST_F(DefaultTapHold, tap_and_hold_mod_tap_hold_key) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     mod_tap_hold_key.press();
     idle_for(TAPPING_TERM + 1);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/hold_on_other_key_press/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/hold_on_other_key_press/test_tap_hold.cpp
@@ -38,26 +38,26 @@ TEST_F(HoldOnOtherKeyPress, short_distinct_taps_of_mod_tap_key_and_regular_key) 
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_REPORT(driver, (KC_A));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, long_distinct_taps_of_mod_tap_key_and_regular_key) {
@@ -72,30 +72,30 @@ TEST_F(HoldOnOtherKeyPress, long_distinct_taps_of_mod_tap_key_and_regular_key) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Idle for tapping term of mod tap hold key. */
     EXPECT_REPORT(driver, (KC_LSFT));
     idle_for(TAPPING_TERM + 1);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_REPORT(driver, (KC_A));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, short_distinct_taps_of_layer_tap_key_and_regular_key) {
@@ -111,26 +111,26 @@ TEST_F(HoldOnOtherKeyPress, short_distinct_taps_of_layer_tap_key_and_regular_key
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer-tap-hold key. */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     layer_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_REPORT(driver, (KC_A));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, long_distinct_taps_of_layer_tap_key_and_regular_key) {
@@ -146,30 +146,30 @@ TEST_F(HoldOnOtherKeyPress, long_distinct_taps_of_layer_tap_key_and_regular_key)
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Idle for tapping term of layer tap hold key. */
     EXPECT_NO_REPORT(driver);
     idle_for(TAPPING_TERM + 1);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer-tap-hold key. */
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_REPORT(driver, (KC_A));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, tap_regular_key_while_mod_tap_key_is_held) {
@@ -184,30 +184,30 @@ TEST_F(HoldOnOtherKeyPress, tap_regular_key_while_mod_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_REPORT(driver, (KC_LSFT));
     EXPECT_REPORT(driver, (KC_A, KC_LSFT));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_REPORT(driver, (KC_LSFT));
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Idle for tapping term of mod tap hold key. */
     idle_for(TAPPING_TERM - 3);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
@@ -222,26 +222,26 @@ TEST_F(HoldOnOtherKeyPress, tap_a_mod_tap_key_while_another_mod_tap_key_is_held)
     EXPECT_NO_REPORT(driver);
     first_mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press second tap-hold key */
     EXPECT_REPORT(driver, (KC_LSFT));
     second_mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release second tap-hold key */
     EXPECT_REPORT(driver, (KC_A, KC_LSFT));
     EXPECT_REPORT(driver, (KC_LSFT));
     second_mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release first mod-tap-hold key */
     EXPECT_EMPTY_REPORT(driver);
     first_mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, tap_regular_key_while_layer_tap_key_is_held) {
@@ -257,25 +257,25 @@ TEST_F(HoldOnOtherKeyPress, tap_regular_key_while_layer_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_REPORT(driver, (KC_B));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer-tap-hold key */
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, nested_tap_of_layer_0_layer_tap_keys) {
@@ -293,25 +293,25 @@ TEST_F(HoldOnOtherKeyPress, nested_tap_of_layer_0_layer_tap_keys) {
     EXPECT_NO_REPORT(driver);
     first_layer_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press second layer-tap key */
     EXPECT_REPORT(driver, (KC_Q));
     second_layer_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release second layer-tap key */
     EXPECT_EMPTY_REPORT(driver);
     second_layer_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release first layer-tap key */
     EXPECT_NO_REPORT(driver);
     first_layer_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, nested_tap_of_layer_tap_keys) {
@@ -331,26 +331,26 @@ TEST_F(HoldOnOtherKeyPress, nested_tap_of_layer_tap_keys) {
     EXPECT_NO_REPORT(driver);
     first_key_layer_0.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press second layer-tap key */
     EXPECT_NO_REPORT(driver);
     second_key_layer_0.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release second layer-tap key */
     EXPECT_REPORT(driver, (KC_Q));
     EXPECT_EMPTY_REPORT(driver);
     second_key_layer_0.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release first layer-tap key */
     EXPECT_NO_REPORT(driver);
     first_key_layer_0.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, roll_mod_tap_key_with_regular_key) {
@@ -365,26 +365,26 @@ TEST_F(HoldOnOtherKeyPress, roll_mod_tap_key_with_regular_key) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_REPORT(driver, (KC_LSFT));
     EXPECT_REPORT(driver, (KC_A, KC_LSFT));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     EXPECT_REPORT(driver, (KC_A));
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(HoldOnOtherKeyPress, roll_layer_tap_key_with_regular_key) {
@@ -401,23 +401,23 @@ TEST_F(HoldOnOtherKeyPress, roll_layer_tap_key_with_regular_key) {
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_REPORT(driver, (KC_B));
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer-tap-hold key */
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/permissive_hold/test_one_shot_keys.cpp
+++ b/tests/tap_hold_configurations/permissive_hold/test_one_shot_keys.cpp
@@ -35,26 +35,26 @@ TEST_P(OneShotParametrizedTestFixture, OSMAsRegularModifierWithAdditionalKeypres
     EXPECT_NO_REPORT(driver);
     osm_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_REPORT(driver, (osm_key.report_code)).Times(2);
     EXPECT_REPORT(driver, (regular_key.report_code, osm_key.report_code)).Times(1);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release OSM */
     EXPECT_EMPTY_REPORT(driver).Times(1);
     osm_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 // clang-format off

--- a/tests/tap_hold_configurations/permissive_hold/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/permissive_hold/test_tap_hold.cpp
@@ -37,13 +37,13 @@ TEST_F(PermissiveHold, tap_regular_key_while_mod_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
@@ -51,13 +51,13 @@ TEST_F(PermissiveHold, tap_regular_key_while_mod_tap_key_is_held) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(PermissiveHold, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
@@ -72,13 +72,13 @@ TEST_F(PermissiveHold, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     first_mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press second mod-tap-hold key */
     EXPECT_NO_REPORT(driver);
     second_mod_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release second mod-tap-hold key */
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
@@ -86,13 +86,13 @@ TEST_F(PermissiveHold, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     second_mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release first mod-tap-hold key */
     EXPECT_EMPTY_REPORT(driver);
     first_mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(PermissiveHold, tap_regular_key_while_layer_tap_key_is_held) {
@@ -108,24 +108,24 @@ TEST_F(PermissiveHold, tap_regular_key_while_layer_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_REPORT(driver, (layer_key.report_code));
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer-tap-hold key */
     EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/quick_tap/test_action_layer.cpp
+++ b/tests/tap_hold_configurations/quick_tap/test_action_layer.cpp
@@ -66,17 +66,17 @@ TEST_F(ActionLayer, LayerTapToggleWithToggleWithKeypress) {
     run_one_scan_loop();
     expect_layer_state(0);
 
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_A)).Times(1);
     regular_key.press();
     run_one_scan_loop();
     expect_layer_state(0);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_EMPTY_REPORT(driver).Times(1);
     regular_key.release();
     run_one_scan_loop();
     expect_layer_state(0);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/quick_tap/test_quick_tap.cpp
+++ b/tests/tap_hold_configurations/quick_tap/test_quick_tap.cpp
@@ -39,32 +39,32 @@ TEST_F(QuickTap, tap_regular_key_while_mod_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key. */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
     EXPECT_NO_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_REPORT(driver, (KC_LSFT));
     mod_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Idle for tapping term of mod tap hold key. */
     EXPECT_REPORT(driver, (KC_LSFT, KC_A));
     EXPECT_REPORT(driver, (KC_LSFT));
     EXPECT_EMPTY_REPORT(driver);
     idle_for(TAPPING_TERM - 3);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(QuickTap, tap_mod_tap_key_while_mod_tap_key_is_held) {
@@ -79,32 +79,32 @@ TEST_F(QuickTap, tap_mod_tap_key_while_mod_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     first_mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press second mod-tap key */
     EXPECT_NO_REPORT(driver);
     second_mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release second tap-hold key */
     EXPECT_NO_REPORT(driver);
     second_mod_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release first mod-tap key */
     EXPECT_REPORT(driver, (KC_LSFT));
     first_mod_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Idle for tapping term of first mod-tap key. */
     EXPECT_REPORT(driver, (KC_LSFT, KC_A));
     EXPECT_REPORT(driver, (KC_LSFT));
     EXPECT_EMPTY_REPORT(driver);
     idle_for(TAPPING_TERM - 3);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(QuickTap, tap_regular_key_while_layer_tap_key_is_held) {
@@ -120,19 +120,19 @@ TEST_F(QuickTap, tap_regular_key_while_layer_tap_key_is_held) {
     EXPECT_NO_REPORT(driver);
     layer_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
     EXPECT_NO_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release layer-tap key */
     EXPECT_REPORT(driver, (KC_P));
@@ -141,7 +141,7 @@ TEST_F(QuickTap, tap_regular_key_while_layer_tap_key_is_held) {
     EXPECT_EMPTY_REPORT(driver);
     layer_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(QuickTap, tap_key_and_tap_again_before_quick_tap_term) {
@@ -155,7 +155,7 @@ TEST_F(QuickTap, tap_key_and_tap_again_before_quick_tap_term) {
     EXPECT_NO_REPORT(driver);
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_REPORT(driver, (KC_P));
@@ -163,19 +163,19 @@ TEST_F(QuickTap, tap_key_and_tap_again_before_quick_tap_term) {
     mod_tap_key.release();
     idle_for(QUICK_TAP_TERM - 10);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press and tap mod-tap key again. */
     EXPECT_REPORT(driver, (KC_P));
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(QuickTap, tap_key_and_hold_again_before_quick_tap_term) {
@@ -189,31 +189,31 @@ TEST_F(QuickTap, tap_key_and_hold_again_before_quick_tap_term) {
     EXPECT_NO_REPORT(driver);
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_key.release();
     idle_for(QUICK_TAP_TERM - 10);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press and hold mod-tap key again. */
     EXPECT_REPORT(driver, (KC_P));
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Wait until tapping term expired */
     EXPECT_NO_REPORT(driver);
     idle_for(TAPPING_TERM);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(QuickTap, tap_key_and_tap_again_after_quick_tap_term) {
@@ -227,7 +227,7 @@ TEST_F(QuickTap, tap_key_and_tap_again_after_quick_tap_term) {
     EXPECT_NO_REPORT(driver);
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_REPORT(driver, (KC_P));
@@ -235,20 +235,20 @@ TEST_F(QuickTap, tap_key_and_tap_again_after_quick_tap_term) {
     mod_tap_key.release();
     idle_for(QUICK_TAP_TERM + 10);
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press mod-tap key again. */
     EXPECT_NO_REPORT(driver);
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(QuickTap, tap_key_and_hold_again_after_quick_tap_term) {
@@ -262,29 +262,29 @@ TEST_F(QuickTap, tap_key_and_hold_again_after_quick_tap_term) {
     EXPECT_NO_REPORT(driver);
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_key.release();
     idle_for(QUICK_TAP_TERM + 10);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press and hold mod-tap key again. */
     EXPECT_NO_REPORT(driver);
     mod_tap_key.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Wait until tapping term expired */
     EXPECT_REPORT(driver, (KC_LSFT));
     idle_for(TAPPING_TERM);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap key. */
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/retro_tapping/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_tap_hold.cpp
@@ -38,7 +38,7 @@ TEST_F(RetroTapping, tap_and_hold_mod_tap_hold_key) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     idle_for(TAPPING_TERM);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod-tap-hold key. */
     /* TODO: Why is LSHIFT send at all? */
@@ -48,5 +48,5 @@ TEST_F(RetroTapping, tap_and_hold_mod_tap_hold_key) {
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/retro_tapping/test_tapping.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_tapping.cpp
@@ -35,18 +35,18 @@ TEST_F(Tapping, HoldA_SHFT_T_KeyReportsShift) {
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_key.press();
     idle_for(TAPPING_TERM);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_LSFT));
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     EXPECT_EMPTY_REPORT(driver);
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }
 
 TEST_F(Tapping, ANewTapWithinTappingTermIsBuggy) {
@@ -60,45 +60,45 @@ TEST_F(Tapping, ANewTapWithinTappingTermIsBuggy) {
     EXPECT_NO_REPORT(driver);
     key_shift_hold_p_tap.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod_tap_hold key */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     key_shift_hold_p_tap.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press mod_tap_hold key again */
     EXPECT_REPORT(driver, (KC_P));
     key_shift_hold_p_tap.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod_tap_hold key again */
     EXPECT_EMPTY_REPORT(driver);
     key_shift_hold_p_tap.release();
     idle_for(TAPPING_TERM + 1);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press mod_tap_hold key again */
     EXPECT_NO_REPORT(driver);
     key_shift_hold_p_tap.press();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod_tap_hold key again */
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_EMPTY_REPORT(driver);
     key_shift_hold_p_tap.release();
     idle_for(TAPPING_TERM + 1);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Press mod_tap_hold key again */
     EXPECT_NO_REPORT(driver);
     key_shift_hold_p_tap.press();
     idle_for(TAPPING_TERM);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Release mod_tap_hold key again */
     /* TODO: Why is KC_LSFT send? */
@@ -108,5 +108,5 @@ TEST_F(Tapping, ANewTapWithinTappingTermIsBuggy) {
     EXPECT_EMPTY_REPORT(driver);
     key_shift_hold_p_tap.release();
     run_one_scan_loop();
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 }

--- a/tests/test_common/test_driver.hpp
+++ b/tests/test_common/test_driver.hpp
@@ -98,6 +98,12 @@ class TestDriver {
  */
 #define EXPECT_NO_REPORT(driver) EXPECT_ANY_REPORT(driver).Times(0)
 
+/**
+ * @brief Verify and clear all gmock expectations that have been setup until
+ * this point.
+ */
+#define VERIFY_AND_CLEAR(driver) testing::Mock::VerifyAndClearExpectations(&driver)
+
 namespace internal {
 void expect_unicode_code_point(TestDriver& driver, uint32_t code_point);
 } // namespace internal

--- a/tests/test_common/test_fixture.cpp
+++ b/tests/test_common/test_fixture.cpp
@@ -82,12 +82,12 @@ TestFixture::~TestFixture() {
 #endif
 
     idle_for(TAPPING_TERM * 10);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
 
     /* Verify that the matrix really is cleared */
     EXPECT_NO_REPORT(driver);
     idle_for(TAPPING_TERM * 10);
-    testing::Mock::VerifyAndClearExpectations(&driver);
+    VERIFY_AND_CLEAR(driver);
     m_this = nullptr;
 
     test_logger.info() << "test fixture clean-up end." << std::endl;


### PR DESCRIPTION
## Description

Which is just a syntactic sugar for `testing::Mock::VerifyAndClearExpectations` to reduce the visual clutter in unit-tests.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
