### PR TITLE
Strip whitespace from CONVERT_TO variables

### DIFF
--- a/builddefs/converters.mk
+++ b/builddefs/converters.mk
@@ -8,6 +8,9 @@ endif
 # TODO: opt in rather than assume everything uses a pro micro
 PIN_COMPATIBLE ?= promicro
 ifneq ($(CONVERT_TO),)
+    # Remove whitespace from any rule.mk provided vars - env cannot have whitespace anyway
+    CONVERT_TO:=$(strip $(CONVERT_TO))
+
     # stash so we can overwrite env provided vars if needed
     ACTIVE_CONVERTER=$(CONVERT_TO)
 
@@ -23,13 +26,13 @@ ifneq ($(CONVERT_TO),)
     TARGET := $(TARGET)_$(CONVERT_TO)
 
     # Configure any defaults
-    OPT_DEFS += -DCONVERT_TO_$(strip $(shell echo $(CONVERT_TO) | tr '[:lower:]' '[:upper:]'))
-    OPT_DEFS += -DCONVERTER_TARGET=\"$(strip $(CONVERT_TO))\"
+    OPT_DEFS += -DCONVERT_TO_$(shell echo $(CONVERT_TO) | tr '[:lower:]' '[:upper:]')
+    OPT_DEFS += -DCONVERTER_TARGET=\"$(CONVERT_TO)\"
     OPT_DEFS += -DCONVERTER_ENABLED
     VPATH += $(CONVERTER)
 
     # Configure for "alias" - worst case it produces an idential define
-    OPT_DEFS += -DCONVERT_TO_$(strip $(shell echo $(ACTIVE_CONVERTER) | tr '[:lower:]' '[:upper:]'))
+    OPT_DEFS += -DCONVERT_TO_$(shell echo $(ACTIVE_CONVERTER) | tr '[:lower:]' '[:upper:]')
 
     # Finally run any converter specific logic
     include $(CONVERTER)/converter.mk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`CONVERT_TO` with trailing whitespace currently produces the following error:

```
make[1]: *** platforms/chibios/converters/promicro_to_kb2040: Is a directory.  Stop.
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
