### PR TITLE
Add `DOUBLE_REPORT` to fix RDP modifier key reliability

### DIFF
--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -270,17 +270,24 @@ void send_keyboard_report(void) {
     keyboard_report->mods |= weak_override_mods;
 #endif
 
-#ifdef PROTOCOL_VUSB
-    host_keyboard_send(keyboard_report);
-#else
     static report_keyboard_t last_report;
 
-    /* Only send the report if there are changes to propagate to the host. */
-    if (memcmp(keyboard_report, &last_report, sizeof(report_keyboard_t)) != 0) {
-        memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
-        host_keyboard_send(keyboard_report);
+#if defined(REPORT_MODS_SEPARATELY)
+    if (last_report.mods != keyboard_report->mods) {
+        //build a keyboard report that only updates the mods
+        report_keyboard_t mod_report;
+        memcpy(&mod_report, &last_report, sizeof(report_keyboard_t));
+        mod_report.mods = keyboard_report->mods;
+
+        host_keyboard_send(&mod_report);
+        memcpy(&last_report, &mod_report, sizeof(report_keyboard_t));
     }
 #endif
+
+    if (memcmp(&last_report, keyboard_report, sizeof(report_keyboard_t)) != 0) {
+        host_keyboard_send(keyboard_report);
+        memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
+    }
 }
 
 /** \brief Get mods

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -270,32 +270,21 @@ void send_keyboard_report(void) {
     keyboard_report->mods |= weak_override_mods;
 #endif
 
-#ifdef PROTOCOL_VUSB
-#   ifdef DOUBLE_REPORT
-    static report_keyboard_t last_report;
-    memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
-#   endif
-
-    host_keyboard_send(keyboard_report);
-
-#   ifdef DOUBLE_REPORT
-    memcpy(keyboard_report, &last_report, sizeof(report_keyboard_t)); // host_keyboard_send() sometimes modifies keyboard_report, so restore it from last_report before sending again
-    host_keyboard_send(keyboard_report);
-#   endif
-#else
     static report_keyboard_t last_report;
 
+#ifndef PROTOCOL_VUSB
     /* Only send the report if there are changes to propagate to the host. */
-    if (memcmp(&last_report, keyboard_report, sizeof(report_keyboard_t)) != 0) {
+    if (memcmp(&last_report, keyboard_report, sizeof(report_keyboard_t)) != 0)
+#endif
+    {
         memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
         host_keyboard_send(keyboard_report);
 
-#   ifdef DOUBLE_REPORT
-        memcpy(keyboard_report, &last_report, sizeof(report_keyboard_t)); // host_keyboard_send() sometimes modifies keyboard_report, so restore it from last_report before sending again
+#ifdef DOUBLE_REPORT
+        memcpy(keyboard_report, &last_report, sizeof(report_keyboard_t)); // host_keyboard_send() sometimes modifies keyboard_report to handle protocol details, so restore the original from last_report
         host_keyboard_send(keyboard_report);
-#   endif
-    }
 #endif
+    }
 }
 
 /** \brief Get mods

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -272,7 +272,7 @@ void send_keyboard_report(void) {
 
     static report_keyboard_t last_report;
 
-#if defined(REPORT_MODS_SEPARATELY)
+#ifdef REPORT_MODS_SEPARATELY
     if (last_report.mods != keyboard_report->mods) {
         //build a keyboard report that only updates the mods
         report_keyboard_t mod_report;
@@ -284,10 +284,16 @@ void send_keyboard_report(void) {
     }
 #endif
 
-    if (memcmp(&last_report, keyboard_report, sizeof(report_keyboard_t)) != 0) {
+#ifdef PROTOCOL_VUSB
+    host_keyboard_send(keyboard_report);
+    memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
+#else
+    /* Only send the report if there are changes to propagate to the host. */
+    if (memcmp(keyboard_report, &last_report, sizeof(report_keyboard_t)) != 0) {
         host_keyboard_send(keyboard_report);
         memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
     }
+#endif
 }
 
 /** \brief Get mods

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -274,7 +274,7 @@ void send_keyboard_report(void) {
 
 #ifdef REPORT_MODS_SEPARATELY
     if (last_report.mods != keyboard_report->mods) {
-        //build a keyboard report that only updates the mods
+        // Build a keyboard report that only updates the mods
         report_keyboard_t mod_report;
         memcpy(&mod_report, &last_report, sizeof(report_keyboard_t));
         mod_report.mods = keyboard_report->mods;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

QMK has trouble sending modifier keys (eg `LSFT(KC_TAB)`) to remote computer GUIs via software such as Microsoft's Remote Desktop, and the local Hyper-V viewer. The modifier is frequently lost, causing the unmodified key to be pressed instead. (Exactly how often the modifiers are lost seems to be environment-specific, but I've experienced as high as 50% for some keys.)

This PR adds the ability for QMK to report changes to modifiers separately from changes to keys. Users need only add `#define DOUBLE_REPORT` to their `config.h`.

In my testing so far, this *almost* completely resolves the issue for MS RDP and Hyper-V. Out of several hundred keypresses, one might still fail to have the correct modifiers applied. This error rate is below typical human error when typing, so it is essentially transparent in real use.

The other proposed solutions I've seen so far (eg #19405, and code snippets in the issues referenced below) all involve adding a delay somewhere in the QMK code. I found in my own testing that this type of solution is not adequate; it can reduce the frequency of occurrence, but it does not seem to completely eliminate it, and may not work with all QMK features. Tuning the delay is also a hassle, and a given delay amount may not even work optimally for all environments.

This solution may also make #4198 obsolete.

This PR replaces #19436.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1037
* #13708
* #15134
* #18931

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).