### PR TITLE
Decrease LED animation frequency to improve performance

### DIFF
--- a/keyboards/annepro2/config_led.h
+++ b/keyboards/annepro2/config_led.h
@@ -20,8 +20,8 @@
 
 #define RGB_MATRIX_LED_COUNT 61
 
-/* Limit animations to 62.5 FPS to avoid tearing. (1/.016 = 62.5 FPS). */
-#define RGB_MATRIX_LED_FLUSH_LIMIT 16
+/* Limit animations to 25 FPS to avoid tearing. (1/.040 = 25 FPS). */
+#define RGB_MATRIX_LED_FLUSH_LIMIT 40
 
 #define RGB_MATRIX_FRAMEBUFFER_EFFECTS
 #define RGB_MATRIX_KEYPRESSES


### PR DESCRIPTION
## Description

The current value `RGB_MATRIX_LED_FLUSH_LIMIT 16` causes noticeable input latency when animated RGB profiles are activated. The latency goes away as soon as the RGB is switched off.

This issue was introduced after refactoring in
https://github.com/qmk/qmk_firmware/pull/18640
There are multiple reports in OpenAnnePro 2 discord channel about this issue.

Maybe a proper fix will be refactoring the logic and adjusting the frequency of UART communication. This is a quick fix to make the keyboard usable with RGB enabled.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* AnnePro2 input latency is improved when animated RGB profiles are enabled

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
