### PR TITLE
Fixed split keyboard issue where custom LED indicators could activate incorrect LEDs (#20203)

### DIFF
--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -459,14 +459,7 @@ void rgb_matrix_indicators_advanced(effect_params_t *params) {
      * and not sure which would be better. Otherwise, this should be called from
      * rgb_task_render, right before the iter++ line.
      */
-#if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < RGB_MATRIX_LED_COUNT
-    uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (params->iter - 1);
-    uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;
-    if (max > RGB_MATRIX_LED_COUNT) max = RGB_MATRIX_LED_COUNT;
-#else
-    uint8_t min = 0;
-    uint8_t max = RGB_MATRIX_LED_COUNT;
-#endif
+    RGB_MATRIX_USE_LIMITS_ITER(min, max, params->iter - 1);
     rgb_matrix_indicators_advanced_kb(min, max);
 }
 

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -60,9 +60,9 @@
             if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
             if (!(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
 #    else
-#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)             \
-            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (iter);       \
-            uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
+#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)       \
+            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (iter); \
+            uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;    \
             if (max > RGB_MATRIX_LED_COUNT) max = RGB_MATRIX_LED_COUNT;
 #    endif
 #else

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -52,33 +52,35 @@
 
 #if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < RGB_MATRIX_LED_COUNT
 #    if defined(RGB_MATRIX_SPLIT)
-#        define RGB_MATRIX_USE_LIMITS(min, max)                                                   \
-            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter;                            \
+#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)                                        \
+            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (iter);                                  \
             uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;                                     \
             if (max > RGB_MATRIX_LED_COUNT) max = RGB_MATRIX_LED_COUNT;                           \
             uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;                                     \
             if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
             if (!(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
 #    else
-#        define RGB_MATRIX_USE_LIMITS(min, max)                        \
-            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * params->iter; \
+#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)             \
+            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (iter);       \
             uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;          \
             if (max > RGB_MATRIX_LED_COUNT) max = RGB_MATRIX_LED_COUNT;
 #    endif
 #else
 #    if defined(RGB_MATRIX_SPLIT)
-#        define RGB_MATRIX_USE_LIMITS(min, max)                                                   \
+#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)                                        \
             uint8_t       min                   = 0;                                              \
             uint8_t       max                   = RGB_MATRIX_LED_COUNT;                           \
             const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;                               \
             if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
             if (!(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
 #    else
-#        define RGB_MATRIX_USE_LIMITS(min, max) \
-            uint8_t min = 0;                    \
+#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter) \
+            uint8_t min = 0;                               \
             uint8_t max = RGB_MATRIX_LED_COUNT;
 #    endif
 #endif
+
+#define RGB_MATRIX_USE_LIMITS(min, max) RGB_MATRIX_USE_LIMITS_ITER(min, max, params->iter)
 
 #define RGB_MATRIX_INDICATOR_SET_COLOR(i, r, g, b) \
     if (i >= led_min && i < led_max) {             \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Changed `rgb_matrix_indicators_advanced` to restrict the RGB index range to the split keyboard's left or right range.
Added `RGB_MATRIX_USE_LIMITS_ITER` macro to reduce code duplication in handling split keyboard RGB index range.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #20203 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
