### PR TITLE
Suggest `qmk list-keyboards` when testing build environment

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -166,6 +166,8 @@ For example, to build a firmware for a Clueboard 66% you would use:
 
     qmk compile -kb clueboard/66/rev3 -km default
 
+You can use `qmk list-keyboards` to see a list of valid keyboards.
+
 When it is done you should have a lot of output that ends similar to this:
 
 ```

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -166,7 +166,7 @@ For example, to build a firmware for a Clueboard 66% you would use:
 
     qmk compile -kb clueboard/66/rev3 -km default
 
-You can use `qmk list-keyboards` to see a list of valid keyboards.
+?> The keyboard option is the path relative to the keyboard directory, the above example would be found in `qmk_firmware/keyboards/clueboard/66/rev4`. If you're unsure you can view a full list of supported keyboards with `qmk list-keyboards`.
 
 When it is done you should have a lot of output that ends similar to this:
 

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -166,7 +166,7 @@ For example, to build a firmware for a Clueboard 66% you would use:
 
     qmk compile -kb clueboard/66/rev3 -km default
 
-?> The keyboard option is the path relative to the keyboard directory, the above example would be found in `qmk_firmware/keyboards/clueboard/66/rev4`. If you're unsure you can view a full list of supported keyboards with `qmk list-keyboards`.
+?> The keyboard option is the path relative to the keyboard directory, the above example would be found in `qmk_firmware/keyboards/clueboard/66/rev3`. If you're unsure you can view a full list of supported keyboards with `qmk list-keyboards`.
 
 When it is done you should have a lot of output that ends similar to this:
 


### PR DESCRIPTION
Add `qmk list-keyboards` to the getting started guide.

As I was going through the install docs, I ran into an error. Since I didn't know any other options for the keyboard, it made it difficult to discern whether it was an issue with the keyboard name that I was using or whether it was due to something else.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
