### PR TITLE
Pr/reorder docker podman check

### DIFF
--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -19,7 +19,7 @@ if [ $# -gt 1 ]; then
 	exit 1
 fi
 
-# Allow $RUNTIME to be overriden by the user as an environment variable
+# Allow $RUNTIME to be overridden by the user as an environment variable
 # Else check if either podman or docker exit and set them as runtime
 # if none are found error out
 if [ -z "$RUNTIME" ]; then

--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -19,14 +19,14 @@ if [ $# -gt 1 ]; then
 	exit 1
 fi
 
-# Allow $RUNTIME to be overridden by the user as an environment variable
-# Else check if either docker or podman exit and set them as runtime
+# Allow $RUNTIME to be overriden by the user as an environment variable
+# Else check if either podman or docker exit and set them as runtime
 # if none are found error out
 if [ -z "$RUNTIME" ]; then
-	if command -v docker >/dev/null 2>&1; then
-		RUNTIME="docker"
-	elif command -v podman >/dev/null 2>&1; then
+	if command -v podman >/dev/null 2>&1; then
 		RUNTIME="podman"
+	elif command -v docker >/dev/null 2>&1; then
+		RUNTIME="docker"
 	else
 		errcho "Error: no compatible container runtime found."
 		errcho "Either podman or docker are required."

--- a/util/docker_cmd.sh
+++ b/util/docker_cmd.sh
@@ -16,13 +16,13 @@ for arg; do
 done
 
 # Allow $RUNTIME to be overridden by the user as an environment variable
-# Else check if either docker or podman exit and set them as runtime
+# Else check if either podman or docker exit and set them as runtime
 # if none are found error out
 if [ -z "$RUNTIME" ]; then
-	if command -v docker >/dev/null 2>&1; then
-		RUNTIME="docker"
-	elif command -v podman >/dev/null 2>&1; then
+	if command -v podman >/dev/null 2>&1; then
 		RUNTIME="podman"
+	elif command -v docker >/dev/null 2>&1; then
+		RUNTIME="docker"
 	else
 		errcho "Error: no compatible container runtime found."
 		errcho "Either podman or docker are required."


### PR DESCRIPTION
- util/docker_build.sh

  * Reordered the check to determine whether Docker or Podman is installed.
  * Checking Podman first ensures that it will detect the correct runtime if the user happens to have aliased docker to podman as is [suggested in the docs](https://developers.redhat.com/blog/2020/11/19/transitioning-from-docker-to-podman#transition_to_the_podman_cli).


## Description

In an environment where both Podman and Docker are installed, evaluating Docker first will cause issues when building using the images as Podman does not support the Docker API 100%. Evaluating Podman first will ensure that this scenario does not happen as if Podman is installed it will be detected first.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A
* Although I could have instead reported this as a Bug.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
