### PR TITLE
[jacky_studio/piggy60] warn about incompatible PCB rev

### DIFF
--- a/keyboards/jacky_studio/piggy60/readme.md
+++ b/keyboards/jacky_studio/piggy60/readme.md
@@ -5,7 +5,8 @@
 A gasket-mounted 60% in the style of the S7 Elephant.
 
 * Keyboard Maintainer: [The QMK Community](https://github.com/qmk)
-* Hardware Supported: Piggy60
+* Hardware Supported: Piggy60 PCB "rev1" (atmega32u4)
+  * **Make sure your PCB uses an `atmega32u4` before flashing!** A PCB that uses an `APM32F103CBT6` with `uf2boot` has been shipped with some extras purchases and to replace some defective units. Flashing that PCB with "rev1" firmware may result in a non-functional PCB which can only be recovered using a hardware programmer (e.g. an ST-Link V2)
 * Hardware Availability: Group Buy took place between 2021-05-22 1600 UTC and 2021-05-25 1600 UTC on [https://jackylab.com/](https://jackylab.com/).
 
 Make example for this keyboard (after setting up your build environment):


### PR DESCRIPTION
## Description

Unfortunately a couple of people have already "bricked" their `jacky_studio/piggy60` PCBs by flashing the firmware I reverse-engineered, not realizing they had a different PCB revision.

PRs to move the current version and add a `rev2` will ensue against `develop`, but I thought this warning would be better off in `master` so someone is likelier to see it before the end of May.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
