### PR TITLE
`qmk compile`/`qmk flash` - Validate keymap argument

### DIFF
--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -19,7 +19,7 @@ def _is_keymap_target(keyboard, keymap):
 
     if locate_keymap(keyboard, keymap):
         return True
-    
+
     return False
 
 

--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -10,7 +10,17 @@ import qmk.path
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json, build_environment
 from qmk.keyboard import keyboard_completer, keyboard_folder
-from qmk.keymap import keymap_completer
+from qmk.keymap import keymap_completer, locate_keymap
+
+
+def _is_keymap_target(keyboard, keymap):
+    if keymap == 'all':
+        return True
+
+    if locate_keymap(keyboard, keymap):
+        return True
+    
+    return False
 
 
 @cli.argument('filename', nargs='?', arg_only=True, type=qmk.path.FileType('r'), completer=FilesCompleter('.json'), help='The configurator export to compile')
@@ -43,6 +53,11 @@ def compile(cli):
 
     elif cli.config.compile.keyboard and cli.config.compile.keymap:
         # Generate the make command for a specific keyboard/keymap.
+        if not _is_keymap_target(cli.config.compile.keyboard, cli.config.compile.keymap):
+            cli.log.error('Invalid keymap argument.')
+            cli.print_help()
+            return False
+
         if cli.args.clean:
             commands.append(create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, 'clean', **envs))
         commands.append(create_make_command(cli.config.compile.keyboard, cli.config.compile.keymap, parallel=cli.config.compile.parallel, **envs))

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -11,8 +11,18 @@ import qmk.path
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.commands import compile_configurator_json, create_make_command, parse_configurator_json, build_environment
 from qmk.keyboard import keyboard_completer, keyboard_folder
-from qmk.keymap import keymap_completer
+from qmk.keymap import keymap_completer, locate_keymap
 from qmk.flashers import flasher
+
+
+def _is_keymap_target(keyboard, keymap):
+    if keymap == 'all':
+        return True
+
+    if locate_keymap(keyboard, keymap):
+        return True
+    
+    return False
 
 
 def _list_bootloaders():
@@ -98,6 +108,11 @@ def flash(cli):
 
     elif cli.config.flash.keyboard and cli.config.flash.keymap:
         # Generate the make command for a specific keyboard/keymap.
+        if not _is_keymap_target(cli.config.flash.keyboard, cli.config.flash.keymap):
+            cli.log.error('Invalid keymap argument.')
+            cli.print_help()
+            return False
+
         if cli.args.clean:
             commands.append(create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, 'clean', **envs))
         commands.append(create_make_command(cli.config.flash.keyboard, cli.config.flash.keymap, cli.args.bootloader, parallel=cli.config.flash.parallel, **envs))

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -21,7 +21,7 @@ def _is_keymap_target(keyboard, keymap):
 
     if locate_keymap(keyboard, keymap):
         return True
-    
+
     return False
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Avoids,
```
$ qmk compile -kb keychron/q1/ansi_encoder -km ~/Downloads/zed.json 
Ψ Compiling keymap with make --jobs=1 keychron/q1/ansi_encoder:/home/zvecr/Downloads/zed.json


QMK Firmware 0.19.6
Making keychron/q1/ansi_encoder with keymap default and target /home/zvecr/Downloads/zed.json  [OK]
Making keychron/q1/ansi_encoder with keymap keychron and target /home/zvecr/Downloads/zed.json [OK]
Making keychron/q1/ansi_encoder with keymap via and target /home/zvecr/Downloads/zed.json      [OK]
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* <https://discord.com/channels/440868230475677696/473506116718952450/1061331426286522399>

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
