### PR TITLE
[Bugfix + Refactor] `qmk painter-convert-graphics`

### DIFF
--- a/lib/python/qmk/painter.py
+++ b/lib/python/qmk/painter.py
@@ -158,7 +158,7 @@ def convert_requested_format(im, format):
     ncolors = format["num_colors"]
     image_format = format["image_format"]
 
-    ## Check if ncolors is valid
+    # -- Check if ncolors is valid
     # Formats accepting several options
     if image_format in ['IMAGE_FORMAT_GRAYSCALE', 'IMAGE_FORMAT_PALETTE']:
         valid = [2, 4, 8, 16, 256]

--- a/lib/python/qmk/painter.py
+++ b/lib/python/qmk/painter.py
@@ -170,12 +170,11 @@ def convert_requested_format(im, format):
         for _, fmt in valid_formats.items():
             if fmt["image_format"] == image_format:
                 # has to be an iterable, to use `in`
-                valid = [ fmt["num_colors"] ]
+                valid = [fmt["num_colors"]]
                 break
 
     if ncolors not in valid:
         raise ValueError(f"Number of colors must be {' '.join(valid)}.")
-
 
     # Work out where we're getting the bytes from
     if image_format == 'IMAGE_FORMAT_GRAYSCALE':

--- a/lib/python/qmk/painter.py
+++ b/lib/python/qmk/painter.py
@@ -171,6 +171,7 @@ def convert_requested_format(im, format):
             if fmt["image_format"] == image_format:
                 # has to be an iterable, to use `in`
                 valid = [ fmt["num_colors"] ]
+                break
 
     if ncolors not in valid:
         raise ValueError(f"Number of colors must be {' '.join(valid)}.")

--- a/lib/python/qmk/painter.py
+++ b/lib/python/qmk/painter.py
@@ -173,7 +173,7 @@ def convert_requested_format(im, format):
                 break
 
     if ncolors not in valid:
-        raise ValueError(f"Number of colors must be {' '.join(valid)}.")
+        raise ValueError(f"Number of colors must be: {', '.join(valid)}.")
 
     # Work out where we're getting the bytes from
     if image_format == 'IMAGE_FORMAT_GRAYSCALE':

--- a/lib/python/qmk/painter.py
+++ b/lib/python/qmk/painter.py
@@ -158,32 +158,35 @@ def convert_requested_format(im, format):
     ncolors = format["num_colors"]
     image_format = format["image_format"]
 
+    ## Check if ncolors is valid
+    # Formats accepting several options
+    if image_format in ['IMAGE_FORMAT_GRAYSCALE', 'IMAGE_FORMAT_PALETTE']:
+        # 'or' is a hack for text formatting
+        valid = [2, 4, 8, 16, 'or', 256]
+
+    # Formats expecting a particular number
+    else:
+        # Read number from specs dict, instead of hardcoding
+        for _, fmt in valid_formats.items():
+            if fmt["image_format"] == image_format:
+                # has to be an iterable, to use `in`
+                valid = [ fmt["num_colors"] ]
+
+    if ncolors not in valid:
+        raise ValueError(f"Number of colors must be {' '.join(valid)}.")
+
+
     # Work out where we're getting the bytes from
     if image_format == 'IMAGE_FORMAT_GRAYSCALE':
-        # Ensure we have a valid number of colors for the palette
-        if ncolors <= 0 or ncolors > 256 or (ncolors & (ncolors - 1) != 0):
-            raise ValueError("Number of colors must be 2, 4, 16, or 256.")
         # If mono, convert input to grayscale, then to RGB, then grab the raw bytes corresponding to the intensity of the red channel
         im = ImageOps.grayscale(im)
         im = im.convert("RGB")
     elif image_format == 'IMAGE_FORMAT_PALETTE':
-        # Ensure we have a valid number of colors for the palette
-        if ncolors <= 0 or ncolors > 256 or (ncolors & (ncolors - 1) != 0):
-            raise ValueError("Number of colors must be 2, 4, 16, or 256.")
         # If color, convert input to RGB, palettize based on the supplied number of colors, then get the raw palette bytes
         im = im.convert("RGB")
         im = im.convert("P", palette=Image.ADAPTIVE, colors=ncolors)
-    elif image_format == 'IMAGE_FORMAT_RGB565':
-        # Ensure we have a valid number of colors for the palette
-        if ncolors != 65536:
-            raise ValueError("Number of colors must be 65536.")
-        # If color, convert input to RGB
-        im = im.convert("RGB")
-    elif image_format == 'IMAGE_FORMAT_RGB888':
-        # Ensure we have a valid number of colors for the palette
-        if ncolors != 1677216:
-            raise ValueError("Number of colors must be 16777216.")
-        # If color, convert input to RGB
+    elif image_format in ['IMAGE_FORMAT_RGB565', 'IMAGE_FORMAT_RGB888']:
+        # Convert input to RGB
         im = im.convert("RGB")
 
     return im

--- a/lib/python/qmk/painter.py
+++ b/lib/python/qmk/painter.py
@@ -161,8 +161,7 @@ def convert_requested_format(im, format):
     ## Check if ncolors is valid
     # Formats accepting several options
     if image_format in ['IMAGE_FORMAT_GRAYSCALE', 'IMAGE_FORMAT_PALETTE']:
-        # 'or' is a hack for text formatting
-        valid = [2, 4, 8, 16, 'or', 256]
+        valid = [2, 4, 8, 16, 256]
 
     # Formats expecting a particular number
     else:


### PR DESCRIPTION
## Description

While updating to 20.0, and after [this Discord message](https://discord.com/channels/440868230475677696/568161140534935572/1080864486132555776) i've decided to try and draw a `rgb888` img on a `rgb565` display.

1) When trying to run the convert command, it error'ed out due to a typo on [here](https://github.com/qmk/qmk_firmware/blob/master/lib/python/qmk/painter.py#L184), the number in the check doesn't actually match the 888 colorspace size

2) QP indeed tries to draw the 24bpp image on the 16bpp which results in garbage, another PR for that coming soon (TM)

To avoid this, i've changed the code to perform a **dynamic** guard clause, i also took the chance to remove the obfuscated 2/4/8/12/256 check which used bitwise operations, and simply use the `in` operator.

NOTE: Using `_, fmt in items()` instead of `fmt in values()` just so we can easily add information about the target format in the exception message if we want to

Haven't tested in detail by trying to draw them, but all formats convert fine, so im pretty sure i haven't broke anything.

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist


- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
