### PR TITLE
Enable RGB by default on bluebell/Swoop

### DIFF
--- a/keyboards/bluebell/swoop/config.h
+++ b/keyboards/bluebell/swoop/config.h
@@ -1,0 +1,61 @@
+/* Copyright 2022 James White <jamesmnw@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include "config_common.h"
+
+
+// key matrix size (rows are doubled)
+#define MATRIX_ROWS 8
+#define MATRIX_COLS 5
+
+// wiring of each half
+#define MATRIX_ROW_PINS { D4, C6, D7, E6 }
+#define MATRIX_COL_PINS { B1, F7, F6, F5, F4 }
+#define DIODE_DIRECTION COL2ROW
+
+// communication between sides
+#define SOFT_SERIAL_PIN D2
+#define EE_HANDS
+
+// encoders
+#define ENCODERS_PAD_A { B4 }
+#define ENCODERS_PAD_B { B5 }
+#define ENCODERS_PAD_A_RIGHT { B5 }
+#define ENCODERS_PAD_B_RIGHT { B4 }
+
+// OLED driver
+#ifdef OLED_DRIVER_ENABLE
+  #define OLED_DISPLAY_128X32
+  #define OLED_TIMEOUT 30000
+#endif
+
+// RGB underglow and per key
+#define RGB_DI_PIN D3
+#ifdef RGB_DI_PIN
+  #define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+  #define RGBLIGHT_EFFECT_RAINBOW_MOOD
+  #define RGBLIGHT_EFFECT_STATIC_GRADIENT
+  #define RGBLIGHT_EFFECT_BREATHING
+  #define RGBLED_NUM 36
+  #define RGBLED_SPLIT \
+        { 18, 18 }
+  #define RGBLIGHT_SPLIT
+  #define RGBLIGHT_LIMIT_VAL 150
+  #define RGBLIGHT_HUE_STEP 10
+  #define RGBLIGHT_SAT_STEP 17
+  #define RGBLIGHT_VAL_STEP 17
+  #define RGBLIGHT_SLEEP
+#endif

--- a/keyboards/bluebell/swoop/info.json
+++ b/keyboards/bluebell/swoop/info.json
@@ -1,0 +1,53 @@
+{
+  "keyboard_name": "Swoop",
+  "url": "https://github.com/jimmerricks/swoop",
+  "maintainer": "jmnw",
+  "manufacturer": "jmnw",
+  "usb": {
+    "vid": "0x1804",
+    "pid": "0x3046",
+    "device_ver": "0x0001"
+  },
+  "layouts": {
+    "LAYOUT_split_3x5_3": {
+      "layout": [
+        {"label":"SW1",  "x":0, "y":0.375},
+        {"label":"SW2",  "x":1, "y":0.125},
+        {"label":"SW3",  "x":2, "y":0},
+        {"label":"SW4",  "x":3, "y":0.125},
+        {"label":"SW5",  "x":4, "y":0.25},
+        {"label":"SW19", "x":8, "y":0.25},
+        {"label":"SW20", "x":9, "y":0.125},
+        {"label":"SW21", "x":10, "y":0},
+        {"label":"SW22", "x":11, "y":0.125},
+        {"label":"SW23", "x":12, "y":0.375},
+        {"label":"SW6",  "x":0, "y":1.375},
+        {"label":"SW7",  "x":1, "y":1.125},
+        {"label":"SW8", "x":2, "y":1},
+        {"label":"SW9", "x":3, "y":1.125},
+        {"label":"SW10", "x":4, "y":1.25},
+        {"label":"SW24", "x":8, "y":1.25},
+        {"label":"SW25", "x":9,  "y":1.125},
+        {"label":"SW26", "x":10, "y":1},
+        {"label":"SW27", "x":11, "y":1.125},
+        {"label":"SW28", "x":12, "y":1.375},
+        {"label":"SW11", "x":0, "y":2.375},
+        {"label":"SW12", "x":1, "y":2.125},
+        {"label":"SW13", "x":2, "y":2},
+        {"label":"SW14", "x":3, "y":2.125},
+        {"label":"SW15", "x":4, "y":2.25},
+        {"label":"SW29", "x":8, "y":2.25},
+        {"label":"SW30", "x":9,  "y":2.125},
+        {"label":"SW31", "x":10, "y":2},
+        {"label":"SW32", "x":11, "y":2.125},
+        {"label":"SW33", "x":12, "y":2.375},
+        {"label":"SW16", "x":2.875, "y":3.25},
+        {"label":"SW17", "x":4, "y":3.375},
+        {"label":"SW28", "x":5.125, "y":3.625},
+        {"label":"SW34", "x":6.875, "y":3.625},
+        {"label":"SW35", "x":8, "y":3.375},
+        {"label":"SW36", "x":9.125, "y":3.25}
+      ]
+    }
+  }
+}

--- a/keyboards/bluebell/swoop/keymaps/default/keymap.c
+++ b/keyboards/bluebell/swoop/keymaps/default/keymap.c
@@ -1,0 +1,42 @@
+/* Copyright 2022 James White <jamesmnw@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+enum layers {
+    _QWERTY
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/*
+ * QWERTY
+ * ,---------------------------------.     ,----------------------------------.
+ * |  Q  |   W  |   E  |   R  |   T  |     |   Y  |   U  |   I  |   O  |   P  |
+ * |-----+------+------+------+------|     |------+------+------+------+------|
+ * |  A  |   S  |   D  |   F  |   G  |     |   H  |   J  |   K  |   L  |   ;  |
+ * |-----+------+------+------+------|     ,------+------+------+------+------|
+ * |  Z  |   X  |   C  |   V  |   B  |     |   N  |   M  |   ,  |   .  |   /  |
+ * `------------+------+------+------|     |------+------+------+-------------'
+ *              | LCTL | BSpc | Esc  |     | Ent  | Spc  | LAlt |
+ *              `--------------------'     `--------------------'
+ */
+
+[_QWERTY] = LAYOUT_split_3x5_3(
+  KC_Q,   KC_W,    KC_E,    KC_R,    KC_T,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+  KC_A,   KC_S,    KC_D,    KC_F,    KC_G,        KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,
+  KC_Z,   KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
+                   KC_LCTL, KC_BSPC, KC_ESC,      KC_ENT,  KC_SPC,  KC_LALT
+)
+};

