### PR TITLE
Added support new variant of ST7735 TFT display panels

### DIFF
--- a/docs/quantum_painter.md
+++ b/docs/quantum_painter.md
@@ -352,6 +352,20 @@ Native color format rgb565 is compatible with ST7735
 
 !> Some ST7735 devices are known to have different drawing offsets -- despite being a 132x162 pixel display controller internally, some display panels are only 80x160, or smaller. These may require an offset to be applied; see `qp_set_viewport_offsets` above for information on how to override the offsets if they aren't correctly rendered.
 
+!> Due to many variant of 80x160 display panels, which they need some changes to work correctly.
+
+Turn on RGB color order if display panels is not render correctly (default is BGR color order):
+
+```c
+#define ST7735_RGB_PANEL TRUE
+```
+
+Turn on invert color if display panels is not render correctly (default is not using invert color):
+
+```c
+#define ST7735_INVERT_COLOR TRUE
+```
+
 #### ** ST7789 **
 
 Enabling support for the ST7789 in Quantum Painter is done by adding the following to `rules.mk`:

--- a/drivers/painter/st77xx/qp_st7735.c
+++ b/drivers/painter/st77xx/qp_st7735.c
@@ -1,6 +1,7 @@
 // Copyright 2021 Paul Cotter (@gr1mr3aver)
 // Copyright 2021 Nick Brassel (@tzarc)
 // Copyright 2022 David Hoelscher (@customMK)
+// Copyright 2023 Pham Duc (@HorrorTroll)
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "qp_internal.h"
@@ -23,6 +24,7 @@ tft_panel_dc_reset_painter_device_t st7735_drivers[ST7735_NUM_DEVICES] = {0};
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Automatic viewport offsets
 
+#if ST7735_RGB_PANEL
 #ifndef ST7735_NO_AUTOMATIC_OFFSETS
 static inline void st7735_automatic_viewport_offsets(painter_device_t device, painter_rotation_t rotation) {
     struct painter_driver_t *driver = (struct painter_driver_t *)device;
@@ -45,6 +47,30 @@ static inline void st7735_automatic_viewport_offsets(painter_device_t device, pa
     }
 }
 #endif // ST7735_NO_AUTOMATIC_OFFSETS
+#else
+#ifndef ST7735_NO_AUTOMATIC_OFFSETS
+static inline void st7735_automatic_viewport_offsets(painter_device_t device, painter_rotation_t rotation) {
+    struct painter_driver_t *driver = (struct painter_driver_t *)device;
+
+    // clang-format off
+    const struct {
+        uint16_t offset_x;
+        uint16_t offset_y;
+    } rotation_offsets_80x160[] = {
+        [QP_ROTATION_0]   = { .offset_x = 26, .offset_y =  1 },
+        [QP_ROTATION_90]  = { .offset_x =  1, .offset_y = 26 },
+        [QP_ROTATION_180] = { .offset_x = 26, .offset_y =  1 },
+        [QP_ROTATION_270] = { .offset_x =  1, .offset_y = 26 },
+    };
+    // clang-format on
+
+    if (driver->panel_width == 80 && driver->panel_height == 160) {
+        driver->offset_x = rotation_offsets_80x160[rotation].offset_x;
+        driver->offset_y = rotation_offsets_80x160[rotation].offset_y;
+    }
+}
+#endif // ST7735_NO_AUTOMATIC_OFFSETS
+#endif // ST7735_RGB_PANEL
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
@@ -55,8 +81,24 @@ __attribute__((weak)) bool qp_st7735_init(painter_device_t device, painter_rotat
         // Command,                 Delay, N, Data[N]
         ST77XX_CMD_RESET,            120,  0,
         ST77XX_CMD_SLEEP_OFF,          5,  0,
+        ST7735_SET_FRAME_RATE_CTL_1,   0,  3, 0x01, 0x2C, 0x2D,
+        ST7735_SET_FRAME_RATE_CTL_2,   0,  3, 0x01, 0x2C, 0x2D,
+        ST7735_SET_FRAME_RATE_CTL_3,   0,  6, 0x01, 0x2C, 0x2D, 0x01, 0x2C, 0x2D,
+        ST7735_SET_INVERSION_CTL,      0,  1, 0x07,
+        ST7735_SET_POWER_CTL_1,        0,  3, 0xA2, 0x02, 0x84,
+        ST7735_SET_POWER_CTL_2,        0,  1, 0xC5,
+        ST7735_SET_POWER_CTL_3,        0,  2, 0x0A, 0x00,
+        ST7735_SET_POWER_CTL_4,        0,  2, 0x8A, 0x2A,
+        ST7735_SET_POWER_CTL_5,        0,  2, 0x8A, 0xEE,
+        ST7735_SET_VCOM_CTL,           0,  1, 0x0E,
         ST77XX_SET_PIX_FMT,            0,  1, 0x55,
+#if ST7735_INVERT_COLOR
+        ST77XX_CMD_INVERT_ON,          0,  0,
+#else
         ST77XX_CMD_INVERT_OFF,         0,  0,
+#endif // ST7735_INVERT_COLOR
+        ST7735_SET_PGAMMA,             0, 16, 0x02, 0x1C, 0x07, 0x12, 0x37, 0x32, 0x29, 0x2D, 0x29, 0x25, 0x2B, 0x39, 0x00, 0x01, 0x03, 0x10,
+        ST7735_SET_NGAMMA,             0, 16, 0x03, 0x1D, 0x07, 0x06, 0x2E, 0x2C, 0x29, 0x2D, 0x2E, 0x2E, 0x37, 0x3F, 0x00, 0x00, 0x02, 0x10,
         ST77XX_CMD_NORMAL_ON,          0,  0,
         ST77XX_CMD_DISPLAY_ON,        20,  0
     };
