### PR TITLE
Add ability for `qmk mass-compile` to build specified targets

### DIFF
--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -76,9 +76,6 @@ all: {keyboard_safe}_{keymap_name}_binary
                     f"""\
 	@rm -rf "{QMK_FIRMWARE}/.build/{keyboard_safe}_{keymap_name}.elf" 2>/dev/null || true
 	@rm -rf "{QMK_FIRMWARE}/.build/{keyboard_safe}_{keymap_name}.map" 2>/dev/null || true
-	@rm -rf "{QMK_FIRMWARE}/.build/{keyboard_safe}_{keymap_name}.hex" 2>/dev/null || true
-	@rm -rf "{QMK_FIRMWARE}/.build/{keyboard_safe}_{keymap_name}.bin" 2>/dev/null || true
-	@rm -rf "{QMK_FIRMWARE}/.build/{keyboard_safe}_{keymap_name}.uf2" 2>/dev/null || true
 	@rm -rf "{QMK_FIRMWARE}/.build/obj_{keyboard_safe}" || true
 	@rm -rf "{QMK_FIRMWARE}/.build/obj_{keyboard_safe}_{keymap_name}" || true
 """# noqa

--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -12,6 +12,7 @@ from qmk.commands import _find_make, get_make_parallel_args
 from qmk.search import search_keymap_targets
 
 
+@cli.argument('builds', nargs='*', arg_only=True, help="List of builds in form <keyboard>:<keymap> to compile in parallel. Specifying this overrides all other target search options.")
 @cli.argument('-t', '--no-temp', arg_only=True, action='store_true', help="Remove temporary files during build.")
 @cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs; 0 means unlimited.")
 @cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
@@ -37,7 +38,11 @@ def mass_compile(cli):
     builddir = Path(QMK_FIRMWARE) / '.build'
     makefile = builddir / 'parallel_kb_builds.mk'
 
-    targets = search_keymap_targets(cli.args.keymap, cli.args.filter)
+    if len(cli.args.builds) > 0:
+        targets = [(e[0], e[1]) for e in [b.split(':') for b in cli.args.builds]]
+    else:
+        targets = search_keymap_targets(cli.args.keymap, cli.args.filter)
+
     if len(targets) == 0:
         return
 


### PR DESCRIPTION
## Description

Adds the ability to `qmk mass-compile` to specify `make` targets on the command line:

```sh
qmk mass-compile -c -t -j 8 planck/rev6:default planck/rev6_drop:default
```

Also modifies the `--no-temp` argument to keep final outputs as they're not temporary.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
