### PR TITLE
Add step summary output to CI builds, with failure logs.

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -39,7 +39,11 @@ jobs:
     - name: Run `qmk mass-compile` (keymap ${{ matrix.keymap }})
       run: |
         export NCPUS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
-        qmk mass-compile -t -j $NCPUS -km ${{ matrix.keymap }}
+        qmk mass-compile -t -j $NCPUS -km ${{ matrix.keymap }} -e DUMP_CI_METADATA=yes
+        # Generate the step summary markdown
+        ./util/ci/generate_failure_markdown.sh > $GITHUB_STEP_SUMMARY
+        # Truncate to a maximum of 1MB to deal with GitHub workflow limit
+        truncate --size='<960K' $GITHUB_STEP_SUMMARY
 
     - name: 'Upload artifacts'
       uses: actions/upload-artifact@v3

--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -29,6 +29,11 @@ KEYBOARD_FILESAFE := $(subst /,_,$(KEYBOARD))
 TARGET ?= $(KEYBOARD_FILESAFE)_$(KEYMAP)
 KEYBOARD_OUTPUT := $(BUILD_DIR)/obj_$(KEYBOARD_FILESAFE)
 
+ifeq ($(strip $(DUMP_CI_METADATA)),yes)
+    $(info CI Metadata: KEYBOARD=$(KEYBOARD))
+    $(info CI Metadata: KEYMAP=$(KEYMAP))
+endif
+
 # Force expansion
 TARGET := $(TARGET)
 

--- a/util/ci/generate_failure_markdown.sh
+++ b/util/ci/generate_failure_markdown.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+this_script="$(realpath "${BASH_SOURCE[0]}")"
+script_dir="$(realpath "$(dirname "$this_script")")"
+qmk_firmware_dir="$(realpath "$script_dir/../../")"
+
+dump_failure_info() {
+    local failure_file="$1"
+    local keyboard=$(cat "$failure_file" | grep 'CI Metadata: KEYBOARD=' | cut -d= -f2)
+    local keymap=$(cat "$failure_file" | grep 'CI Metadata: KEYMAP=' | cut -d= -f2)
+    echo "## ${keyboard}:${keymap}"
+    echo "\`\`\`"
+    cat "$failure_file" | sed -e $'s/\x1b\[[0-9;]*m//g' | grep -v "CI Metadata:" | grep -vP "(Entering|Leaving) directory"
+    echo "\`\`\`"
+}
+
+for failure_file in $(find "$qmk_firmware_dir/.build" -name 'failed.log.*' | sort); do
+    dump_failure_info "$failure_file"
+done


### PR DESCRIPTION
## Description

Adds a step summary for each build during CI.
See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
