### PR TITLE
Fix MATRIX_COLS and MATRIX_ROWS generation for custom matrix

### DIFF
--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -62,7 +62,7 @@ def matrix_pins(matrix_pins, postfix=''):
 def generate_matrix_size(kb_info_json, config_h_lines):
     """Add the matrix size to the config.h.
     """
-    if 'matrix_pins' in kb_info_json:
+    if 'matrix_size' in kb_info_json:
         config_h_lines.append(generate_define('MATRIX_COLS', kb_info_json['matrix_size']['cols']))
         config_h_lines.append(generate_define('MATRIX_ROWS', kb_info_json['matrix_size']['rows']))
 


### PR DESCRIPTION
## Description

The code which generated the `MATRIX_COLS` and `MATRIX_ROWS` defines from the JSON information was checking the presence of the `matrix_pins` key, which may not exist if a custom matrix is used.  Check the presence of `matrix_size` instead.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
