### PR TITLE
Revert to hex output for kint41

### DIFF
--- a/keyboards/kinesis/kint41/rules.mk
+++ b/keyboards/kinesis/kint41/rules.mk
@@ -13,3 +13,5 @@ BOOTLOADER = halfkay
 # this because the Cherry MX keyswitches on the Kinesis only produce noise while
 # pressed.
 DEBOUNCE_TYPE = sym_eager_pk
+
+FIRMWARE_FORMAT = hex


### PR DESCRIPTION
## Description

Fixes configurator spitting out the wrong firmware format.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_configurator/issues/1253

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
