### PR TITLE
Fixup horrortroll/handwired_k552

### DIFF
--- a/keyboards/horrortroll/handwired_k552/config.h
+++ b/keyboards/horrortroll/handwired_k552/config.h
@@ -32,10 +32,6 @@
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE 5
 
-/* Bootmagic reset */
-#define BOOTMAGIC_LITE_ROW 0
-#define BOOTMAGIC_LITE_COLUMN 0
-
 /* Forcing to use NKRO instead 6KRO */
 #define FORCE_NKRO
 

--- a/keyboards/horrortroll/handwired_k552/rules.mk
+++ b/keyboards/horrortroll/handwired_k552/rules.mk
@@ -7,7 +7,7 @@ MCU = STM32F103
 # Cannot use `BOOTLOADER = stm32duino` due to the need to override
 # `MCU_LDSCRIPT`, therefore all parameters need to be specified here manually.
 OPT_DEFS += -DBOOTLOADER_STM32DUINO
-MCU_LDSCRIPT = STM32F103xC_stm32duino_bootloader
+MCU_LDSCRIPT = k552_f103
 BOARD = STM32_F103_STM32DUINO
 BOOTLOADER_TYPE = stm32duino
 DFU_ARGS = -d 1EAF:0003 -a 2 -R


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`STM32F103xC_stm32duino_bootloader.ld` doesn't exist. I presume the linker script in the keyboard directory is what's meant to be used.
cc @HorrorTroll 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
