### PR TITLE
CLI: Add `qmk info-migrate`

### DIFF
--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -66,6 +66,7 @@ subcommands = [
     'qmk.cli.import.keyboard',
     'qmk.cli.import.keymap',
     'qmk.cli.info',
+    'qmk.cli.info_migrate',
     'qmk.cli.json2c',
     'qmk.cli.lint',
     'qmk.cli.kle2json',

--- a/lib/python/qmk/cli/info_migrate.py
+++ b/lib/python/qmk/cli/info_migrate.py
@@ -1,0 +1,38 @@
+"""Migrate info.json keys
+"""
+import json
+from pathlib import Path
+from dotty_dict import dotty
+
+from milc import cli
+
+from qmk.keyboard import keyboard_completer, keyboard_folder
+from qmk.info import find_info_json
+from qmk.json_encoders import InfoJSONEncoder
+from qmk.json_schema import json_load
+
+
+@cli.argument('-f', '--from', arg_only=True, help="The old info.json key")
+@cli.argument('-t', '--to', arg_only=True, help="The new info.json key")
+@cli.argument('-kb', '--keyboard', arg_only=True, type=keyboard_folder, completer=keyboard_completer, required=True, help='The keyboard\'s name')
+@cli.subcommand('Migrate info.json keys.', hidden=True)
+def info_migrate(cli):
+    """Migrate info.json keys
+    """
+
+    # Find all the info.json files for this keyboard
+    target_infos = find_info_json(cli.args.keyboard)
+    info_datas = [(target_info, dotty(json_load(Path(target_info)))) for target_info in target_infos]
+
+    for file, info_data in info_datas:
+        value = info_data.get(cli.args['from'])
+
+        # Does this info.json have the "from" key?
+        if value is not None:
+            cli.log.info(f"Updating {cli.args['from']} -> {cli.args.to} (value: {value}) in {file}")
+
+            # Remove the old key, add the new key with the same value
+            del info_data[cli.args['from']]
+            info_data[cli.args.to] = value
+
+            file.write_text(json.dumps(info_data.to_dict(), cls=InfoJSONEncoder) + '\n', newline='\n')

--- a/lib/python/qmk/cli/migrate.py
+++ b/lib/python/qmk/cli/migrate.py
@@ -75,7 +75,7 @@ def migrate(cli):
 
     # Finally write out updated info.json
     cli.log.info(f'  Updating {target_info}')
-    target_info.write_text(json.dumps(info_data.to_dict(), cls=InfoJSONEncoder))
+    target_info.write_text(json.dumps(info_data.to_dict(), cls=InfoJSONEncoder) + '\n', newline='\n')
 
     cli.log.info(f'{{fg_green}}Migration of keyboard {{fg_cyan}}{cli.args.keyboard}{{fg_green}} complete!{{fg_reset}}')
     cli.log.info(f"Verify build with {{fg_yellow}}qmk compile -kb {cli.args.keyboard} -km default{{fg_reset}}.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A simple helper for moving info.json keys (eg. `rgblight.pin` -> `ws2812.pin`). Will probably come in handy when reworking the matrix config (`diode_direction` -> `matrix.driver`?).

Also tweaked the existing `qmk migrate` output to enforce Unix line endings even on Windows, and ensure newline at EOF.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
