### PR TITLE
Don't print error message when there are no row pins and no col pins

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -728,6 +728,7 @@ def _check_matrix(info_data):
             col_count = len(info_data['matrix_pins']['cols'])
             row_count = len(info_data['matrix_pins']['rows'])
         elif 'cols' not in info_data['matrix_pins'] and 'rows' not in info_data['matrix_pins']:
+            # This case caters for custom matrix implementations where normal rows/cols are specified
             return
 
         if col_count != actual_col_count and col_count != (actual_col_count / 2):

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -727,6 +727,8 @@ def _check_matrix(info_data):
         elif 'cols' in info_data['matrix_pins'] and 'rows' in info_data['matrix_pins']:
             col_count = len(info_data['matrix_pins']['cols'])
             row_count = len(info_data['matrix_pins']['rows'])
+        elif 'cols' not in info_data['matrix_pins'] and 'rows' not in info_data['matrix_pins']:
+            return
 
         if col_count != actual_col_count and col_count != (actual_col_count / 2):
             # FIXME: once we can we should detect if split is enabled to do the actual_col_count/2 check.


### PR DESCRIPTION
## Description

This error message could be triggered for example if MATRIX_IO_DELAY is configured in config.h, but the matrix is a custom one. The custom matrix can still call back to existing delay functions that make use of the MATRIX_IO_DELAY macro. In this case 'matrix_pins' in info_data will be true, but there will be no 'direct' 'cols' or 'rows' in info_data['matrix_pins'], and without this commit it would trigger an invalid error.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
