### PR TITLE
changed the undefined ON and OFF parameters to the above defined constant

### DIFF
--- a/docs/feature_midi.md
+++ b/docs/feature_midi.md
@@ -60,9 +60,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case MIDI_CC80:
             if (record->event.pressed) {
-                midi_send_cc(&midi_device, midi_config.channel, 80, ON);
+                midi_send_cc(&midi_device, midi_config.channel, 80, MIDI_CC_ON);
             } else {
-                midi_send_cc(&midi_device, midi_config.channel, 80, OFF);
+                midi_send_cc(&midi_device, midi_config.channel, 80, MIDI_CC_OFF);
             }
             return true;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

the compiler returns an undefined error when using the midi_send_cc() function, I think the docs meant to use the declared constant defined as MIDI_CC_OFF and MIDI_CC_ON which have a defined value that corresponds the one meant to be put as parameters.

 
```
./keyboards/ergodox_ez/keymaps/soggywhale/keymap.c:158:69: error: 'ON' undeclared (first use in this function); did you mean 'ONE'?
                 midi_send_cc(&midi_device, midi_config.channel, 80, ON);```
```
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
