### PR TITLE
Add direction to dynamic_macro_record_start_user

### DIFF
--- a/docs/feature_dynamic_macros.md
+++ b/docs/feature_dynamic_macros.md
@@ -59,7 +59,7 @@ There are a number of hooks that you can use to add custom functionality and fee
 
 Note, that direction indicates which macro it is, with `1` being Macro 1, `-1` being Macro 2, and 0 being no macro. 
 
-* `dynamic_macro_record_start_user(void)` - Triggered when you start recording a macro.
+* `dynamic_macro_record_start_user(int8_t direction)` - Triggered when you start recording a macro.
 * `dynamic_macro_play_user(int8_t direction)` - Triggered when you play back a macro.
 * `dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record)` - Triggered on each keypress while recording a macro.
 * `dynamic_macro_record_end_user(int8_t direction)` - Triggered when the macro recording is stopped. 

--- a/docs/ja/feature_dynamic_macros.md
+++ b/docs/ja/feature_dynamic_macros.md
@@ -64,7 +64,7 @@ QMK はその場で作られた一時的なマクロをサポートします。�
 
 direction がどのマクロであるかを示すことに注意してください。`1` がマクロ 1、`-1` がマクロ 2、0 がマクロ無しです。
 
-* `dynamic_macro_record_start_user(void)` - マクロの記録を開始する時に起動されます。
+* `dynamic_macro_record_start_user(int8_t direction)` - マクロの記録を開始する時に起動されます。
 * `dynamic_macro_play_user(int8_t direction)` - マクロを再生する時に起動されます。
 * `dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record)` - マクロの記録中に各キー押下で起動されます。
 * `dynamic_macro_record_end_user(int8_t direction)` - マクロの記録を停止した時に起動されます。

--- a/keyboards/40percentclub/mf68/keymaps/delivrance/keymap.c
+++ b/keyboards/40percentclub/mf68/keymaps/delivrance/keymap.c
@@ -138,7 +138,7 @@ void led_blink(void) {
     backlight_toggle();
 }
 
