### PR TITLE
[bootloader] Add Ubaboot support

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -190,6 +190,7 @@
                 "stm32-dfu",
                 "stm32duino",
                 "tinyuf2",
+                "ubaboot",
                 "uf2boot",
                 "unknown",
                 "usbasploader",

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -403,6 +403,7 @@ This is a [make](https://www.gnu.org/software/make/manual/make.html) file that i
   * `caterina`
   * `bootloadhid`
   * `usbasploader`
+  * `ubaboot`
 
 ## Feature Options :id=feature-options
 

--- a/docs/driver_installation_zadig.md
+++ b/docs/driver_installation_zadig.md
@@ -97,3 +97,4 @@ The device name here is the name that appears in Zadig, and may not be what the 
 |`kiibohd`     |Kiibohd DFU Bootloader        |`1C11:B007`   |WinUSB |
 |`stm32duino`  |Maple 003                     |`1EAF:0003`   |WinUSB |
 |`qmk-hid`     |(keyboard name) Bootloader    |`03EB:2067`   |HidUsb |
+|`ubaboot`     |ATmega32u4                    |`1d50:611c`   |libusb0|

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -442,3 +442,23 @@ CLI Flashing sequence:
 4. Wait for the keyboard to become available
 
 <sup>1</sup>: This works only if QMK was compiled with `RP2040_BOOTLOADER_DOUBLE_TAP_RESET` defined.
+
+## Ubaboot
+
+This is a little bootloader (less than 512 bytes) developed by RREvans. The `rules.mk` setting for this
+bootloader is `ubaboot`.
+
+Compatible flashers:
+
+Ubaboot uses its own protocol, including by default a python3-written flasher called `ubaboot.py`.
+Rastersoft created a compatible C-language flasher. Installing any of them in the path should work.
+
+Flashing sequence:
+
+1. Enter the bootloader using any of the following methods:
+    * Press the `QK_BOOT` keycode
+    * Press the `RESET` button on the PCB if available
+    * short RST to GND quickly
+2. Wait for the OS to detect the device
+3. Flash a .hex file
+4. Reset the device into application mode (may be done automatically)

--- a/docs/isp_flashing_guide.md
+++ b/docs/isp_flashing_guide.md
@@ -217,6 +217,13 @@ Precompiled `.hex` files are generally not available, but you can compile it you
 
 Note that some boards may have their own specialized build of this bootloader in a separate repository. This will usually be linked to in the board's readme.
 
+### Ubaboot
+
+This bootloader is designed to occupy the bare minimum possible, using less that 512 bytes of flash. It runs on ATmega32U4 MCUs. It can be flashed with any ISP supported by avrdude.
+There is no pre-built .hex file, it must be built using the included Makefile.
+
+https://github.com/rrevans/ubaboot
+
 ## Flashing the Bootloader
 
 Open a new Terminal window - if you are on Windows, use MSYS2 or QMK MSYS, not the Command Prompt. Navigate to the directory your bootloader `.hex` is in. Now it's time to run the `avrdude` command.

--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -109,7 +109,8 @@ BOOTLOADER_VIDS_PIDS = {
     'hid-bootloader': {
         ("03eb", "2067"),  # QMK HID
         ("16c0", "0478")  # PJRC halfkay
-    }
+    },
+    'ubaboot': {("1d50", "611c")}
 }
 
 # Common format strings

--- a/lib/python/qmk/flashers.py
+++ b/lib/python/qmk/flashers.py
@@ -196,6 +196,10 @@ def _flash_uf2(file):
     cli.run(['util/uf2conv.py', '--deploy', file], capture_output=False)
 
 
+def _flash_ubaboot(file):
+    cli.run(['util/ubaboot.py', 'write', file], capture_output=False)
+
+
 def flasher(mcu, file):
     bl, details = _find_bootloader()
     # Add a small sleep to avoid race conditions
@@ -222,6 +226,8 @@ def flasher(mcu, file):
         _flash_mdloader(file)
     elif bl == '_uf2_compatible_':
         _flash_uf2(file)
+    elif bl == 'ubaboot':
+        _flash_ubaboot(file)
     else:
         return (True, "Known bootloader found but flashing not currently supported!")
 

--- a/platforms/avr/bootloader.mk
+++ b/platforms/avr/bootloader.mk
@@ -133,6 +133,13 @@ lufa_warning: $(FIRMWARE_FORMAT)
 	$(info It is extremely prone to bricking, and is only included to support existing boards.)
 	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
 endif
