### PR TITLE
Prevent Tri-Layer keys from stopping caps word

### DIFF
--- a/quantum/process_keycode/process_caps_word.c
+++ b/quantum/process_keycode/process_caps_word.c
@@ -95,6 +95,7 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
             case QK_TOGGLE_LAYER ... QK_TOGGLE_LAYER_MAX:
             case QK_LAYER_TAP_TOGGLE ... QK_LAYER_TAP_TOGGLE_MAX:
             case QK_ONE_SHOT_LAYER ... QK_ONE_SHOT_LAYER_MAX:
+            case QK_TRI_LAYER_LOWER ... QK_TRI_LAYER_UPPER:
             // Ignore AltGr.
             case KC_RALT:
             case OSM(MOD_RALT):

--- a/tests/caps_word/test_caps_word.cpp
+++ b/tests/caps_word/test_caps_word.cpp
@@ -371,6 +371,11 @@ INSTANTIATE_TEST_CASE_P(
             "OSL", OSL(1), 1, KC_NO, true},
         CapsWordPressUserParams{
             "LT_held", LT_1_KC_A, TAPPING_TERM + 1, KC_NO, true},
+        // Tri-Layer keys are ignored and continue Caps Word.
+        CapsWordPressUserParams{
+            "TL_LOWR", TL_LOWR, 1, KC_NO, true},
+        CapsWordPressUserParams{
+            "TL_UPPR", TL_UPPR, 1, KC_NO, true},
         // AltGr keys are ignored and continue Caps Word.
         CapsWordPressUserParams{
             "KC_RALT", KC_RALT, 1, KC_NO, true},


### PR DESCRIPTION
The newly introduced Tri-Layer keys do not behave like other layer tap/toggle keys when using the caps word feature.

This PR makes caps word continue on when one of those keys is pressed just like other layer keycodes.

## Description

Added the 2 new tri layer keys to the switch statement that ignores keycodes in the `process_caps_word` function.


## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
