### PR TITLE
Add commit info to `version.h`

### DIFF
--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -29,7 +29,7 @@ def generate_version_h(cli):
         current_time = strftime(TIME_FMT)
 
     if cli.args.skip_git:
-        git_dirty = ""  # so that it evaluates as False
+        git_dirty = False
         git_commit = "NA"
         git_version = "NA"
         chibios_version = "NA"

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -6,7 +6,7 @@ from milc import cli
 
 from qmk.path import normpath
 from qmk.commands import dump_lines
-from qmk.git import git_get_commit_hash, git_get_version, git_is_dirty
+from qmk.git import git_get_qmk_hash, git_get_version, git_is_dirty
 from qmk.constants import GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE
 
 TIME_FMT = '%Y-%m-%d-%H:%M:%S'
@@ -30,14 +30,14 @@ def generate_version_h(cli):
 
     if cli.args.skip_git:
         git_dirty = False
-        git_commit = "NA"
         git_version = "NA"
+        git_qmk_hash = "NA"
         chibios_version = "NA"
         chibios_contrib_version = "NA"
     else:
         git_dirty = git_is_dirty()
-        git_commit = git_get_commit_hash()
         git_version = git_get_version() or current_time
+        git_qmk_hash = git_get_qmk_hash()
         chibios_version = git_get_version("chibios", "os") or current_time
         chibios_contrib_version = git_get_version("chibios-contrib", "os") or current_time
 
@@ -48,9 +48,9 @@ def generate_version_h(cli):
         f"""
 #define QMK_VERSION "{git_version}"
 #define QMK_BUILDDATE "{current_time}"
+#define QMK_GIT_HASH  "{git_qmk_hash}{'*' if git_dirty else ''}"
 #define CHIBIOS_VERSION "{chibios_version}"
 #define CHIBIOS_CONTRIB_VERSION "{chibios_contrib_version}"
-#define GIT_COMMIT "{git_commit}{'*' if git_dirty else ''}"
 """
     )
 

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -44,13 +44,15 @@ def generate_version_h(cli):
     # Build the version.h file.
     version_h_lines = [GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE, '#pragma once']
 
-    version_h_lines.append(f"""
+    version_h_lines.append(
+        f"""
 #define QMK_VERSION "{git_version}"
 #define QMK_BUILDDATE "{current_time}"
 #define CHIBIOS_VERSION "{chibios_version}"
 #define CHIBIOS_CONTRIB_VERSION "{chibios_contrib_version}"
 #define GIT_COMMIT "{git_commit}{'*' if git_dirty else ''}"
-""")
+"""
+    )
 
     # Show the results
     dump_lines(cli.args.output, version_h_lines, cli.args.quiet)

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -6,7 +6,7 @@ from milc import cli
 
 from qmk.path import normpath
 from qmk.commands import dump_lines
-from qmk.git import git_get_version
+from qmk.git import git_get_commit_hash, git_is_dirty, git_get_version
 from qmk.constants import GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE
 
 TIME_FMT = '%Y-%m-%d-%H:%M:%S'
@@ -29,10 +29,14 @@ def generate_version_h(cli):
         current_time = strftime(TIME_FMT)
 
     if cli.args.skip_git:
+        git_dirty = ""  # so that it evaluates as False
+        git_commit = "NA"
         git_version = "NA"
         chibios_version = "NA"
         chibios_contrib_version = "NA"
     else:
+        git_dirty = git_is_dirty()
+        git_commit = git_get_commit_hash()
         git_version = git_get_version() or current_time
         chibios_version = git_get_version("chibios", "os") or current_time
         chibios_contrib_version = git_get_version("chibios-contrib", "os") or current_time
@@ -45,6 +49,7 @@ def generate_version_h(cli):
 #define QMK_BUILDDATE "{current_time}"
 #define CHIBIOS_VERSION "{chibios_version}"
 #define CHIBIOS_CONTRIB_VERSION "{chibios_contrib_version}"
+#define GIT_COMMIT "{git_commit}{'*' if git_dirty else ''}"
 """)
 
     # Show the results

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -37,7 +37,7 @@ def generate_version_h(cli):
     else:
         git_dirty = git_is_dirty()
         git_version = git_get_version() or current_time
-        git_qmk_hash = git_get_qmk_hash()
+        git_qmk_hash = git_get_qmk_hash() or "Unknown"
         chibios_version = git_get_version("chibios", "os") or current_time
         chibios_contrib_version = git_get_version("chibios-contrib", "os") or current_time
 

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -6,7 +6,7 @@ from milc import cli
 
 from qmk.path import normpath
 from qmk.commands import dump_lines
-from qmk.git import git_get_commit_hash, git_is_dirty, git_get_version
+from qmk.git import git_get_commit_hash, git_get_version, git_is_dirty
 from qmk.constants import GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE
 
 TIME_FMT = '%Y-%m-%d-%H:%M:%S'

--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -141,6 +141,6 @@ def git_get_ignored_files(check_dir='.'):
 def git_get_qmk_hash():
     output = cli.run(['git', 'rev-parse', '--short', 'HEAD'])
     if output.returncode != 0:
-        return "Unknown"
+        return None
 
     return output.stdout.strip()

--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -136,3 +136,11 @@ def git_get_ignored_files(check_dir='.'):
     if invalid.returncode != 0:
         return []
     return invalid.stdout.strip().splitlines()
+
+
+def git_get_commit_hash():
+    output = cli.run(['git', 'rev-parse', '--short', 'HEAD'])
+    if output.returncode != 0:
+        print("Unknown")
+
+    return output.stdout.strip()

--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -138,7 +138,7 @@ def git_get_ignored_files(check_dir='.'):
     return invalid.stdout.strip().splitlines()
 
 
-def git_get_commit_hash():
+def git_get_qmk_hash():
     output = cli.run(['git', 'rev-parse', '--short', 'HEAD'])
     if output.returncode != 0:
         return "Unknown"

--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -141,6 +141,6 @@ def git_get_ignored_files(check_dir='.'):
 def git_get_commit_hash():
     output = cli.run(['git', 'rev-parse', '--short', 'HEAD'])
     if output.returncode != 0:
-        print("Unknown")
+        return "Unknown"
 
     return output.stdout.strip()


### PR DESCRIPTION
## Description
Small changes to the CLI to add the current commit's hash into `version.h` aswell as a marker(`*`) to know if the repository contained any un-commited changes when firmware was compiled.
This way we can `print` stuff like: `firmware built with commit: e725d6b199*`.
I made this to show the hash on a corner of my Quantum Painter screen(s) but thought it could be useful to other people thus sharing it.

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
