### PR TITLE
Adds a crkbd revision supporting the Blok MCU

### DIFF
--- a/keyboards/crkbd/blok/README.md
+++ b/keyboards/crkbd/blok/README.md
@@ -1,0 +1,20 @@
+# Corne Blok
+
+An edition of the Corne keyboard using the RP2040-based Blok microcontroller.
+The Blok is pin-compatible with the ProMicro and other similar boards.
+
+Make example for this board (after setting up your build environment):
+
+```sh
+qmk compile -kb crkbd/blok -km default
+```
+
+
+## Bootloader
+
+Enter the bootloader in 4 ways:
+
+* **Bootmagic reset**: Hold down the key in the Q or P positions according to
+  the QWERTY layout
+* **BOOT button** Hold down right button on the bottom of the Blok MCU
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available.

--- a/keyboards/crkbd/blok/blok.c
+++ b/keyboards/crkbd/blok/blok.c
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 @foostan
+Copyright 2023 Noah Pederson <@chiefnoah>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "blok.h"
+
+#ifdef RGB_MATRIX_ENABLE
+
+// Logical Layout
+// Columns
+// Left
+// 0  1  2  3  4  5
+//                   ROWS
+// 25 24 19 18 11 10   0
+//    03    02    01
+// 26 23 20 17 12 09   1
+//    04    05    06
+// 27 22 21 16 13 08   2
+//
+//          15 14 07   3
+//
+// Right
+// 0  1  2  3  4  5
+//                    ROWS
+// 25 24 19 18 11 10   4
+//    03    02    01
+// 26 23 20 17 12 09   5
+//    04    05    06
+// 27 22 21 16 13 08   6
+//
+//          15 14 07   7
+//
+// Physical Layout
+// Columns
+// 0  1  2  3  4  5  6  7  8  9  10 11 12 13
+//                                           ROWS
+// 25 24 19 18 11 10       10 11 18 19 24 25  0
+//    03    02    01       01    02    03
+// 26 23 20 17 12 09       09 12 17 20 23 26  1
+//    04                               04
+// 27 22 21 16 13 08       08 13 16 21 22 27  2
+//          05    06       06    05
+//           15 14 07     07 14 15              3
+
+led_config_t g_led_config = {{{24, 23, 18, 17, 10, 9}, {25, 22, 19, 16, 11, 8}, {26, 21, 20, 15, 12, 7}, {NO_LED, NO_LED, NO_LED, 14, 13, 6}, {51, 50, 45, 44, 37, 36}, {52, 49, 46, 43, 38, 35}, {53, 48, 47, 42, 39, 34}, {NO_LED, NO_LED, NO_LED, 41, 40, 33}}, {{85, 16}, {50, 13}, {16, 20}, {16, 38}, {50, 48}, {85, 52}, {95, 63}, {85, 39}, {85, 21}, {85, 4}, {68, 2}, {68, 19}, {68, 37}, {80, 58}, {60, 55}, {50, 35}, {50, 13}, {50, 0}, {33, 3}, {33, 20}, {33, 37}, {16, 42}, {16, 24}, {16, 7}, {0, 7}, {0, 24}, {0, 41}, {139, 16}, {174, 13}, {208, 20}, {208, 38}, {174, 48}, {139, 52}, {129, 63}, {139, 39}, {139, 21}, {139, 4}, {156, 2}, {156, 19}, {156, 37}, {144, 58}, {164, 55}, {174, 35}, {174, 13}, {174, 0}, {191, 3}, {191, 20}, {191, 37}, {208, 42}, {208, 24}, {208, 7}, {224, 7}, {224, 24}, {224, 41}}, {2, 2, 2, 2, 2, 2, 1, 4, 4, 4, 4, 4, 4, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1, 2, 2, 2, 2, 2, 2, 1, 4, 4, 4, 4, 4, 4, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 1, 1, 1}};
+
+void suspend_power_down_kb(void) {
+    rgb_matrix_set_suspend_state(true);
+    suspend_power_down_user();
+}
+
+void suspend_wakeup_init_kb(void) {
+    rgb_matrix_set_suspend_state(false);
+    suspend_wakeup_init_user();
+}
+#endif
+
+#ifdef OLED_ENABLE
+bool oled_task_kb(void) {
+    if (!oled_task_user()) {
+        return false;
+    }
+    return true;
+}
+#endif

