### PR TITLE
[Keyboard] Olly Orion: Disable SWD and JTAG

### DIFF
--- a/keyboards/mechlovin/olly/orion/orion.c
+++ b/keyboards/mechlovin/olly/orion/orion.c
@@ -16,13 +16,19 @@
 
 #include "orion.h"
 
+void board_init(void) {
+   //JTAG-DP Disabled and SW-DP Enabled    
+   AFIO->MAPR = (AFIO->MAPR & ~AFIO_MAPR_SWJ_CFG_Msk) | AFIO_MAPR_SWJ_CFG_DISABLE;
+}
+
 void led_init_ports(void) {
   setPinOutput(B5);
   setPinOutput(B6);
   setPinOutput(B7);
   setPinOutput(B8);
   setPinOutput(B9);
-
+  setPinOutput(A13);
+  setPinOutput(A14);
 }
 
 layer_state_t layer_state_set_kb(layer_state_t state) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Set SWD pins as GPIO pins for LED indicator.
Thanks.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
