### PR TITLE
Allow for wildcard filtering in `qmk mass-compile`

### DIFF
--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -59,7 +59,8 @@ def _load_keymap_info(keyboard, keymap):
     arg_only=True,
     action='append',
     default=[],
-    help="Filter the list of keyboards based on the supplied value in rules.mk. Matches info.json structure, and accepts the format 'features.rgblight=true'. May be passed multiple times, all filters need to match. Value may include wildcards such as '*' and '?'."
+    help=
+    "Filter the list of keyboards based on the supplied value in rules.mk. Matches info.json structure, and accepts the format 'features.rgblight=true'. May be passed multiple times, all filters need to match. Value may include wildcards such as '*' and '?'."
 )
 @cli.argument('-km', '--keymap', type=str, default='default', help="The keymap name to build. Default is 'default'.")
 @cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")
@@ -105,6 +106,7 @@ def mass_compile(cli):
                     def _make_filter(k, v):
                         expr = fnmatch.translate(v)
                         rule = re.compile(expr, re.IGNORECASE)
+
                         def f(e):
                             lhs = e[2].get(k)
                             lhs = str(False if lhs is None else lhs)

--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -2,6 +2,7 @@
 
 This will compile everything in parallel, for testing purposes.
 """
+import fnmatch
 import logging
 import multiprocessing
 import os
@@ -58,7 +59,7 @@ def _load_keymap_info(keyboard, keymap):
     arg_only=True,
     action='append',
     default=[],
-    help="Filter the list of keyboards based on the supplied value in rules.mk. Matches info.json structure, and accepts the format 'features.rgblight=true'. May be passed multiple times, all filters need to match."
+    help="Filter the list of keyboards based on the supplied value in rules.mk. Matches info.json structure, and accepts the format 'features.rgblight=true'. May be passed multiple times, all filters need to match. Value may include wildcards such as '*' and '?'."
 )
 @cli.argument('-km', '--keymap', type=str, default='default', help="The keymap name to build. Default is 'default'.")
 @cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")
@@ -102,11 +103,12 @@ def mass_compile(cli):
                     cli.log.info(f'Filtering on condition ("{key}" == "{value}")...')
 
                     def _make_filter(k, v):
+                        expr = fnmatch.translate(v)
+                        rule = re.compile(expr, re.IGNORECASE)
                         def f(e):
                             lhs = e[2].get(k)
-                            lhs = str(False if lhs is None else lhs).lower()
-                            rhs = str(v).lower()
-                            return lhs == rhs
+                            lhs = str(False if lhs is None else lhs)
+                            return rule.search(lhs) is not None
 
                         return f
 

--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -59,8 +59,8 @@ def _load_keymap_info(keyboard, keymap):
     arg_only=True,
     action='append',
     default=[],
-    help=
-    "Filter the list of keyboards based on the supplied value in rules.mk. Matches info.json structure, and accepts the format 'features.rgblight=true'. May be passed multiple times, all filters need to match. Value may include wildcards such as '*' and '?'."
+    help=  # noqa: `format-python` and `pytest` don't agree here.
+    "Filter the list of keyboards based on the supplied value in rules.mk. Matches info.json structure, and accepts the format 'features.rgblight=true'. May be passed multiple times, all filters need to match. Value may include wildcards such as '*' and '?'."  # noqa: `format-python` and `pytest` don't agree here.
 )
 @cli.argument('-km', '--keymap', type=str, default='default', help="The keymap name to build. Default is 'default'.")
 @cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")


### PR DESCRIPTION
## Description

Adds the ability to use filename-style wildcards to `qmk mass-compile`'s filter values.
e.g.
```sh
qmk mass-compile -j 4 -f 'processor=STM32F4*' # Builds F401, F405, F407, F411, F446, etc.
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
