### PR TITLE
Make QP comms functions weak

### DIFF
--- a/drivers/painter/comms/qp_comms_spi.c
+++ b/drivers/painter/comms/qp_comms_spi.c
@@ -9,7 +9,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Base SPI support
 
-bool qp_comms_spi_init(painter_device_t device) {
+__attribute__((weak)) bool qp_comms_spi_init(painter_device_t device) {
     struct painter_driver_t *     driver       = (struct painter_driver_t *)device;
     struct qp_comms_spi_config_t *comms_config = (struct qp_comms_spi_config_t *)driver->comms_config;
 
@@ -23,14 +23,14 @@ bool qp_comms_spi_init(painter_device_t device) {
     return true;
 }
 
-bool qp_comms_spi_start(painter_device_t device) {
+__attribute__((weak)) bool qp_comms_spi_start(painter_device_t device) {
     struct painter_driver_t *     driver       = (struct painter_driver_t *)device;
     struct qp_comms_spi_config_t *comms_config = (struct qp_comms_spi_config_t *)driver->comms_config;
 
     return spi_start(comms_config->chip_select_pin, comms_config->lsb_first, comms_config->mode, comms_config->divisor);
 }
 
-uint32_t qp_comms_spi_send_data(painter_device_t device, const void *data, uint32_t byte_count) {
+__attribute__((weak)) uint32_t qp_comms_spi_send_data(painter_device_t device, const void *data, uint32_t byte_count) {
     uint32_t       bytes_remaining = byte_count;
     const uint8_t *p               = (const uint8_t *)data;
     while (bytes_remaining > 0) {
@@ -43,7 +43,7 @@ uint32_t qp_comms_spi_send_data(painter_device_t device, const void *data, uint3
     return byte_count - bytes_remaining;
 }
 
-void qp_comms_spi_stop(painter_device_t device) {
+__attribute__((weak)) void qp_comms_spi_stop(painter_device_t device) {
     struct painter_driver_t *     driver       = (struct painter_driver_t *)device;
     struct qp_comms_spi_config_t *comms_config = (struct qp_comms_spi_config_t *)driver->comms_config;
     spi_stop();
@@ -62,7 +62,7 @@ const struct painter_comms_vtable_t spi_comms_vtable = {
 
 #    ifdef QUANTUM_PAINTER_SPI_DC_RESET_ENABLE
 
-bool qp_comms_spi_dc_reset_init(painter_device_t device) {
+__attribute__((weak)) bool qp_comms_spi_dc_reset_init(painter_device_t device) {
     if (!qp_comms_spi_init(device)) {
         return false;
     }
@@ -88,21 +88,21 @@ bool qp_comms_spi_dc_reset_init(painter_device_t device) {
     return true;
 }
 
-uint32_t qp_comms_spi_dc_reset_send_data(painter_device_t device, const void *data, uint32_t byte_count) {
+__attribute__((weak)) uint32_t qp_comms_spi_dc_reset_send_data(painter_device_t device, const void *data, uint32_t byte_count) {
     struct painter_driver_t *              driver       = (struct painter_driver_t *)device;
     struct qp_comms_spi_dc_reset_config_t *comms_config = (struct qp_comms_spi_dc_reset_config_t *)driver->comms_config;
     writePinHigh(comms_config->dc_pin);
     return qp_comms_spi_send_data(device, data, byte_count);
 }
 
-void qp_comms_spi_dc_reset_send_command(painter_device_t device, uint8_t cmd) {
+__attribute__((weak)) void qp_comms_spi_dc_reset_send_command(painter_device_t device, uint8_t cmd) {
     struct painter_driver_t *              driver       = (struct painter_driver_t *)device;
     struct qp_comms_spi_dc_reset_config_t *comms_config = (struct qp_comms_spi_dc_reset_config_t *)driver->comms_config;
     writePinLow(comms_config->dc_pin);
     spi_write(cmd);
 }
 
-void qp_comms_spi_dc_reset_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
+__attribute__((weak)) void qp_comms_spi_dc_reset_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
     for (size_t i = 0; i < sequence_len;) {
         uint8_t command   = sequence[i];
         uint8_t delay     = sequence[i + 1];


### PR DESCRIPTION
## Description

As per title, add ability to override the implementation.
This doesn't change the "core" code at `quantum/painter/qp_comms.c` (which calls the functions on the `vtable`) but the specific `vtable`'s functions at `drivers` (so far, there's only SPI).
Such change should not affect (break) existing code, but would make things easier to customize.

The idea for this comes from custom code i've wrote to drive control signals (DC/CS/RST) with SIPO shift registers instead of GPIOs, to reduce the amount of used pins.
My current code is messy and uses an abstraction function which changes at compile time based on the SIPO feature being enabled or not, can be seen at [my fork](https://github.com/elpekenin/qmk_firmware/blob/pekelop/drivers/painter/comms/qp_comms_spi.h#L9-L33) (this also needed a customized `spi_master.c` to support multiple drivers, a bus used for displays and a second one for registers)
This would be even better/easier with an abstraction layer over how pins are controlled (real vs SIPO virtual pins), but making functions overridable is a good improvement for now.

## Types of Changes

- [X] Core
- [ ] Bugfix
- [X] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
