### PR TITLE
[keyboard] Prevent LED flicker when connecting AnnePro 2

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -101,8 +101,6 @@ void keyboard_post_init_kb(void) {
     // loop to clear out receive buffer from ble wakeup
     while (!sdGetWouldBlock(&SD1)) sdGet(&SD1);
 
-    ap2_led_get_status();
-
     #ifdef RGB_MATRIX_ENABLE
     ap2_led_set_manual_control(1);
     ap2_led_enable();

--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -104,8 +104,8 @@ void keyboard_post_init_kb(void) {
     ap2_led_get_status();
 
     #ifdef RGB_MATRIX_ENABLE
-    ap2_led_enable();
     ap2_led_set_manual_control(1);
+    ap2_led_enable();
     #endif
 
     keyboard_post_init_user();

--- a/keyboards/annepro2/ap2_led.c
+++ b/keyboards/annepro2/ap2_led.c
@@ -60,8 +60,6 @@ void ap2_led_enable(void) { proto_tx(CMD_LED_ON, NULL, 0, 3); }
 
 void ap2_led_set_profile(uint8_t prof) { proto_tx(CMD_LED_SET_PROFILE, &prof, sizeof(prof), 3); }
 
-void ap2_led_get_status(void) { proto_tx(CMD_LED_GET_STATUS, NULL, 0, 3); }
-
 void ap2_led_next_profile(void) { proto_tx(CMD_LED_NEXT_PROFILE, NULL, 0, 3); }
 
 void ap2_led_next_intensity(void) { proto_tx(CMD_LED_NEXT_INTENSITY, NULL, 0, 3); }

--- a/keyboards/annepro2/ap2_led.h
+++ b/keyboards/annepro2/ap2_led.h
@@ -49,7 +49,6 @@ void ap2_set_IAP(void);
 void ap2_led_disable(void);
 void ap2_led_enable(void);
 void ap2_led_set_profile(uint8_t prof);
-void ap2_led_get_status(void);
 void ap2_led_next_profile(void);
 void ap2_led_prev_profile(void);
 void ap2_led_next_intensity(void);

--- a/keyboards/annepro2/protocol.h
+++ b/keyboards/annepro2/protocol.h
@@ -36,7 +36,7 @@ enum {
     CMD_LED_MASK_SET_MONO = 0x12,
 
     /* Reactive / status */
-    CMD_LED_GET_STATUS = 0x20,
+    CMD_LED_GET_STATUS = 0x20, /* unused */
     CMD_LED_KEY_BLINK  = 0x21,
     CMD_LED_KEY_DOWN   = 0x22,
     CMD_LED_KEY_UP     = 0x23, /* TODO */


### PR DESCRIPTION
## Description

The current implementation enables LEDs and then sets mode
to manual. Because of this, [shine firmware](
https://github.com/OpenAnnePro/AnnePro2-Shine)
initially starts it own LED profiles and after processing next
message switches to manual mode where LEDs are controlled by QMK.
The effect of this is that for less than a second, keyboard
lights up all white and then switches to QMK profile.

The adjustment makes sure that no Shine profile logic is used at all.

Also, the second commit removes an unhandled command
`CMD_LED_GET_STATUS`. It does nothing on Shine side and should probably
be removed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* LED flicker is removed during keyboard connect/boot
* Unnecessary call to an unhandled command `CMD_LED_GET_STATUS` is removed