### PR TITLE
Allow encoder pins to be specified as integer

### DIFF
--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -111,8 +111,8 @@ def generate_encoder_config(encoder_json, config_h_lines, postfix=''):
     b_pads = []
     resolutions = []
     for encoder in encoder_json.get("rotary", []):
-        a_pads.append(encoder["pin_a"])
-        b_pads.append(encoder["pin_b"])
+        a_pads.append(str(encoder["pin_a"]))
+        b_pads.append(str(encoder["pin_b"]))
         resolutions.append(encoder.get("resolution", None))
 
     config_h_lines.append(generate_define(f'ENCODERS_PAD_A{postfix}', f'{{ {", ".join(a_pads)} }}'))

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -270,8 +270,8 @@ def _extract_encoders_values(config_c, postfix=''):
     default_resolution = config_c.get('ENCODER_RESOLUTION', None)
 
     if a_pad and b_pad:
-        a_pad = list(filter(None, a_pad.split(',')))
-        b_pad = list(filter(None, b_pad.split(',')))
+        a_pad = list(map(lambda pad: int(pad) if pad.isdigit() else pad, filter(None, a_pad.split(','))))
+        b_pad = list(map(lambda pad: int(pad) if pad.isdigit() else pad, filter(None, b_pad.split(','))))
         resolutions = list(filter(None, resolutions.split(',')))
         if default_resolution:
             resolutions += [default_resolution] * (len(a_pad) - len(resolutions))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

According to [keyboard.jsonschema](data/schemas/keyboard.jsonschema) and [definitions.jsonschema](data/schemas/definitions.jsonschema), the encoders pin_a and pin_b can be integer. However, specifying integers causes an error because info.py and config_h.py implicitly treat them as string.
In contrast, for matrix_pins definition, they correctly handle both string and integer.

This pull request allows encoder pins to be specified as integer.

Here is an example.

```jsonc
// info.json
{
  "matrix_pins": {
    // OK (specify string only)
    "cols": ["A0", "A1"],

    // OK (specify both integer and string)
    "rows": [0, "B1"]
  },
  "encoder": {
    "rotary": [
      // OK (specify string only)
      {"pin_a": "A1", "pin_b": "A2"},

      // error (specify both integer and string)
      {"pin_a": "A1", "pin_b": 2}
    ]
  }
}
```

```c
// config.h

// OK (specify string(integer type constant) only)
#define MATRIX_ROW_PINS { A1, A2 }

// OK (specify both integer and string)
#define MATRIX_ROW_PINS { A1, 2 }

// OK (specify string(integer type constant) only)
#define ENCODERS_PIN_A { A1, A2 }

// error (specify both integer and string)
#define ENCODERS_PIN_A { A1, 2 } 
```

This PR resolves all of the above error cases.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

> 