--- a/keyboards/bluebell/swoop/keymaps/kyek/config.h
+++ b/keyboards/bluebell/swoop/keymaps/kyek/config.h
@@ -1,0 +1,18 @@
+/* Copyright 2022 Duccio Breschi <ducciobreschi@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#define ONESHOT_TIMEOUT 1000
+#define COMBO_COUNT 2

--- a/keyboards/bluebell/swoop/keymaps/kyek/keymap.c
+++ b/keyboards/bluebell/swoop/keymaps/kyek/keymap.c
@@ -1,0 +1,114 @@
+/* Copyright 2022 Duccio Breschi <ducciobreschi@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+#include "keymap_italian.h"
+
+enum layers {
+    _BASE = 0,
+    _SYM1,
+    _EXT,
+    _FNC,
+    _SYM2,
+    _ACC,
+    _SET,
+};
+
+// Combo Layers
+enum combos {
+  ACC,
+  SET,
+};
+const uint16_t PROGMEM accent_combo[] = {KC_SPC, MO(_SYM1), COMBO_END};
+const uint16_t PROGMEM settings_combo[] = {MO(_EXT), SFT_T(KC_SPC), COMBO_END};
+combo_t key_combos[COMBO_COUNT] = {
+  [ACC] = COMBO(accent_combo, MO(_ACC)),
+  [SET] = COMBO(settings_combo, MO(_SET)),
+};
+// -----
+
+// Layer Aliases
+#define SYM1 MO(_SYM1)
+#define EXT MO(_EXT)
+#define FNC MO(_FNC)
+#define SYM2 MO(_SYM2)
+// #define ACC MO(_ACC)
+// #define SET MO(_SET)
+// Oneshot Aliases
+#define OS_CTL OSM(MOD_LCTL)
+#define OS_ALT OSM(MOD_LALT)
+#define OS_SFT OSM(MOD_LSFT)
+#define OS_GUI OSM(MOD_LGUI)
+#define OS_RALT OSM(MOD_RALT)
+// Other Aliases
+#define DEL_WORD LCTL(KC_BSPC)
+#define UNDO LCTL(KC_Z)
+#define COPY LCTL(KC_C)
+#define CUT LCTL(KC_X)
+#define PASTE LCTL(KC_V)
+#define BACKTICK RALT(KC_MINS)
+#define TILDE RALT(KC_EQL)
+#define CEGR RSA(KC_E)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+[_BASE] = LAYOUT_split_3x5_3(
+  IT_Q,   IT_W,    IT_E,    IT_R,    IT_T,        IT_Y,    IT_U,    IT_I,    IT_O,    IT_P,
+  IT_A,   IT_S,    IT_D,    IT_F,    IT_G,        IT_H,    IT_J,    IT_K,    IT_L,    IT_OGRV,
+  IT_Z,   IT_X,    IT_C,    IT_V,    IT_B,        IT_N,    IT_M,    IT_COMM, IT_DOT,  IT_UGRV,
+                   XXXXXXX, EXT, SFT_T(KC_SPC),      KC_SPC,  SYM1,  XXXXXXX
+),
+[_SYM1] = LAYOUT_split_3x5_3(
+  IT_1,   IT_2,    IT_3,    IT_4,    IT_5,        IT_6,    IT_7,    IT_8,    IT_9,    IT_0,
+  IT_LABK,   IT_PERC,    IT_LPRN,    IT_LCBR,    IT_LBRC,        IT_EQL,    IT_QUES,    IT_QUOT,    IT_PLUS,    IT_ASTR,
+  IT_RABK,   IT_DLR,    IT_RPRN,    IT_RCBR,    IT_RBRC,        IT_AT,    IT_EXLM,    IT_DQUO, IT_MINS,  IT_SLSH,
+                   XXXXXXX, FNC, SYM2,          _______,  _______,  XXXXXXX
+),
+[_EXT] = LAYOUT_split_3x5_3(
+  KC_ESC, _______, _______, _______, _______,        KC_PAGE_UP, KC_HOME, KC_UP, KC_END, KC_CAPS,
+  OS_ALT, OS_GUI, OS_SFT, OS_CTL, OS_RALT,        KC_PAGE_DOWN, KC_LEFT, KC_DOWN, KC_RIGHT, KC_DELETE,
+  UNDO, CUT, COPY, KC_TAB, PASTE,                 DEL_WORD, KC_BSPC, _______, _______, _______, 
+                    _______, _______, _______,        KC_ENT, FNC, _______
+),
+[_FNC] = LAYOUT_split_3x5_3(
+  KC_F1, KC_F2, KC_F3, KC_F4, KC_F5,        KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, 
+  OS_ALT, OS_GUI, OS_SFT, OS_CTL, OS_RALT,           KC_F11, KC_F12, KC_PSCR, _______, _______, 
+  _______, _______, _______, _______, _______,        _______, _______, _______, _______, _______,  
+                    _______, _______, _______,        _______, _______, _______
+),
+[_SYM2] = LAYOUT_split_3x5_3(
+  IT_CIRC, IT_UNDS, IT_PND, IT_EURO, IT_HASH,        _______, _______, _______, _______, _______, 
+  BACKTICK, TILDE, IT_BSLS, IT_PIPE, IT_AMPR,        _______, _______, _______, _______, _______, 
+  _______, _______, _______, _______, _______,        _______, _______, _______, _______, _______,  
+                    _______, _______, _______,        _______, _______, _______
+),
+[_ACC] = LAYOUT_split_3x5_3(
+  _______, _______, _______, CEGR, _______,        _______, _______, _______, _______, _______, 
+  IT_AGRV, IT_IGRV, IT_OGRV, IT_EGRV, IT_EACU,        _______, _______, _______, _______, _______, 
+  _______, _______, _______, IT_UGRV, _______,        _______, _______, _______, _______, _______,  
+                    _______, _______, _______,        _______, _______, _______
+),
+[_SET] = LAYOUT_split_3x5_3(
+  _______, _______, _______, RGB_RMOD, RGB_MOD,        RGB_VAI, RGB_VAD, _______, _______, _______, 
+  _______, _______, _______, RGB_M_B, RGB_M_P,        RGB_HUI, RGB_HUD, _______, _______, _______, 
+  QK_BOOT, _______, _______, RGB_M_R, RGB_TOG,        RGB_SAI, RGB_SAD, _______, _______, QK_BOOT,  
+                    _______, _______, _______,        _______, _______, _______
+),
+// [_TEMP] = LAYOUT_split_3x5_3(
+//   _______, _______, _______, _______, _______,        _______, _______, _______, _______, _______, 
+//   _______, _______, _______, _______, _______,        _______, _______, _______, _______, _______, 
+//   _______, _______, _______, _______, _______,        _______, _______, _______, _______, _______,  
+//                     _______, _______, _______,        _______, _______, _______
+// ),
+};

--- a/keyboards/bluebell/swoop/keymaps/kyek/keymap_italian.h
+++ b/keyboards/bluebell/swoop/keymaps/kyek/keymap_italian.h
@@ -1,0 +1,164 @@
+/* Copyright 2015-2016 Matthias Schmidtt
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "keymap.h"
+
+// clang-format off
+
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ \ │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ ' │ ì │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ Q │ W │ E │ R │ T │ Y │ U │ I │ O │ P │ è │ + │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │ A │ S │ D │ F │ G │ H │ J │ K │ L │ ò │ à │ ù │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ < │ Z │ X │ C │ V │ B │ N │ M │ , │ . │ - │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define IT_BSLS KC_GRV  // (backslash)
+#define IT_1    KC_1    // 1
+#define IT_2    KC_2    // 2
+#define IT_3    KC_3    // 3
+#define IT_4    KC_4    // 4
+#define IT_5    KC_5    // 5
+#define IT_6    KC_6    // 6
+#define IT_7    KC_7    // 7
+#define IT_8    KC_8    // 8
+#define IT_9    KC_9    // 9
+#define IT_0    KC_0    // 0
+#define IT_QUOT KC_MINS // '
+#define IT_IGRV KC_EQL  // ì
+// Row 2
+#define IT_Q    KC_Q    // Q
+#define IT_W    KC_W    // W
+#define IT_E    KC_E    // E
+#define IT_R    KC_R    // R
+#define IT_T    KC_T    // T
+#define IT_Y    KC_Y    // Y
+#define IT_U    KC_U    // U
+#define IT_I    KC_I    // I
+#define IT_O    KC_O    // O
+#define IT_P    KC_P    // P
+#define IT_EGRV KC_LBRC // è
+#define IT_PLUS KC_RBRC // +
+// Row 3
+#define IT_A    KC_A    // A
+#define IT_S    KC_S    // S
+#define IT_D    KC_D    // D
+#define IT_F    KC_F    // F
+#define IT_G    KC_G    // G
+#define IT_H    KC_H    // H
+#define IT_J    KC_J    // J
+#define IT_K    KC_K    // K
+#define IT_L    KC_L    // L
+#define IT_OGRV KC_SCLN // ò
+#define IT_AGRV KC_QUOT // à
+#define IT_UGRV KC_NUHS // ù
+// Row 4
+#define IT_LABK KC_NUBS // <
+#define IT_Z    KC_Z    // Z
+#define IT_X    KC_X    // X
+#define IT_C    KC_C    // C
+#define IT_B    KC_B    // B
+#define IT_V    KC_V    // V
+#define IT_N    KC_N    // N
+#define IT_M    KC_M    // M
+#define IT_COMM KC_COMM // ,
+#define IT_DOT  KC_DOT  // .
+#define IT_MINS KC_SLSH // -
+
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ | │ ! │ " │ £ │ $ │ % │ & │ / │ ( │ ) │ = │ ? │ ^ │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │   │ é │ * │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │ ç │ ° │ § │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ > │   │   │   │   │   │   │   │ ; │ : │ _ │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 1
+#define IT_PIPE S(IT_BSLS) // |
+#define IT_EXLM S(IT_1)    // !
+#define IT_DQUO S(IT_2)    // "
+#define IT_PND  S(IT_3)    // £
+#define IT_DLR  S(IT_4)    // $
+#define IT_PERC S(IT_5)    // %
+#define IT_AMPR S(IT_6)    // &
+#define IT_SLSH S(IT_7)    // /
+#define IT_LPRN S(IT_8)    // (
+#define IT_RPRN S(IT_9)    // )
+#define IT_EQL  S(IT_0)    // =
+#define IT_QUES S(IT_QUOT) // ?
+#define IT_CIRC S(IT_IGRV) // ^
+// Row 2
+#define IT_EACU S(IT_EGRV) // é
+#define IT_ASTR S(IT_PLUS) // *
+// Row 3
+#define IT_CCED S(IT_OGRV) // ç
+#define IT_DEG  S(IT_AGRV) // °
+#define IT_SECT S(IT_UGRV) // §
+// Row 4
+#define IT_RABK S(IT_LABK) // >
+#define IT_COLN S(IT_DOT)  // :
+#define IT_SCLN S(IT_COMM) // ;
+#define IT_UNDS S(IT_MINS) // _
+
+/* AltGr symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │   │   │   │   │   │   │   │   │   │   │   │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │ € │   │   │   │   │   │   │   │ [ │ ] │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │ @ │ # │   │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │   │   │   │   │   │   │   │   │   │   │   │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 2
+#define IT_EURO ALGR(IT_E)    // €
+#define IT_LBRC ALGR(IT_EGRV) // [
+#define IT_RBRC ALGR(IT_PLUS) // ]
+// Row 3
+#define IT_AT   ALGR(IT_OGRV) // @
+#define IT_HASH ALGR(IT_AGRV) // #
+
+/* Shift+AltGr symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │   │   │   │   │   │   │   │   │   │   │   │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │   │   │ { │ } │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │   │   │   │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │   │   │   │   │   │   │   │   │   │   │   │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+// Row 2
+#define IT_LCBR S(ALGR(IT_EGRV)) // {
+#define IT_RCBR S(ALGR(IT_PLUS)) // }

--- a/keyboards/bluebell/swoop/keymaps/kyek/rules.mk
+++ b/keyboards/bluebell/swoop/keymaps/kyek/rules.mk
@@ -1,0 +1,15 @@
+# Enables Link Time Optimization (LTO) when compiling the keyboard. This makes the process take longer,
+# but it can significantly reduce the compiled size (and since the firmware is small, the added time is not noticeable).
+LTO_ENABLE = no
+
+# Audio control and System control
+EXTRAKEY_ENABLE = no
+
+# ENCODER_ENABLE = no
+# OLED_DRIVER_ENABLE = no
+# WPM_ENABLE = no
+
+# Enable keyboard underlight functionality
+RGBLIGHT_ENABLE = yes
+
+COMBO_ENABLE = yes

--- a/keyboards/bluebell/swoop/readme.md
+++ b/keyboards/bluebell/swoop/readme.md
@@ -1,0 +1,27 @@
+# Swoop
+
+![Swoop](https://i.imgur.com/mMlmEsdh.jpg)
+
+*The Swoop is an open source split keyboard based on the Ferris/Sweep.*
+
+* Keyboard Maintainer: [Jimmerricks](https://github.com/jimmerricks)
+* Hardware Supported: *Swoop MX, Swoop LP + Pro-micro or equivalent*
+* Hardware Availability: [*Swoop Repository*](https://github.com/jimmerricks/swoop)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make bluebell/swoop:default
+
+Flashing example for this keyboard:
+
+    make bluebell/swoop:default:avrdude-split-right
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Entering the bootloader:
+
+<!-- * **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard -->
+* **Physical reset button**: Briefly press the small button on the inner side of the PCB - you may have pads you must short instead
+<!-- * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available -->

--- a/keyboards/bluebell/swoop/rules.mk
+++ b/keyboards/bluebell/swoop/rules.mk
@@ -1,0 +1,19 @@
+# MCU name
+MCU = atmega32u4
+
+# Bootloader selection
+BOOTLOADER = caterina
+
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = yes       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = no            # Enable N-Key Rollover
+RGBLIGHT_ENABLE = yes				# Enable keyboard underlight functionality
+SPLIT_KEYBOARD = yes
+
+LAYOUTS = split_3x5_3

--- a/keyboards/bluebell/swoop/swoop.c
+++ b/keyboards/bluebell/swoop/swoop.c
@@ -1,0 +1,16 @@
+/* Copyright 2022 James White <jamesmnw@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "swoop.h"

--- a/keyboards/bluebell/swoop/swoop.h
+++ b/keyboards/bluebell/swoop/swoop.h
@@ -1,0 +1,36 @@
+/* Copyright 2022 James White <jamesmnw@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include "quantum.h"
+
+#define ___ KC_NO
+
+#define LAYOUT_split_3x5_3( \
+    L00, L01, L02, L03, L04,          R00, R01, R02, R03, R04, \
+    L10, L11, L12, L13, L14,          R10, R11, R12, R13, R14, \
+    L20, L21, L22, L23, L24,          R20, R21, R22, R23, R24, \
+              L30, L31, L32,          R30, R31, R32 \
+    ) \
+    { \
+        { L00, L01, L02, L03, L04 }, \
+        { L10, L11, L12, L13, L14 }, \
+        { L20, L21, L22, L23, L24 }, \
+        { ___, ___, L30, L31, L32 }, \
+        { R04, R03, R02, R01, R00 }, \
+        { R14, R13, R12, R11, R10 }, \
+        { R24, R23, R22, R21, R20 }, \
+        { ___, ___, R32, R31, R30 } \
+    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
People that are configuring their keyboard through the online configurator are unable to use RGB unless we enable it by default.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
