### PR TITLE
Make Pointing Device Auto Layer more configurable

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -605,7 +605,7 @@ There are several functions that allow for more advanced interaction with the au
 | `set_auto_mouse_timeout(uint16_t timeout)`                 | Change/set the timeout for turing off the layer                                      |                           |    `void`(None) |
 | `get_auto_mouse_timeout(void)`                             | Return the current timeout for turing off the layer                                  |                           |      `uint16_t` |
 | `set_auto_mouse_debounce(uint16_t timeout)`                | Change/set the debounce for preventing layer activation                              |                           |    `void`(None) |
-| `get_auto_mouse_debounce(void)`                            | Return the current debounce for preventing layer activation                          |                           |      `uint8_t` |
+| `get_auto_mouse_debounce(void)`                            | Return the current debounce for preventing layer activation                          |                           |       `uint8_t` |
 
 _NOTES:_   
     - _Due to the nature of how some functions work, the `auto_mouse_trigger_reset`, and `auto_mouse_layer_off` functions should never be called in the `layer_state_set_*` stack as this can cause indefinite loops._   

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -602,6 +602,10 @@ There are several functions that allow for more advanced interaction with the au
 | `auto_mouse_layer_off(void)`                               | Disable target layer if appropriate will call (makes call to `layer_state_set`)      |                           |   `void`(None)  |
 | `auto_mouse_toggle(void)`                                  | Toggle on/off target toggle state (disables layer deactivation when true)            |                           |    `void`(None) |
 | `get_auto_mouse_toggle(void)`                              | Return value of toggling state variable                                              |                           |          `bool` |
+| `set_auto_mouse_timeout(uint16_t timeout)`                 | Change/set the timeout for turing off the layer                                      |                           |    `void`(None) |
+| `get_auto_mouse_timeout(void)`                             | Return the current timeout for turing off the layer                                  |                           |      `uint16_t` |
+| `set_auto_mouse_debounce(uint16_t timeout)`                | Change/set the debounce for preventing layer activation                              |                           |    `void`(None) |
+| `get_auto_mouse_debounce(void)`                            | Return the current debounce for preventing layer activation                          |                           |      `uint8_t` |
 
 _NOTES:_   
     - _Due to the nature of how some functions work, the `auto_mouse_trigger_reset`, and `auto_mouse_layer_off` functions should never be called in the `layer_state_set_*` stack as this can cause indefinite loops._   

--- a/quantum/pointing_device/pointing_device_auto_mouse.c
+++ b/quantum/pointing_device/pointing_device_auto_mouse.c
@@ -21,9 +21,9 @@
 
 /* local data structure for tracking auto mouse */
 static auto_mouse_context_t auto_mouse_context = {
-    .config.layer    = (uint8_t)AUTO_MOUSE_DEFAULT_LAYER,
-    .config.timeout  = (uint16_t)AUTO_MOUSE_TIME,
-    .config.debounce = (uint8_t)AUTO_MOUSE_DEBOUNCE,
+    .config.layer    = (uint8_t)(AUTO_MOUSE_DEFAULT_LAYER),
+    .config.timeout  = (uint16_t)(AUTO_MOUSE_TIME),
+    .config.debounce = (uint8_t)(AUTO_MOUSE_DEBOUNCE),
 };
 
 /* local functions */

--- a/quantum/pointing_device/pointing_device_auto_mouse.c
+++ b/quantum/pointing_device/pointing_device_auto_mouse.c
@@ -20,7 +20,11 @@
 #    include "pointing_device_auto_mouse.h"
 
 /* local data structure for tracking auto mouse */
-static auto_mouse_context_t auto_mouse_context = {.config.layer = (uint8_t)AUTO_MOUSE_DEFAULT_LAYER};
+static auto_mouse_context_t auto_mouse_context = {
+    .config.layer    = (uint8_t)AUTO_MOUSE_DEFAULT_LAYER,
+    .config.timeout  = (uint16_t)AUTO_MOUSE_TIME,
+    .config.debounce = (uint8_t)AUTO_MOUSE_DEBOUNCE,
+};
 
 /* local functions */
 static bool is_mouse_record(uint16_t keycode, keyrecord_t* record);
