### PR TITLE
Add data-driven alias support for converters

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -368,8 +368,8 @@ endif
 # Disable features that a keyboard doesn't support
 -include $(BUILDDEFS_PATH)/disable_features.mk
 
-ifneq ("$(CONVERTER)","")
-    -include $(CONVERTER)/post_converter.mk
+ifneq ("$(CONVERTER_PATH)","")
+    -include $(CONVERTER_PATH)/post_converter.mk
 endif
 
 # Pull in post_rules.mk files from all our subfolders

--- a/data/mappings/converters.hjson
+++ b/data/mappings/converters.hjson
@@ -5,11 +5,7 @@
         "bonsai_c4": {},
         "elite_pi": {},
         "kb2040": {},
-        "promicro_rp2040": {
-            "aliases": [
-                "Frood"
-            ]
-        },
+        "promicro_rp2040": {},
         "proton_c": {
             "aliases": [
                 "bonsai_c3"

--- a/data/mappings/converters.hjson
+++ b/data/mappings/converters.hjson
@@ -1,0 +1,24 @@
+{
+    "promicro": {
+        "bit_c_pro": {},
+        "blok": {},
+        "bonsai_c4": {},
+        "elite_pi": {},
+        "kb2040": {},
+        "promicro_rp2040": {
+            "aliases": [
+                "Frood"
+            ]
+        },
+        "proton_c": {
+            "aliases": [
+                "bonsai_c3"
+            ]
+        },
+        "stemcell": {}
+    },
+    "elite_c": {
+        "elite_pi": {},
+        "stemcell": {}
+    }
+}

--- a/data/schemas/keymap.jsonschema
+++ b/data/schemas/keymap.jsonschema
@@ -7,7 +7,8 @@
         "author": {"type": "string"},
         "converter": {
             "type": "string",
-            "enum": ["elite_pi", "proton_c", "kb2040", "promicro_rp2040", "blok", "bit_c_pro", "stemcell", "bonsai_c4"]
+            "minLength": 1,
+            "pattern": "^[a-z][0-9a-z_]*$"
         },
         "host_language": {"$ref": "qmk.definitions.v1#/text_identifier"},
         "keyboard": {"$ref": "qmk.definitions.v1#/text_identifier"},

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -50,6 +50,7 @@ subcommands = [
     'qmk.cli.generate.autocorrect_data',
     'qmk.cli.generate.compilation_database',
     'qmk.cli.generate.config_h',
+    'qmk.cli.generate.converter_mk',
     'qmk.cli.generate.develop_pr_list',
     'qmk.cli.generate.dfu_header',
     'qmk.cli.generate.docs',

--- a/lib/python/qmk/cli/generate/converter_mk.py
+++ b/lib/python/qmk/cli/generate/converter_mk.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from milc import cli
+
+from qmk.path import normpath
+from qmk.commands import dump_lines
+from qmk.json_schema import json_load
+from qmk.constants import GPL2_HEADER_SH_LIKE, GENERATED_HEADER_SH_LIKE
+
+
+@cli.argument('-o', '--output', arg_only=True, type=normpath, help='File to write to')
+@cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
+@cli.argument('-e', '--escape', arg_only=True, action='store_true', help="Escape spaces in quiet mode")
+@cli.argument('-c', '--converter', required=True, arg_only=True, help='Target for conversion')
+@cli.argument('-p', '--pin-compatible', required=True, arg_only=True, help='Base for conversion')
+@cli.subcommand('Used by the make system to generate converter helpers from data', hidden=True)
+def generate_converter_mk(cli):
+    info_rules_map = json_load(Path('data/mappings/converters.hjson'))
+
+    mk_lines = [GPL2_HEADER_SH_LIKE, GENERATED_HEADER_SH_LIKE]
+
+    active_converter = None
+    candidates = info_rules_map.get(cli.args.pin_compatible, {})
+    if cli.args.converter in candidates:
+        active_converter = cli.args.converter
+
+    # if no direct match - search aliases
+    if not active_converter:
+        for key, value in candidates.items():
+            if cli.args.converter in value.get('aliases', []):
+                active_converter = key
+
+    if active_converter:
+        converter_path = next(Path('platforms/').glob(f'*/converters/{cli.args.pin_compatible}_to_{active_converter}'))
+        mk_lines.append(f'CONVERTER_PATH = {converter_path}')
+        mk_lines.append(f'CONVERTER_ACTIVE = {active_converter}')
+
+    # Show the results
+    dump_lines(cli.args.output, mk_lines, cli.args.quiet)
+
+    if cli.args.output:
+        if cli.args.quiet:
+            if cli.args.escape:
+                print(cli.args.output.as_posix().replace(' ', '\\ '))
+            else:
+                print(cli.args.output)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
* Avoid duplication of converters
  * dirty solution would be symlinks but we disallow those in the repo
* Adds config that can later be used for configurator to provide available converters for a given keyboard

- [ ] What happens if we implement `definition of optional pins` and the aliases items have different extra pins?
- [ ] What about just adding folders with "magic" mk files that overwrite variables? - [example implementation](https://github.com/zvecr/qmk_firmware/tree/feature/converter_aliases_alt)?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
