### PR TITLE
[Bug] Fix non-functional S3 wakeup / resume from suspense 

### DIFF
--- a/platforms/chibios/boards/GENERIC_PROMICRO_RP2040/configs/mcuconf.h
+++ b/platforms/chibios/boards/GENERIC_PROMICRO_RP2040/configs/mcuconf.h
@@ -106,7 +106,6 @@
 #define RP_USB_USE_USBD0                    TRUE
 #define RP_USB_FORCE_VBUS_DETECT            TRUE
 #define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
-#define RP_USB_USE_SOF_INTR                 TRUE
 #define RP_USB_USE_ERROR_DATA_SEQ_INTR      FALSE
 
 #endif /* MCUCONF_H */

--- a/platforms/chibios/boards/GENERIC_RP_RP2040/configs/mcuconf.h
+++ b/platforms/chibios/boards/GENERIC_RP_RP2040/configs/mcuconf.h
@@ -106,7 +106,6 @@
 #define RP_USB_USE_USBD0                    TRUE
 #define RP_USB_FORCE_VBUS_DETECT            TRUE
 #define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
-#define RP_USB_USE_SOF_INTR                 TRUE
 #define RP_USB_USE_ERROR_DATA_SEQ_INTR      FALSE
 
 #endif /* MCUCONF_H */

--- a/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
@@ -80,7 +80,3 @@ void __early_init(void) {
 void boardInit(void) {
 
 }
-
-void restart_usb_driver(USBDriver *usbp) {
-  // Do nothing. Restarting the USB driver on these boards breaks it.
-}

--- a/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
@@ -80,7 +80,3 @@ void __early_init(void) {
 void boardInit(void) {
 
 }
-
-void restart_usb_driver(USBDriver *usbp) {
-  // Do nothing. Restarting the USB driver on these boards breaks it.
-}

--- a/platforms/chibios/boards/IC_TEENSY_3_1/board/board.c
+++ b/platforms/chibios/boards/IC_TEENSY_3_1/board/board.c
@@ -144,8 +144,3 @@ void __early_init(void) {
  * @todo    Add your board-specific code, if any.
  */
 void boardInit(void) {}
-
-
-void restart_usb_driver(USBDriver *usbp) {
-    // Do nothing. Restarting the USB driver on these boards breaks it.
-}

--- a/platforms/chibios/boards/PJRC_TEENSY_3_5/board/board.mk
+++ b/platforms/chibios/boards/PJRC_TEENSY_3_5/board/board.mk
@@ -1,7 +1,7 @@
 include $(CHIBIOS_CONTRIB)/os/hal/boards/PJRC_TEENSY_3_5/board.mk
 
 # List of all the board related files.
-BOARDSRC += $(BOARD_PATH)/board/extra.c
+BOARDSRC +=
 
 # Required include directories
 BOARDINC += $(BOARD_PATH)/board

--- a/platforms/chibios/boards/PJRC_TEENSY_3_5/board/extra.c
+++ b/platforms/chibios/boards/PJRC_TEENSY_3_5/board/extra.c
@@ -1,7 +1,0 @@
-#include <hal.h>
-
-void restart_usb_driver(USBDriver *usbp) {
-    // Do nothing. Restarting the USB driver on the Teensy 3.6 breaks it,
-    // resulting in a keyboard which can wake up a PC from Suspend-to-RAM, but
-    // does not actually produce any keypresses until you un-plug and re-plug.
-}

--- a/platforms/chibios/boards/PJRC_TEENSY_3_6/board/board.mk
+++ b/platforms/chibios/boards/PJRC_TEENSY_3_6/board/board.mk
@@ -1,7 +1,7 @@
 include $(CHIBIOS_CONTRIB)/os/hal/boards/PJRC_TEENSY_3_6/board.mk
 
 # List of all the board related files.
-BOARDSRC += $(BOARD_PATH)/board/extra.c
+BOARDSRC +=
 
 # Required include directories
 BOARDINC += $(BOARD_PATH)/board

--- a/platforms/chibios/boards/PJRC_TEENSY_3_6/board/extra.c
+++ b/platforms/chibios/boards/PJRC_TEENSY_3_6/board/extra.c
@@ -1,7 +1,0 @@
-#include <hal.h>
-
-void restart_usb_driver(USBDriver *usbp) {
-    // Do nothing. Restarting the USB driver on the Teensy 3.6 breaks it,
-    // resulting in a keyboard which can wake up a PC from Suspend-to-RAM, but
-    // does not actually produce any keypresses until you un-plug and re-plug.
-}

--- a/platforms/chibios/boards/QMK_PM2040/configs/mcuconf.h
+++ b/platforms/chibios/boards/QMK_PM2040/configs/mcuconf.h
@@ -106,7 +106,6 @@
 #define RP_USB_USE_USBD0                    TRUE
 #define RP_USB_FORCE_VBUS_DETECT            TRUE
 #define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
-#define RP_USB_USE_SOF_INTR                 TRUE
 #define RP_USB_USE_ERROR_DATA_SEQ_INTR      FALSE
 
 #endif /* MCUCONF_H */

--- a/platforms/chibios/suspend.c
+++ b/platforms/chibios/suspend.c
@@ -42,6 +42,7 @@ void suspend_wakeup_init(void) {
     clear_keys();
 #ifdef MOUSEKEY_ENABLE
     mousekey_clear();
+    mousekey_send();
 #endif /* MOUSEKEY_ENABLE */
 #ifdef PROGRAMMABLE_BUTTON_ENABLE
     programmable_button_clear();

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -858,7 +858,7 @@ void protocol_post_init(void) {
 void protocol_pre_task(void) {
 #if !defined(NO_USB_STARTUP_CHECK)
     if (USB_DeviceState == DEVICE_STATE_Suspended) {
-        print("[s]");
+        dprintln("suspending keyboard");
         while (USB_DeviceState == DEVICE_STATE_Suspended) {
             suspend_power_down();
             if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {


### PR DESCRIPTION
## Description

Waking a suspended host was previously broken for RP2040 and STM32 OTGv1 based keyboards on ChibiOS. Waking a host either didn't work at all or the host resumed operation but the keyboard was soft-bricked as it didn't recognized that the host was woken successfully.

The underlying cause was that the USB hal and low level USB drivers `USBv1` and `OTGv1` didn't recognized a resumed USB bus and therefore never signaled this to QMK's suspend/resume logic. Both drivers where fixed in `ChibiOS` and `ChibiOS-Contrib`. See:

* ChibiOS/ChibiOS@358678f9793ee11afd43ea467938be566140698d (STM32 OTGv1 LLD + HAL **already in `develop`**)
* ChibiOS/ChibiOS@e8413011051be737d33275b9cd443cdcf9044a1a (HAL **already in `develop`**)
* ChibiOS/ChibiOS-Contrib@e284aabd95ed57307dcf72dc94c163fbe23f4769 (RP2040 USBv1 LLD)

The former workaround by restarting the whole USB driver after sending a remote wakeup signal has been removed as it is not needed anymore and caused problems for other MCUs.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #19663 is fixed with this

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
