### PR TITLE
Add an alternate layout definition for Keyboardio Model 01

### DIFF
--- a/keyboards/keyboardio/model01/model01.h
+++ b/keyboards/keyboardio/model01/model01.h
@@ -38,6 +38,24 @@
       {R30, R31, R32, R33, R34, R35, R36, R37} \
   }
 
+#define LAYOUT_thumb_row( \
+  L07, L06, L05, L04, L03, L02,            R05, R04, R03, R02, R01, R00, \
+  L17, L16, L15, L14, L13, L12, L01,  R06, R15, R14, R13, R12, R11, R10, \
+  L27, L26, L25, L24, L23, L22, L11,  R16, R25, R24, R23, R22, R21, R20, \
+  L37, L36, L35, L34, L33, L32, L21,  R26, R35, R34, R33, R32, R31, R30, \
+                 L00, L10, L20, L30,  R37, R27, R17, R07,                \
+                                L31,  R36                                \
+  ) { \
+      {L00, L01, L02, L03, L04, L05, L06, L07}, \
+      {L10, L11, L12, L13, L14, L15, L16, L17}, \
+      {L20, L21, L22, L23, L24, L25, L26, L27}, \
+      {L30, L31, L32, L33, L34, L35, L36, L37}, \
+      {R00, R01, R02, R03, R04, R05, R06, R07}, \
+      {R10, R11, R12, R13, R14, R15, R16, R17}, \
+      {R20, R21, R22, R23, R24, R25, R26, R27}, \
+      {R30, R31, R32, R33, R34, R35, R36, R37} \
+  }
+
 #include "wire-protocol-constants.h"
 #define I2C_ADDR_LEFT   (0x58 << 1)
 #define I2C_ADDR_RIGHT  (I2C_ADDR_LEFT + 6)


### PR DESCRIPTION
## Description

This gives an alternate arrangement option that sees the thumb keys as a single row rather than 4.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
