### PR TITLE
cantor: fix LT(layer, kc) do not work after waking up PC #16406

### DIFF
--- a/keyboards/cantor/cantor.c
+++ b/keyboards/cantor/cantor.c
@@ -1,0 +1,11 @@
+// Copyright 2023 Alessio Caiazza (@nolith)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+
+// Workaround for https://github.com/qmk/qmk_firmware/issues/16406
+__attribute__ ((weak))
+void suspend_wakeup_init_kb(void) {
+    NVIC_SystemReset();
+    suspend_wakeup_init_user();
+}

--- a/keyboards/cantor/rules.mk
+++ b/keyboards/cantor/rules.mk
@@ -1,2 +1,4 @@
 SPLIT_KEYBOARD = yes
 SERIAL_DRIVER = usart
+
+SRC += cantor.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Reset the cantor after a wakeup event to unblock `LT(layer, kc)` keys. 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Refactor of the original @philong workaround https://github.com/qmk/qmk_firmware/issues/16406#issuecomment-1475771324.

Instead of a user function in the keymap this commit applies the workarund at the keyboard level to make it available to every cantor user.

As the author said in the issue,

> It basically just resets the keyboard after waking up from suspend. Although it works for me, it does not fix the real cause of the issue.

I don't have the knowledge to make a proper fix for the BlackPill board, but this small workaround is working for me on cantor remix (36 keys version) and I think is worth make it more available to the users.

This could be reverted as soon as someone have a proper fix for the underlaying problem.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* It's a workaround for https://github.com/qmk/qmk_firmware/issues/16406 only for the cantor keyboard

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
