### PR TITLE
Fix rgblight layers when animations aren't enabled

### DIFF
--- a/quantum/rgblight/rgblight.h
+++ b/quantum/rgblight/rgblight.h
@@ -174,6 +174,10 @@ typedef struct {
     uint8_t val;
 } rgblight_segment_t;
 
+// rgblight_set_layer_state doesn't take effect until the next time
+// rgblight_task runs, so timers must be enabled for layers to work.
+#    define RGBLIGHT_USE_TIMER
+
 #    define RGBLIGHT_END_SEGMENT_INDEX (255)
 #    define RGBLIGHT_END_SEGMENTS \
         { RGBLIGHT_END_SEGMENT_INDEX, 0, 0, 0 }


### PR DESCRIPTION
## Description

PR #18338 introduced a change that deferred rgblight_set after a call to rgblight_set_layer_state to the next invocation of rgblight_task.

However, rgblight_task is a no-op unless RGBLIGHT_USE_TIMER is set, which only happens automatically if an RGB animation is enabled, or if RGBLIGHT_LAYER_BLINK is enabled.

If neither of these are enabled, rgblight_set is never called automatically after rgblight_set_layer_state, so the LED state is never actually set.

This commit fixes this issue by ensuring that RGBLIGHT_USER_TIMER is set if rgblight layers are enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #19520

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
