### PR TITLE
Add common layout to Piantor

### DIFF
--- a/keyboards/beekeeb/piantor/info.json
+++ b/keyboards/beekeeb/piantor/info.json
@@ -22,6 +22,7 @@
     "split": {
         "enabled": true
     },
+    "community_layouts": ["split_3x6_3"],
     "layouts": {
         "LAYOUT_split_3x6_3": {
             "layout": [

--- a/keyboards/beekeeb/piantor/rules.mk
+++ b/keyboards/beekeeb/piantor/rules.mk
@@ -1,1 +1,3 @@
 SERIAL_DRIVER = vendor
+
+LAYOUTS = split_3x6_3

--- a/keyboards/beekeeb/piantor/rules.mk
+++ b/keyboards/beekeeb/piantor/rules.mk
@@ -1,3 +1,1 @@
 SERIAL_DRIVER = vendor
-
-LAYOUTS = split_3x6_3


### PR DESCRIPTION
## Description

Piantor is a split_3x6_3 as defined in info.json. Add the layout to community layouts so we can take advantage of layouts with a common implementation (e.g. manna-harbour_miryoku).

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
