### PR TITLE
[Bugfix] Check QGF's bpp against display's native_bits_per_pixel

### DIFF
--- a/quantum/painter/qp_draw_image.c
+++ b/quantum/painter/qp_draw_image.c
@@ -273,6 +273,11 @@ static bool qp_drawimage_recolor_impl(painter_device_t device, uint16_t x, uint1
         if (ret && output_state.pixel_write_pos > 0) {
             ret &= driver->driver_vtable->pixdata(device, qp_internal_global_pixdata_buffer, output_state.pixel_write_pos);
         }
+    }
+    else if (frame_info->bpp != driver->native_bits_per_pixel) {
+        // Prevent stuff like drawing 24bpp images on 16bpp displays
+        qp_dprintf("Image's bpp doesn't match the target display's native_bits_per_pixel\n");
+        return false;
     } else {
         // Set up the output state
         struct qp_internal_byte_output_state output_state = {.device = device, .byte_write_pos = 0, .max_bytes = qp_internal_num_pixels_in_buffer(device) * driver->native_bits_per_pixel / 8};

--- a/quantum/painter/qp_draw_image.c
+++ b/quantum/painter/qp_draw_image.c
@@ -273,8 +273,7 @@ static bool qp_drawimage_recolor_impl(painter_device_t device, uint16_t x, uint1
         if (ret && output_state.pixel_write_pos > 0) {
             ret &= driver->driver_vtable->pixdata(device, qp_internal_global_pixdata_buffer, output_state.pixel_write_pos);
         }
-    }
-    else if (frame_info->bpp != driver->native_bits_per_pixel) {
+    } else if (frame_info->bpp != driver->native_bits_per_pixel) {
         // Prevent stuff like drawing 24bpp images on 16bpp displays
         qp_dprintf("Image's bpp doesn't match the target display's native_bits_per_pixel\n");
         return false;


### PR DESCRIPTION
## Description

As already commented on [19994](https://github.com/qmk/qmk_firmware/pull/19994), there's an edge case
Scenario: Having a 16/24bpp QGF, and ofc, native color support enabled
Problem: On multi-device firmwares, you could also try and draw it on another display which doesn't use such format. 

\> Tested on ILI9163 and ILI9341 (RGB565) it indeed draws garbage with an RGB888 image

Thus i've added a small guard clause comparing the sizes before trying to draw. I guess the driver could store the ID of the data format (we can get bpp from it) for this kind of checks to be more useful.

Note: Im assuming the `<= 8` bpp formats are being converted to `hsv888` by the `qp_internal_decode_palette` function (didn't understand its code much), and then the `palette_convert` function on each driver can take care of converting into the format that each display wants. Support for such a conversion could also be added for these 2 new formats, to allow any target display to draw them instead of "locking" 16/24bpp to only be drawable on 16/24bpp displays.

Note2: Perhaps we should store info about the format, not just bpp on the drivers (ie this code would still allow a RGB565 drawing any other format which is also 16bpp)

## Types of Changes

- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
