### PR TITLE
Allow for CI builds to run for 23 hours, instead of 6.

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -11,7 +11,9 @@ on:
 
 jobs:
   ci_builds:
+    name: "CI Build: {{ matrix.keymap }}"
     runs-on: self-hosted
+    timeout-minutes: 1380
 
     if: github.repository == 'qmk/qmk_firmware'
 


### PR DESCRIPTION
## Description

Runner default stops after 6 hours -- current QMK default keymaps get to `t` at that point.
Extends to 23 hours for the moment until we work out how to drop the number of required builds.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
