### PR TITLE
Fix converter alias after 19603

### DIFF
--- a/builddefs/converters.mk
+++ b/builddefs/converters.mk
@@ -19,7 +19,7 @@ ifneq ($(CONVERT_TO),)
 
     -include $(CONVERTER)/pre_converter.mk
 
-    PLATFORM_KEY = $(shell echo $(CONVERTER) | rev | cut -d "/" -f4 | rev)
+    PLATFORM_KEY = $(shell echo $(CONVERTER) | cut -d "/" -f2)
     TARGET := $(TARGET)_$(CONVERT_TO)
 
     # Configure any defaults


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Was trying to handle the case where `PLATFORM_PATH` has parents, but for now its easier to handle folders not having trailing slashes? Most of this logic should go with the move to DD converters anyway.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