@@ -60,6 +64,24 @@ bool get_auto_mouse_enable(void) {
  */
 uint8_t get_auto_mouse_layer(void) {
     return auto_mouse_context.config.layer;
+}
+
+/**
+ * @brief Get the current timeout to turn off mouse layer
+ *
+ * @return uint16_t timeout in ms
+ */
+uint16_t get_auto_mouse_timeout(void) {
+    return auto_mouse_context.config.timeout;
+}
+
+/**
+ * @brief Get the auto mouse debouncing timeout
+ *
+ * @return uint8_t
+ */
+uint8_t get_auto_mouse_debounce(void) {
+    return auto_mouse_context.config.debounce;
 }
 
 /**
@@ -111,6 +133,28 @@ void set_auto_mouse_layer(uint8_t layer) {
     // skip if unchanged
     if (auto_mouse_context.config.layer == layer) return;
     auto_mouse_context.config.layer = layer;
+    auto_mouse_reset();
+}
+
+/**
+ * @brief Changes the timeout for the mouse auto layer to be disabled
+ *
+ * @param timeout
+ */
+void set_auto_mouse_timeout(uint16_t timeout) {
+    if (auto_mouse_context.config.timeout == timeout) return;
+    auto_mouse_context.config.timeout = timeout;
+    auto_mouse_reset();
+}
+
+/**
+ * @brief Set the auto mouse key debounce
+ *
+ * @param debounce
+ */
+void set_auto_mouse_debounce(uint8_t debounce) {
+    if (auto_mouse_context.config.debounce == debounce) return;
+    auto_mouse_context.config.debounce = debounce;
     auto_mouse_reset();
 }
 
@@ -181,7 +225,7 @@ __attribute__((weak)) bool auto_mouse_activation(report_mouse_t mouse_report) {
  */
 void pointing_device_task_auto_mouse(report_mouse_t mouse_report) {
     // skip if disabled, delay timer running, or debounce
-    if (!(AUTO_MOUSE_ENABLED) || timer_elapsed(auto_mouse_context.timer.active) <= AUTO_MOUSE_DEBOUNCE || timer_elapsed(auto_mouse_context.timer.delay) <= AUTO_MOUSE_DELAY) {
+    if (!(AUTO_MOUSE_ENABLED) || timer_elapsed(auto_mouse_context.timer.active) <= auto_mouse_context.config.debounce || timer_elapsed(auto_mouse_context.timer.delay) <= AUTO_MOUSE_DELAY) {
         return;
     }
     // update activation and reset debounce
@@ -192,7 +236,7 @@ void pointing_device_task_auto_mouse(report_mouse_t mouse_report) {
         if (!layer_state_is((AUTO_MOUSE_TARGET_LAYER))) {
             layer_on((AUTO_MOUSE_TARGET_LAYER));
         }
-    } else if (layer_state_is((AUTO_MOUSE_TARGET_LAYER)) && timer_elapsed(auto_mouse_context.timer.active) > AUTO_MOUSE_TIME) {
+    } else if (layer_state_is((AUTO_MOUSE_TARGET_LAYER)) && timer_elapsed(auto_mouse_context.timer.active) > auto_mouse_context.config.timeout) {
         layer_off((AUTO_MOUSE_TARGET_LAYER));
         auto_mouse_context.timer.active = 0;
     }

--- a/quantum/pointing_device/pointing_device_auto_mouse.h
+++ b/quantum/pointing_device/pointing_device_auto_mouse.h
@@ -43,8 +43,10 @@
 /* data structure */
 typedef struct {
     struct {
-        bool    is_enabled;
-        uint8_t layer;
+        bool     is_enabled;
+        uint8_t  layer;
+        uint16_t timeout;
+        uint8_t  debounce;
     } config;
     struct {
         uint16_t active;
@@ -62,6 +64,10 @@ void          set_auto_mouse_enable(bool enable);                       // enabl
 bool          get_auto_mouse_enable(void);                              // get auto_mouse_enable
 void          set_auto_mouse_layer(uint8_t layer);                      // set target layer by index
 uint8_t       get_auto_mouse_layer(void);                               // get target layer index
+void          set_auto_mouse_timeout(uint16_t timeout);
+uint16_t      get_auto_mouse_timeout(void);
+void          set_auto_mouse_debounce(uint8_t debounce);
+uint8_t       get_auto_mouse_debounce(void);
 void          auto_mouse_layer_off(void);                               // disable target layer if appropriate (DO NOT USE in layer_state_set stack!!)
 layer_state_t remove_auto_mouse_layer(layer_state_t state, bool force); // remove auto mouse target layer from state if appropriate (can be forced)
 

--- a/quantum/pointing_device/pointing_device_auto_mouse.h
+++ b/quantum/pointing_device/pointing_device_auto_mouse.h
@@ -64,10 +64,10 @@ void          set_auto_mouse_enable(bool enable);                       // enabl
 bool          get_auto_mouse_enable(void);                              // get auto_mouse_enable
 void          set_auto_mouse_layer(uint8_t layer);                      // set target layer by index
 uint8_t       get_auto_mouse_layer(void);                               // get target layer index
-void          set_auto_mouse_timeout(uint16_t timeout);
-uint16_t      get_auto_mouse_timeout(void);
-void          set_auto_mouse_debounce(uint8_t debounce);
-uint8_t       get_auto_mouse_debounce(void);
+void          set_auto_mouse_timeout(uint16_t timeout);                 // set layer timeout
+uint16_t      get_auto_mouse_timeout(void);                             // get layer timeout
+void          set_auto_mouse_debounce(uint8_t debounce);                // set debounce
+uint8_t       get_auto_mouse_debounce(void);                            // get debounce
 void          auto_mouse_layer_off(void);                               // disable target layer if appropriate (DO NOT USE in layer_state_set stack!!)
 layer_state_t remove_auto_mouse_layer(layer_state_t state, bool force); // remove auto mouse target layer from state if appropriate (can be forced)
 


### PR DESCRIPTION
## Description

As the title says. 

Specifically make the layer timeout and debouncing configurable at runtime.



## Types of Changes

- [x] Core
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Discord comments in bastardkb #firmware channel

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
