### PR TITLE
Add Discord webhook at end of each CI run.

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -10,11 +10,10 @@ on:
 
 jobs:
   ci_builds:
+    if: github.repository == 'qmk/qmk_firmware'
     name: "CI Build"
     runs-on: self-hosted
     timeout-minutes: 1380
-
-    if: github.repository == 'qmk/qmk_firmware'
 
     strategy:
       fail-fast: false
@@ -58,3 +57,12 @@ jobs:
           *.hex
           *.uf2
           .build/failed.*
+
+    - name: 'CI Discord Notification'
+      if: always()
+      working-directory: util/ci/
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.CI_DISCORD_WEBHOOK }}
+      run: |
+        python3 -m pip install -r requirements.txt
+        python3 ./discord-results.py --branch ${{ matrix.branch }} --keymap ${{ matrix.keymap }} --url ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}

--- a/lib/python/qmk/cli/format/python.py
+++ b/lib/python/qmk/cli/format/python.py
@@ -7,7 +7,7 @@ from milc import cli
 from qmk.path import normpath
 
 py_file_suffixes = ('py',)
-py_dirs = ['lib/python']
+py_dirs = ['lib/python', 'util/ci']
 
 
 def yapf_run(files):

--- a/util/ci/discord-results.py
+++ b/util/ci/discord-results.py
@@ -37,9 +37,9 @@ if len(failed_builds) > 0:
             break
         failstr += f'{f}\n'
 
-    embed = DiscordEmbed(title=f':infinity: CI Build Failure ({args.branch}, {args.keymap})', description=f'{successful_builds} builds succeeded, {len(failed_builds)} builds failed:```{failstr}```', color='ff9999')
+    embed = DiscordEmbed(title=f':infinity: CI Build Failure ({args.branch}, {args.keymap})', description=f'**{successful_builds}** builds succeeded, **{len(failed_builds)}** builds failed:```{failstr}```', color='ff9999')
 else:
-    embed = DiscordEmbed(title=f':infinity: CI Build Success ({args.branch}, {args.keymap})', description=f'{successful_builds} builds succeeded.', color='99ff99')
+    embed = DiscordEmbed(title=f':infinity: CI Build Success ({args.branch}, {args.keymap})', description=f'**{successful_builds}** builds succeeded.', color='99ff99')
 
 embed.add_embed_field(name='Build Target', value=f'[**{args.branch}**](https://github.com/qmk/qmk_firmware/tree/{args.branch}) / **{args.keymap}** keymap')
 embed.add_embed_field(name='Workflow Run', value=f'[**Link**]({args.url})')

--- a/util/ci/discord-results.py
+++ b/util/ci/discord-results.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from discord_webhook import DiscordWebhook, DiscordEmbed
+
+parser = argparse.ArgumentParser(prog='discord-results.py', description='Sends a Discord webhook notification at the end of a CI run.')
+parser.add_argument('-b', '--branch')
+parser.add_argument('-k', '--keymap')
+parser.add_argument('-u', '--url')
+args = parser.parse_args()
+
+qmk_dir = Path(__file__).resolve().parents[2].resolve()
+
+keyboard_re = re.compile(r'CI Metadata: KEYBOARD=(.*)$', re.MULTILINE)
+keymap_re = re.compile(r'CI Metadata: KEYMAP=(.*)$', re.MULTILINE)
+
+successful_builds = sum([len(list(qmk_dir.glob(f'*.{extension}'))) for extension in ['uf2', 'bin', 'hex']])
+failures = list(sorted([f.resolve() for f in (qmk_dir / '.build/').glob('failed.log.*')]))
+failed_builds = []
+for f in failures:
+    with open(f) as fh:
+        data = fh.read()
+        kb = keyboard_re.search(data).group(1)
+        km = keymap_re.search(data).group(1)
+        failed_builds.append(f'{kb}:{km}')
+
+webhook = DiscordWebhook(url=os.getenv('DISCORD_WEBHOOK'), username="QMK GitHub CI")
+if len(failed_builds) > 0:
+    failstr = ''
+    for f in failed_builds:
+        if len(failstr) >= 1800:
+            failstr += '<<snip>>'
+            break
+        failstr += f'{f}\n'
+
+    embed = DiscordEmbed(title=f':infinity: CI Build Failure ({args.branch}, {args.keymap})', description=f'{successful_builds} builds succeeded, {len(failed_builds)} builds failed:```{failstr}```', color='ff9999')
+else:
+    embed = DiscordEmbed(title=f':infinity: CI Build Success ({args.branch}, {args.keymap})', description=f'{successful_builds} builds succeeded.', color='99ff99')
+
+embed.add_embed_field(name='Build Target', value=f'[**{args.branch}**](https://github.com/qmk/qmk_firmware/tree/{args.branch}) / **{args.keymap}** keymap')
+embed.add_embed_field(name='Workflow Run', value=f'[**Link**]({args.url})')
+embed.set_timestamp()
+
+webhook.add_embed(embed)
+webhook.execute()

--- a/util/ci/requirements.txt
+++ b/util/ci/requirements.txt
@@ -1,0 +1,1 @@
+discord-webhook


### PR DESCRIPTION
## Description

Closes the loop on Discord -- #webhooks_ci.

Have already set up the new repo secret accordingly.

Example:
![image](https://user-images.githubusercontent.com/2985843/230553501-0bc3fc3d-aedf-4906-9065-a38cc1d3d5bb.png)


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
