### PR TITLE
Ketch LGUI/LALT key transposed on Minivan layout

### DIFF
--- a/keyboards/trashman/ketch/ketch.h
+++ b/keyboards/trashman/ketch/ketch.h
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright 2021 Evan Sailer, Jetpacktuxedo, & QMK Firmware
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -32,7 +32,7 @@ SOFTWARE.
     { K0, K1, K2, K3, K4, K5, K6, K7 },\
     { K8, K9, K10, K11, K12, K13, K14, K15 },\
     { K16, K17, K18, K19, K20, K21, K22, K23 },\
-    { K24, KC_NO, K26, K27, K28, K29, KC_NO, K31 },\
+    { KC_NO, K24, K26, K27, K28, K29, KC_NO, K31 },\
     { K32, K33, K34, K35, K36, K37, K38, KC_NO },\
     { K39, K40, K41, K42, K43, K44, K45, KC_NO }\
 }


### PR DESCRIPTION
## Description

When soldering a Minivan layout to the Ketch (3 physical keys left of space bar).  The location of left ALT/GUI is transposed, and mapped to the location of the 4th key.  

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
