### PR TITLE
Fix MATRIX_HAS_GHOST when MATRIX_COL > 16

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -171,9 +171,9 @@ static matrix_row_t get_real_keys(uint8_t row, matrix_row_t rowdata) {
     matrix_row_t out = 0;
     for (uint8_t col = 0; col < MATRIX_COLS; col++) {
         // read each key in the row data and check if the keymap defines it as a real key
-        if (keycode_at_keymap_location(0, row, col) && (rowdata & (1 << col))) {
+        if (keycode_at_keymap_location(0, row, col) && (rowdata & (((matrix_row_t)1) << col))) {
             // this creates new row data, if a key is defined in the keymap, it will be set here
-            out |= 1 << col;
+            out |= ((matrix_row_t)1) << col;
         }
     }
     return out;


### PR DESCRIPTION
## Description

When MATRIX_COL > 16 get_real_keys() does not work correctly because the `1 << col` shift overflows, since matrix_row_t is uint32_t. This causes key presses to be lost on keyboards with more than 16 columns.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
