### PR TITLE
Add split USB detection support

### DIFF
--- a/keyboards/ferris/keymaps/via/config.h
+++ b/keyboards/ferris/keymaps/via/config.h
@@ -7,3 +7,7 @@
 #define TAPPING_TERM 230
 #define IGNORE_MOD_TAP_INTERRUPT
 
+// Handle master/slave detection on low cost Promicro
+#ifdef __AVR__
+#    define SPLIT_USB_DETECT
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Generic cheap Promicros are often used to build the austere ferris/sweep board. Most of these controllers require `SPLIT_USB_DETECT` to function correctly and this change eliminates a frequent issue for first time builders testing their hardware.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
