### PR TITLE
Fix quantum ring_buffer for ChibiOS

### DIFF
--- a/platforms/atomic_util.h
+++ b/platforms/atomic_util.h
@@ -24,9 +24,13 @@
 #        define ATOMIC_BLOCK _Static_assert(0, "ATOMIC_BLOCK not implemented")
 #        define ATOMIC_BLOCK_RESTORESTATE _Static_assert(0, "ATOMIC_BLOCK_RESTORESTATE not implemented")
 #        define ATOMIC_BLOCK_FORCEON _Static_assert(0, "ATOMIC_BLOCK_FORCEON not implemented")
+#        define ATOMIC_FORCEON _Static_assert(0, "ATOMIC_FORCEON not implemented")
+#        define ATOMIC_RESTORESTATE _Static_assert(0, "ATOMIC_RESTORESTATE not implemented")
 #    endif
 #else /* do nothing atomic macro */
-#    define ATOMIC_BLOCK for (uint8_t __ToDo = 1; __ToDo; __ToDo = 0)
-#    define ATOMIC_BLOCK_RESTORESTATE ATOMIC_BLOCK
-#    define ATOMIC_BLOCK_FORCEON ATOMIC_BLOCK
+#    define ATOMIC_BLOCK(t) for (uint8_t __ToDo = 1; __ToDo; __ToDo = 0)
+#    define ATOMIC_FORCEON
+#    define ATOMIC_RESTORESTATE
+#    define ATOMIC_BLOCK_RESTORESTATE ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+#    define ATOMIC_BLOCK_FORCEON ATOMIC_BLOCK(ATOMIC_FORCEON)
 #endif

--- a/quantum/ring_buffer.h
+++ b/quantum/ring_buffer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <util/atomic.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "atomic_util.h"
 
 #ifndef RBUF_SIZE
 #    define RBUF_SIZE 32


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
While using ring_buffer for the RIOT port, noticed it was effectively AVR only. AVR only code should really not exist within the `quantum` folder.

The minimum change to get RIOT working would be the `#include <util/atomic.h>` to `#include "atomic_util.h"` part, but i've attempted to align the missing ChibiOS functionality. If there are concerns on the additional changes, I can stage them as a separate PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
