### PR TITLE
zweihander-macos: Update keys, add capslock

### DIFF
--- a/layouts/community/ergodox/zweihander-macos/keymap.c
+++ b/layouts/community/ergodox/zweihander-macos/keymap.c
@@ -40,7 +40,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *   |  L⌃  |  L⌥  |  L⌘  |   ←  |   →  |                                       |   ↑  |   ↓  |   [  |   ]  |  ↩︎   |
  *   `----------------------------------'                                       `----------------------------------'
  *                                        ,-------------.       ,---------------.
- *                                        |  `~  |  '"  |       |   ⎋  |    ⌫   |
+ *                                        |  `~  |  ⇪   |       |   ⎋  |    ⌫   |
  *                                 ,------|------|------|       |------+--------+------.
  *                                 |      |      |  L⌥  |       |  R⌥  |        |      |
  *                                 |   ↩︎  |  ⇥  |------|       |------|   ⇥   |      |
@@ -56,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_BSPC,        KC_A,         KC_S,     KC_D,   KC_F,   KC_G,
         KC_LSFT,        KC_Z,         KC_X,     KC_C,   KC_V,   KC_B,   KC_LGUI,
         KC_LCTL,        KC_LALT,      KC_LGUI,  KC_LEFT,KC_RGHT,
-                                                KC_GRV, KC_QUOT,
+                                                KC_GRV, KC_CAPS,
                                                                 KC_LALT,
                                                 KC_ENT ,KC_TAB ,KC_LCTL,
         // right hand

--- a/layouts/community/ergodox/zweihander-macos/keymap.c
+++ b/layouts/community/ergodox/zweihander-macos/keymap.c
@@ -134,7 +134,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 // MEDIA AND MOUSE
 [MDIA] = LAYOUT_ergodox(
-       KC_TRNS,     KC_F14 ,        KC_F15 ,            KC_PSCR,        KC_SLCK,                KC_PAUS,        KC_TRNS,  /* F14 dims screen, F15 brightens */
+       KC_TRNS,     KC_F14 ,        KC_F15 ,            KC_PSCR,        KC_SCRL,                KC_PAUS,        KC_TRNS,  /* F14 dims screen, F15 brightens */
        KC_TRNS,     KC_TRNS,        LALT(KC_UP),        KC_PGUP,        LALT(KC_DOWN),          KC_TRNS,        KC_TRNS,
        KC_TRNS,     KC_TRNS,        KC_HOME,            KC_PGDN,        KC_END ,                KC_TRNS,        
        KC_TRNS,     KC_TRNS,        KC_TRNS,            KC_TRNS,        KC_TRNS,                KC_TRNS,        KC_TRNS,
@@ -143,7 +143,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                                                                                 KC_TRNS,
                                                         KC_TRNS,        KC_TRNS,                KC_TRNS,
     // right hand
-       KC_TRNS,     LGUI(KC_W),     LGUI(LSFT(KC_GRV)), LGUI(KC_GRV),   KC_TRNS,                KC_EJCT,        KC_POWER,
+       KC_TRNS,     LGUI(KC_W),     LGUI(LSFT(KC_GRV)), LGUI(KC_GRV),   KC_TRNS,                KC_EJCT,        KC_PWR,
        KC_TRNS,     LGUI(KC_RBRC),  LGUI(LALT(KC_UP)),  KC_UP  ,        LGUI(LALT(KC_DOWN)),    KC_TRNS,        KC_TRNS,
                     LGUI(KC_LBRC),  KC_LEFT,            KC_DOWN,        KC_RGHT,                KC_TRNS,        KC_F16 ,
        KC_TRNS,     KC_TRNS,        KC_MPLY,            KC_MPRV,        KC_MNXT,                KC_TRNS,        KC_TRNS,

--- a/layouts/community/ergodox/zweihander-macos/readme.markdown
+++ b/layouts/community/ergodox/zweihander-macos/readme.markdown
@@ -71,6 +71,10 @@ If you’re on the second layer, pressing `v` will send the string `"\n- "`, not
 
 F16, accessed by holding ; and pressing the ' key next to it, is intended for Siri.
 
+## use the fn/🌐︎︎︎ key
+
+A thumb key is bound to Caps Lock. You are not expected to use this for Caps Lock. You would probably be happier going into System Settings, opening the “Customize modifier keys” part of it, and having Caps Lock work as the fn key. macOS is convinced that Ergodoxen EZ have fn keys, so you might as well have one in a place that lends itself tolerably well to keyboard shortcuts.
+
 ## use it with an iPad
 
 This layout overrides `USB_MAX_POWER_CONSUMPTION` to turn it down to 100 mA instead of the default of 500 mA. This is not what you want if your Ergodox EZ has the Shine or Glow lights, but good if you want to be able to plug it into your iPad’s lightning port with a USB adapter. The indicator lights that tell you what layer you’re on are _not_ Shine or Glow lights.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This updates the Zweihander layout for the Ergodox EZ:

- changes the power and scroll-lock keys' names to currently-supported versions
- replaces the `'` key on the left-hand thumb with a caps-lock key (intended to be used as an `fn` key)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* (none)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
