### PR TITLE
[Bug] Fix tri layer compiler issue if NO_ACTION_LAYER is defined

### DIFF
--- a/quantum/action_layer.c
+++ b/quantum/action_layer.c
@@ -350,6 +350,7 @@ action_t layer_switch_get_action(keypos_t key) {
     return action_for_key(layer_switch_get_layer(key), key);
 }
 
+#ifndef NO_ACTION_LAYER
 layer_state_t update_tri_layer_state(layer_state_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
     layer_state_t mask12 = ((layer_state_t)1 << layer1) | ((layer_state_t)1 << layer2);
     layer_state_t mask3  = (layer_state_t)1 << layer3;
@@ -359,3 +360,4 @@ layer_state_t update_tri_layer_state(layer_state_t state, uint8_t layer1, uint8_
 void update_tri_layer(uint8_t layer1, uint8_t layer2, uint8_t layer3) {
     layer_state_set(update_tri_layer_state(layer_state, layer1, layer2, layer3));
 }
+#endif


### PR DESCRIPTION
## Description

Forgot to check compilation if `NO_ACTION_LAYER` is defined.  Errors currently, due to multiple definitions.  This fixes it by wrapping the functions in preprocessors, properly.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
