### PR TITLE
Remove `config.h` include from quantum files

### DIFF
--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -19,7 +19,6 @@
 
 #include "led_matrix.h"
 #include "progmem.h"
-#include "info_config.h"
 #include "eeprom.h"
 #include <string.h>
 #include <math.h>

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -19,7 +19,7 @@
 
 #include "led_matrix.h"
 #include "progmem.h"
-#include "config.h"
+#include "info_config.h"
 #include "eeprom.h"
 #include <string.h>
 #include <math.h>

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -18,7 +18,6 @@
 
 #include "rgb_matrix.h"
 #include "progmem.h"
-#include "info_config.h"
 #include "eeprom.h"
 #include <string.h>
 #include <math.h>

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -18,7 +18,7 @@
 
 #include "rgb_matrix.h"
 #include "progmem.h"
-#include "config.h"
+#include "info_config.h"
 #include "eeprom.h"
 #include <string.h>
 #include <math.h>

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -16,7 +16,6 @@
 #include "split_util.h"
 #include "matrix.h"
 #include "keyboard.h"
-#include "info_config.h"
 #include "timer.h"
 #include "transport.h"
 #include "quantum.h"

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -16,7 +16,7 @@
 #include "split_util.h"
 #include "matrix.h"
 #include "keyboard.h"
-#include "config.h"
+#include "info_config.h"
 #include "timer.h"
 #include "transport.h"
 #include "quantum.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Title. As many data driven keyboards omit a traditional `config.h` file.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core

## Issues Fixed or Closed by This PR

tz ci
```
Compiling: quantum/split_common/split_util.c                                                       quantum/split_common/split_util.c:19:10: fatal error: config.h: No such file or directory                                                           
 #include "config.h"                                                                                                                                                                                                                                   
          ^~~~~~~~~~
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