@@ -64,12 +106,21 @@ __attribute__((weak)) bool qp_st7735_init(painter_device_t device, painter_rotat
     qp_comms_bulk_command_sequence(device, st7735_init_sequence, sizeof(st7735_init_sequence));
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
+#if ST7735_RGB_PANEL
     const uint8_t madctl[] = {
-        [QP_ROTATION_0]   = ST77XX_MADCTL_BGR,
-        [QP_ROTATION_90]  = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MX | ST77XX_MADCTL_MV,
-        [QP_ROTATION_180] = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MX | ST77XX_MADCTL_MY,
-        [QP_ROTATION_270] = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MV | ST77XX_MADCTL_MY,
+        [QP_ROTATION_0]   = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MY,
+        [QP_ROTATION_90]  = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MX | ST77XX_MADCTL_MV | ST77XX_MADCTL_MY,
+        [QP_ROTATION_180] = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MX,
+        [QP_ROTATION_270] = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MV,
     };
+#else
+    const uint8_t madctl[] = {
+        [QP_ROTATION_0]   = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MX | ST77XX_MADCTL_MY,
+        [QP_ROTATION_90]  = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MV | ST77XX_MADCTL_MY,
+        [QP_ROTATION_180] = ST77XX_MADCTL_BGR,
+        [QP_ROTATION_270] = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MX | ST77XX_MADCTL_MV,
+    };
+#endif // ST7735_RGB_PANEL
     qp_comms_command_databyte(device, ST77XX_SET_MADCTL, madctl[rotation]);
 
 #ifndef ST7735_NO_AUTOMATIC_VIEWPORT_OFFSETS

--- a/drivers/painter/st77xx/qp_st7735.h
+++ b/drivers/painter/st77xx/qp_st7735.h
@@ -1,6 +1,7 @@
 // Copyright 2021 Paul Cotter (@gr1mr3aver)
 // Copyright 2021 Nick Brassel (@tzarc)
 // Copyright 2022 David Hoelscher (@customMK)
+// Copyright 2023 Pham Duc (@HorrorTroll)
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
@@ -17,6 +18,22 @@
  *      Increasing this number allows for multiple displays to be used.
  */
 #    define ST7735_NUM_DEVICES 1
+#endif
+
+#ifndef ST7735_INVERT_COLOR
+/**
+ * @def This controls the invert color of ST7735 devices that Quantum Painter render on panel.
+ *      Default config is not inverted.
+ */
+#    define ST7735_INVERT_COLOR FALSE
+#endif
+
+#ifndef ST7735_RGB_PANEL
+/**
+ * @def This controls the color order of ST7735 devices that Quantum Painter render on panel.
+ *      Default config is BGR color order.
+ */
+#    define ST7735_RGB_PANEL FALSE
 #endif
 
 // Additional configuration options to be copied to your keyboard's config.h (don't change here):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Due to problem that ST7735 (80x160) have many variant of different specs. Which is not render correctly on panel using BGR color order and wrong other thing.

Could you please testing your TFT screen and see if there are any issues? @infinityis

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
