### PR TITLE
Add basic profiler.

### DIFF
--- a/quantum/basic_profiling.h
+++ b/quantum/basic_profiling.h
@@ -9,13 +9,13 @@
 
         #include "basic_profiling.h"
 
-        // Before:
+        // Original code:
         matrix_task();
 
-        // After (variant 1, automatic naming):
+        // Delete the original, replace with the following (variant 1, automatic naming):
         PROFILE_CALL(1000, matrix_task());
 
-        // After (variant 2, explicit naming):
+        // Delete the original, replace with the following (variant 2, explicit naming):
         PROFILE_CALL_NAMED(1000, "matrix_task", {
             matrix_task();
         });

--- a/quantum/basic_profiling.h
+++ b/quantum/basic_profiling.h
@@ -13,10 +13,14 @@
         matrix_task();
 
         // After (variant 1, automatic naming):
-        PROFILE_CALL(1000, matrix_task());
+        PROFILE_CALL(1000, {
+            matrix_task();
+        });
 
         // After (variant 2, explicit naming):
-        PROFILE_CALL_NAMED(1000, "matrix_task", matrix_task());
+        PROFILE_CALL_NAMED(1000, "matrix_task", {
+            matrix_task();
+        });
 */
 
 #if defined(PROTOCOL_LUFA)

--- a/quantum/basic_profiling.h
+++ b/quantum/basic_profiling.h
@@ -29,6 +29,8 @@
 #    define TIMESTAMP_GETTER (_Static_assert(FALSE, "arm_atsam not currently supported"), 0)
 #elif defined(PROTOCOL_VUSB)
 #    define TIMESTAMP_GETTER (_Static_assert(FALSE, "VUSB not currently supported"), 0)
+#else
+#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "Unknown protocol in use"), 0)
 #endif
 
 #define PROFILE_CALL_NAMED(count, name, call)                                                                         \

--- a/quantum/basic_profiling.h
+++ b/quantum/basic_profiling.h
@@ -24,7 +24,7 @@
 #if defined(PROTOCOL_LUFA)
 #    define TIMESTAMP_GETTER (_Static_assert(FALSE, "LUFA not currently supported"), 0)
 #elif defined(PROTOCOL_CHIBIOS)
-#    define TIMESTAMP_GETTER chSysGetRealtimeCounterX
+#    define TIMESTAMP_GETTER chSysGetRealtimeCounterX()
 #elif defined(PROTOCOL_ARM_ATSAM)
 #    define TIMESTAMP_GETTER (_Static_assert(FALSE, "arm_atsam not currently supported"), 0)
 #elif defined(PROTOCOL_VUSB)
@@ -40,14 +40,14 @@
         uint32_t        start_ts;                                                                                     \
         static uint32_t end_ts;                                                                                       \
         static uint32_t write_location = 0;                                                                           \
-        start_ts                       = TIMESTAMP_GETTER();                                                          \
+        start_ts                       = TIMESTAMP_GETTER;                                                            \
         if (write_location > 0) {                                                                                     \
             outer_sum += start_ts - end_ts;                                                                           \
         }                                                                                                             \
         do {                                                                                                          \
             call;                                                                                                     \
         } while (0);                                                                                                  \
