### PR TITLE
Teleport native bugfix (changed F411CC wear levelling)

### DIFF
--- a/keyboards/teleport/native/info.json
+++ b/keyboards/teleport/native/info.json
@@ -15,7 +15,7 @@
         "command": false,
         "console": false,
         "extrakey": true,
-        "mousekey": false,
+        "mousekey": true,
         "nkro": true
     },
     "diode_direction": "ROW2COL",

--- a/keyboards/teleport/native/rules.mk
+++ b/keyboards/teleport/native/rules.mk
@@ -3,3 +3,7 @@ RGB_MATRIX_DRIVER = IS31FL3733
 RGB_MATRIX_CUSTOM_KB = yes
 
 DEFAULT_FOLDER = teleport/native/iso
+
+# Temporary workaround while waiting fixes of F411xC flash size definitions
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = legacy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This PR is, as talked about on the QMK discord, a bugfix to keep this firmware from softbricking keyboards if compiled off the current master branch.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Apart from enabling mousekeys (people asked for it, figured I'd throw it in with the bugfix) this switches to the legacy eeprom wear levelling driver, as the new default one seems to brick F411CC based boards due to wrong flash size defines in configs.

New FW is tested on hardware and works as expected.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
