### PR TITLE
Clean up APA102 config and add DD mapping

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -10,6 +10,9 @@
     // deprecated: Default `false`. Set to `true` to turn on warning when a value exists
     // invalid: Default `false`. Set to `true` to generate errors when a value exists
     // replace_with: use with a key marked deprecated or invalid to designate a replacement
+    "APA102_DI_PIN": {"info_key": "apa102.data_pin"},
+    "APA102_CI_PIN": {"info_key": "apa102.clock_pin"},
+    "APA102_DEFAULT_BRIGHTNESS": {"info_key": "apa102.default_brightness", "value_type": "int"},
     "AUDIO_VOICES": {"info_key": "audio.voices", "value_type": "bool"},
     "BACKLIGHT_BREATHING": {"info_key": "backlight.breathing", "value_type": "bool"},
     "BREATHING_PERIOD": {"info_key": "backlight.breathing_period", "value_type": "int"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -96,6 +96,19 @@
                 "unknown"
             ]
         },
+        "apa102": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "data_pin": {"$ref": "qmk.definitions.v1#/mcu_pin"},
+                "clock_pin": {"$ref": "qmk.definitions.v1#/mcu_pin"},
+                "default_brightness": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 31
+                }
+            }
+        },
         "audio": {
             "type": "object",
             "additionalProperties": false,

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -383,9 +383,9 @@ Configure the hardware via your `config.h`:
 
 ```c
 // The pin connected to the data pin of the LEDs
-#define RGB_DI_PIN D7
+#define APA102_DI_PIN D7
 // The pin connected to the clock pin of the LEDs
-#define RGB_CI_PIN D6
+#define APA102_CI_PIN D6
 // The number of LEDs connected
 #define RGB_MATRIX_LED_COUNT 70
 ```

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -35,8 +35,9 @@ At minimum you must define the data pin your LED strip is connected to, and the 
 
 |Define         |Description                                                                                              |
 |---------------|---------------------------------------------------------------------------------------------------------|
-|`RGB_DI_PIN`   |The pin connected to the data pin of the LEDs                                                            |
-|`RGB_CI_PIN`   |The pin connected to the clock pin of the LEDs (APA102 only)                                             |
+|`RGB_DI_PIN`   |The pin connected to the data pin of the LEDs (WS2812)                                                   |
+|`APA102_DI_PIN`|The pin connected to the data pin of the LEDs (APA102)                                                   |
+|`APA102_CI_PIN`|The pin connected to the clock pin of the LEDs (APA102)                                                  |
 |`RGBLED_NUM`   |The number of LEDs connected                                                                             |
 |`RGBLED_SPLIT` |(Optional) For split keyboards, the number of LEDs connected on each half directly wired to `RGB_DI_PIN` |
 

--- a/drivers/led/apa102.c
+++ b/drivers/led/apa102.c
@@ -27,7 +27,7 @@
 #        if defined(STM32F0XX) || defined(STM32F1XX) || defined(STM32F3XX) || defined(STM32F4XX) || defined(STM32L0XX) || defined(GD32VF103)
 #            define APA102_NOPS (100 / (1000000000L / (CPU_CLOCK / 4))) // This calculates how many loops of 4 nops to run to delay 100 ns
 #        else
-#            error("APA102_NOPS configuration required")
+#            error APA102_NOPS configuration required
 #            define APA102_NOPS 0 // this just pleases the compile so the above error is easier to spot
 #        endif
 #    endif
@@ -43,14 +43,14 @@
         }                                       \
     } while (0)
 
