### PR TITLE
Fix joystick build for ChibiOS

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -87,7 +87,7 @@ union {
     report_digitizer_t digitizer;
 #endif
 #ifdef JOYSTICK_ENABLE
-    joystick_report_t joystick;
+    report_joystick_t joystick;
 #endif
 } universal_report_blank = {0};
 


### PR DESCRIPTION
## Description

The code for the joystick feature failed to build on ChibiOS, because the old `joystick_report_t` type name was used instead of `report_joystick_t`.  Apparently the code in #14814 was written before #19052, but has been merged after that PR without updating.

The master branch is not affected — the offending code is only in develop.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
