### PR TITLE
Fix Odin V2 product ID

### DIFF
--- a/keyboards/kbdfans/odin/v2/info.json
+++ b/keyboards/kbdfans/odin/v2/info.json
@@ -5,7 +5,7 @@
     "maintainer": "lexbrugman",
     "usb": {
         "vid": "0x4B42",
-        "pid": "0x0101",
+        "pid": "0x0104",
         "device_version": "0.0.1"
     },
     "indicators": {


### PR DESCRIPTION
Kbdfans Odin V2 has the same product ID as Odin Soldered, changing it to something unique.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
