### PR TITLE
Fix Layer Mod mishandling of right-handed mods, a mixup of 5-bit vs. 8-bit mods representation.

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -128,7 +128,7 @@ action_t action_for_keycode(uint16_t keycode) {
         case QK_LAYER_MOD ... QK_LAYER_MOD_MAX:
             mod          = mod_config(QK_LAYER_MOD_GET_MODS(keycode));
             action_layer = QK_LAYER_MOD_GET_LAYER(keycode);
-            action.code  = ACTION_LAYER_MODS(action_layer, mod);
+            action.code  = ACTION_LAYER_MODS(action_layer, (mod & 0x10) ? mod << 4 : mod);
             break;
 #endif
 #ifndef NO_ACTION_TAPPING


### PR DESCRIPTION
Layer mod has a mixup between 5-bit vs. 8-bit mods representation, and this PR fixes that.

## Description

Layer mod `LM(layer, mod)` has a bug with right-handed mods. The keycode encodes the mods in a 5-bit format, it would seem intending the same 5-bit encoding as used in `LT` and `OSM` keys ([code link](https://github.com/qmk/qmk_firmware/blob/e922b46a866aec40f34d9e0dfcb15932adeb0563/quantum/quantum_keycodes.h#L101-L104)):

```c
// L-ayer M-od: Momentary switch layer with modifiers active - 16 layer max
#define LM(layer, mod) (QK_LAYER_MOD | (((layer)&0xF) << 5) | ((mod)&0x1F))
#define QK_LAYER_MOD_GET_MODS(kc) ((kc)&0x1F)
```

However the existing keymap_common code handles `LM` mods as if they were in 8-bit format. For instance, the key `LM(MOD_RALT)` incorrectly holds Left Alt + Right Ctrl, when it should hold Right Alt.

This commit adds conversion from 5-bit to 8-bit format at the appropriate time, concisely done with `(mod & 0x10) ? mod << 4 : mod`. A couple unit test cases are added, which would fail before this commit and pass after.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
