### PR TITLE
Fix RGB_TOG like keycodes not working well with RETRO_TAPPING

### DIFF
--- a/quantum/process_keycode/process_rgb.c
+++ b/quantum/process_keycode/process_rgb.c
@@ -57,6 +57,13 @@ bool process_rgb(const uint16_t keycode, const keyrecord_t *record) {
 #else
     if (record->event.pressed) {
 #endif
+#ifndef NO_ACTION_TAPPING
+#    if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+        extern int retro_tapping_counter;
+        int        retro_tapping_counter_save = retro_tapping_counter;
+        retro_tapping_counter = 0;
+#    endif
+#endif
 #if (defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_DISABLE_KEYCODES)) || (defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_KEYCODES))
         uint8_t shifted = get_mods() & MOD_MASK_SHIFT;
 #endif
@@ -212,6 +219,11 @@ bool process_rgb(const uint16_t keycode, const keyrecord_t *record) {
 #endif
                 return false;
         }
+#ifndef NO_ACTION_TAPPING
+#    if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+        retro_tapping_counter = retro_tapping_counter_save;
+#    endif
+#endif
     }
 
     return true;


### PR DESCRIPTION
## Description

Define a key1 LT(1, KC_SPC) on layer 0, and other key2 RGB_TOG on layer 1. When hold key1 and press key2 and release key1, it will always send tap_code(KC_SPC) when defined RETRO_TAPPING, this PR fix that bug.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
