### PR TITLE
typing_heatmap: Add macro to configure increase steps

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -690,6 +690,14 @@ Remove the spread effect entirely.
 #define RGB_MATRIX_TYPING_HEATMAP_SLIM
 ```
 
+It's also possible to adjust the tempo of *heating up*. It's defined as the number of shades that are
+increased on the [HSV scale](https://en.wikipedia.org/wiki/HSL_and_HSV). . Decreasing this value increases
+the number of keystrokes needed to fully heat up the key.
+
+```c
+#define RGB_MATRIX_TYPING_HEATMAP_INCREASE_STEP 32
+```
+
 ### RGB Matrix Effect Solid Reactive :id=rgb-matrix-effect-solid-reactive
 
 Solid reactive effects will pulse RGB light on key presses with user configurable hues. To enable gradient mode that will automatically change reactive color, add the following define:

--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -691,7 +691,7 @@ Remove the spread effect entirely.
 ```
 
 It's also possible to adjust the tempo of *heating up*. It's defined as the number of shades that are
-increased on the [HSV scale](https://en.wikipedia.org/wiki/HSL_and_HSV). . Decreasing this value increases
+increased on the [HSV scale](https://en.wikipedia.org/wiki/HSL_and_HSV). Decreasing this value increases
 the number of keystrokes needed to fully heat up the key.
 
 ```c

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -1,6 +1,9 @@
 #if defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && defined(ENABLE_RGB_MATRIX_TYPING_HEATMAP)
 RGB_MATRIX_EFFECT(TYPING_HEATMAP)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#        ifndef RGB_MATRIX_TYPING_HEATMAP_INCREASE_STEP
+#            define RGB_MATRIX_TYPING_HEATMAP_INCREASE_STEP 32
+#        endif
 
 #        ifndef RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS
 #            define RGB_MATRIX_TYPING_HEATMAP_DECREASE_DELAY_MS 25
@@ -16,7 +19,7 @@ RGB_MATRIX_EFFECT(TYPING_HEATMAP)
 void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
 #        ifdef RGB_MATRIX_TYPING_HEATMAP_SLIM
     // Limit effect to pressed keys
-    g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
+    g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], RGB_MATRIX_TYPING_HEATMAP_INCREASE_STEP);
 #        else
     if (g_led_config.matrix_co[row][col] == NO_LED) { // skip as pressed key doesn't have an led position
         return;
@@ -27,7 +30,7 @@ void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
                 continue;
             }
             if (i_row == row && i_col == col) {
-                g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], 32);
+                g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], RGB_MATRIX_TYPING_HEATMAP_INCREASE_STEP);
             } else {
 #            define LED_DISTANCE(led_a, led_b) sqrt16(((int16_t)(led_a.x - led_b.x) * (int16_t)(led_a.x - led_b.x)) + ((int16_t)(led_a.y - led_b.y) * (int16_t)(led_a.y - led_b.y)))
                 uint8_t distance = LED_DISTANCE(g_led_config.point[g_led_config.matrix_co[row][col]], g_led_config.point[g_led_config.matrix_co[i_row][i_col]]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

There are a lot of configuration values for configuring the cooldown of the heatmap. However, for fast typers, the process of heating up might be too fast. Right now, manual changes to the codebase were necessary which in turn require to understand it first.

By defining a macro and allowing to override it, it's now easier to adjust this value as wanted.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
