### PR TITLE
analog.c: Fix `pinToMux()` for STM32F0xx

### DIFF
--- a/platforms/chibios/drivers/analog.c
+++ b/platforms/chibios/drivers/analog.c
@@ -138,22 +138,22 @@ static ADCConversionGroup adcConversionGroup = {
 __attribute__((weak)) adc_mux pinToMux(pin_t pin) {
     switch (pin) {
 #if defined(STM32F0XX)
-        case A0:  return TO_MUX( ADC_CHSELR_CHSEL0,  0 );
-        case A1:  return TO_MUX( ADC_CHSELR_CHSEL1,  0 );
-        case A2:  return TO_MUX( ADC_CHSELR_CHSEL2,  0 );
-        case A3:  return TO_MUX( ADC_CHSELR_CHSEL3,  0 );
-        case A4:  return TO_MUX( ADC_CHSELR_CHSEL4,  0 );
-        case A5:  return TO_MUX( ADC_CHSELR_CHSEL5,  0 );
-        case A6:  return TO_MUX( ADC_CHSELR_CHSEL6,  0 );
-        case A7:  return TO_MUX( ADC_CHSELR_CHSEL7,  0 );
-        case B0:  return TO_MUX( ADC_CHSELR_CHSEL8,  0 );
-        case B1:  return TO_MUX( ADC_CHSELR_CHSEL9,  0 );
-        case C0:  return TO_MUX( ADC_CHSELR_CHSEL10, 0 );
-        case C1:  return TO_MUX( ADC_CHSELR_CHSEL11, 0 );
-        case C2:  return TO_MUX( ADC_CHSELR_CHSEL12, 0 );
-        case C3:  return TO_MUX( ADC_CHSELR_CHSEL13, 0 );
-        case C4:  return TO_MUX( ADC_CHSELR_CHSEL14, 0 );
-        case C5:  return TO_MUX( ADC_CHSELR_CHSEL15, 0 );
+        case A0:  return TO_MUX( 0,  0 );
+        case A1:  return TO_MUX( 1,  0 );
+        case A2:  return TO_MUX( 2,  0 );
+        case A3:  return TO_MUX( 3,  0 );
+        case A4:  return TO_MUX( 4,  0 );
+        case A5:  return TO_MUX( 5,  0 );
+        case A6:  return TO_MUX( 6,  0 );
+        case A7:  return TO_MUX( 7,  0 );
+        case B0:  return TO_MUX( 8,  0 );
+        case B1:  return TO_MUX( 9,  0 );
+        case C0:  return TO_MUX( 10, 0 );
+        case C1:  return TO_MUX( 11, 0 );
+        case C2:  return TO_MUX( 12, 0 );
+        case C3:  return TO_MUX( 13, 0 );
+        case C4:  return TO_MUX( 14, 0 );
+        case C5:  return TO_MUX( 15, 0 );
 #elif defined(STM32F3XX)
         case A0:  return TO_MUX( ADC_CHANNEL_IN1,  0 );
         case A1:  return TO_MUX( ADC_CHANNEL_IN2,  0 );


### PR DESCRIPTION
## Description

The `adc_read()` code for STM32F0xx expects to get the 0-based channel number in `mux.input`, but the `pinToMux()` code for STM32F0xx was attempting to pass the CHSELR bit mask in that field, which resulted in selecting a wrong channel, therefore `analogReadPin()` did not work properly for the STM32F0xx chips.  Fix `pinToMux()` to put the channel number in that field (this matches the behavior for other supported chips and also allows selection of channels 16...18, which can be used to access the builtin temperature, reference voltage and VBAT sensors).

(It could be possible to fix this in a different way — by doing `adcConversionGroup.chselr = mux.input` in `adc_read()` and continuing to put the bit mask into `mux.input`; however, it would break things for people who may be working around the bug by using `adc_read()` directly instead of going through `analogReadPin()`, and would not give access to any channels above 15, because `mux.input` is `uint16_t`.  And specifying multiple channels in the `adc_read()` argument does not make sense anyway, because that function returns only a single value; a completely different API would be needed to support multichannel conversions.)

Tested on a development board with STM32F072CBT6 — pins `A0`…`A7`, `B0`, `B1` verified working correctly with the `adc` and `joystick` keymaps; don't have the hardware to test the `C0`…`C5` pins.

The temperature sensor and the reference voltage input show *something*; the VBAT input seems to show a plausible value if `ADC_SAMPLING_RATE` is configured to increase the sampling time (the development board that I am using has VBAT tied to VCC).  Using those channels requires setting the corresponding bits in `ADC->CCR`, which can be done either directly or through the `adcSTM32SetCCR()` API provided by the ChibiOS LLD (there are also specific functions like `adcSTM32EnableVREF()`).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
