### PR TITLE
Check all rows have the correct number of columns when parsing `g_led_config`

### DIFF
--- a/lib/python/qmk/c_parse.py
+++ b/lib/python/qmk/c_parse.py
@@ -211,10 +211,13 @@ def _coerce_led_token(_type, value):
         return value_map[value]
 
 
-def _validate_led_config(matrix, matrix_rows, matrix_indexes, position, position_raw, flags):
+def _validate_led_config(matrix, matrix_rows, matrix_cols, matrix_indexes, position, position_raw, flags):
     # TODO: Improve crude parsing/validation
     if len(matrix) != matrix_rows and len(matrix) != (matrix_rows / 2):
         raise ValueError("Unable to parse g_led_config matrix data")
+    for index, row in enumerate(matrix):
+        if len(row) != matrix_cols:
+            raise ValueError(f"Number of columns in row {index} ({len(row)}) does not match matrix ({matrix_cols})")
     if len(position) != len(flags):
         raise ValueError(f"Number of g_led_config physical positions ({len(position)}) does not match number of flags ({len(flags)})")
     if len(matrix_indexes) and (max(matrix_indexes) >= len(flags)):
@@ -228,13 +231,16 @@ def _validate_led_config(matrix, matrix_rows, matrix_indexes, position, position
 def _parse_led_config(file, matrix_cols, matrix_rows):
     """Return any 'raw' led/rgb matrix config
     """
-    matrix_raw = []
+    matrix = []
     position_raw = []
     flags = []
 
     found_led_config = False
     bracket_count = 0
     section = 0
+    current_row_index = 0
+    current_row = []
+
     for _type, value in lex(_preprocess_c_file(file), CLexer()):
         # Assume g_led_config..stuff..;
         if value == 'g_led_config':
@@ -248,12 +254,16 @@ def _parse_led_config(file, matrix_cols, matrix_rows):
                 if bracket_count == 2:
                     section += 1
             elif value == '}':
+                if section == 1 and bracket_count == 3:
+                    matrix.append(current_row)
+                    current_row = []
+                    current_row_index += 1
                 bracket_count -= 1
             else:
                 # Assume any non whitespace value here is important enough to stash
                 if _type in [Token.Literal.Number.Integer, Token.Literal.Number.Float, Token.Literal.Number.Hex, Token.Name]:
                     if section == 1 and bracket_count == 3:
-                        matrix_raw.append(_coerce_led_token(_type, value))
+                        current_row.append(_coerce_led_token(_type, value))
                     if section == 2 and bracket_count == 3:
                         position_raw.append(_coerce_led_token(_type, value))
                     if section == 3 and bracket_count == 2:
@@ -263,16 +273,15 @@ def _parse_led_config(file, matrix_cols, matrix_rows):
                     return None
 
     # Slightly better intrim format
-    matrix = list(_get_chunks(matrix_raw, matrix_cols))
     position = list(_get_chunks(position_raw, 2))
-    matrix_indexes = list(filter(lambda x: x is not None, matrix_raw))
+    matrix_indexes = list(filter(lambda x: x is not None, sum(matrix, [])))
 
     # If we have not found anything - bail with no error
     if not section:
         return None
 
     # Throw any validation errors
-    _validate_led_config(matrix, matrix_rows, matrix_indexes, position, position_raw, flags)
+    _validate_led_config(matrix, matrix_rows, matrix_cols, matrix_indexes, position, position_raw, flags)
 
     return (matrix, position, flags)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This area of the code naively assumes that a keyboard's `g_led_config.matrix_co` is the same shape as the switch matrix, as it gathers all the LED indexes and chunks them up by the row count. The result is that if one row is missing an element (not the same as having `NO_LED` set), it ends up parsing the matrix-to-LED-index mappings as follows:
```
...
{  3,  2,  1 },
{  7,  6,  5,  4 },
{ 11, 10,  9,  8 }
{ 15, 14, 13, 12 }
...

row 0: (3, 2, 1, 7)
row 1: (6, 5, 4, 11)
row 2: (10, 9, 8, 15)
row 3: (14, 13, 12)
```

Instead, we keep track of the current row using the same bracket-counting system and only add a row once it is "completed". Now we can validate the dimensions much better.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
