### PR TITLE
add rgb-effects qmk sub command

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -387,6 +387,7 @@ ifneq ("$(KEYMAP_H)","")
 endif
 
 OPT_DEFS += -DKEYMAP_C=\"$(KEYMAP_C)\"
+OPT_DEFS += -save-temps=obj
 
 # If a keymap or userspace places their keymap array in another file instead, allow for it to be included
 # !!NOTE!! -- For this to work, the source file cannot be part of $(SRC), so users should not add it via `SRC += <file>`

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -78,6 +78,7 @@ subcommands = [
     'qmk.cli.new.keymap',
     'qmk.cli.painter',
     'qmk.cli.pytest',
+    'qmk.cli.rgb_effects',
     'qmk.cli.via2json',
 ]
 

--- a/lib/python/qmk/cli/rgb_effects.py
+++ b/lib/python/qmk/cli/rgb_effects.py
@@ -1,0 +1,57 @@
+import json
+import os
+
+from milc import cli
+from qmk.decorators import automagic_keyboard, automagic_keymap
+from qmk.keyboard import keyboard_completer, keyboard_folder
+from qmk.path import is_keyboard
+from pathlib import Path
+from qmk.constants import KEYBOARD_OUTPUT_PREFIX
+from qmk.c_parse import extract_enum_from_c_file_as_dict
+from qmk.json_encoders import InfoJSONEncoder
+
+
+@cli.argument("-kb", "--keyboard", type=keyboard_folder, completer=keyboard_completer)
+@cli.argument('-km', '--keymap', help='keymap to evaluate')
+@cli.subcommand("RGB Effect information")
+@automagic_keyboard
+@automagic_keymap
+def rgb_effects(cli):
+    """Output enabled RGB matrix effects as json list format for use with via"""
+
+    # Determine our keyboard(s)
+    if not cli.args.keyboard:
+        cli.log.error('Missing parameter: --keyboard')
+        cli.subcommands['rgb-effects'].print_help()
+        return False
+
+    if not is_keyboard(cli.args.keyboard):
+        cli.log.error('Invalid keyboard: "%s"', cli.args.keyboard)
+        return False
+
+    if not cli.args.keymap:
+        cli.log.error('Missing parameter: --keymap')
+        cli.subcommands['rgb-effects'].print_help()
+        return False
+
+    keymap = cli.args.keymap
+    keyboard = cli.args.keyboard
+    keyboard_filesafe = keyboard.replace('/', '_')
+    rgb_matrix_path = Path(f'{KEYBOARD_OUTPUT_PREFIX}{keyboard_filesafe}_{keymap}/quantum/rgb_matrix/rgb_matrix.i')
+
+    if not os.path.exists(rgb_matrix_path):
+        cli.log.error(f"{rgb_matrix_path} does not exist.")
+        cli.log.error("Please compile the image first.")
+        return False
+
+    with open(rgb_matrix_path, 'r') as f:
+        file_contents = f.read()
+    enum_as_dict = {key: value for (key, value) in extract_enum_from_c_file_as_dict(file_contents, "rgb_matrix_effects").items() if key != "RGB_MATRIX_EFFECT_MAX"}
+
+    max_value = max(enum_as_dict.values())
+
+    def enum_name_to_effect_name(x):
+        return x.replace("RGB_MATRIX_", "")
+
+    formatted = [[f"{str(idx).zfill(len(str(max_value)))}. {enum_name_to_effect_name(enum_name)}", value] for idx, [enum_name, value] in enumerate(enum_as_dict.items())]
+    print(json.dumps(formatted, cls=InfoJSONEncoder))