-        end_ts = TIMESTAMP_GETTER();                                                                                  \
+        end_ts = TIMESTAMP_GETTER;                                                                                    \
         inner_sum += end_ts - start_ts;                                                                               \
         ++write_location;                                                                                             \
         if (write_location >= (count)) {                                                                              \

--- a/quantum/basic_profiling.h
+++ b/quantum/basic_profiling.h
@@ -13,9 +13,7 @@
         matrix_task();
 
         // After (variant 1, automatic naming):
-        PROFILE_CALL(1000, {
-            matrix_task();
-        });
+        PROFILE_CALL(1000, matrix_task());
 
         // After (variant 2, explicit naming):
         PROFILE_CALL_NAMED(1000, "matrix_task", {

--- a/quantum/basic_profiling.h
+++ b/quantum/basic_profiling.h
@@ -21,16 +21,14 @@
         });
 */
 
-#if defined(PROTOCOL_LUFA)
-#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "LUFA not currently supported"), 0)
+#if defined(PROTOCOL_LUFA) || defined(PROTOCOL_VUSB)
+#    define TIMESTAMP_GETTER TCNT0
 #elif defined(PROTOCOL_CHIBIOS)
 #    define TIMESTAMP_GETTER chSysGetRealtimeCounterX()
 #elif defined(PROTOCOL_ARM_ATSAM)
-#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "arm_atsam not currently supported"), 0)
-#elif defined(PROTOCOL_VUSB)
-#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "VUSB not currently supported"), 0)
+#    error arm_atsam not currently supported
 #else
-#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "Unknown protocol in use"), 0)
+#    error Unknown protocol in use
 #endif
 
 #define PROFILE_CALL_NAMED(count, name, call)                                                                         \

--- a/quantum/basic_profiling.h
+++ b/quantum/basic_profiling.h
@@ -1,0 +1,59 @@
+// Copyright 2023 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+/*
+    This API allows for basic profiling information to be printed out over console.
+
+    Usage example:
+
+        #include "basic_profiling.h"
+
+        // Before:
+        matrix_task();
+
+        // After (variant 1, automatic naming):
+        PROFILE_CALL(1000, matrix_task());
+
+        // After (variant 2, explicit naming):
+        PROFILE_CALL_NAMED(1000, "matrix_task", matrix_task());
+*/
+
+#if defined(PROTOCOL_LUFA)
+#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "LUFA not currently supported"), 0)
+#elif defined(PROTOCOL_CHIBIOS)
+#    define TIMESTAMP_GETTER chSysGetRealtimeCounterX
+#elif defined(PROTOCOL_ARM_ATSAM)
+#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "arm_atsam not currently supported"), 0)
+#elif defined(PROTOCOL_VUSB)
+#    define TIMESTAMP_GETTER (_Static_assert(FALSE, "VUSB not currently supported"), 0)
+#endif
+
+#define PROFILE_CALL_NAMED(count, name, call)                                                                         \
+    do {                                                                                                              \
+        static uint64_t inner_sum = 0;                                                                                \
+        static uint64_t outer_sum = 0;                                                                                \
+        uint32_t        start_ts;                                                                                     \
+        static uint32_t end_ts;                                                                                       \
+        static uint32_t write_location = 0;                                                                           \
+        start_ts                       = TIMESTAMP_GETTER();                                                          \
+        if (write_location > 0) {                                                                                     \
+            outer_sum += start_ts - end_ts;                                                                           \
+        }                                                                                                             \
+        do {                                                                                                          \
+            call;                                                                                                     \
+        } while (0);                                                                                                  \
+        end_ts = TIMESTAMP_GETTER();                                                                                  \
+        inner_sum += end_ts - start_ts;                                                                               \
+        ++write_location;                                                                                             \
+        if (write_location >= (count)) {                                                                              \
+            uint32_t inner_avg = inner_sum / ((count)-1);                                                             \
+            uint32_t outer_avg = outer_sum / ((count)-1);                                                             \
+            dprintf("%s -- Percentage time spent: %d%%\n", (name), (int)(inner_avg * 100 / (inner_avg + outer_avg))); \
+            inner_sum      = 0;                                                                                       \
+            outer_sum      = 0;                                                                                       \
+            write_location = 0;                                                                                       \
+        }                                                                                                             \
+    } while (0)
+
+#define PROFILE_CALL(count, call) PROFILE_CALL_NAMED(count, #call, call)


### PR DESCRIPTION
## Description

Adds basic profiling support in order to determine the percentage of time spent within a function or block of code.

```
/*
    This API allows for basic profiling information to be printed out over console.

    Usage example:

        #include "basic_profiling.h"

        // Original code:
        matrix_task();

        // Delete the original, replace with the following (variant 1, automatic naming):
        PROFILE_CALL(1000, matrix_task());

        // Delete the original, replace with the following (variant 2, explicit naming):
        PROFILE_CALL_NAMED(1000, "matrix_task", {
            matrix_task();
        });
*/
```

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
