### PR TITLE
Fix preprocessor condition for SPLIT_HAPTIC_ENABLE

### DIFF
--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -213,7 +213,7 @@ typedef struct _split_shared_memory_t {
     bool watchdog_pinged;
 #endif // defined(SPLIT_WATCHDOG_ENABLE)
 
-#if defined(HAPTIC_ENABLE)
+#if defined(HAPTIC_ENABLE) && defined(SPLIT_HAPTIC_ENABLE)
     split_slave_haptic_sync_t haptic_sync;
 #endif // defined(HAPTIC_ENABLE)
 


### PR DESCRIPTION
## Description

I have a custom split keyboard with haptic (solenoid). One solenoid for each half.
I am not interested at the moment to have `SPLIT_HAPTIC_ENABLE` enabled because I want to fire only the solenoid located on the same half of the pressed key.

This PR only fixes a small preprocessor condition, introduced in #19203 (sending much love to @drashna)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Compiling a split keyboard with haptic (solenoid) and no `SPLIT_HAPTIC_ENABLE` I get:

```
Compiling: quantum/matrix_common.c                                                                 In file included from quantum/split_common/transactions.h:24,
                 from quantum/matrix_common.c:9:
quantum/split_common/transport.h:217:5: error: unknown type name 'split_slave_haptic_sync_t'
  217 |     split_slave_haptic_sync_t haptic_sync;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
 [ERRORS]
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
