### PR TITLE
[Driver] IL91874 on Quantum Painter

### DIFF
--- a/drivers/painter/eink_panel/qp_eink_panel.c
+++ b/drivers/painter/eink_panel/qp_eink_panel.c
@@ -1,0 +1,142 @@
+// Copyright 2022 Pablo Martinez (@elpekenin)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qp_internal.h"
+#include "qp_comms.h"
+#include "qp_draw.h"
+#include "qp_eink_panel.h"
+#include "qp_surface.h"
+
+// TODO: Add support for screens with partial refresh
+// TODO: Add support for displays with builtin RAM
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter API implementations
+
+// Power control
+bool qp_eink_panel_power(painter_device_t device, bool power_on) {
+    struct painter_driver_t *                           driver = (struct painter_driver_t *)device;
+    struct eink_panel_dc_reset_painter_driver_vtable_t *vtable = (struct eink_panel_dc_reset_painter_driver_vtable_t *)driver->driver_vtable;
+
+    qp_comms_command(device, power_on ? vtable->opcodes.display_on : vtable->opcodes.display_off);
+
+    return true;
+}
+
+// Screen clear
+bool qp_eink_panel_clear(painter_device_t device) {
+    struct eink_panel_dc_reset_painter_device_t *driver = (struct eink_panel_dc_reset_painter_device_t *)device;
+
+    qp_init(driver->black_surface, driver->base.rotation);
+    qp_init(driver->red_surface,   driver->base.rotation);
+
+    return true;
+}
+
+uint32_t can_flush_callback(uint32_t trigger_time, void *cb_arg) {
+    struct eink_panel_dc_reset_painter_device_t *driver = (struct eink_panel_dc_reset_painter_device_t *) cb_arg;
+    driver->can_flush = true;
+    return 0;
+}
+
+// Screen flush
+bool qp_eink_panel_flush(painter_device_t device) {
+    // Flushing sends the framebuffers in RAM + refresh command to apply them
+    struct eink_panel_dc_reset_painter_device_t        *driver = (struct eink_panel_dc_reset_painter_device_t *)device;
+    struct eink_panel_dc_reset_painter_driver_vtable_t *vtable = (struct eink_panel_dc_reset_painter_driver_vtable_t *)driver->base.driver_vtable;
+    struct surface_painter_device_t                    *black  = (struct surface_painter_device_t *)driver->black_surface;
+    struct surface_painter_device_t                    *red    = (struct surface_painter_device_t *)driver->red_surface;
+
+    if (!driver->can_flush) {
+        qp_dprintf("qp_eink_panel_flush: fail (can_flush is false)\n");
+        return false;
+    }
+
+    uint32_t n_bytes = driver->base.panel_width * driver->base.panel_height / 8;
+
+    qp_comms_command(device, vtable->opcodes.send_black_data);
+    qp_comms_send(device, black->buffer, n_bytes);
+
+    qp_comms_command(device, vtable->opcodes.send_red_data);
+    qp_comms_send(device, red->buffer,   n_bytes);
+
+    qp_comms_command(device, vtable->opcodes.refresh);
+
+    // Set device on can't flush mode and schedule a function to clean the flag after timeout
+    driver->can_flush = false;
+    defer_exec(driver->timeout, can_flush_callback, (void *) device);
+
+    return true;
+}
+
+// Viewport to draw to
+bool qp_eink_panel_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom) {
+    struct eink_panel_dc_reset_painter_device_t *driver = (struct eink_panel_dc_reset_painter_device_t *)device;
+
+    qp_viewport(driver->black_surface, left, top, right, bottom);
+    qp_viewport(driver->red_surface,   left, top, right, bottom);
+
+    return true;
+}
+
+// Stream pixel data to the current write position in GRAM
+bool qp_eink_panel_pixdata(painter_device_t device, const void *pixel_data, uint32_t native_pixel_count) {
+    struct eink_panel_dc_reset_painter_device_t *driver = (struct eink_panel_dc_reset_painter_device_t *)device;
+    struct painter_driver_t                     *black  = (struct painter_driver_t *)driver->black_surface;
+    struct painter_driver_t                     *red    = (struct painter_driver_t *)driver->red_surface;
+
+    uint8_t *pixels = (uint8_t *) pixel_data;
+
+    for (uint32_t i = 0; i < native_pixel_count; ++i) {
+        // Calling driver function manually instead of `qp_pixdata` to avoid getting LOTS of `qp_dprintf` slowing it
+        black->driver_vtable->pixdata((const void *) black, (const void *) (pixels[i] >> 0), 1);
+        red->driver_vtable->pixdata(  (const void *) red,   (const void *) (pixels[i] >> 1), 1);
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Convert supplied palette entries into their native equivalents
+
+uint16_t hsv_distance(uint8_t h, uint8_t s, uint8_t v, HSV hsv) {
+    return (h-hsv.h)*(h-hsv.h) + (s-hsv.s)*(s-hsv.s) + (v-hsv.v)*(v-hsv.v);
+}
+
+bool qp_eink_panel_palette_convert_eink3(painter_device_t device, int16_t palette_size, qp_pixel_t *palette) {
+    for (int16_t i = 0; i < palette_size; ++i) {
+        HSV hsv = (HSV){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v};
+        uint16_t black_distance = hsv_distance(HSV_BLACK, hsv);
+        uint16_t red_distance   = hsv_distance(HSV_RED, hsv);
+        uint16_t white_distance = hsv_distance(HSV_WHITE, hsv);
+
+        uint8_t value;
+        uint16_t min_distance = QP_MIN(black_distance, QP_MIN(red_distance, white_distance));
+        if (min_distance == black_distance)
+            value = 0b01;
+
+        else if (min_distance == red_distance)
+            value = 0b10;
+
+        else
+            value = 0b00;
+
+        palette[i].mono = value;
+    }
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Append pixels to the target location, keyed by the pixel index
+
+bool qp_eink_panel_append_pixels_eink3(painter_device_t device, uint8_t *target_buffer, qp_pixel_t *palette, uint32_t pixel_offset, uint32_t pixel_count, uint8_t *palette_indices) {
+    // Black data
+    for (uint32_t i = 0; i < pixel_count; ++i) {
+        // TODO: Optimize code so that each pixel takes 2 bits instead of a whole byte
+        // Current format: | 0000 00BR | 0000 00BR | ...
+        target_buffer[pixel_offset + i] = palette[palette_indices[i]].mono;
+    }
+
+    return true;
+}
+

--- a/drivers/painter/eink_panel/qp_eink_panel.h
+++ b/drivers/painter/eink_panel/qp_eink_panel.h
@@ -1,0 +1,68 @@
+// Copyright 2022 Pablo Martinez (@elpekenin)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "color.h"
+#include "qp_internal.h"
+
+#ifdef QUANTUM_PAINTER_SPI_ENABLE
+#    include "qp_comms_spi.h"
+#endif // QUANTUM_PAINTER_SPI_ENABLE
+
+#define EINK_BYTES_REQD(w, h) (2 * SURFACE_REQUIRED_BUFFER_BYTE_SIZE(w, h, 1))
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Common TFT panel implementation using D/C, and RST pins.
+
+// Driver vtable with extras
+struct eink_panel_dc_reset_painter_driver_vtable_t {
+    struct painter_driver_vtable_t base; // must be first, so it can be cast to/from the painter_driver_vtable_t* type
+
+    // Number of bytes for transmitting x/y coordinates
+    uint8_t num_window_bytes;
+
+    // Whether or not the x/y coords should be swapped on 90/270 rotation
+    bool swap_window_coords;
+
+    // Opcodes for normal display operation
+    // On/Off may not be needed, or even worse not exist on other displays
+    struct {
+        uint8_t display_on;
+        uint8_t display_off;
+        uint8_t send_black_data;
+        uint8_t send_red_data;
+        uint8_t refresh;
+    } opcodes;
+};
+
+// Device definition
+typedef struct eink_panel_dc_reset_painter_device_t {
+    struct painter_driver_t base; // must be first, so it can be cast to/from the painter_device_t* type
+
+    painter_device_t black_surface;
+    painter_device_t red_surface;
+
+    uint32_t timeout; // time to wait between flushes to avoid damaging the screen, in ms
+    bool can_flush;
+
+    union {
+#ifdef QUANTUM_PAINTER_SPI_ENABLE
+        // SPI-based configurables
+        struct qp_comms_spi_dc_reset_config_t spi_dc_reset_config;
+#endif // QUANTUM_PAINTER_SPI_ENABLE
+
+        // TODO: I2C/parallel etc.
+    };
+} eink_panel_dc_reset_painter_device_t;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Forward declarations for injecting into concrete driver vtables
+
+bool qp_eink_panel_power(painter_device_t device, bool power_on);
+bool qp_eink_panel_clear(painter_device_t device);
+bool qp_eink_panel_flush(painter_device_t device);
+bool qp_eink_panel_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom);
+bool qp_eink_panel_pixdata(painter_device_t device, const void *pixel_data, uint32_t native_pixel_count);
+
+bool qp_eink_panel_palette_convert_eink3(painter_device_t device, int16_t palette_size, qp_pixel_t *palette);
+
+bool qp_eink_panel_append_pixels_eink3(painter_device_t device, uint8_t *target_buffer, qp_pixel_t *palette, uint32_t pixel_offset, uint32_t pixel_count, uint8_t *palette_indices);

--- a/drivers/painter/il91874/qp_il91874.c
+++ b/drivers/painter/il91874/qp_il91874.c
@@ -1,0 +1,129 @@
+// Copyright 2022 Pablo Martinez (@elpekenin)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qp_internal.h"
+#include "qp_comms.h"
+#include "qp_il91874.h"
+#include "qp_il91874_opcodes.h"
+#include "qp_eink_panel.h"
+#include "qp_surface.h"
+
+#ifdef QUANTUM_PAINTER_IL91874_SPI_ENABLE
+#    include <qp_comms_spi.h>
+#endif // QUANTUM_PAINTER_IL91874_SPI_ENABLE
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Common
+
+// Driver storage
+eink_panel_dc_reset_painter_device_t il91874_drivers[IL91874_NUM_DEVICES] = {0};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Initialization
+
+bool qp_il91874_init(painter_device_t device, painter_rotation_t rotation) {
+    struct eink_panel_dc_reset_painter_device_t *driver = (struct eink_panel_dc_reset_painter_device_t *)device;
+
+    // clang-format off
+    const uint8_t il91874_init_sequence[] = {
+        // Command,                 Delay,  N, Data[N]
+        IL91874_POWER_ON,             120,  0,
+        IL91874_PANEL_SETTING,          0,  1, 0xAF,
+        IL91874_PLL,                    0,  1, 0x3A,
+        IL91874_POWER_SETTING,          0,  5, 0x03, 0x00, 0x2B, 0x2B, 0x09,
+        IL91874_BOOSTER_SOFT_START,     0,  3, 0x07, 0x07, 0x17,
+        IL91874_MISTERY_COMMAND,        0,  2, 0x60, 0xA5,
+        IL91874_MISTERY_COMMAND,        0,  2, 0x89, 0xA5,
+        IL91874_MISTERY_COMMAND,        0,  2, 0x90, 0x00,
+        IL91874_MISTERY_COMMAND,        0,  2, 0x93, 0xAD,
+        IL91874_MISTERY_COMMAND,        0,  2, 0x73, 0x41,
+        IL91874_VCM_DC_SETTING,         0,  1, 0x12,
+        IL91874_CDI,                    0,  1, 0x87,
+        IL91874_LUT1,                   0, 44, 0x0, 0x0, 0x0, 0x1A, 0x1A, 0x0, 0x0, 0x01, 0x0, 0xA, 0xA, 0x0, 0x0, 0x8, 0x0, 0xE, 0x1, 0xE, 0x1, 0x10, 0x0, 0xA, 0xA, 0x0, 0x0, 0x8, 0x0, 0x4, 0x10, 0x0, 0x0, 0x5, 0x0, 0x3, 0xE, 0x0, 0x0, 0xA, 0x0, 0x23, 0x0, 0x0, 0x0, 0x1,
+        IL91874_LUTWW,                  0, 42, 0x90, 0x1A, 0x1A, 0x0, 0x0, 0x1, 0x40, 0x0A, 0x0A, 0x0, 0x0, 0x8, 0x84, 0xE, 0x1, 0xE, 0x1, 0x10, 0x80, 0xA, 0xA, 0x0, 0x0, 0x8, 0x0, 0x4, 0x10, 0x0, 0x0, 0x5, 0x0, 0x3, 0xE, 0x0, 0x0, 0xA, 0x0, 0x23, 0x0, 0x0, 0x0, 0x1,
+        IL91874_LUTBW,                  0, 42, 0xA0, 0x1A, 0x1A, 0x0, 0x0, 0x1, 0x0, 0xA, 0xA, 0x0, 0x0, 0x8, 0x84, 0xE, 0x1, 0xE, 0x1, 0x10, 0x90, 0xA, 0xA, 0x0, 0x0, 0x8, 0xB0, 0x4, 0x10, 0x0, 0x0, 0x5, 0xB0, 0x3, 0xE, 0x0, 0x0, 0xA, 0xC0, 0x23, 0x0, 0x0, 0x0, 0x1,
+        IL91874_LUTWB,                  0, 42, 0x90, 0x1A, 0x1A, 0x0, 0x0, 0x1, 0x40, 0xA, 0xA, 0x0, 0x0, 0x8, 0x84, 0xE, 0x1, 0xE, 0x1, 0x10, 0x80, 0xA, 0xA, 0x0, 0x0, 0x8, 0x0, 0x4, 0x10, 0x0, 0x0, 0x5, 0x0, 0x3, 0xE, 0x0, 0x0, 0xA, 0x0, 0x23, 0x0, 0x0, 0x0, 0x1,
+        IL91874_LUTBB,                  0, 42, 0x90, 0x1a, 0x1A, 0x0, 0x0, 0x1, 0x20, 0xA, 0xA, 0x0, 0x0, 0x8, 0x84, 0xE, 0x1, 0xE, 0x1, 0x10, 0x10, 0xA, 0xA, 0x0, 0x0, 0x8, 0x0, 0x4, 0x10, 0x0, 0x0, 0x5, 0x0, 0x3, 0xE, 0x0, 0x0, 0xA, 0x0, 0x23, 0x0, 0x0, 0x0, 0x1,
+        IL91874_RESOLUTION,             0,  4, (driver->base.panel_width >> 8) & 0xFF, (driver->base.panel_width) & 0xFF, (driver->base.panel_height >> 8) & 0xFF, (driver->base.panel_height) & 0xFF,
+        IL91874_PDRF,                   0,  1, 0x00
+    };
+    // clang-format on
+    qp_comms_bulk_command_sequence(device, il91874_init_sequence, sizeof(il91874_init_sequence));
+    driver->base.rotation = rotation;
+
+    qp_init(driver->black_surface, rotation);
+    qp_init(driver->red_surface,   rotation);
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Driver vtable
+
+const struct eink_panel_dc_reset_painter_driver_vtable_t il91874_driver_vtable = {
+    .base =
+        {
+            .init            = qp_il91874_init,
+            .power           = qp_eink_panel_power,
+            .clear           = qp_eink_panel_clear,
+            .flush           = qp_eink_panel_flush,
+            .pixdata         = qp_eink_panel_pixdata,
+            .viewport        = qp_eink_panel_viewport,
+            .palette_convert = qp_eink_panel_palette_convert_eink3,
+            .append_pixels   = qp_eink_panel_append_pixels_eink3,
+        },
+    .num_window_bytes   = 2,
+    .swap_window_coords = false,
+    .opcodes =
+        {
+            .display_on  = IL91874_POWER_ON,
+            .display_off = IL91874_POWER_OFF,
+            .send_black_data = IL91874_SEND_BLACK,
+            .send_red_data = IL91874_SEND_RED,
+            .refresh = IL91874_DISPLAY_REFRESH,
+        }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// SPI
+
+#ifdef QUANTUM_PAINTER_IL91874_SPI_ENABLE
+
+// Factory function for creating a handle to the IL91874 device
+painter_device_t qp_il91874_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode, void *ptr) {
+    for (uint32_t i = 0; i < IL91874_NUM_DEVICES; ++i) {
+        eink_panel_dc_reset_painter_device_t *driver = &il91874_drivers[i];
+        if (!driver->base.driver_vtable) {
+            driver->base.driver_vtable         = (const struct painter_driver_vtable_t *)&il91874_driver_vtable;
+            driver->base.comms_vtable          = (const struct painter_comms_vtable_t *)&spi_comms_with_dc_shiftreg_vtable;
+            driver->base.native_bits_per_pixel = 8; // Black and red channels
+            driver->base.panel_width           = panel_width;
+            driver->base.panel_height          = panel_height;
+            driver->base.rotation              = QP_ROTATION_0;
+            driver->base.offset_x              = 0;
+            driver->base.offset_y              = 0;
+
+            driver->black_surface = qp_make_mono1bpp_surface(panel_width, panel_height, ptr);
+            driver->red_surface = qp_make_mono1bpp_surface(panel_width, panel_height, ptr+SURFACE_REQUIRED_BUFFER_BYTE_SIZE(panel_width, panel_height, 1));
+
+            driver->timeout = 3 * 60 * 1000; // 3 minutes as suggested by Adafruit
+            driver->can_flush = true;
+
+            // SPI and other pin configuration
+            driver->base.comms_config                              = &driver->spi_dc_reset_config;
+            driver->spi_dc_reset_config.spi_config.chip_select_pin = chip_select_pin;
+            driver->spi_dc_reset_config.spi_config.divisor         = spi_divisor;
+            driver->spi_dc_reset_config.spi_config.lsb_first       = false;
+            driver->spi_dc_reset_config.spi_config.mode            = spi_mode;
+            driver->spi_dc_reset_config.dc_pin                     = dc_pin;
+            driver->spi_dc_reset_config.reset_pin                  = reset_pin;
+
+            return (painter_device_t)driver;
+        }
+    }
+    return NULL;
+}
+
+#endif // QUANTUM_PAINTER_IL91874_SPI_ENABLE
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/il91874/qp_il91874.h
+++ b/drivers/painter/il91874/qp_il91874.h
@@ -1,0 +1,39 @@
+// Copyright 2022 Pablo Martinez (@elpekenin)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "gpio.h"
+#include "qp_internal.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter IL91874_NUM_DEVICES configurables (add to your keyboard's config.h)
+
+#ifndef IL91874_NUM_DEVICES
+/**
+ * @def This controls the maximum number of IL91874_NUM_DEVICES devices that Quantum Painter can communicate with at any one time.
+ *      Increasing this number allows for multiple displays to be used.
+ */
+#    define IL91874_NUM_DEVICES 1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter IL91874_NUM_DEVICES device factories
+
+#ifdef QUANTUM_PAINTER_IL91874_SPI_ENABLE
+/**
+ * Factory method for an IL91874 SPI LCD device.
+ *
+ * @param panel_width[in] the width of the display panel
+ * @param panel_height[in] the height of the display panel
+ * @param chip_select_pin[in] the GPIO pin used for SPI chip select
+ * @param dc_pin[in] the GPIO pin used for D/C control
+ * @param reset_pin[in] the GPIO pin used for RST
+ * @param spi_divisor[in] the SPI divisor to use when communicating with the display
+ * @param spi_mode[in] the SPI mode to use when communicating with the display
+ * @param ptr[in] the array in which pixel data is stored
+ * @return the device handle used with all drawing routines in Quantum Painter
+ */
+painter_device_t qp_il91874_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode, void *ptr);
+
+#endif // QUANTUM_PAINTER_IL91874_SPI_ENABLE

--- a/drivers/painter/il91874/qp_il91874_opcodes.h
+++ b/drivers/painter/il91874/qp_il91874_opcodes.h
@@ -1,0 +1,32 @@
+// Copyright 2022 Pablo Martinez (@elpekenin)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter IL91874 command opcodes
+#define IL91874_PANEL_SETTING 0x00
+#define IL91874_POWER_SETTING 0x01
+#define IL91874_POWER_OFF 0x02
+#define IL91874_POWER_OFF_SEQUENCE 0x03
+#define IL91874_POWER_ON 0x04
+#define IL91874_POWER_ON_MEASURE 0x05
+#define IL91874_BOOSTER_SOFT_START 0x06
+#define IL91874_DEEP_SLEEP 0x07
+#define IL91874_SEND_BLACK 0x10
+#define IL91874_DATA_STOP 0x11
+#define IL91874_DISPLAY_REFRESH 0x12
+#define IL91874_SEND_RED 0x13
+#define IL91874_PDTM1 0x14
+#define IL91874_PDTM2 0x15
+#define IL91874_PDRF 0x16
+#define IL91874_LUT1 0x20
+#define IL91874_LUTWW 0x21
+#define IL91874_LUTBW 0x22
+#define IL91874_LUTWB 0x23
+#define IL91874_LUTBB 0x24
+#define IL91874_PLL 0x30
+#define IL91874_CDI 0x50
+#define IL91874_RESOLUTION 0x61
+#define IL91874_VCM_DC_SETTING 0x82
+#define IL91874_MISTERY_COMMAND 0xF8 // Undocummented command on Adafruit's sample code


### PR DESCRIPTION
## Description
Added driver for 3-color eink panels, specifically the IL91874, it is simply a wrapper around 2 1bpp `surface` "screens", one holding black data and another for red. 

## Pre-Requisites
Merge #18521 so we have the `shiftreg_vtable` and `send_parameters` function exists on Quantum Painter
Merge `surface` changes on tzarc's branch such that we have the "base" 1bpp drivers

## To-Do
- [ ] Update docs
- [ ] Add `quantum/painter/rules.mk` changes once the requisites are merged, to avoid conflicts
- [ ] Some cleanup?

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