--- a/lib/python/qmk/tests/c_parse.py
+++ b/lib/python/qmk/tests/c_parse.py
@@ -1,0 +1,94 @@
+from qmk.c_parse import extract_enum_from_c_file_as_dict
+
+
+def test_extract_enum_from_c_file_as_dict():
+    test_cases = [
+        {
+            'input_1': 'enum my_enum {};',
+            'input_2': 'my_enum',
+            'expected_output': {}
+        },
+        {
+            'input_1': 'enum my_enum { A };',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 0
+            }
+        },
+        {
+            'input_1': 'enum my_enum { A = 5, B = 10, C = 15 };',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 5,
+                'B': 10,
+                'C': 15
+            }
+        },
+        {
+            'input_1': 'enum my_enum { A, B = 10, C };',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 0,
+                'B': 10,
+                'C': 11
+            }
+        },
+        {
+            'input_1': 'enum my_enum {\n    A,\n    B, // This comment refers to letter B\n    C\n};',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 0,
+                'B': 1,
+                'C': 2
+            }
+        },
+        {
+            'input_1': 'enum my_enum { A = 0, B = 0, C = 1 };',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 0,
+                'B': 0,
+                'C': 1
+            }
+        },
+        {
+            'input_1': 'enum my_enum {\n    A,\n    B,\n    C\n};\n\nenum my_other_enum {\n  D\n};',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 0,
+                'B': 1,
+                'C': 2
+            }
+        },
+        {
+            'input_1': '/* Valid C comments */\nenum my_enum {\n    A,\n    B,\n    C\n};',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 0,
+                'B': 1,
+                'C': 2
+            }
+        },
+        {
+            'input_1': 'enum my_enum {\n    A,\n    B,\n    C\n};',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 0,
+                'B': 1,
+                'C': 2
+            }
+        },
+        {
+            'input_1': 'enum my_enum {\n    A = 42,\n    B,\n    C\n};',
+            'input_2': 'my_enum',
+            'expected_output': {
+                'A': 42,
+                'B': 43,
+                'C': 44
+            }
+        },
+    ]
+
+    for test_case in test_cases:
+        result = extract_enum_from_c_file_as_dict(test_case["input_1"], test_case["input_2"])
+        assert test_case["expected_output"] == result


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I have enabled a few more effects for my keyboard and the list of effects that is selectable in the VIA frontend does not match the effects in the firmware any longer.
Since the enum `rgb_matrix_effects` is highly dynamic and depends on the specific keyboard/keymap and can also configured on various levels it is best to directly parse the `enum` that is the result of the preprocessor and the input of the compiler.

This is achieved by also emitting the temporary files (`.i`) when building a firmware. These files can then later be consumed by other tools, in this case with a new subcommand in `qmk`.

Example output:

```
❯ qmk rgb-effects -kb keychron/q1/ansi_stm32l432_encoder -km via
[
    ["00. NONE", 0],
    ["01. SOLID_COLOR", 1],
    ["02. ALPHAS_MODS", 2],
    ["03. GRADIENT_UP_DOWN", 3],
    ["04. GRADIENT_LEFT_RIGHT", 4],
    ["05. BREATHING", 5],
    ["06. BAND_SAT", 6],
    ["07. BAND_VAL", 7],
    ["08. BAND_PINWHEEL_SAT", 8],
    ["09. BAND_PINWHEEL_VAL", 9],
    ["10. BAND_SPIRAL_SAT", 10],
    ["11. BAND_SPIRAL_VAL", 11],
    ["12. CYCLE_ALL", 12],
    ["13. CYCLE_LEFT_RIGHT", 13],
    ["14. CYCLE_UP_DOWN", 14],
    ["15. RAINBOW_MOVING_CHEVRON", 15],
    ["16. CYCLE_OUT_IN", 16],
    ["17. CYCLE_OUT_IN_DUAL", 17],
    ["18. CYCLE_PINWHEEL", 18],
    ["19. CYCLE_SPIRAL", 19],
    ["20. DUAL_BEACON", 20],
    ["21. RAINBOW_BEACON", 21],
    ["22. RAINBOW_PINWHEELS", 22],
    ["23. RAINDROPS", 23],
    ["24. JELLYBEAN_RAINDROPS", 24],
    ["25. HUE_BREATHING", 25],
    ["26. HUE_PENDULUM", 26],
    ["27. HUE_WAVE", 27],
    ["28. PIXEL_RAIN", 28],
    ["29. PIXEL_FLOW", 29],
    ["30. PIXEL_FRACTAL", 30],
    ["31. TYPING_HEATMAP", 31],
    ["32. DIGITAL_RAIN", 32],
    ["33. SOLID_REACTIVE_SIMPLE", 33],
    ["34. SOLID_REACTIVE", 34],
    ["35. SOLID_REACTIVE_WIDE", 35],
    ["36. SOLID_REACTIVE_MULTIWIDE", 36],
    ["37. SOLID_REACTIVE_CROSS", 37],
    ["38. SOLID_REACTIVE_MULTICROSS", 38],
    ["39. SOLID_REACTIVE_NEXUS", 39],
    ["40. SOLID_REACTIVE_MULTINEXUS", 40],
    ["41. SPLASH", 41],
    ["42. MULTISPLASH", 42],
    ["43. SOLID_SPLASH", 43],
    ["44. SOLID_MULTISPLASH", 44],
    ["45. RANDOM_FILL", 45]
]
```

This can then be copied into the VIA json as the options list for `id_qmk_rgb_matrix_effect`.

@lalalademaxiya1 pinging you as the keychron VIA json files are often brought up as a reference. Maybe you have a similar tool
and/or would benefit from this.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
