### PR TITLE
Resolve keyboard names for `qmk mass-compile`.

### DIFF
--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -9,6 +9,7 @@ from milc import cli
 
 from qmk.constants import QMK_FIRMWARE
 from qmk.commands import _find_make, get_make_parallel_args
+from qmk.keyboard import resolve_keyboard
 from qmk.search import search_keymap_targets
 
 
@@ -39,7 +40,7 @@ def mass_compile(cli):
     makefile = builddir / 'parallel_kb_builds.mk'
 
     if len(cli.args.builds) > 0:
-        targets = [(e[0], e[1]) for e in [b.split(':') for b in cli.args.builds]]
+        targets = list(sorted(set([(resolve_keyboard(e[0]), e[1]) for e in [b.split(':') for b in cli.args.builds]])))
     else:
         targets = search_keymap_targets(cli.args.keymap, cli.args.filter)
 


### PR DESCRIPTION
## Description

Anything with a `DEFAULT_FOLDER` wasn't being correctly resolved.

Example issue:
```sh
qmk mass-compile -c durgod/dgk6x:default durgod/dgk6x/hades:default
```

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
