### PR TITLE
Fix Aurora Lily58 default encoder behaviour

### DIFF
--- a/keyboards/splitkb/aurora/lily58/lily58.c
+++ b/keyboards/splitkb/aurora/lily58/lily58.c
@@ -286,8 +286,8 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
     if (!encoder_update_user(index, clockwise)) {
         return false;
     }
-    // 0 and 1 are left-half encoders,
-    // 2 and 3 are right-half encoders
+    // 0 is left-half encoder,
+    // 1 is right-half encoder
     if (index == 0) {
         // Volume control
         if (clockwise) {
@@ -296,20 +296,6 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
             tap_code(KC_VOLD);
         }
     } else if (index == 1) {
-        // Volume control
-        if (clockwise) {
-            tap_code(KC_VOLU);
-        } else {
-            tap_code(KC_VOLD);
-        }
-    } else if (index == 2) {
-        // Page up/Page down
-        if (clockwise) {
-            tap_code(KC_PGDN);
-        } else {
-            tap_code(KC_PGUP);
-        }
-    } else if (index == 3) {
         // Page up/Page down
         if (clockwise) {
             tap_code(KC_PGDN);


### PR DESCRIPTION
Fix Aurora Lily58 default encoder behaviour.

## Description

The Aurora Lily58 has *one* encoder per half, not two. The previous behaviour made both left and right encoders act like volume control. This was unintended: the right half is supposed to be PgUp / PgDown.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A, mentioned on the splitkb.com Discord by casuanoob#0425

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
