### PR TITLE
[Bug] rp2040: fix timer wrap deadlock in ws2812 vendor driver

### DIFF
--- a/platforms/chibios/drivers/vendor/RP/RP2040/ws2812_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/ws2812_vendor.c
@@ -1,10 +1,13 @@
 // Copyright 2022 Stefan Kerkmann (@KarlK90)
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "quantum.h"
 #include "ws2812.h"
-#include "hardware/pio.h"
+#include "hardware/timer.h"
 #include "hardware/clocks.h"
+// Keep this exact include order otherwise we run into naming conflicts between
+// pico-sdk and rp2040.h which we don't control.
+#include "quantum.h"
+#include "hardware/pio.h"
 
 #if !defined(MCU_RP)
 #    error PIO Driver is only available for Raspberry Pi 2040 MCUs!
@@ -132,7 +135,7 @@ static uint32_t                RP_DMA_MODE_WS2812;
 static int                     STATE_MACHINE = -1;
 
 static SEMAPHORE_DECL(TRANSFER_COUNTER, 1);
-static rtcnt_t LAST_TRANSFER;
+static absolute_time_t LAST_TRANSFER;
 
 /**
  * @brief Convert RGBW value into WS2812 compatible 32-bit data word.
@@ -161,7 +164,7 @@ static void ws2812_dma_callback(void* p, uint32_t ct) {
     // Convert from ns to us
     time_to_completion /= 1000;
 
-    LAST_TRANSFER = chSysGetRealtimeCounterX() + time_to_completion + WS2812_TRST_US;
+    LAST_TRANSFER = time_us_64() + time_to_completion + WS2812_TRST_US;
 
     osalSysLockFromISR();
     chSemSignalI(&TRANSFER_COUNTER);
@@ -256,7 +259,7 @@ static inline void sync_ws2812_transfer(void) {
     }
 
     // Busy wait until last transfer has finished
-    while (unlikely(!timer_expired32(chSysGetRealtimeCounterX(), LAST_TRANSFER))) {
+    while (unlikely(!time_reached(LAST_TRANSFER))) {
     }
 }
 

--- a/platforms/chibios/drivers/vendor/RP/RP2040/ws2812_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/ws2812_vendor.c
@@ -164,7 +164,7 @@ static void ws2812_dma_callback(void* p, uint32_t ct) {
     // Convert from ns to us
     time_to_completion /= 1000;
 
-    LAST_TRANSFER = time_us_64() + time_to_completion + WS2812_TRST_US;
+    update_us_since_boot(&LAST_TRANSFER, time_us_64() + time_to_completion + WS2812_TRST_US);
 
     osalSysLockFromISR();
     chSemSignalI(&TRANSFER_COUNTER);
@@ -259,8 +259,7 @@ static inline void sync_ws2812_transfer(void) {
     }
 
     // Busy wait until last transfer has finished
-    while (unlikely(!time_reached(LAST_TRANSFER))) {
-    }
+    busy_wait_until(LAST_TRANSFER);
 }
 
 void ws2812_setleds(LED_TYPE* ledarray, uint16_t leds) {

--- a/platforms/chibios/vendors/RP/RP2040.mk
+++ b/platforms/chibios/vendors/RP/RP2040.mk
@@ -25,6 +25,7 @@ PICOSDKROOT   := $(TOP_DIR)/lib/pico-sdk
 PICOSDKSRC     = $(PICOSDKROOT)/src/rp2_common/hardware_clocks/clocks.c \
                  $(PICOSDKROOT)/src/rp2_common/hardware_pll/pll.c \
                  $(PICOSDKROOT)/src/rp2_common/hardware_pio/pio.c \
+                 $(PICOSDKROOT)/src/rp2_common/hardware_timer/timer.c \
                  $(PICOSDKROOT)/src/rp2_common/hardware_flash/flash.c \
                  $(PICOSDKROOT)/src/rp2_common/hardware_gpio/gpio.c \
                  $(PICOSDKROOT)/src/rp2_common/hardware_claim/claim.c \
@@ -44,6 +45,7 @@ PICOSDKINC     = $(CHIBIOS)//os/various/pico_bindings/dumb/include \
                  $(PICOSDKROOT)/src/rp2_common/hardware_pll/include \
                  $(PICOSDKROOT)/src/rp2_common/hardware_pio/include \
                  $(PICOSDKROOT)/src/rp2_common/hardware_sync/include \
+                 $(PICOSDKROOT)/src/rp2_common/hardware_timer/include \
                  $(PICOSDKROOT)/src/rp2_common/hardware_resets/include \
                  $(PICOSDKROOT)/src/rp2_common/hardware_watchdog/include \
                  $(PICOSDKROOT)/src/rp2_common/hardware_xosc/include \


### PR DESCRIPTION
## Description

The current implementation could be deadlocked if the last update was more then ~35min ago. This is due to the time resolution for the RP2040 on ChibiOS being 32bit and the counter running at 1MHz and `timer_expired32()` only handling timer intervals up to `(UINT32_MAX / 2)`. This can easily happen if the keyboard is put to sleep or the RGB being disabled for this time.

The solution is to use the full 64bit time resolution of the RP2040 which wraps after ~584942 years - let me know if you happen to witness this. Unfortunately we have fallback to the pico-sdk implementation as there is no 64bit timer resolution support in the ChibiOS implementation of the RP2040.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #19600 (?)
* #18591 (?)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
