### PR TITLE
[QP] Fix up delta frame boundaries

### DIFF
--- a/lib/python/qmk/painter_qgf.py
+++ b/lib/python/qmk/painter_qgf.py
@@ -372,8 +372,8 @@ def _save(im, fp, filename):
             delta_descriptor = QGFFrameDeltaDescriptorV1()
             delta_descriptor.left = location[0]
             delta_descriptor.top = location[1]
-            delta_descriptor.right = location[0] + size[0]
-            delta_descriptor.bottom = location[1] + size[1]
+            delta_descriptor.right = location[0] + size[0] - 1
+            delta_descriptor.bottom = location[1] + size[1] - 1
 
             # Write the delta frame to the output
             vprint(f'{f"Frame {idx:3d} delta":26s} {fp.tell():5d}d / {fp.tell():04X}h')


### PR DESCRIPTION
## Description

Geometry needs to be specified as pixel-inclusive -- delta frames forgot about that.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