--- a/keyboards/crkbd/blok/blok.h
+++ b/keyboards/crkbd/blok/blok.h
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 @foostan
+Copyright 2023 Noah Pederson <@chiefnoah>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "crkbd.h"
+#include "quantum.h"
+
+// clang-format off
+#define LAYOUT_split_3x6_3( \
+  L00, L01, L02, L03, L04, L05,           R00, R01, R02, R03, R04, R05, \
+  L10, L11, L12, L13, L14, L15,           R10, R11, R12, R13, R14, R15, \
+  L20, L21, L22, L23, L24, L25,           R20, R21, R22, R23, R24, R25, \
+                      L30, L31, L32, R30, R31, R32 \
+  ) \
+  { \
+    { L00, L01, L02, L03, L04, L05 }, \
+    { L10, L11, L12, L13, L14, L15 }, \
+    { L20, L21, L22, L23, L24, L25 }, \
+    { KC_NO, KC_NO, KC_NO, L30, L31, L32 }, \
+    { R05, R04, R03, R02, R01, R00 }, \
+    { R15, R14, R13, R12, R11, R10 }, \
+    { R25, R24, R23, R22, R21, R20 }, \
+    { KC_NO, KC_NO, KC_NO, R32, R31, R30 } \
+  }
+
+#define LAYOUT_split_3x5_3( \
+  L00, L01, L02, L03, L04,           R00, R01, R02, R03, R04, \
+  L10, L11, L12, L13, L14,           R10, R11, R12, R13, R14, \
+  L20, L21, L22, L23, L24,           R20, R21, R22, R23, R24, \
+                 L30, L31, L32, R30, R31, R32 \
+  ) \
+  { \
+    { KC_NO, L00, L01, L02, L03, L04 }, \
+    { KC_NO, L10, L11, L12, L13, L14 }, \
+    { KC_NO, L20, L21, L22, L23, L24 }, \
+    { KC_NO, KC_NO, KC_NO, L30, L31, L32 }, \
+    { KC_NO, R04, R03, R02, R01, R00 }, \
+    { KC_NO, R14, R13, R12, R11, R10 }, \
+    { KC_NO, R24, R23, R22, R21, R20 }, \
+    { KC_NO, KC_NO, KC_NO, R32, R31, R30 } \
+  }
+
+
+#define LAYOUT LAYOUT_split_3x6_3

--- a/keyboards/crkbd/blok/config.h
+++ b/keyboards/crkbd/blok/config.h
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 Noah Pederson <@chiefnoah>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable action features */
+// #define NO_ACTION_LAYER
+// #define NO_ACTION_TAPPING
+// #define NO_ACTION_ONESHOT
+
+#define RGB_DI_PIN GP0
+#define SOFT_SERIAL_PIN GP1
+#define WS2812_PIO_USE_PIO1
+
+#ifdef OLED_ENABLE
+#    define OLED_DISPLAY_128X32
+#    define I2C1_SCL_PIN GP17
+#    define I2C1_SDA_PIN GP16
+#    define I2C_DRIVER I2CD1
+#    define OLED_FONT_H "keyboards/crkbd/lib/glcdfont.c"
+#    define SPLIT_OLED_ENABLE
+#endif
+
+#define DIODE_DIRECTION COL2ROW
+
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET              // Activates the double-tap behavior
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 200U // Timeout window in ms in which the double tap can occur.
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP25     // Specify a optional status led by GPIO number which blinks when entering the bootloader
+
+#ifdef RGBLIGHT_ENABLE
+#    define RGBLED_NUM 54 // Number of LEDs
+#    define RGBLED_SPLIT \
+        { 27, 27 }
+#    define RGBLIGHT_SPLIT
+#endif
+
+#ifdef RGB_MATRIX_ENABLE
+#    define RGBLED_NUM 54 // Number of LEDs
+#    define RGB_MATRIX_LED_COUNT RGBLED_NUM
+#    define RGB_MATRIX_SPLIT \
+        { 27, 27 }
+#    define SPLIT_TRANSPORT_MIRROR
+#endif
+
+#define MATRIX_ROW_PINS \
+    { GP4, GP5, GP6, GP7 }
+#define MATRIX_COL_PINS \
+    { GP29, GP28, GP27, GP26, GP22, GP20 }
+// #define MATRIX_COL_PINS { B2, B3, B1, F7, F6, F5, F4 } //uncomment this line and comment line above if you need to reverse left-to-right key order

