### PR TITLE
[Bug] Fix compilation error when defining QUICK_TAP_TERM_PER_KEY

### DIFF
--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -122,7 +122,7 @@ void action_tapping_process(keyrecord_t record) {
  * readable. The conditional definition of tapping_keycode and all the
  * conditional uses of it are hidden inside macros named TAP_...
  */
-#    if (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || defined(PERMISSIVE_HOLD_PER_KEY) || defined(QUICK_TAP_TERM_PER_KEY) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
+#    if (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || defined(PERMISSIVE_HOLD_PER_KEY) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
 #        define TAP_DEFINE_KEYCODE uint16_t tapping_keycode = get_record_keycode(&tapping_key, false)
 #    else
 #        define TAP_DEFINE_KEYCODE

--- a/tests/tap_hold_configurations/quick_tap/config.h
+++ b/tests/tap_hold_configurations/quick_tap/config.h
@@ -19,3 +19,4 @@
 #include "test_common.h"
 
 #define QUICK_TAP_TERM 100
+#define QUICK_TAP_TERM_PER_KEY

--- a/tests/tap_hold_configurations/quick_tap/config.h
+++ b/tests/tap_hold_configurations/quick_tap/config.h
@@ -19,4 +19,7 @@
 #include "test_common.h"
 
 #define QUICK_TAP_TERM 100
+// Although a seemingly superfluous addition since the default per-key function behaves
+// no differently from defining a single global QUICK_TAP_TERM, this has been useful
+// to catch compilation errors and prevent regressions in the future; see PR #19893.
 #define QUICK_TAP_TERM_PER_KEY


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Defining only `QUICK_TAP_TERM_PER_KEY` creates the variable `tapping_keycode` but if that is the only option enabled, the `tapping_keycode` variable is unused and thus throws a compilation error.
```c
#    if (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)) || defined(PERMISSIVE_HOLD_PER_KEY) || || defined(QUICK_TAP_TERM_PER_KEY) || defined(HOLD_ON_OTHER_KEY_PRESS_PER_KEY)
#        define TAP_DEFINE_KEYCODE uint16_t tapping_keycode = get_record_keycode(&tapping_key, false)
#    else
#        define TAP_DEFINE_KEYCODE
#    endif
```

I removed the define from the `if` and added `#define QUICK_TAP_TERM_PER_KEY` in the config.h file of the unit test so that it catches the error.

Bug discovered by @XeroOl
Related discussion with @sigprof and @filterpaper  on Discord: https://discord.com/channels/440868230475677696/869812721552601088/1077140624643477534

PS: Should I add a comment to the PER_KEY define in the unit test config file linking to this PR? At face value, I can imagine some people in the future thinking it is totally useless.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
