### PR TITLE
[Keyboard] Fix typos in readme for Lily58 R2G

### DIFF
--- a/keyboards/lily58/r2g/readme.md
+++ b/keyboards/lily58/r2g/readme.md
@@ -1,21 +1,20 @@
 # Lily58 R2G
 
-Lily58 R2G is factory assembled version of the lilly 58 featuring hotswap and perkey rgb
-
 ![Lily58_R2G](https://i.imgur.com/4vPkIQ5.png)
-Keyboard Maintainer: [Elliot Powell](https://github.com/e11i0t23)
-Hardware Supported: Lily58 R2G PCB
-Hardware Availability: [Mechboards UK](https://mechboards.co.uk/products/lily58-r2g-ready2go-kit)
+
+Lily58 R2G is factory assembled version of the Lily 58 featuring hotswap and perkey RGB.
+
+* Keyboard Maintainer: [Elliot Powell](https://github.com/e11i0t23)
+* Hardware Supported: Lily58 R2G PCB
+* Hardware Availability: [Mechboards UK](https://mechboards.co.uk/products/lily58-r2g-ready2go-kit)
 
 Make example for this keyboard (after setting up your build environment):
-```sh
-make crkbd/r2g:mb_via
-```
 
-Flash example for this keyboard:  
-```sh
-make crkbd/r2g:mb_via:flash
-```
+    make lily58/r2g:mb_via
+
+Flash example for this keyboard:
+
+    make lily58/r2g:mb_via:flash
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 
@@ -23,5 +22,4 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 These PCBs have a reset on the underside of the PCB next to the controller which may be pressed to enter in to the bootloader.
 
-Additionally, if you hold down the "ESC" or "GRV" buttons when plugging in that half of the keyboard (per the default QWERTY layout), this will jump to the bootloader and reset the EEPROM (persistent storage).  
-
+Additionally, if you hold down the "ESC" or "GRV" buttons when plugging in that half of the keyboard (per the default QWERTY layout), this will jump to the bootloader and reset the EEPROM (persistent storage).


### PR DESCRIPTION
## Description

Fix typos in readme for Lily58 R2G

* `lilly 58` -> `Lily 58`
* `crkbd/r2g:mb_via` -> `lily58/r2g:mb_via`
* some changes to keep the template like others...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
