### PR TITLE
Optionally keep intermediate file listings in order to do comparisons between builds.

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -441,6 +441,14 @@ $(eval $(call add_qmk_prefix_defs,MCU_FAMILY,MCU_FAMILY))
 $(eval $(call add_qmk_prefix_defs,MCU_SERIES,MCU_SERIES))
 $(eval $(call add_qmk_prefix_defs,BOARD,BOARD))
 
+# Control whether intermediate file listings are generated
+# e.g.:
+#    make handwired/onekey/blackpill_f411:default KEEP_INTERMEDIATES=yes
+#    cat .build/obj_handwired_onekey_blackpill_f411_default/quantum/quantum.i | sed -e 's@^#.*@@g' -e 's@^\s*//.*@@g' -e '/^\s*$/d' | clang-format
+ifeq ($(strip $(KEEP_INTERMEDIATES)), yes)
+    OPT_DEFS += -save-temps=obj
+endif
+
 # TODO: remove this bodge?
 PROJECT_DEFS := $(OPT_DEFS)
 PROJECT_INC := $(VPATH) $(EXTRAINCDIRS) $(KEYBOARD_PATHS)


### PR DESCRIPTION
## Description

Adds a new flag to the build -- `KEEP_INTERMEDIATES=yes` -- which instructs the compiler to keep the post-preprocessor output in `.build` as a sibling to the object file output that the compiler created.

This can then be diff'ed between builds in order to determine if preprocessor or include ordering etc. changes outputs.

Also factors in with the SHA1 verifications, so that code-wise differences can be determined, rather than looking at assembly.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
