### PR TITLE
remove non-existent method from ploopy documentation

### DIFF
--- a/keyboards/ploopyco/trackball/readme.md
+++ b/keyboards/ploopyco/trackball/readme.md
@@ -29,17 +29,15 @@ The PCB should indicate which revision this is.
 
 While the defaults are designed so that it can be plugged in and used right away, there are a number of things that you may want to change.  Such as adding DPI control, or to use the ball to scroll while holding a button.   To allow for this sort of control, there is a callback for both the scroll wheel and the mouse sensor. 
 
-The default behavior for this is:
 
 ```c
-void process_wheel_user(report_mouse_t* mouse_report, int16_t h, int16_t v) {
-    mouse_report->h = h;
-    mouse_report->v = v;
-}
-
-void process_mouse_user(report_mouse_t* mouse_report, int16_t x, int16_t y) {
-    mouse_report->x = x;
-    mouse_report->y = y;
+report_mouse_t pointing_device_task_user(report_mouse_t mouse_report){
+   // executed each time step as the mouse position is updated
+   ... = mouse_report.x // int8_t x translation of the cursor
+   ... = mouse_report.y // int8_t y translation of the cursor
+   ... = mouse_report.h // int8_t horizontal scroll distance
+   ... = mouse_report.v // int8_t vertical scroll distance
+   return mouse_report;
 }
 ```
 

--- a/keyboards/ploopyco/trackball/readme.md
+++ b/keyboards/ploopyco/trackball/readme.md
@@ -32,12 +32,12 @@ While the defaults are designed so that it can be plugged in and used right away
 
 ```c
 report_mouse_t pointing_device_task_user(report_mouse_t mouse_report){
-   // executed each time step as the mouse position is updated
-   ... = mouse_report.x // int8_t x translation of the cursor
-   ... = mouse_report.y // int8_t y translation of the cursor
-   ... = mouse_report.h // int8_t horizontal scroll distance
-   ... = mouse_report.v // int8_t vertical scroll distance
-   return mouse_report;
+    // executed each time step as the mouse position is updated
+    ... = mouse_report.x // int8_t x translation of the cursor
+    ... = mouse_report.y // int8_t y translation of the cursor
+    ... = mouse_report.h // int8_t horizontal scroll distance
+    ... = mouse_report.v // int8_t vertical scroll distance
+    return mouse_report;
 }
 ```
 

--- a/keyboards/ploopyco/trackball/readme.md
+++ b/keyboards/ploopyco/trackball/readme.md
@@ -32,14 +32,13 @@ While the defaults are designed so that it can be plugged in and used right away
 
 ```c
 report_mouse_t pointing_device_task_user(report_mouse_t mouse_report){
-    // executed each time step as the mouse position is updated
-    ... = mouse_report.x // int8_t x translation of the cursor
-    ... = mouse_report.y // int8_t y translation of the cursor
-    ... = mouse_report.h // int8_t horizontal scroll distance
-    ... = mouse_report.v // int8_t vertical scroll distance
+    // executed each time the sensor is updated
+    // mouse_report.<attribute> - can be used to access indivdual mouse attributes
     return mouse_report;
 }
 ```
+
+More information on `report_mouse_t` may be found [here](https://docs.qmk.fm/#/feature_pointing_device?id=manipulating-mouse-reports).
 
 This should allow you to more heavily customize the behavior. 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fix the Ploopy trackball documentation so that the non-existant methods `process_mouse_user` and `process_wheel_user` are no longer referenced.  Instead, I added documentation for a similar method `pointing_device_task_user`.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
