### PR TITLE
add random fill rgb effect 🎆

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -579,6 +579,7 @@ enum rgb_matrix_effects {
 #if defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS)
     RGB_MATRIX_TYPING_HEATMAP,      // How hot is your WPM!
     RGB_MATRIX_DIGITAL_RAIN,        // That famous computer simulation
+    RGB_MATRIX_RANDOM_FILL,         // Fill keyboard randomly, empty randomly
 #endif
 #if defined(RGB_MATRIX_KEYPRESSES) || defined(RGB_MATRIX_KEYRELEASES)
     RGB_MATRIX_SOLID_REACTIVE_SIMPLE,   // Pulses keys hit to hue & value then fades value out
@@ -639,6 +640,7 @@ You can enable a single effect by defining `ENABLE_[EFFECT_NAME]` in your `confi
 |------------------------------------------------------|----------------------------------------------|
 |`#define ENABLE_RGB_MATRIX_TYPING_HEATMAP`            |Enables `RGB_MATRIX_TYPING_HEATMAP`           |
 |`#define ENABLE_RGB_MATRIX_DIGITAL_RAIN`              |Enables `RGB_MATRIX_DIGITAL_RAIN`             |
+|`#define ENABLE_RGB_MATRIX_RANDOM_FILL`               |Enables `RGB_MATRIX_RANDOM_FILL`              |
 
 ?> These modes also require the `RGB_MATRIX_FRAMEBUFFER_EFFECTS` define to be available.
 

--- a/quantum/rgb_matrix/animations/random_fill.h
+++ b/quantum/rgb_matrix/animations/random_fill.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Maximilian Güntner <code@mguentner.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#if defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && defined(ENABLE_RGB_RANDOM_FILL)
+RGB_MATRIX_EFFECT(RANDOM_FILL)
+#    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+static bool is_filling = true;
+
+bool RANDOM_FILL(effect_params_t* params) {
+    static uint32_t wait_timer = 0;
+
+    inline uint32_t interval(void) {
+        return 500 / scale16by8(qadd8(rgb_matrix_config.speed, 16), 16);
+    }
+
+    inline void random_fill(void) {
+        bool only_ones  = true;
+        bool only_zeros = true;
+        for (uint8_t i_row = 0; i_row < MATRIX_ROWS; i_row++) {
+            for (uint8_t i_col = 0; i_col < MATRIX_COLS; i_col++) {
+                if (g_rgb_frame_buffer[i_row][i_col] != 0 && only_zeros) {
+                    only_zeros = false;
+                }
+                if (g_rgb_frame_buffer[i_row][i_col] != 1 && only_ones) {
+                    only_ones = false;
+                }
+            }
+        }
+        if (is_filling == true && only_ones) {
+            is_filling = false;
+        }
+        if (is_filling == false && only_zeros) {
+            is_filling = true;
+        }
+
+        uint8_t row = random8_max(MATRIX_ROWS);
+        uint8_t col = random8_max(MATRIX_COLS);
+        RGB     rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
+        if (is_filling == true) {
+            g_rgb_frame_buffer[row][col] = 1;
+        } else {
+            g_rgb_frame_buffer[row][col] = 0;
+        }
+
+        for (uint8_t i_row = 0; i_row < MATRIX_ROWS; i_row++) {
+            for (uint8_t i_col = 0; i_col < MATRIX_COLS; i_col++) {
+                uint8_t led_index = g_led_config.matrix_co[i_row][i_col];
+                if (g_rgb_frame_buffer[i_row][i_col]) {
+                    rgb_matrix_set_color(led_index, rgb.r, rgb.g, rgb.b);
+                } else {
+                    rgb_matrix_set_color(led_index, 0, 0, 0);
+                }
+            }
+        }
+        wait_timer = g_rgb_timer + interval();
+    }
+
+    if (params->init) {
+        rgb_matrix_set_color_all(0, 0, 0);
+        memset(g_rgb_frame_buffer, 0, sizeof g_rgb_frame_buffer);
+    }
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+    if (g_rgb_timer > wait_timer) {
+        random_fill();
+    }
+
+    return rgb_matrix_check_finished_leds(led_max);
+}
+#    endif
+#endif // ENABLE_RGB_RANDOM_FILL

--- a/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
@@ -38,3 +38,4 @@
 #include "solid_reactive_nexus.h"
 #include "splash_anim.h"
 #include "solid_splash_anim.h"
+#include "random_fill.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

adds a new effect that "fills" the keyboard randomly with `rgb_matrix_config.hsv`, i.e. switches LEDs on and once full,
empties it again by switching the LEDs off randomly.

As it brute forces these conditions, the effect is fast in the beginning and slow in the end which makes
it quite pleasant to look at.
The effect observes `rgb_matrix_config.speed`.

### Video

https://user-images.githubusercontent.com/668926/225391137-085d897f-4ece-4adb-a1ab-c93b8ba77b7c.mp4





## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