+ifeq ($(strip $(BOOTLOADER)), ubaboot)
+    OPT_DEFS += -DBOOTLOADER_UBABOOT
+    BOOTLOADER_TYPE = ubaboot
+
+    BOOTLOADER_SIZE = 512
+endif
+
 ifdef BOOTLOADER_SIZE
     OPT_DEFS += -DBOOTLOADER_SIZE=$(strip $(BOOTLOADER_SIZE))
 endif

--- a/platforms/avr/bootloaders/ubaboot.c
+++ b/platforms/avr/bootloaders/ubaboot.c
@@ -1,0 +1,51 @@
+/* Copyright 2023 Raster Software Vigo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bootloader.h"
+#include <avr/wdt.h>
+
+void bootloader_jump(void) {
+    /* According to the documentation, user code can enter the bootloader by
+     *   - disabling interrupts
+     *   - resetting the USB and PLL registers to reset values
+     *   - setting SPL, SPH to the top of SRAM
+     *   - setting MCUSR to zero
+     *   - jumping to the beginning of the bootloader
+     */
+
+    asm volatile("cli\n\t"
+                 "ldi r16, 0x0A\n\t"
+                 "out 0x3E, r16\n\t" // SPH <- 0x0A
+                 "ldi r16, 0xFF\n\t"
+                 "out 0x3D, r16\n\t" // SPL <- 0xFF
+                 "ldi r16, 0x00\n\t"
+                 "out 0x34, r16\n\t" // MCUSR <- 0x00
+                 "sts 0xDA, r16\n\t" // USBINT <- 0x00
+                 "sts 0xD7, r16\n\t" // UHWCON <- 0x00
+                 "sts 0xE2, r16\n\t" // UDIEN <- 0x00
+                 "ldi r16, 0x20\n\t"
+                 "sts 0xD8, r16\n\t" // USBCON <- 0x20
+                 "jmp 0x7E00\n\t");
+}
+
+void mcu_reset(void) {
+    // setup watchdog timeout
+    wdt_enable(WDTO_60MS);
+
+    // wait for watchdog timer to trigger
+    while (1) {
+    }
+}

--- a/platforms/avr/flash.mk
+++ b/platforms/avr/flash.mk
@@ -165,6 +165,10 @@ define EXEC_HID_LUFA
 	$(HID_BOOTLOADER_CLI) -mmcu=$(MCU) -w -v $(BUILD_DIR)/$(TARGET).hex
 endef
 
+define EXEC_UBABOOT
+	util/ubaboot.py --wait write $(BUILD_DIR)/$(TARGET).hex
+endef
+
 hid_bootloader: $(BUILD_DIR)/$(TARGET).hex check-size cpfirmware
 	$(call EXEC_HID_LUFA)
 
@@ -184,6 +188,8 @@ else ifeq ($(strip $(BOOTLOADER)), bootloadhid)
 	$(UNSYNC_OUTPUT_CMD) && $(call EXEC_BOOTLOADHID)
 else ifeq ($(strip $(BOOTLOADER)), qmk-hid)
 	$(UNSYNC_OUTPUT_CMD) && $(call EXEC_HID_LUFA)
+else ifeq ($(strip $(BOOTLOADER)), ubaboot)
+	$(UNSYNC_OUTPUT_CMD) && $(call EXEC_UBABOOT)
 else
 	$(PRINT_OK); $(SILENT) || printf "$(MSG_FLASH_BOOTLOADER)"
 endif

