### PR TITLE
Fix OSMs getting stuck

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -446,7 +446,7 @@ void process_action(keyrecord_t *record, action_t action) {
                                 ac_dprintf("MODS_TAP: Toggling oneshot");
                                 register_mods(mods);
                                 del_oneshot_mods(mods);
-                                set_oneshot_locked_mods(mods | get_oneshot_locked_mods());
+                                add_oneshot_locked_mods(mods);
 #        endif
                             }
                         } else {

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -436,7 +436,7 @@ void process_action(keyrecord_t *record, action_t action) {
                         if (event.pressed) {
                             if (tap_count == 0) {
                                 ac_dprintf("MODS_TAP: Oneshot: 0\n");
-                                register_mods(mods | get_oneshot_mods());
+                                register_mods(mods);
                             } else if (tap_count == 1) {
                                 ac_dprintf("MODS_TAP: Oneshot: start\n");
                                 set_oneshot_mods(mods | get_oneshot_mods());
@@ -450,7 +450,6 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             if (tap_count == 0) {
-                                clear_oneshot_mods();
                                 unregister_mods(mods);
                             } else if (tap_count == 1) {
                                 // Retain Oneshot mods

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -444,19 +444,20 @@ void process_action(keyrecord_t *record, action_t action) {
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 ac_dprintf("MODS_TAP: Toggling oneshot");
                                 register_mods(mods);
-                                clear_oneshot_mods();
+                                del_oneshot_mods(mods);
                                 set_oneshot_locked_mods(mods | get_oneshot_locked_mods());
 #        endif
                             }
                         } else {
                             if (tap_count == 0) {
                                 unregister_mods(mods);
+                                del_oneshot_mods(mods);
                                 del_oneshot_locked_mods(mods);
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == 1 && (mods & get_mods())) {
                                 unregister_mods(mods);
+                                del_oneshot_mods(mods);
                                 del_oneshot_locked_mods(mods);
-                                clear_oneshot_mods();
 #        endif
                             }
                         }

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -451,16 +451,11 @@ void process_action(keyrecord_t *record, action_t action) {
                         } else {
                             if (tap_count == 0) {
                                 unregister_mods(mods);
-                            } else if (tap_count == 1) {
-                                // Retain Oneshot mods
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
-                                if (mods & get_mods()) {
-                                    unregister_mods(mods);
-                                    clear_oneshot_mods();
-                                    set_oneshot_locked_mods(~mods & get_oneshot_locked_mods());
-                                }
-                            } else if (tap_count == ONESHOT_TAP_TOGGLE) {
-                                // Toggle Oneshot Layer
+                            } else if (tap_count == 1 && (mods & get_mods())) {
+                                unregister_mods(mods);
+                                clear_oneshot_mods();
+                                set_oneshot_locked_mods(~mods & get_oneshot_locked_mods());
 #        endif
                             }
                         }

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -447,8 +447,6 @@ void process_action(keyrecord_t *record, action_t action) {
                                 clear_oneshot_mods();
                                 set_oneshot_locked_mods(mods | get_oneshot_locked_mods());
 #        endif
-                            } else {
-                                register_mods(mods | get_oneshot_mods());
                             }
                         } else {
                             if (tap_count == 0) {
@@ -465,9 +463,6 @@ void process_action(keyrecord_t *record, action_t action) {
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 // Toggle Oneshot Layer
 #        endif
-                            } else {
-                                unregister_mods(mods);
-                                clear_oneshot_mods();
                             }
                         }
                     }

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -451,11 +451,12 @@ void process_action(keyrecord_t *record, action_t action) {
                         } else {
                             if (tap_count == 0) {
                                 unregister_mods(mods);
+                                del_oneshot_locked_mods(mods);
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == 1 && (mods & get_mods())) {
                                 unregister_mods(mods);
+                                del_oneshot_locked_mods(mods);
                                 clear_oneshot_mods();
-                                set_oneshot_locked_mods(~mods & get_oneshot_locked_mods());
 #        endif
                             }
                         }

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -435,11 +435,12 @@ void process_action(keyrecord_t *record, action_t action) {
                     } else {
                         if (event.pressed) {
                             if (tap_count == 0) {
+                                // Not a tap, but a hold: register the held mod
                                 ac_dprintf("MODS_TAP: Oneshot: 0\n");
                                 register_mods(mods);
                             } else if (tap_count == 1) {
                                 ac_dprintf("MODS_TAP: Oneshot: start\n");
-                                set_oneshot_mods(mods | get_oneshot_mods());
+                                add_oneshot_mods(mods);
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 ac_dprintf("MODS_TAP: Toggling oneshot");
@@ -450,6 +451,7 @@ void process_action(keyrecord_t *record, action_t action) {
                             }
                         } else {
                             if (tap_count == 0) {
+                                // Release hold: unregister the held mod and its variants
                                 unregister_mods(mods);
                                 del_oneshot_mods(mods);
                                 del_oneshot_locked_mods(mods);

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -58,6 +58,12 @@ void clear_oneshot_locked_mods(void) {
         oneshot_locked_mods_changed_kb(oneshot_locked_mods);
     }
 }
+void del_oneshot_locked_mods(uint8_t mods) {
+    if (oneshot_locked_mods & mods) {
+        oneshot_locked_mods &= ~mods;
+        oneshot_locked_mods_changed_kb(oneshot_locked_mods);
+    }
+}
 #    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
 static uint16_t oneshot_time = 0;
 bool            has_oneshot_mods_timed_out(void) {

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -46,6 +46,12 @@ static uint8_t oneshot_locked_mods = 0;
 uint8_t        get_oneshot_locked_mods(void) {
     return oneshot_locked_mods;
 }
+void add_oneshot_locked_mods(uint8_t mods) {
+    if ((oneshot_locked_mods & mods) != mods) {
+        oneshot_locked_mods |= mods;
+        oneshot_locked_mods_changed_kb(oneshot_locked_mods);
+    }
+}
 void set_oneshot_locked_mods(uint8_t mods) {
     if (mods != oneshot_locked_mods) {
         oneshot_locked_mods = mods;

--- a/quantum/action_util.h
+++ b/quantum/action_util.h
@@ -64,6 +64,7 @@ void    clear_oneshot_mods(void);
 bool    has_oneshot_mods_timed_out(void);
 
 uint8_t get_oneshot_locked_mods(void);
+void    add_oneshot_locked_mods(uint8_t mods);
 void    set_oneshot_locked_mods(uint8_t mods);
 void    clear_oneshot_locked_mods(void);
 void    del_oneshot_locked_mods(uint8_t mods);

--- a/quantum/action_util.h
+++ b/quantum/action_util.h
@@ -66,6 +66,7 @@ bool    has_oneshot_mods_timed_out(void);
 uint8_t get_oneshot_locked_mods(void);
 void    set_oneshot_locked_mods(uint8_t mods);
 void    clear_oneshot_locked_mods(void);
+void    del_oneshot_locked_mods(uint8_t mods);
 
 typedef enum { ONESHOT_PRESSED = 0b01, ONESHOT_OTHER_KEY_PRESSED = 0b10, ONESHOT_START = 0b11, ONESHOT_TOGGLED = 0b100 } oneshot_fullfillment_t;
 void    set_oneshot_layer(uint8_t layer, uint8_t state);

--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -160,6 +160,151 @@ INSTANTIATE_TEST_CASE_P(
         ));
 // clang-format on
 
+TEST_F(OneShot, OSMChainingTwoOSMs) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osm_key1    = KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT};
+    KeymapKey  osm_key2    = KeymapKey{0, 0, 1, OSM(MOD_LCTL), KC_LCTL};
+    KeymapKey  regular_key = KeymapKey{0, 1, 0, KC_A};
+
+    set_keymap({osm_key1, osm_key2, regular_key});
+
+    /* Press and release OSM1 */
+    EXPECT_NO_REPORT(driver);
+    osm_key1.press();
+    run_one_scan_loop();
+    osm_key1.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and relesea OSM2 */
+    EXPECT_NO_REPORT(driver);
+    osm_key2.press();
+    run_one_scan_loop();
+    osm_key2.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold regular key */
+    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(OneShot, OSMDoubleTapNotLockingOSMs) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osm_key1    = KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT};
+    KeymapKey  osm_key2    = KeymapKey{0, 0, 1, OSM(MOD_LCTL), KC_LCTL};
+    KeymapKey  regular_key = KeymapKey{0, 1, 0, KC_A};
+
+    set_keymap({osm_key1, osm_key2, regular_key});
+
+    /* Press and release OSM1 */
+    EXPECT_NO_REPORT(driver);
+    osm_key1.press();
+    run_one_scan_loop();
+    osm_key1.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and release OSM2 twice */
+    EXPECT_NO_REPORT(driver);
+    osm_key2.press();
+    run_one_scan_loop();
+    osm_key2.release();
+    run_one_scan_loop();
+    osm_key2.press();
+    run_one_scan_loop();
+    osm_key2.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold regular key */
+    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold regular key */
+    EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(OneShot, OSMHoldNotLockingOSMs) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osm_key1    = KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT};
+    KeymapKey  osm_key2    = KeymapKey{0, 0, 1, OSM(MOD_LCTL), KC_LCTL};
+    KeymapKey  regular_key = KeymapKey{0, 1, 0, KC_A};
+
+    set_keymap({osm_key1, osm_key2, regular_key});
+
+    /* Press and release OSM1 */
+    EXPECT_NO_REPORT(driver);
+    osm_key1.press();
+    run_one_scan_loop();
+    osm_key1.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold OSM2 */
+    EXPECT_NO_REPORT(driver);
+    osm_key2.press();
+    run_one_scan_loop();
+    //osm_key2.release();
+    //run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold regular key */
+    EXPECT_NO_REPORT(driver);
+    regular_key.press();
+    run_one_scan_loop();
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
+    EXPECT_EMPTY_REPORT(driver);
+    osm_key2.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold regular key */
+    EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
 TEST_F(OneShot, OSLWithAdditionalKeypress) {
     TestDriver driver;
     InSequence s;

--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -185,7 +185,7 @@ TEST_F(OneShot, OSMChainingTwoOSMs) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    /* Press and hold regular key */
+    /* Press regular key */
     EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
     regular_key.press();
     run_one_scan_loop();
@@ -227,7 +227,7 @@ TEST_F(OneShot, OSMDoubleTapNotLockingOSMs) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    /* Press and hold regular key */
+    /* Press regular key */
     EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
     regular_key.press();
     run_one_scan_loop();
@@ -239,7 +239,7 @@ TEST_F(OneShot, OSMDoubleTapNotLockingOSMs) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    /* Press and hold regular key */
+    /* Press regular key */
     EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
     regular_key.press();
     run_one_scan_loop();
@@ -270,29 +270,28 @@ TEST_F(OneShot, OSMHoldNotLockingOSMs) {
     VERIFY_AND_CLEAR(driver);
 
     /* Press and hold OSM2 */
-    EXPECT_NO_REPORT(driver);
+    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code)).Times(1);
     osm_key2.press();
     run_one_scan_loop();
-    //osm_key2.release();
-    //run_one_scan_loop();
+    idle_for(TAPPING_TERM);
     VERIFY_AND_CLEAR(driver);
 
-    /* Press and hold regular key */
-    EXPECT_NO_REPORT(driver);
+    /* Press and release regular key */
+    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
+    EXPECT_REPORT(driver, (osm_key2.report_code)).Times(1);
     regular_key.press();
     run_one_scan_loop();
     regular_key.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    /* Release regular key */
-    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
+    /* Release OSM2 */
     EXPECT_EMPTY_REPORT(driver);
     osm_key2.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    /* Press and hold regular key */
+    /* Press regular key */
     EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
     regular_key.press();
     run_one_scan_loop();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR fixes OSMs getting stuck with double tapping or holding another mod. The bug was caused by `oneshot_mods` being converted to regular mods with `registed_mods` and thus loosing possibility to unregister those mods, and also not clearing the mods.

The commits of this PR are: 

1. Remove handling of multiple taps: other than `ONESHOT_TAP_TOGGLE` functionality, single tap and double tap (or n-tap) should be treated equally
2. Leave OSMs intact on press-and-hold: holding an OSM should behave exactly like a regular mod, and should have no effect on OSMs
3. Remove redundant outer conditional block: this is mainly to improve readability and also to make it clearer that key-up of a tap has only effect with `ONESHOT_TAP_TOGGLE`
4. Add function `del_oneshot_locked_mods()`: improves readability over `set_oneshot_locked_mods(~mods & get_oneshot_locked_mods());` and also makes it clearer that releasing a held mod unlocks it, if it was locked
5. Fix clearing OSMs: locking a mod with toggle should not clear all OSMs, only the toggled OSM 
6. Improve readability: add comments and change setting OSMs to explicit adding of one mod
7. Add `add_oneshot_locked_mods()`: align utils for locked mods with other mods utils 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #3963 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
