### PR TITLE
Fix for ES_ACUT dead key for spanish languaje

### DIFF
--- a/quantum/keymap_extras/sendstring_spanish.h
+++ b/quantum/keymap_extras/sendstring_spanish.h
@@ -80,7 +80,7 @@ const uint8_t ascii_to_dead_lut[16] PROGMEM = {
     KCLUT_ENTRY(1, 0, 0, 0, 0, 0, 0, 0),
     KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
     KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
-    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0)
+    KCLUT_ENTRY(0, 0, 0, 1, 0, 0, 0, 0)
 };
 
 const uint8_t ascii_to_keycode_lut[128] PROGMEM = {


### PR DESCRIPTION
## Description

Fix issue with ES_ACUTE ´ dead key, missing in sendstring_spanish for spanish iso layout

## Types of Changes

- [ ] Core
- [ x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

