### PR TITLE
[Feature] Add QP resources to compilation

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -182,6 +182,12 @@ endif
 QUANTUM_PAINTER_ENABLE ?= no
 ifeq ($(strip $(QUANTUM_PAINTER_ENABLE)), yes)
     include $(QUANTUM_DIR)/painter/rules.mk
+    # add any keyboard-, keymap-, or user- level fonts and images
+    # TODO: generate a header file (with CLI) which includes all the headers found (?)
+    QP_DIRS := $(KEYBOARD_PATHS) $(KEYMAP_PATH) $(USER_PATH)
+    QP_FONTS := $(foreach dir,$(QP_DIRS),$(wildcard $(dir)/painter/fonts/*.qff.c))
+    QP_IMGS := $(foreach dir,$(QP_DIRS),$(wildcard $(dir)/painter/images/*.qgf.c))
+    SRC += $(QP_FONTS) $(QP_IMGS)
 endif
 
 VALID_EEPROM_DRIVER_TYPES := vendor custom transient i2c spi wear_leveling legacy_stm32_flash


### PR DESCRIPTION
## Description

Dynamically add QGF and QFF files -> no need for manually `SRC +=`. It looks at all keyboard's nesting levels, keymap and userspace, so it should cover all use cases i can think of... except for shared stuff like `keychron/common`. However, this standarizes the location for those (`painter/images` and `painter/fonts`), which im not sure whether i like, perhaps the filter could be more generic.

Files found are saved in variables instead of directly `SRC +=`'ing them, such that another PR can be made on the future to add support on CLI to generate a header file to `#include` all of them easily

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