-#define APA102_SEND_BIT(byte, bit)               \
-    do {                                         \
-        writePin(RGB_DI_PIN, (byte >> bit) & 1); \
-        io_wait;                                 \
-        writePinHigh(RGB_CI_PIN);                \
-        io_wait;                                 \
-        writePinLow(RGB_CI_PIN);                 \
-        io_wait;                                 \
+#define APA102_SEND_BIT(byte, bit)                  \
+    do {                                            \
+        writePin(APA102_DI_PIN, (byte >> bit) & 1); \
+        io_wait;                                    \
+        writePinHigh(APA102_CI_PIN);                \
+        io_wait;                                    \
+        writePinLow(APA102_CI_PIN);                 \
+        io_wait;                                    \
     } while (0)
 
 uint8_t apa102_led_brightness = APA102_DEFAULT_BRIGHTNESS;
@@ -77,11 +77,11 @@ void rgblight_call_driver(LED_TYPE *start_led, uint8_t num_leds) {
 }
 
 void static apa102_init(void) {
-    setPinOutput(RGB_DI_PIN);
-    setPinOutput(RGB_CI_PIN);
+    setPinOutput(APA102_DI_PIN);
+    setPinOutput(APA102_CI_PIN);
 
-    writePinLow(RGB_DI_PIN);
-    writePinLow(RGB_CI_PIN);
+    writePinLow(APA102_DI_PIN);
+    writePinLow(APA102_CI_PIN);
 }
 
 void apa102_set_brightness(uint8_t brightness) {

--- a/keyboards/handwired/onekey/blackpill_f401/config.h
+++ b/keyboards/handwired/onekey/blackpill_f401/config.h
@@ -23,8 +23,6 @@
 
 #define ADC_PIN A0
 
-#define RGB_CI_PIN A2
-
 #define SOLENOID_PIN B12
 #define SOLENOID_PINS { B12, B13, B14, B15 }
 #define SOLENOID_PINS_ACTIVE_STATE { high, high, low }

--- a/keyboards/handwired/onekey/blackpill_f401/info.json
+++ b/keyboards/handwired/onekey/blackpill_f401/info.json
@@ -10,5 +10,9 @@
     },
     "rgblight": {
         "pin": "A1"
+    },
+    "apa102": {
+        "data_pin": "A1",
+        "clock_pin": "A2"
     }
 }

--- a/keyboards/handwired/onekey/blackpill_f401_tinyuf2/config.h
+++ b/keyboards/handwired/onekey/blackpill_f401_tinyuf2/config.h
@@ -23,8 +23,6 @@
 
 #define ADC_PIN A0
 
-#define RGB_CI_PIN A2
-
 #define SOLENOID_PIN B12
 #define SOLENOID_PINS { B12, B13, B14, B15 }
 #define SOLENOID_PINS_ACTIVE_STATE { high, high, low }

--- a/keyboards/handwired/onekey/blackpill_f401_tinyuf2/info.json
+++ b/keyboards/handwired/onekey/blackpill_f401_tinyuf2/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A1"
+    },
+    "apa102": {
+        "data_pin": "A1",
+        "clock_pin": "A2"
     }
 }

--- a/keyboards/handwired/onekey/blackpill_f411/config.h
+++ b/keyboards/handwired/onekey/blackpill_f411/config.h
@@ -23,8 +23,6 @@
 
 #define ADC_PIN A0
 
-#define RGB_CI_PIN A2
-
 #define SOLENOID_PIN B12
 #define SOLENOID_PINS { B12, B13, B14, B15 }
 #define SOLENOID_PINS_ACTIVE_STATE { high, high, low }

--- a/keyboards/handwired/onekey/blackpill_f411/info.json
+++ b/keyboards/handwired/onekey/blackpill_f411/info.json
@@ -10,5 +10,9 @@
     },
     "rgblight": {
         "pin": "A1"
+    },
+    "apa102": {
+        "data_pin": "A1",
+        "clock_pin": "A2"
     }
 }

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/config.h
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/config.h
@@ -23,8 +23,6 @@
 
 #define ADC_PIN A0
 
-#define RGB_CI_PIN A2
-
 #define SOLENOID_PIN B12
 #define SOLENOID_PINS { B12, B13, B14, B15 }
 #define SOLENOID_PINS_ACTIVE_STATE { high, high, low }

--- a/keyboards/handwired/onekey/blackpill_f411_tinyuf2/info.json
+++ b/keyboards/handwired/onekey/blackpill_f411_tinyuf2/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A1"
+    },
+    "apa102": {
+        "data_pin": "A1",
+        "clock_pin": "A2"
     }
 }

--- a/keyboards/handwired/onekey/bluepill/config.h
+++ b/keyboards/handwired/onekey/bluepill/config.h
@@ -21,5 +21,3 @@
 #define BACKLIGHT_PWM_CHANNEL 1
 
 #define ADC_PIN A0
-
-#define RGB_CI_PIN A2

--- a/keyboards/handwired/onekey/bluepill/info.json
+++ b/keyboards/handwired/onekey/bluepill/info.json
@@ -10,5 +10,9 @@
     },
     "rgblight": {
         "pin": "A1"
+    },
+    "apa102": {
+        "data_pin": "A1",
+        "clock_pin": "A2"
     }
 }

--- a/keyboards/handwired/onekey/bluepill_f103c6/config.h
+++ b/keyboards/handwired/onekey/bluepill_f103c6/config.h
@@ -22,8 +22,6 @@
 
 #define ADC_PIN A0
 
-#define RGB_CI_PIN A2
-
 // This code does not fit into the really small flash of STM32F103x6 together
 // with CONSOLE_ENABLE=yes, and the debugging console is probably more
 // important for the "onekey" testing firmware.  In a real firmware you may be

