### PR TITLE
Remove pointless `USE_I2C` blocks in keyboard headers

### DIFF
--- a/keyboards/adkb96/rev1/rev1.h
+++ b/keyboards/adkb96/rev1/rev1.h
@@ -2,14 +2,6 @@
 
 #include "adkb96.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 // Keymap with right side flipped
 // (TRRS jack on both halves are to the right)
 #define LAYOUT_ortho_6x16( \

--- a/keyboards/ergotravel/rev1/rev1.h
+++ b/keyboards/ergotravel/rev1/rev1.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define XXX KC_NO
 
 #define LAYOUT( \

--- a/keyboards/handwired/dactyl_promicro/dactyl_promicro.h
+++ b/keyboards/handwired/dactyl_promicro/dactyl_promicro.h
@@ -2,15 +2,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
-
 #define LAYOUT_6x6(\
     L00, L01, L02, L03, L04, L05,                       R00, R01, R02, R03, R04, R05, \
     L10, L11, L12, L13, L14, L15,                       R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/iris/rev1/rev1.h
+++ b/keyboards/keebio/iris/rev1/rev1.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     L00, L01, L02, L03, L04, L05,           R00, R01, R02, R03, R04, R05, \
     L10, L11, L12, L13, L14, L15,           R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/iris/rev1_led/rev1_led.h
+++ b/keyboards/keebio/iris/rev1_led/rev1_led.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     L00, L01, L02, L03, L04, L05,           R00, R01, R02, R03, R04, R05, \
     L10, L11, L12, L13, L14, L15,           R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/iris/rev2/rev2.h
+++ b/keyboards/keebio/iris/rev2/rev2.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     L00, L01, L02, L03, L04, L05,           R00, R01, R02, R03, R04, R05, \
     L10, L11, L12, L13, L14, L15,           R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/iris/rev3/rev3.h
+++ b/keyboards/keebio/iris/rev3/rev3.h
@@ -3,15 +3,6 @@
 #include "iris.h"
 #include "quantum.h"
 
-
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     L00, L01, L02, L03, L04, L05,           R00, R01, R02, R03, R04, R05, \
     L10, L11, L12, L13, L14, L15,           R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/iris/rev4/rev4.h
+++ b/keyboards/keebio/iris/rev4/rev4.h
@@ -3,14 +3,6 @@
 #include "iris.h"
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     LA1, LA2, LA3, LA4, LA5, LA6,           RA6, RA5, RA4, RA3, RA2, RA1, \
     LB1, LB2, LB3, LB4, LB5, LB6,           RB6, RB5, RB4, RB3, RB2, RB1, \

--- a/keyboards/keebio/levinson/rev1/rev1.h
+++ b/keyboards/keebio/levinson/rev1/rev1.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/keebio/levinson/rev2/rev2.h
+++ b/keyboards/keebio/levinson/rev2/rev2.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/keebio/levinson/rev3/rev3.h
+++ b/keyboards/keebio/levinson/rev3/rev3.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
 	L00, L01, L02, L03, L04, L05, R00, R01, R02, R03, R04, R05, \
 	L10, L11, L12, L13, L14, L15, R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/nyquist/rev1/rev1.h
+++ b/keyboards/keebio/nyquist/rev1/rev1.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/keebio/nyquist/rev2/rev2.h
+++ b/keyboards/keebio/nyquist/rev2/rev2.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/keebio/nyquist/rev3/rev3.h
+++ b/keyboards/keebio/nyquist/rev3/rev3.h
@@ -3,14 +3,6 @@
 #include "nyquist.h"
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
 	L00, L01, L02, L03, L04, L05, R00, R01, R02, R03, R04, R05, \
 	L10, L11, L12, L13, L14, L15, R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/quefrency/rev1/rev1.h
+++ b/keyboards/keebio/quefrency/rev1/rev1.h
@@ -4,15 +4,6 @@
 
 #include "quantum.h"
 
-
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-  #include <avr/io.h>
-  #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
   LA1, LA2, LA3, LA4, LA5, LA6, LA7, RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, \
   LB1, LB2, LB3, LB4, LB5, LB6,      RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, \