--- a/util/ubaboot.py
+++ b/util/ubaboot.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 by Robert Evans (rrevans@gmail.com)
+#
+# This file is part of ubaboot.
+#
+# ubaboot is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ubaboot is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ubaboot.  If not, see <http://www.gnu.org/licenses/>.
+
+import usb.core
+import argparse
+from collections import namedtuple
+import time
+# yapf: disable
+# Default vendor/product id assigned by openmoko.
+DEFAULT_DEV = '1d50:611c'
+
+def parse_args():
+    """Parses command line arguments.
+
+    See --help for details.
+    """
+    vidpid = lambda s: [int(v, 16) for v in s.split(':', 1)]
+    number = lambda s: int(s, 0)
+
+    dev = vidpid(DEFAULT_DEV) if DEFAULT_DEV else None
+    dev_required = dev is None
+    dev_help = 'sets the USB device ID ({})'.format(
+        "default {}".format(DEFAULT_DEV) if dev else "required")
+
+    parser = argparse.ArgumentParser(description='ubaboot demo client')
+    parser.add_argument('--dev', type=vidpid, default=dev, metavar='VID:PID',
+                        required=dev_required, help=dev_help)
+    parser.add_argument('--wait', action='store_const', const=True, default=False,
+                        help='Wait until the device is set in programming mode')
+    subparsers = parser.add_subparsers(title='loader commands',
+                                       metavar='<command>')
+    stat = subparsers.add_parser('stat', help='read signature/fuses')
+    stat.set_defaults(mode='stat')
+
+    read = subparsers.add_parser('read', help='read memory')
+    read.set_defaults(mode='read')
+    read.add_argument('start', type=number, help='start address')
+    read.add_argument('count', type=number, help='length to read')
+    read.add_argument('--type', choices=('eeprom', 'flash'), default='flash',
+                      help='selects memory to read (default flash)')
+
+    write = subparsers.add_parser('write', help='write memory')
+    write.set_defaults(mode='write')
+    write.add_argument('file', help='input file to write')
+    write.add_argument('--no-reboot', action='store_false', dest='reboot',
+                       help='do not reboot after programming')
+    write.add_argument('--type', choices=('eeprom', 'flash'), default='flash',
+                       help='selects memory to write (default flash)')
+
+    verify = subparsers.add_parser('verify', help='verify memory')
+    verify.set_defaults(mode='verify')
+    verify.add_argument('file', help='input file to verify')
+    verify.add_argument('--type', choices=('eeprom', 'flash'), default='flash',
+                        help='selects memory to verify (default flash)')
+
+    reboot = subparsers.add_parser('reboot', help='reboot device')
+    reboot.set_defaults(mode='reboot', reboot=True)
+    return parser.parse_args()
+
+class IHexLine(namedtuple('IHexLine', 'addr type data')):
+    """Stores one line of an Intel hex file."""
+
+    @staticmethod
+    def parse(s):
+        """Parse one input line."""
+        s = s.strip()
+        if s[0] != ':':
+            raise ValueError('missing start byte')
+        if len(s) % 2 != 1:
+            raise ValueError('expected even number of input chars')
+        b = bytearray(int(s[i:i+2], 16) for i in range(1, len(s), 2))
+        if len(b) != b[0] + 5:
+            raise ValueError('invalid byte count')
+        if sum(b) & 0xff:
+            raise ValueError('invalid checksum byte')
+        return IHexLine(addr=(b[1] << 8) + b[2], type=b[3], data=b[4:-1])
+
+    def __str__(self):
+        """Print the hex line in Intel format.
+
+        This is suitable for output in a .hex file.
+        The trailing newline is not included.
+        """
+        hdr = [len(self.data), self.addr >> 8, self.addr & 0xff, self.type]
+        data = bytearray(hdr)
+        data.extend(self.data)
+        data.append(-sum(data) & 0xff)
+        return ':' + ''.join('%02X' % v for v in data)
+
+def read_ihex(f):
+    """Parse input lines and return the parsed program bytes."""
+    pgm = bytearray()
+    for line in f:
+        l = IHexLine.parse(line)
+        if l.type == 0:
+            end = l.addr + len(l.data)
+            if end > len(pgm):
+                pgm += bytearray(end - len(pgm))
+            pgm[l.addr:end] = l.data
+    return pgm
+
+class UbabootDevice(object):
+    """Sends requests to ubaboot USB device via pyusb."""
+
+    # Requests
+    GET_SIGNATURE = 1
+    READ_FLASH = 2
+    WRITE_FLASH = 3
+    REBOOT = 4
+    READ_EEPROM = 5
+    WRITE_EEPROM = 6
+    GET_LOCK = 7
+
+    # Request types
+    DEV_READ = 0xc0
+    DEV_WRITE = 0x40
+
+    def __init__(self, dev):
+        self.__dev = dev
+
+    def get_signature(self):
+        return self.__dev_read(UbabootDevice.GET_SIGNATURE, 0, 0, 3)
+
+    def get_lock(self):
+        return self.__dev_read(UbabootDevice.GET_LOCK, 0, 0, 4)
+
+    def read_flash(self, base, length):
+        return self.__read_mem(UbabootDevice.READ_FLASH, base, length, 512)
+
+    def read_eeprom(self, base, length):
+        return self.__read_mem(UbabootDevice.READ_EEPROM, base, length, 16)
+
+    def write_flash(self, base, pgm):
+        return self.__write_mem(UbabootDevice.WRITE_FLASH, base, pgm, 512)
+
+    def write_eeprom(self, base, pgm):
+        return self.__write_mem(UbabootDevice.WRITE_EEPROM, base, pgm, 16)
+
+    def reboot(self):
+        return self.__dev_write(UbabootDevice.REBOOT, 0, 0, b'')
+
+    def __dev_read(self, *args):
+        return self.__dev.ctrl_transfer(UbabootDevice.DEV_READ, *args)
+
+    def __dev_write(self, *args):
+        return self.__dev.ctrl_transfer(UbabootDevice.DEV_WRITE, *args)
+
+    def __read_mem(self, cmd, base, length, blksz):
+        pgm = bytearray()
+        for offset in range(0, length, blksz):
+            addr = base + offset
+            nb = min(blksz, length - offset)
+            pgm.extend(self.__dev_read(cmd, addr, 0, nb))
+        return pgm
+
+    def __write_mem(self, cmd, base, pgm, blksz):
+        for offset in range(0, len(pgm), blksz):
+            block = pgm[offset:offset+blksz]
+            padding = ((len(block) + blksz - 1) & ~(blksz-1)) - len(block)
+            block += bytearray(b'\xff') * padding
+            self.__dev_write(cmd, base+offset, 0, block)
+
+def main():
+    args = parse_args()
+
+    vid, pid = args.dev
+    dev = usb.core.find(idVendor=vid, idProduct=pid)
+    if not dev:
+        if (args.wait):
+            while True:
+                dev = usb.core.find(idVendor=vid, idProduct=pid)
+                if dev:
+                    break
+                print("Cannot open ubaboot device. Retrying...")
+                time.sleep(1)
+        else:
+            raise ValueError('cannot open ubaboot device')
+
+    ubaboot = UbabootDevice(dev)
+
+    if args.mode == 'stat':
+        to_hex = lambda v: '%02X' % (v,)
+        sig = ubaboot.get_signature()
+        lofuse, lock, extfuse, hifuse = bytearray(ubaboot.get_lock())
+        fuses = [lofuse, hifuse, extfuse]
+        print('Signature:', ''.join(to_hex(v) for v in bytearray(sig)), \
+            'Fuses: L:{0} H:{1} E:{2}'.format(*(to_hex(v) for v in fuses)), \
+            'Lock: {0}'.format(to_hex(lock)))
+
+    if args.mode in ('verify', 'write'):
+        with open(args.file) as f:
+            pgm = read_ihex(f)
+        print('Loaded', len(pgm), 'bytes from', args.file)
+
+    if args.mode in ('read', 'write', 'verify'):
+        if args.type == 'flash':
+            read, write = ubaboot.read_flash, ubaboot.write_flash
+        elif args.type == 'eeprom':
+            read, write = ubaboot.read_eeprom, ubaboot.write_eeprom
+
+    if args.mode == 'read':
+        start = args.start
+        count = args.count
+        mem = read(start, count)
+        mem = mem.rstrip(bytearray(b'\xff'))
+        for offset in range(0, len(mem), 16):
+            print(IHexLine(addr=start+offset, type=0, data=mem[offset:offset+16]))
+        print(IHexLine(addr=0, type=1, data=''))
+
+    if args.mode == 'write':
+        write(0, pgm)
+        print('Wrote', len(pgm), 'bytes OK')
+
+    if args.mode in ('verify', 'write'):
+        actual = read(0, len(pgm))
+        for pos in range(len(pgm)):
+            if actual[pos] != pgm[pos]:
+                raise ValueError('mismatch at offset 0x%x' % (pos,))
+        print('Verified', len(pgm), 'bytes OK')
+
+    if args.mode in ('write', 'reboot') and args.reboot:
+        ubaboot.reboot()
+        print('Rebooting')
+
+if __name__ == '__main__':
+    main()

--- a/util/udev/50-qmk.rules
+++ b/util/udev/50-qmk.rules
@@ -84,3 +84,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", TAG+="uacc
 
 # WB32 DFU
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="342d", ATTRS{idProduct}=="dfa0", TAG+="uaccess"
+
+# ubaboot
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="611c", TAG+="uaccess"


### PR DESCRIPTION
This MR adds full Ubaboot support, both for creating firmware for devices having it, and for flashing it from the QMK tool.

It supports both the default python flasher, and the new C flasher.

Ubaboot repository: https://github.com/rrevans/ubaboot

<!--- Describe your changes in detail here. -->

It adds Ubaboot support, implementing:

- build firmware that takes into account the size used by it (512 bytes)
- flash the firmware using the QMK tool
- reboot the CPU using QK_REBOOT
- enter the programming mode using QK_BOOTLOADER

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
