### PR TITLE
De-duplicate platform detection

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -184,6 +184,12 @@ include $(BUILDDEFS_PATH)/converters.mk
 
 include $(BUILDDEFS_PATH)/mcu_selection.mk
 
+# PLATFORM_KEY should be detected in info.json via key 'processor' (or rules.mk 'MCU')
+ifeq ($(PLATFORM_KEY),)
+    $(call CATASTROPHIC_ERROR,Platform not defined)
+endif
+PLATFORM=$(shell echo $(PLATFORM_KEY) | tr '[:lower:]' '[:upper:]')
+
 # Find all the C source files to be compiled in subfolders.
 KEYBOARD_SRC :=
 
@@ -255,24 +261,6 @@ ifneq ("$(wildcard $(KEYBOARD_PATH_4)/$(KEYBOARD_FOLDER_4).h)","")
 endif
 ifneq ("$(wildcard $(KEYBOARD_PATH_5)/$(KEYBOARD_FOLDER_5).h)","")
     FOUND_KEYBOARD_H = $(KEYBOARD_FOLDER_5).h
-endif
-
-# Determine and set parameters based on the keyboard's processor family.
-# We can assume a ChibiOS target When MCU_FAMILY is defined since it's
-# not used for LUFA
-ifdef MCU_FAMILY
-    PLATFORM=CHIBIOS
-    PLATFORM_KEY=chibios
-    FIRMWARE_FORMAT?=bin
-    OPT_DEFS += -DMCU_$(MCU_FAMILY)
-else ifdef ARM_ATSAM
-    PLATFORM=ARM_ATSAM
-    PLATFORM_KEY=arm_atsam
-    FIRMWARE_FORMAT=bin
-else
-    PLATFORM=AVR
-    PLATFORM_KEY=avr
-    FIRMWARE_FORMAT?=hex
 endif
 
 # Find all of the config.h files and add them to our CONFIG_H define.

--- a/builddefs/converters.mk
+++ b/builddefs/converters.mk
@@ -19,6 +19,7 @@ ifneq ($(CONVERT_TO),)
 
     -include $(CONVERTER)/pre_converter.mk
 
+    PLATFORM_KEY = $(shell echo $(CONVERTER) | rev | cut -d "/" -f4 | rev)
     TARGET := $(TARGET)_$(CONVERT_TO)
 
     # Configure any defaults

--- a/data/mappings/info_rules.hjson
+++ b/data/mappings/info_rules.hjson
@@ -38,6 +38,8 @@
     "PS2_MOUSE_ENABLE": {"info_key": "ps2.mouse_enabled", "value_type": "bool"},
     "PS2_DRIVER": {"info_key": "ps2.driver"},
 
+    "PLATFORM_KEY": {"info_key": "platform_key", "to_json": false},
+
     // Items we want flagged in lint
     "CTPC": {"info_key": "_deprecated.ctpc", "deprecated": true, "replace_with": "CONVERT_TO=proton_c"},
     "CONVERT_TO_PROTON_C": {"info_key": "_deprecated.ctpc", "deprecated": true, "replace_with": "CONVERT_TO=proton_c"},

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -751,6 +751,7 @@ def arm_processor_rules(info_data, rules):
     """
     info_data['processor_type'] = 'arm'
     info_data['protocol'] = 'ChibiOS'
+    info_data['platform_key'] = 'chibios'
 
     if 'STM32' in info_data['processor']:
         info_data['platform'] = 'STM32'
@@ -758,6 +759,7 @@ def arm_processor_rules(info_data, rules):
         info_data['platform'] = rules['MCU_SERIES']
     elif 'ARM_ATSAM' in rules:
         info_data['platform'] = 'ARM_ATSAM'
+        info_data['platform_key'] = 'arm_atsam'
 
     return info_data
 
@@ -767,6 +769,7 @@ def avr_processor_rules(info_data, rules):
     """
     info_data['processor_type'] = 'avr'
     info_data['platform'] = rules['ARCH'] if 'ARCH' in rules else 'unknown'
+    info_data['platform_key'] = 'avr'
     info_data['protocol'] = 'V-USB' if info_data['processor'] in VUSB_PROCESSORS else 'LUFA'
 
     # FIXME(fauxpark/anyone): Eventually we should detect the protocol by looking at PROTOCOL inherited from mcu_selection.mk:

--- a/platforms/arm_atsam/bootloader.mk
+++ b/platforms/arm_atsam/bootloader.mk
@@ -27,6 +27,8 @@
 # the respective file under `platforms/<PLATFORM>/bootloaders/custom.c` to see
 # which functions may be overridden.
 
+FIRMWARE_FORMAT?=bin
+
 ifeq ($(strip $(BOOTLOADER)), custom)
     OPT_DEFS += -DBOOTLOADER_CUSTOM
     BOOTLOADER_TYPE = custom

--- a/platforms/avr/bootloader.mk
+++ b/platforms/avr/bootloader.mk
@@ -37,6 +37,8 @@
 # BOOTLOADER_SIZE can still be defined manually, but it's recommended
 # you add any possible configuration to this list
 
+FIRMWARE_FORMAT?=hex
+
 ifeq ($(strip $(BOOTLOADER)), custom)
     OPT_DEFS += -DBOOTLOADER_CUSTOM
     BOOTLOADER_TYPE = custom

--- a/platforms/chibios/bootloader.mk
+++ b/platforms/chibios/bootloader.mk
@@ -36,6 +36,8 @@
 # the respective file under `platforms/<PLATFORM>/bootloaders/custom.c` to see
 # which functions may be overridden.
 
+FIRMWARE_FORMAT?=bin
+
 ifeq ($(strip $(BOOTLOADER)), custom)
     OPT_DEFS += -DBOOTLOADER_CUSTOM
     BOOTLOADER_TYPE = custom

--- a/platforms/chibios/platform.mk
+++ b/platforms/chibios/platform.mk
@@ -442,6 +442,9 @@ LDFLAGS  += $(SHARED_LDFLAGS) $(SHARED_LDSYMBOLS) $(TOOLCHAIN_LDFLAGS) $(TOOLCHA
 # Tell QMK that we are hosting it on ChibiOS.
 OPT_DEFS += -DPROTOCOL_CHIBIOS
 
+# And what flavor of MCU
+OPT_DEFS += -DMCU_$(MCU_FAMILY)
+
 # ChibiOS supports synchronization primitives like a Mutex
 OPT_DEFS += -DPLATFORM_SUPPORTS_SYNCHRONIZATION
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Attempt 2 after #19545 caused converters to fail.

Avoids logic being in 2 different places, and reducing issues when a new platform is introduced. 

`info.json` having "platform" already being used for another value, with a somewhat meaningless value, is a shame. That could be reworked at a later date. Ive added to 16598 to cover the case where `qmk info -f json -kb <keyboard> -km <keymap_with_convert_to>` shows pre-converted info (incorrect mcu/bootloader/protocol/etc)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
