### PR TITLE
[Keyboard] Add LED startup sequence to Lumberjack

### DIFF
--- a/keyboards/peej/lumberjack/keymaps/via/keymap.c
+++ b/keyboards/peej/lumberjack/keymaps/via/keymap.c
@@ -48,3 +48,25 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 )
 
 };
+
+void keyboard_pre_init_user() {
+    writePin(LED1, true);
+    writePin(LED2, true);
+}
+
+void keyboard_post_init_user() {
+    writePin(LED1, false);
+    writePin(LED2, false);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    writePin(LED1, record->event.pressed);
+
+    return true;
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    writePin(LED2, state);
+
+    return state;
+}

--- a/keyboards/peej/lumberjack/lumberjack.c
+++ b/keyboards/peej/lumberjack/lumberjack.c
@@ -16,14 +16,9 @@
 
 #include "lumberjack.h"
 
-bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-    writePin(LED1, record->event.pressed);
+void keyboard_pre_init_kb() {
+    setPinOutput(LED1);
+    setPinOutput(LED2);
 
-    return process_record_user(keycode, record);
-}
-
-layer_state_t layer_state_set_kb(layer_state_t state) {
-    writePin(LED2, state);
-
-    return layer_state_set_user(state);
+    keyboard_pre_init_user();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When building the PCB, some people have issues knowing if the keyboard has power, so this PR adds a LED startup sequence to make the LEDs flash on powerup.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