--- a/keyboards/crkbd/blok/mcuconf.h
+++ b/keyboards/crkbd/blok/mcuconf.h
@@ -1,6 +1,5 @@
 /*
-Copyright 2019 @foostan
-Copyright 2020 Drashna Jaelre <@drashna>
+Copyright 2023 Noah Pederson <@chiefnoah>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -16,16 +15,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
+#include_next <mcuconf.h>
 
-#ifdef KEYBOARD_crkbd_rev1
-#    include "rev1.h"
-#endif
-#ifdef KEYBOARD_crkbd_r2g
-#    include "r2g.h"
-#endif
-#ifdef KEYBOARD_crkbd_blok
-#    include "blok.h"
-#endif
+#undef RP_I2C_USE_I2C0
+#define RP_I2C_USE_I2C0 TRUE
 
-
-#include "quantum.h"
+#undef RP_I2C_USE_I2C1
+#define RP_I2C_USE_I2C1 FALSE

--- a/keyboards/crkbd/blok/rules.mk
+++ b/keyboards/crkbd/blok/rules.mk
@@ -1,0 +1,8 @@
+# Configure the board
+MCU              = RP2040
+BOOTLOADER       = rp2040
+BOARD            = QMK_PM2040
+PIN_COMPATIBLE   = promicro
+SERIAL_DRIVER    = vendor
+WS2812_DRIVER    = vendor
+SPLIT_KEYBOARD   = yes

--- a/keyboards/crkbd/config.h
+++ b/keyboards/crkbd/config.h
@@ -24,13 +24,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Rows are doubled-up
 #define MATRIX_ROWS  8
 #define MATRIX_COLS  6
-#define MATRIX_ROW_PINS \
-    { D4, C6, D7, E6 }
-
-// wiring of each half
-#define MATRIX_COL_PINS \
-    { F4, F5, F6, F7, B1, B3 }
-// #define MATRIX_COL_PINS { B2, B3, B1, F7, F6, F5, F4 } //uncomment this line and comment line above if you need to reverse left-to-right key order
 
 /* define if matrix has ghost */
 //#define MATRIX_HAS_GHOST

--- a/keyboards/crkbd/r2g/config.h
+++ b/keyboards/crkbd/r2g/config.h
@@ -19,6 +19,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+/* Matrix pins */
+#define MATRIX_ROW_PINS \
+    { D4, C6, D7, E6 }
+
+// wiring of each half
+#define MATRIX_COL_PINS \
+    { F4, F5, F6, F7, B1, B3 }
+// #define MATRIX_COL_PINS { B2, B3, B1, F7, F6, F5, F4 } //uncomment this line and comment line above if you need to reverse left-to-right key order
+
 #define SOFT_SERIAL_PIN D2
 
 /* ws2812 RGB LED */

--- a/keyboards/crkbd/rev1/config.h
+++ b/keyboards/crkbd/rev1/config.h
@@ -18,6 +18,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+/* Matrix pins */
+#define MATRIX_ROW_PINS \
+    { D4, C6, D7, E6 }
+
+// wiring of each half
+#define MATRIX_COL_PINS \
+    { F4, F5, F6, F7, B1, B3 }
+// #define MATRIX_COL_PINS { B2, B3, B1, F7, F6, F5, F4 } //uncomment this line and comment line above if you need to reverse left-to-right key order
+
 #define SOFT_SERIAL_PIN D2
 
 /* ws2812 RGB LED */


### PR DESCRIPTION
## Description

The pin mapping is different between the RP2040 used in the Blok and the identifiers used in AVR MCUs such as the ProMicro. This commit moves the existing pin mapping into the existing 2 revisions for the crkbd/corne to prevent redef errors and adds new files for supporting the Blok.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
