### PR TITLE
Add a feature to let keyboards programmatically change the keycode.

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -132,6 +132,8 @@ __attribute__((weak)) void post_process_record_kb(uint16_t keycode, keyrecord_t 
 
 __attribute__((weak)) void post_process_record_user(uint16_t keycode, keyrecord_t *record) {}
 
+__attribute__((weak)) void process_remap_keycode_user(uint16_t *keycode, keyrecord_t *record) {}
+
 void shutdown_quantum(void) {
     clear_keyboard();
 #if defined(MIDI_ENABLE) && defined(MIDI_BASIC)
@@ -242,6 +244,12 @@ bool process_record_quantum(keyrecord_t *record) {
     if (velocikey_enabled() && record->event.pressed) {
         velocikey_accelerate();
     }
+#endif
+
+#ifdef KEY_REMAP_ENABLE
+    // Must run before nearly anything so that callers can modify the
+    // keycode.
+    process_remap_keycode_user(&keycode, record);
 #endif
 
 #ifdef WPM_ENABLE


### PR DESCRIPTION
## Description

Initial demo commit for discussion -- doesn't yet include tests, docs, etc.

The theory is that if a keyboard or keymap wants to change the active keycode via logic (rather than something static like the `MAGIC_` remapping codes), there's no way to do that all the way down in `process_record_user`, and you'd want to do that way at the start of keycode processing anyway (to make it a true remap).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
