### PR TITLE
Unbreak switchplate/southpaw_65 after #16277

### DIFF
--- a/keyboards/switchplate/southpaw_65/matrix.c
+++ b/keyboards/switchplate/southpaw_65/matrix.c
@@ -54,9 +54,9 @@ static uint32_t read_cols(void) {
     uint8_t state_1 = 0;
     uint8_t state_2 = 0;
     uint8_t state_3 = 0;
-    pca9555_readPins(IC2, PCA9555_PORT0, &state_1);
-    pca9555_readPins(IC2, PCA9555_PORT1, &state_2);
-    pca9555_readPins(IC1, PCA9555_PORT1, &state_3);
+    pca9555_readPins(IC1, PCA9555_PORT1, &state_1);
+    pca9555_readPins(IC2, PCA9555_PORT0, &state_2);
+    pca9555_readPins(IC2, PCA9555_PORT1, &state_3);
 
     uint32_t state = ((((uint32_t)state_3 & 0b01111111) << 12) | ((uint32_t)state_2 << 4) | (((uint32_t)state_1 & 0b11110000) >> 4));
     return ~state;


### PR DESCRIPTION
## Description

Apparently the changes done in #16277 swapped the values read from the PCA9555 expanders by mistake, which resulted in mixed up matrix columns. Fix the chip and register addresses to match the original code.

The broken change is [this](https://github.com/qmk/qmk_firmware/pull/16277/files#diff-921203cf4ee047ea3650fecd282a5709f92b83c88c0cbfbf3542f7f4fb60a63b); looks like the sequence of `pca9555_readPins()` calls was mistakenly copied from `xiudi/xd96`.

@elegantalchemist, are you able to compile the code locally to test these changes?  You can use the `switchplate-southpaw_65-fix-matrix` branch from `sigprof/qmk_firmware` directly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #20014

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
