### PR TITLE
`qmk info`: account for ISO enter when calculating layout X offset

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -50,6 +50,11 @@ def _valid_community_layout(layout):
     return (Path('layouts/default') / layout).exists()
 
 
+def _get_key_left_position(key):
+    # Special case for ISO enter
+    return key['x'] - 0.25 if key.get('h', 1) == 2 and key.get('w', 1) == 1.25 else key['x']
+
+
 def _additional_validation(keyboard, info_data):
     """Non schema checks
     """
@@ -64,7 +69,7 @@ def _additional_validation(keyboard, info_data):
 
     # Warn if physical positions are offset (at least one key should be at x=0, and at least one key at y=0)
     for layout_name, layout_data in layouts.items():
-        offset_x = min([k['x'] for k in layout_data['layout']])
+        offset_x = min([_get_key_left_position(k) for k in layout_data['layout']])
         if offset_x > 0:
             _log_warning(info_data, f'Layout "{layout_name}" is offset on X axis by {offset_x}')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
⚠ botanicalkeyboards/fm2u: Layout "LAYOUT_isoenter" is offset on X axis by 0.25
⚠ illuminati/is0: Layout "LAYOUT" is offset on X axis by 0.25
⚠ kb_elmo/isolation: Layout "LAYOUT" is offset on X axis by 0.25
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
