### PR TITLE
QP: Correct rotation and offset when using LVGL

### DIFF
--- a/quantum/painter/lvgl/qp_lvgl.c
+++ b/quantum/painter/lvgl/qp_lvgl.c
@@ -109,14 +109,22 @@ bool qp_lvgl_attach(painter_device_t device) {
 
     selected_display = device;
 
+    uint16_t           panel_width, panel_height, offset_x, offset_y;
+    painter_rotation_t rotation;
+
+    qp_get_geometry(selected_display, &panel_width, &panel_height, &rotation, &offset_x, &offset_y);
+
+    panel_width -= offset_x;
+    panel_height -= offset_y;
+
     // Setting up display driver
-    static lv_disp_drv_t disp_drv;            /*Descriptor of a display driver*/
-    lv_disp_drv_init(&disp_drv);              /*Basic initialization*/
-    disp_drv.flush_cb = qp_lvgl_flush;        /*Set your driver function*/
-    disp_drv.draw_buf = &draw_buf;            /*Assign the buffer to the display*/
-    disp_drv.hor_res  = driver->panel_width;  /*Set the horizontal resolution of the display*/
-    disp_drv.ver_res  = driver->panel_height; /*Set the vertical resolution of the display*/
-    lv_disp_drv_register(&disp_drv);          /*Finally register the driver*/
+    static lv_disp_drv_t disp_drv;     /*Descriptor of a display driver*/
+    lv_disp_drv_init(&disp_drv);       /*Basic initialization*/
+    disp_drv.flush_cb = qp_lvgl_flush; /*Set your driver function*/
+    disp_drv.draw_buf = &draw_buf;     /*Assign the buffer to the display*/
+    disp_drv.hor_res  = panel_width;   /*Set the horizontal resolution of the display*/
+    disp_drv.ver_res  = panel_height;  /*Set the vertical resolution of the display*/
+    lv_disp_drv_register(&disp_drv);   /*Finally register the driver*/
 
     return true;
 }

--- a/quantum/painter/lvgl/qp_lvgl.c
+++ b/quantum/painter/lvgl/qp_lvgl.c
@@ -110,9 +110,7 @@ bool qp_lvgl_attach(painter_device_t device) {
     selected_display = device;
 
     uint16_t           panel_width, panel_height, offset_x, offset_y;
-    painter_rotation_t rotation;
-
-    qp_get_geometry(selected_display, &panel_width, &panel_height, &rotation, &offset_x, &offset_y);
+    qp_get_geometry(selected_display, &panel_width, &panel_height, NULL, &offset_x, &offset_y);
 
     panel_width -= offset_x;
     panel_height -= offset_y;

--- a/quantum/painter/lvgl/qp_lvgl.c
+++ b/quantum/painter/lvgl/qp_lvgl.c
@@ -109,7 +109,7 @@ bool qp_lvgl_attach(painter_device_t device) {
 
     selected_display = device;
 
-    uint16_t           panel_width, panel_height, offset_x, offset_y;
+    uint16_t panel_width, panel_height, offset_x, offset_y;
     qp_get_geometry(selected_display, &panel_width, &panel_height, NULL, &offset_x, &offset_y);
 
     panel_width -= offset_x;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Small correction for the LVGL bindings when attaching a display.  

When setting up the LVGL display driver it took the original display width and height without taking in consideration the rotation and offsets

For example, if the display is 240x320 and the display was rotated using `qp_init(display, QP_ROTATION_90);` and applied a Y offset using `qp_set_viewport_offsets`, the LVGL driver will be set up with a resolution of 240x320 instead of a corrected resolution of 320x240 (minus the viewport offset).

Current implementation (170x320 display rotated 90 with 35px of Y-offset): LVGL is rendering only 240 wide (instead of 320) and the circle is being cut because of the offset.
![250D845D-4D0D-4DCF-83F3-B6602B25439FL0001 png png](https://user-images.githubusercontent.com/6202305/215359404-1fd4d2b9-bed2-4015-8b89-cb8f76282d84.jpg)

With this PR: 0,0 is now at the top-left corner without any cut-off and it is rendering the whole screen.
![73845442-440A-4C38-BFBA-CB66E7AE6691L0001 png png](https://user-images.githubusercontent.com/6202305/215359648-8bcc6fc9-9d7b-4478-bf96-72a1a980c226.jpg)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
