### PR TITLE
Update platformdev_rp2040.md

### DIFF
--- a/docs/platformdev_rp2040.md
+++ b/docs/platformdev_rp2040.md
@@ -4,7 +4,7 @@ The following table shows the current driver status for peripherals on RP2040 MC
 
 |                              System                              |                    Support                     |
 | ---------------------------------------------------------------- | ---------------------------------------------- |
-| [ADC driver](adc_driver.md)                                      | Support planned (no ETA)                       |
+| [ADC driver](adc_driver.md)                                      | :heavy_check_mark:                             |
 | [Audio](audio_driver.md#pwm-hardware)                            | :heavy_check_mark:                             |
 | [Backlight](feature_backlight.md)                                | :heavy_check_mark:                             |
 | [I2C driver](i2c_driver.md)                                      | :heavy_check_mark:                             |


### PR DESCRIPTION
Edit to show support for the RP2040 ADC driver

An upstream ChibiOS HAL issue was stalling:
https://github.com/qmk/qmk_firmware/pull/19453
https://github.com/ChibiOS/ChibiOS-Contrib/pull/355 

This has since been fixed, both are now merged to provide ADC support on the RP2040.

Thus support was changed from "planned with no eta" to a check mark in this document.

Cheers