### PR TITLE
Fix scroll lock and windows lock status LEDs

### DIFF
--- a/keyboards/feker/ik75/keymaps/bkzshen/keymap.c
+++ b/keyboards/feker/ik75/keymaps/bkzshen/keymap.c
@@ -195,8 +195,8 @@ bool rgb_matrix_indicators_user(void) {
     rgb_matrix_set_color(104, 0, 0, 0);
 
     uint8_t red = host_keyboard_led_state().caps_lock ? 255 : 0;
-    uint8_t green = host_keyboard_led_state().scroll_lock ? 255 : 0;
-    uint8_t blue = keymap_config.no_gui ? 255 : 0;
+    uint8_t blue = host_keyboard_led_state().scroll_lock ? 255 : 0;
+    uint8_t green = keymap_config.no_gui ? 255 : 0;
 
 
     if ((rgb_matrix_get_flags() & LED_FLAG_KEYLIGHT)) {

--- a/keyboards/feker/ik75/keymaps/default/keymap.c
+++ b/keyboards/feker/ik75/keymaps/default/keymap.c
@@ -139,8 +139,8 @@ bool rgb_matrix_indicators_user(void) {
     rgb_matrix_set_color(104, 0, 0, 0);
 
     uint8_t red = host_keyboard_led_state().caps_lock ? 255 : 0;
-    uint8_t green = host_keyboard_led_state().scroll_lock ? 255 : 0;
-    uint8_t blue = keymap_config.no_gui ? 255 : 0;
+    uint8_t blue = host_keyboard_led_state().scroll_lock ? 255 : 0;
+    uint8_t green = keymap_config.no_gui ? 255 : 0;
 
 
     if ((rgb_matrix_get_flags() & LED_FLAG_KEYLIGHT)) {

--- a/keyboards/feker/ik75/keymaps/via/keymap.c
+++ b/keyboards/feker/ik75/keymaps/via/keymap.c
@@ -195,8 +195,8 @@ bool rgb_matrix_indicators_user(void) {
     rgb_matrix_set_color(104, 0, 0, 0);
 
     uint8_t red = host_keyboard_led_state().caps_lock ? 255 : 0;
-    uint8_t green = host_keyboard_led_state().scroll_lock ? 255 : 0;
-    uint8_t blue = keymap_config.no_gui ? 255 : 0;
+    uint8_t blue = host_keyboard_led_state().scroll_lock ? 255 : 0;
+    uint8_t green = keymap_config.no_gui ? 255 : 0;
 
 
     if ((rgb_matrix_get_flags() & LED_FLAG_KEYLIGHT)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Status LEDs for Windows key lock and Scroll lock are messed up and should be swapped.
At the moment when you lock Windows key - LED with "S" lights up. The same when you Scroll lock lights up "W".
I was managed to fix it by swapping colors for indicators in keymap, now they are in line with the case markings.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/19287

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
