### PR TITLE
Implement XAP style merge semantics for DD keycodes

### DIFF
--- a/lib/python/qmk/json_schema.py
+++ b/lib/python/qmk/json_schema.py
@@ -1,12 +1,13 @@
 """Functions that help us generate and use info.json files.
 """
 import json
-from collections.abc import Mapping
-from functools import lru_cache
-from pathlib import Path
-
 import hjson
 import jsonschema
+from collections.abc import Mapping
+from functools import lru_cache
+from typing import OrderedDict
+from pathlib import Path
+
 from milc import cli
 
 
@@ -101,3 +102,34 @@ def deep_update(origdict, newdict):
             origdict[key] = value
 
     return origdict
+
+
+def merge_ordered_dicts(dicts):
+    """Merges nested OrderedDict objects resulting from reading a hjson file.
+    Later input dicts overrides earlier dicts for plain values.
+    Arrays will be appended. If the first entry of an array is "!reset!", the contents of the array will be cleared and replaced with RHS.
+    Dictionaries will be recursively merged. If any entry is "!reset!", the contents of the dictionary will be cleared and replaced with RHS.
+    """
+    result = OrderedDict()
+
+    def add_entry(target, k, v):
+        if k in target and isinstance(v, (OrderedDict, dict)):
+            if "!reset!" in v:
+                target[k] = v
+            else:
+                target[k] = merge_ordered_dicts([target[k], v])
+            if "!reset!" in target[k]:
+                del target[k]["!reset!"]
+        elif k in target and isinstance(v, list):
+            if v[0] == '!reset!':
+                target[k] = v[1:]
+            else:
+                target[k] = target[k] + v
+        else:
+            target[k] = v
+
+    for d in dicts:
+        for (k, v) in d.items():
+            add_entry(result, k, v)
+
+    return result

--- a/lib/python/qmk/keycodes.py
+++ b/lib/python/qmk/keycodes.py
@@ -51,7 +51,10 @@ def _find_versions(path, prefix):
 def _potential_search_versions(version, lang=None):
     versions = list_versions(lang)
     versions.reverse()
-    return versions[:versions.index(version)+1]
+
+    loc = versions.index(version) + 1
+
+    return versions[:loc]
 
 
 def _search_path(lang=None):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`keycodes_0.0.2_quantum.hjson` could contain the following to ignore any existing keycodes
```json
{
    "keycodes": {
        "!reset!":0,

        "0x7C00": {
            "group": "quantum",
            "key": "QK_BOOTLOADER",
            "aliases": [
                "QK_BOOT"
            ]
        },
    }
}
```

Likewise `keycodes_0.0.2.hjson` could contain the following to ignore any existing ranges
```json
{
    "ranges": {
        "!reset!":0,

        "0x0000/0x00FF": {
            "define": "QK_BASIC"
        },
    }
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