-void dynamic_macro_record_start_user(void) {
+void dynamic_macro_record_start_user(int8_t direction) {
     led_blink();
 }
 

--- a/keyboards/dztech/dz65rgb/keymaps/drootz/keymap.c
+++ b/keyboards/dztech/dz65rgb/keymaps/drootz/keymap.c
@@ -720,7 +720,7 @@ void leader_end_user(void) {
 
 /**************** DYNAMIC MACRO *********************/
 
-void dynamic_macro_record_start_user(void) {
+void dynamic_macro_record_start_user(int8_t direction) {
     onMac = false; /* reset layer bool as dynamic macro clear the keyboard and reset layers. */
     if (!isBlinking && !isRecording) {
         reset_blink_cycle();

--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -408,7 +408,7 @@ static bool is_on = false;
 static bool is_dynamic_recording = false;
 static uint16_t dynamic_loop_timer;
 
-void dynamic_macro_record_start_user(void) {
+void dynamic_macro_record_start_user(int8_t direction) {
     is_dynamic_recording = true;
     dynamic_loop_timer = timer_read();
     ergodox_right_led_1_on();

--- a/keyboards/gmmk/pro/rev1/ansi/keymaps/mattgauf/keymap.c
+++ b/keyboards/gmmk/pro/rev1/ansi/keymaps/mattgauf/keymap.c
@@ -113,7 +113,7 @@ bool rgb_matrix_indicators_user(void) {
 
 
 // Called on start
-void dynamic_macro_record_start_user(void) {
+void dynamic_macro_record_start_user(int8_t direction) {
     dprint("-- Recording Started\n");
     layer_on(_UTILITY);
 }

--- a/keyboards/handwired/dactyl_manuform/3x5_3/keymaps/dlford/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/3x5_3/keymaps/dlford/keymap.c
@@ -234,7 +234,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 }
 
 // Dynamic Macro Recording Backlight
-void dynamic_macro_record_start_user(void) {
+void dynamic_macro_record_start_user(int8_t direction) {
     is_macro_recording = true;
 }
 

--- a/keyboards/kprepublic/bm40hsrgb/keymaps/coffee/keymap.c
+++ b/keyboards/kprepublic/bm40hsrgb/keymaps/coffee/keymap.c
@@ -27,7 +27,7 @@ enum layout_names {
     static uint16_t REC = DM_REC1;
     static uint16_t PLY = DM_PLY1;
 
-    void dynamic_macro_record_start_user(void) {
+    void dynamic_macro_record_start_user(int8_t direction) {
         REC = DM_RSTP;
         RECORDING = true;
     }

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -28,7 +28,7 @@ bool is_launching     = false;
 #ifdef DYNAMIC_MACRO_ENABLE
 static bool is_dynamic_recording = false;
 
-void dynamic_macro_record_start_user(void) { is_dynamic_recording = true; }
+void dynamic_macro_record_start_user(int8_t direction) { is_dynamic_recording = true; }
 
 void dynamic_macro_record_end_user(int8_t direction) {
     is_dynamic_recording = false;

--- a/keyboards/mschwingen/modelm/modelm.c
+++ b/keyboards/mschwingen/modelm/modelm.c
@@ -204,7 +204,7 @@ void update_layer_leds(void) {
 
 #endif
 
-void dynamic_macro_record_start_user(void) {
+void dynamic_macro_record_start_user(int8_t direction) {
     isRecording++;
     blink_cycle_timer = timer_read();
 }

--- a/keyboards/planck/keymaps/tk/keymap.c
+++ b/keyboards/planck/keymaps/tk/keymap.c
@@ -318,7 +318,7 @@ void keyboard_post_init_user(void) {
 
 static bool prerecord_clicky = false;
 
-void dynamic_macro_record_start_user(void) {
+void dynamic_macro_record_start_user(int8_t direction) {
     prerecord_clicky = is_clicky_on();
     if (!prerecord_clicky) {
         clicky_on();

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -29,7 +29,7 @@ void dynamic_macro_led_blink(void) {
 
 /* User hooks for Dynamic Macros */
 
-__attribute__((weak)) void dynamic_macro_record_start_user(void) {
+__attribute__((weak)) void dynamic_macro_record_start_user(int8_t direction) {
     dynamic_macro_led_blink();
 }
 
@@ -62,10 +62,10 @@ __attribute__((weak)) bool dynamic_macro_valid_key_user(uint16_t keycode, keyrec
  * @param[out] macro_pointer The new macro buffer iterator.
  * @param[in]  macro_buffer  The macro buffer used to initialize macro_pointer.
  */
-void dynamic_macro_record_start(keyrecord_t **macro_pointer, keyrecord_t *macro_buffer) {
+void dynamic_macro_record_start(keyrecord_t **macro_pointer, keyrecord_t *macro_buffer, int8_t direction) {
     dprintln("dynamic macro recording: started");
 
-    dynamic_macro_record_start_user();
+    dynamic_macro_record_start_user(direction);
 
     clear_keyboard();
     layer_clear();
@@ -213,11 +213,11 @@ bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
         if (!record->event.pressed) {
             switch (keycode) {
                 case QK_DYNAMIC_MACRO_RECORD_START_1:
-                    dynamic_macro_record_start(&macro_pointer, macro_buffer);
+                    dynamic_macro_record_start(&macro_pointer, macro_buffer, +1);
                     macro_id = 1;
                     return false;
                 case QK_DYNAMIC_MACRO_RECORD_START_2:
-                    dynamic_macro_record_start(&macro_pointer, r_macro_buffer);
+                    dynamic_macro_record_start(&macro_pointer, r_macro_buffer, -1);
                     macro_id = 2;
                     return false;
                 case QK_DYNAMIC_MACRO_PLAY_1:

--- a/quantum/process_keycode/process_dynamic_macro.h
+++ b/quantum/process_keycode/process_dynamic_macro.h
@@ -35,7 +35,7 @@
 
 void dynamic_macro_led_blink(void);
 bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record);
-void dynamic_macro_record_start_user(void);
+void dynamic_macro_record_start_user(int8_t direction);
 void dynamic_macro_play_user(int8_t direction);
 void dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record);
 void dynamic_macro_record_end_user(int8_t direction);


### PR DESCRIPTION
This provides a means for user code to know which macro is being recorded, e.g., to display different indicators on an OLED.

Adds a `direction` argument to `dynamic_macro_record_start_user()`, just like the other `dynamic_macro_*_user()` functions.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Change `void dynamic_macro_record_start_user(void)` to `void dynamic_macro_record_start_user(int8_t direction)`.
`direction` is either `+1` or `-1` to indicate which dynamic macro is being recorded, making it similar to the other `dynamic_macro_*_user()` functions (which already take a `direction`).

Updated keyboard code with the new function signatures, as well as the documentation.

I did not touch the deprecated `quantum/dynamic_macro.h` which has a very different API.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

None 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
