### PR TITLE
[Bug] Use correct functions for RGB Matrix support in VIA

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -704,11 +704,11 @@ void via_qmk_rgb_matrix_set_value(uint8_t *data) {
             break;
         }
         case id_qmk_rgb_matrix_effect_speed: {
-            rgblight_set_speed_noeeprom(value_data[0]);
+            rgb_matrix_set_speed_noeeprom(value_data[0]);
             break;
         }
         case id_qmk_rgb_matrix_color: {
-            rgblight_sethsv_noeeprom(value_data[0], value_data[1], rgb_matrix_get_val());
+            rgb_matrix_sethsv_noeeprom(value_data[0], value_data[1], rgb_matrix_get_val());
             break;
         }
     }


### PR DESCRIPTION
## Description

VIA uses RGBLIGHT functions in the RGB Matrix section.  Normally, this is okay, but if you have both features enabled .... not so much.  So, naturally, I run into this. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
