### PR TITLE
[Bug] Fix Song List configuration for Audio feature

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -46,6 +46,7 @@ endif
 
 AUDIO_ENABLE ?= no
 ifeq ($(strip $(AUDIO_ENABLE)), yes)
+    CONFIG_H := $(QUANTUM_PATH)/audio/song_list.h $(CONFIG_H)
     ifeq ($(PLATFORM),CHIBIOS)
         AUDIO_DRIVER ?= dac_basic
         ifeq ($(strip $(AUDIO_DRIVER)), dac_basic)


### PR DESCRIPTION
## Description

See Title. 

But speciflcally, the song list needs to be included in the config.h "stuff" or custom song values will not be respected. 

#19714 breaks this, and #19722 further breaks this.  I can confirm that this breaks ALL of these configs: https://docs.qmk.fm/#/feature_audio?id=audio-config

This was mentioned by me already: [link
](https://discord.com/channels/669696814995210240/669696815448326166/1048063035308257280)


If there is a better solution that will respect the settings, I'm open for it, but right now, this is completely broken.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* #19714
* #19722


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have *actually* tested the changes and verified that they work and don't break anything (as well as I can manage).