--- a/keyboards/handwired/onekey/bluepill_f103c6/info.json
+++ b/keyboards/handwired/onekey/bluepill_f103c6/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A1"
+    },
+    "apa102": {
+        "data_pin": "A1",
+        "clock_pin": "A2"
     }
 }

--- a/keyboards/handwired/onekey/bluepill_uf2boot/config.h
+++ b/keyboards/handwired/onekey/bluepill_uf2boot/config.h
@@ -21,5 +21,3 @@
 #define BACKLIGHT_PWM_CHANNEL 1
 
 #define ADC_PIN A0
-
-#define RGB_CI_PIN A2

--- a/keyboards/handwired/onekey/bluepill_uf2boot/info.json
+++ b/keyboards/handwired/onekey/bluepill_uf2boot/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A1"
+    },
+    "apa102": {
+        "data_pin": "A1",
+        "clock_pin": "A2"
     }
 }

--- a/keyboards/handwired/onekey/elite_c/config.h
+++ b/keyboards/handwired/onekey/elite_c/config.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-
-#define RGB_CI_PIN B1
-
 #define ADC_PIN F6
 
 #define QMK_WAITING_TEST_BUSY_PIN F6

--- a/keyboards/handwired/onekey/elite_c/info.json
+++ b/keyboards/handwired/onekey/elite_c/info.json
@@ -10,5 +10,9 @@
     },
     "rgblight": {
         "pin": "F6"
+    },
+    "apa102": {
+        "data_pin": "F6",
+        "clock_pin": "B1"
     }
 }

--- a/keyboards/handwired/onekey/evb_wb32f3g71/config.h
+++ b/keyboards/handwired/onekey/evb_wb32f3g71/config.h
@@ -11,7 +11,6 @@
 #define BACKLIGHT_PAL_MODE    2
 
 #define APA102_NOPS (100 / (1000000000L / (CPU_CLOCK / 4)))
-#define RGB_CI_PIN B8
 
 #define SOLENOID_PIN B12
 #define SOLENOID_PINS { B12, B13, B14, B15 }

--- a/keyboards/handwired/onekey/evb_wb32f3g71/info.json
+++ b/keyboards/handwired/onekey/evb_wb32f3g71/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A0"
+    },
+    "apa102": {
+        "data_pin": "A0",
+        "clock_pin": "B8"
     }
 }

--- a/keyboards/handwired/onekey/evb_wb32fq95/config.h
+++ b/keyboards/handwired/onekey/evb_wb32fq95/config.h
@@ -11,7 +11,6 @@
 #define BACKLIGHT_PAL_MODE    2
 
 #define APA102_NOPS (100 / (1000000000L / (CPU_CLOCK / 4)))
-#define RGB_CI_PIN B8
 
 #define SOLENOID_PIN B12
 #define SOLENOID_PINS { B12, B13, B14, B15 }

--- a/keyboards/handwired/onekey/evb_wb32fq95/info.json
+++ b/keyboards/handwired/onekey/evb_wb32fq95/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A0"
+    },
+    "apa102": {
+        "data_pin": "A0",
+        "clock_pin": "B8"
     }
 }

--- a/keyboards/handwired/onekey/nucleo_f446re/config.h
+++ b/keyboards/handwired/onekey/nucleo_f446re/config.h
@@ -7,8 +7,6 @@
 #define BACKLIGHT_PWM_CHANNEL 3
 #define BACKLIGHT_PAL_MODE    2
 
-#define RGB_CI_PIN B13
-
 #define ADC_PIN A0
 
 #define SOLENOID_PINS { B12, B13, B14, B15 }

--- a/keyboards/handwired/onekey/nucleo_f446re/info.json
+++ b/keyboards/handwired/onekey/nucleo_f446re/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A0"
+    },
+    "apa102": {
+        "data_pin": "A0",
+        "clock_pin": "B13"
     }
 }

--- a/keyboards/handwired/onekey/nucleo_l432kc/config.h
+++ b/keyboards/handwired/onekey/nucleo_l432kc/config.h
@@ -7,6 +7,4 @@
 #define BACKLIGHT_PWM_CHANNEL 3
 #define BACKLIGHT_PAL_MODE    2
 
-#define RGB_CI_PIN B13
-
 #define ADC_PIN A0

--- a/keyboards/handwired/onekey/nucleo_l432kc/info.json
+++ b/keyboards/handwired/onekey/nucleo_l432kc/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "A0"
+    },
+    "apa102": {
+        "data_pin": "A0",
+        "clock_pin": "B13"
     }
 }