--- a/keyboards/keebio/quefrency/rev2/rev2.h
+++ b/keyboards/keebio/quefrency/rev2/rev2.h
@@ -3,14 +3,6 @@
 #include "quefrency.h"
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT_60( \
   LA3, LA4, LA5, LA6, LA7, LA8, LA9,      RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, \
   LB3, LB4, LB5, LB6, LB7, LB8,           RB1, RB2, RB3, RB4, RB5, RB6, RB7, RB8, \

--- a/keyboards/keebio/rorschach/rev1/rev1.h
+++ b/keyboards/keebio/rorschach/rev1/rev1.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     L00, L01, L02, L03, L04, L05,           R00, R01, R02, R03, R04, R05, \
     L10, L11, L12, L13, L14, L15,           R10, R11, R12, R13, R14, R15, \

--- a/keyboards/keebio/sinc/rev1/rev1.h
+++ b/keyboards/keebio/sinc/rev1/rev1.h
@@ -3,14 +3,6 @@
 #include "sinc.h"
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT_75( \
   LF3, LF4, LF5, LF6, LF7, LF8, LF9,           RF2, RF3, RF4, RF5, RF6, RF7, RF8, \
   LA3, LA4, LA5, LA6, LA7, LA8, LA9,      RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, \

--- a/keyboards/keebio/sinc/rev2/rev2.h
+++ b/keyboards/keebio/sinc/rev2/rev2.h
@@ -19,14 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "sinc.h"
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT_75( \
   LF3, LF4, LF5, LF6, LF7, LF8, LF9,           RF2, RF3, RF4, RF5, RF6, RF7, RF8, \
   LA3, LA4, LA5, LA6, LA7, LA8, LA9,      RA1, RA2, RA3, RA4, RA5, RA6, RA7, RA8, \

--- a/keyboards/keebio/viterbi/rev1/rev1.h
+++ b/keyboards/keebio/viterbi/rev1/rev1.h
@@ -3,14 +3,6 @@
 #include "viterbi.h"
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/keebio/viterbi/rev2/rev2.h
+++ b/keyboards/keebio/viterbi/rev2/rev2.h
@@ -3,15 +3,6 @@
 #include "viterbi.h"
 #include "quantum.h"
 
-
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     L00, L01, L02, L03, L04, L05, L06, R00, R01, R02, R03, R04, R05, R06, \
     L10, L11, L12, L13, L14, L15, L16, R10, R11, R12, R13, R14, R15, R16, \

--- a/keyboards/lets_split/rev2/rev2.h
+++ b/keyboards/lets_split/rev2/rev2.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/lets_split/sockets/sockets.h
+++ b/keyboards/lets_split/sockets/sockets.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/lily58/rev1/rev1.h
+++ b/keyboards/lily58/rev1/rev1.h
@@ -9,14 +9,6 @@
 #include "ws2812.h"
 #endif
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 #define LAYOUT( \
 	L00, L01, L02, L03, L04, L05,           R00, R01, R02, R03, R04, R05,  \

--- a/keyboards/omkbd/ergodash/mini/mini.h
+++ b/keyboards/omkbd/ergodash/mini/mini.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/omkbd/ergodash/rev1/rev1.h
+++ b/keyboards/omkbd/ergodash/rev1/rev1.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define XXX KC_NO
 
 #ifndef FLIP_HALF

--- a/keyboards/pinky/3/3.h
+++ b/keyboards/pinky/3/3.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT_split_3x7_4( \
   L00, L01, L02, L03, L04, L05, L06,  R00, R01, R02, R03, R04, R05, R06, \
   L10, L11, L12, L13, L14, L15, L16,  R10, R11, R12, R13, R14, R15, R16, \

--- a/keyboards/pinky/4/4.h
+++ b/keyboards/pinky/4/4.h
@@ -4,14 +4,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT_split_4x7_4( \
   L00, L01, L02, L03, L04, L05, L06,  R00, R01, R02, R03, R04, R05, R06, \
   L10, L11, L12, L13, L14, L15, L16,  R10, R11, R12, R13, R14, R15, R16, \

--- a/keyboards/qwertyydox/rev1/rev1.h
+++ b/keyboards/qwertyydox/rev1/rev1.h
@@ -2,14 +2,6 @@
 
 #include "qwertyydox.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
     L00, L01, L02, L03, L04, L05, L06,       R00, R01, R02, R03, R04, R05, R06, \
     L10, L11, L12, L13, L14, L15,            R10, R11, R12, R13, R14, R15, R16, \

--- a/keyboards/redox/rev1/rev1.h
+++ b/keyboards/redox/rev1/rev1.h
@@ -8,14 +8,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-  #include <avr/io.h>
-  #include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
   k00, k01, k02, k03, k04, k05,                          k08, k09, k10, k11, k12, k13, \
   k14, k15, k16, k17, k18, k19, k06,                k07, k22, k23, k24, k25, k26, k27, \

--- a/keyboards/salicylic_acid3/naked48/rev1/rev1.h
+++ b/keyboards/salicylic_acid3/naked48/rev1/rev1.h
@@ -25,14 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ws2812.h"
 #endif
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 //////////////////////////////////////////////////////////////////////////////
 // When only use Naked48.
 //////////////////////////////////////////////////////////////////////////////

--- a/keyboards/unikeyboard/diverge3/diverge3.h
+++ b/keyboards/unikeyboard/diverge3/diverge3.h
@@ -18,14 +18,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-    #include <avr/io.h>
-    #include <avr/interrupt.h>
-#endif
-#endif
-
 #define XXX KC_NO
 
 // This a shortcut to help you visually see your layout.

--- a/keyboards/unikeyboard/divergetm2/divergetm2.h
+++ b/keyboards/unikeyboard/divergetm2/divergetm2.h
@@ -19,14 +19,6 @@
 
 #include "quantum.h"
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #ifndef FLIP_HALF
 // Standard Keymap
 // (TRRS jack on the left half is to the right, TRRS jack on the right half is to the left)

--- a/keyboards/vitamins_included/vitamins_included.h
+++ b/keyboards/vitamins_included/vitamins_included.h
@@ -8,14 +8,6 @@
     #include "rev2.h"
 #endif
 
-#ifdef USE_I2C
-#include <stddef.h>
-#ifdef __AVR__
-	#include <avr/io.h>
-	#include <avr/interrupt.h>
-#endif
-#endif
-
 #define LAYOUT( \
 	L00, L01, L02, L03, L04, L05, R00, R01, R02, R03, R04, R05, \
 	L10, L11, L12, L13, L14, L15, R10, R11, R12, R13, R14, R15, \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
