### PR TITLE
Allow a larger int for the idle timeout for urbanvanilla keymap

### DIFF
--- a/keyboards/massdrop/alt/keymaps/urbanvanilla/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/urbanvanilla/keymap.c
@@ -49,7 +49,7 @@ uint8_t currentWPM;
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 static uint32_t key_timer;
-idle_timer = timer_read();
+idle_timer = timer_read32();
 
 
     switch (keycode) {
@@ -146,7 +146,7 @@ idle_timer = timer_read();
 
 void matrix_scan_user(void) {
 //custom idle rbg switch off function
-    if (timer_elapsed(idle_timer) > IDLE_TIMER_DURATION) {
+    if (timer_elapsed32(idle_timer) > IDLE_TIMER_DURATION) {
         idle_timer = 0;
         timer_clear();
         rgbkeyIdle = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Existing code used a uint32_t for the idle timer, but the comparisons were done with timer_read and timer_elapsed so actual comparison was on uint16_t.  This meant the idle timer could not be more than 65535 milliseconds, or just over 1 minute.

Switched the comparisons to timer_read32 and timer_elapsed32 so that the largest possible timeout is 4,294,967,295ms, or 136 years.  While that would be pretty ridiculous, at least this way more reasonable longer timeouts like 15 minutes or an hour will work.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