--- a/keyboards/handwired/onekey/promicro/config.h
+++ b/keyboards/handwired/onekey/promicro/config.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-
-#define RGB_CI_PIN B1
-
 #define ADC_PIN F6
 
 #define QMK_WAITING_TEST_BUSY_PIN F6

--- a/keyboards/handwired/onekey/promicro/info.json
+++ b/keyboards/handwired/onekey/promicro/info.json
@@ -10,5 +10,9 @@
     },
     "rgblight": {
         "pin": "F6"
+    },
+    "apa102": {
+        "data_pin": "F6",
+        "clock_pin": "B1"
     }
 }

--- a/keyboards/handwired/onekey/proton_c/config.h
+++ b/keyboards/handwired/onekey/proton_c/config.h
@@ -21,6 +21,4 @@
 #define BACKLIGHT_PWM_CHANNEL 3
 #define BACKLIGHT_PAL_MODE    2
 
-#define RGB_CI_PIN B13
-
 #define ADC_PIN A0

--- a/keyboards/handwired/onekey/proton_c/info.json
+++ b/keyboards/handwired/onekey/proton_c/info.json
@@ -10,5 +10,9 @@
     },
     "rgblight": {
         "pin": "A0"
+    },
+    "apa102": {
+        "data_pin": "A0",
+        "clock_pin": "B13"
     }
 }

--- a/keyboards/handwired/onekey/sipeed_longan_nano/config.h
+++ b/keyboards/handwired/onekey/sipeed_longan_nano/config.h
@@ -20,8 +20,6 @@
 #define BACKLIGHT_PWM_DRIVER PWMD5 /* GD32 numbering scheme starts from 0, TIMER4 on GD32 boards is TIMER5 on STM32 boards. */
 #define BACKLIGHT_PWM_CHANNEL 2    /* GD32 numbering scheme starts from 0, Channel 1 on GD32 boards is Channel 2 on STM32 boards. */
 
-#define RGB_CI_PIN B13
-
 #define ADC_PIN A0
 
 #define I2C1_CLOCK_SPEED 1000000 /* GD32VF103 supports fast mode plus. */

--- a/keyboards/handwired/onekey/sipeed_longan_nano/info.json
+++ b/keyboards/handwired/onekey/sipeed_longan_nano/info.json
@@ -12,5 +12,9 @@
     },
     "rgblight": {
         "pin": "A2"
+    },
+    "apa102": {
+        "data_pin": "A2",
+        "clock_pin": "B13"
     }
 }

--- a/keyboards/handwired/onekey/stm32f0_disco/config.h
+++ b/keyboards/handwired/onekey/stm32f0_disco/config.h
@@ -22,5 +22,3 @@
 #define BACKLIGHT_PAL_MODE    0
 
 #define ADC_PIN A0
-
-#define RGB_CI_PIN B13

--- a/keyboards/handwired/onekey/stm32f0_disco/info.json
+++ b/keyboards/handwired/onekey/stm32f0_disco/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "B15"
+    },
+    "apa102": {
+        "data_pin": "B15",
+        "clock_pin": "B13"
     }
 }

--- a/keyboards/handwired/onekey/teensy_2/config.h
+++ b/keyboards/handwired/onekey/teensy_2/config.h
@@ -19,7 +19,5 @@
 
 #define ADC_PIN F6
 
-#define RGB_CI_PIN F7
-
 #define QMK_WAITING_TEST_BUSY_PIN F6
 #define QMK_WAITING_TEST_YIELD_PIN F7

--- a/keyboards/handwired/onekey/teensy_2/info.json
+++ b/keyboards/handwired/onekey/teensy_2/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "F6"
+    },
+    "apa102": {
+        "data_pin": "F6",
+        "clock_pin": "F7"
     }
 }

--- a/keyboards/handwired/onekey/teensy_2pp/config.h
+++ b/keyboards/handwired/onekey/teensy_2pp/config.h
@@ -19,7 +19,5 @@
 
 #define ADC_PIN F6
 
-#define RGB_CI_PIN F7
-
 #define QMK_WAITING_TEST_BUSY_PIN F6
 #define QMK_WAITING_TEST_YIELD_PIN F7

--- a/keyboards/handwired/onekey/teensy_2pp/info.json
+++ b/keyboards/handwired/onekey/teensy_2pp/info.json
@@ -11,5 +11,9 @@
     },
     "rgblight": {
         "pin": "F6"
+    },
+    "apa102": {
+        "data_pin": "F6",
+        "clock_pin": "F7"
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Only the driver needs to know what the clock and data pins are. RGBlight does not reference `RGB_DI_PIN` at all so these defines can be renamed for clarity.

Eventually this should also be done for WS2812.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
