### PR TITLE
Let's use workflows to parallelise the builds.

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -22,6 +22,43 @@ jobs:
         keymap:
         - default
         - via
+        keyboard_folder:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - a
+        - b
+        - c
+        - d
+        - e
+        - f
+        - g
+        - h
+        - i
+        - j
+        - k
+        - l
+        - m
+        - n
+        - o
+        - p
+        - q
+        - r
+        - s
+        - t
+        - u
+        - v
+        - w
+        - x
+        - y
+        - z
 
     container: qmkfm/qmk_cli
 
@@ -36,5 +73,14 @@ jobs:
     - name: Install dependencies
       run: pip3 install -r requirements.txt
 
-    - name: Run `qmk mass-compile` (keymap ${{ matrix.keymap }})
-      run: qmk mass-compile -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null) -km ${{ matrix.keymap }}
+    - name: Run `qmk mass-compile` (keyboards ${{ matrix.keyboard_folder }}*, keymap ${{ matrix.keymap }})
+      run: qmk mass-compile -j $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null) -km ${{ matrix.keymap }} -f 'keyboard_folder=${{ matrix.keyboard_folder }}*'
+
+    - name: 'Upload binaries'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Artifacts-${{ matrix.keyboard_folder }}-${{ matrix.keymap }}
+        path: |
+          *.bin
+          *.hex
+          *.uf2

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -19,46 +19,8 @@ jobs:
 
     strategy:
       matrix:
-        keymap:
-        - default
-        - via
-        keyboard_folder:
-        - 0
-        - 1
-        - 2
-        - 3
-        - 4
-        - 5
-        - 6
-        - 7
-        - 8
-        - 9
-        - a
-        - b
-        - c
-        - d
-        - e
-        - f
-        - g
-        - h
-        - i
-        - j
-        - k
-        - l
-        - m
-        - n
-        - o
-        - p
-        - q
-        - r
-        - s
-        - t
-        - u
-        - v
-        - w
-        - x
-        - y
-        - z
+        keymap: [default, via]
+        keyboard_folder: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
 
     container: qmkfm/qmk_cli
 
@@ -79,7 +41,7 @@ jobs:
     - name: 'Upload binaries'
       uses: actions/upload-artifact@v3
       with:
-        name: Artifacts-${{ matrix.keyboard_folder }}-${{ matrix.keymap }}
+        name: binaries-${{ matrix.keyboard_folder }}-${{ matrix.keymap }}
         if-no-files-found: ignore
         path: |
           *.bin

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -80,6 +80,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Artifacts-${{ matrix.keyboard_folder }}-${{ matrix.keymap }}
+        if-no-files-found: ignore
         path: |
           *.bin
           *.hex

--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -106,7 +106,7 @@ def mass_compile(cli):
 
                     def _make_filter(k, v):
                         expr = fnmatch.translate(v)
-                        rule = re.compile(expr, re.IGNORECASE)
+                        rule = re.compile(f'^{expr}$', re.IGNORECASE)
 
                         def f(e):
                             lhs = e[2].get(k)


### PR DESCRIPTION
## Description

Super naive version of parallelism.
Splits up per-keyboard folder.
Uploads build artifacts.

Also fixes the wildcard filtering for `qmk mass-compile -f ...`.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
