### PR TITLE
onekey: Fix console output on AVR

### DIFF
--- a/keyboards/handwired/onekey/keymaps/adc/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/adc/keymap.c
@@ -19,7 +19,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 char buffer[50];
                 sprintf(buffer, "ADC:%u\n", val);
 #ifdef CONSOLE_ENABLE
-                    printf(buffer);
+                    uprintf("%s", buffer);
 #else
                     send_string(buffer);
 #endif

--- a/keyboards/handwired/onekey/keymaps/hardware_id/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/hardware_id/keymap.c
@@ -17,7 +17,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 char buffer[100];
                 sprintf(buffer, "ID:%lu:%lu:%lu:%lu\n", id.data[0], id.data[1], id.data[2], id.data[3]);
 #ifdef CONSOLE_ENABLE
-                    printf(buffer);
+                    uprintf("%s", buffer);
 #else
                     send_string(buffer);
 #endif


### PR DESCRIPTION
## Description

Plain `printf()` does not work for console output on AVR (the `xprintf` code does not replace `printf()`, and QMK does not set up `stdout` for the avr-libc `printf` implementation).  Use `uprintf()` instead, which should work for all supported platforms.

Note that `uprintf()` requires the format string to be a constant (on AVR it uses `PSTR()` internally to put the format string into PROGMEM), therefore `uprintf(buffer)` cannot be used (and it would be wrong anyway if the buffer has some chance to contain any format characters).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* The `adc` and `hardware_id` keymaps for `handwired/onekey` boards did not output anything to the debug console on AVR-based boards (e.g., `handwired/onekey/promicro`).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
