### PR TITLE
[Bug] Fix compilation issue with Swap Hands and Encoder Map

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -39,6 +39,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "pointing_device.h"
 #endif
 
+#if defined(ENCODER_ENABLE) && defined(ENCODER_MAP_ENABLE) && defined(SWAP_HANDS_ENABLE)
+#    include "encoder.h"
+#endif
+
 int tp_buttons;
 
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))


### PR DESCRIPTION
## Description

in some cases, when encoder map and swap hands are both enabled, it will generate errors because NUM_ENCODERS isn't included in action.c: 

```
Compiling: quantum/action.c                                                                        quantum/action.c:139:55: error: 'NUM_ENCODERS' undeclared here (not in a function)
 extern const uint8_t PROGMEM encoder_hand_swap_config[NUM_ENCODERS];
                                                       ^~~~~~~~~~~~
quantum/action.c: In function 'process_hand_swap':
quantum/action.c:188:24: error: unused variable 'encoder_swap_state' [-Werror=unused-variable]
         static uint8_t encoder_swap_state[((NUM_ENCODERS) + (CHAR_BIT)-1) / (CHAR_BIT)];
                        ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```


## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
