### PR TITLE
[Feature] QMK versioning (if-able) on `version.h`

### DIFF
--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -34,9 +34,7 @@ def generate_version_h(cli):
         git_qmk_hash = "NA"
         chibios_version = "NA"
         chibios_contrib_version = "NA"
-        # these variable aren't wrapped on quotes when generating the version file as they are number when git isn't skipped
-        # we add double quoting here such that generated code is valid
-        qmk_major, qmk_minor, qmk_patch, qmk_global = ['"NA"'] * 4
+        qmk_major, qmk_minor, qmk_patch = 0, 0, 0
     else:
         git_dirty = git_is_dirty()
         git_version = git_get_version() or current_time
@@ -44,10 +42,6 @@ def generate_version_h(cli):
         chibios_version = git_get_version("chibios", "os") or current_time
         chibios_contrib_version = git_get_version("chibios-contrib", "os") or current_time
         qmk_major, qmk_minor, qmk_patch = git_get_qmk_major_minor_patch()
-        # number that can be used to order all versions, eg '#if __QMK__ == 000020005' (for 0.20.5)
-        # TODO: proper handling when function fails and returns "NA", so int() doesn't error out (?)
-        # FIXME: may need to reserve more than 3 digits for each number
-        qmk_global = int(f"{qmk_major:03}{qmk_minor:03}{qmk_patch:03}")
 
     dirty_indicator = "*" if git_dirty else ""
 
@@ -59,7 +53,8 @@ def generate_version_h(cli):
         f'#define QMK_MAJOR {qmk_major}',
         f'#define QMK_MINOR {qmk_minor}',
         f'#define QMK_PATCH {qmk_patch}',
-        f'#define __QMK__ {qmk_global}',
+        f'// number that can be used to order all versions, eg: "#if __QMK__ == 0x00200005ul" (for 0.20.5) -- prefer to have a 0x prefix otherwise leading zeros would be interpreted as octal numbers.',
+        f'#define __QMK__ 0x{qmk_major:02}{qmk_minor:02}{qmk_patch:04}ul',
         f'#define QMK_BUILDDATE "{current_time}"',
         f'#define QMK_GIT_HASH  "{git_qmk_hash}{dirty_indicator}"',
         f'#define CHIBIOS_VERSION "{chibios_version}"',

--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -145,13 +145,13 @@ def git_get_qmk_hash():
 
     return output.stdout.strip()
 
+
 def git_get_qmk_major_minor_patch():
     output = cli.run(['git', 'describe', '--tags'])
     if output.returncode != 0:
-        # we dont want to return numbers here, as it would make stuff like (#if QMK_MAJOR > 19)
-        # to compile just fine, and run into undefined behaviours
-        # instead, making it a string should break compilation
-        return "NA", "NA", "NA"
+        # we intentionally return zero here, as it would automatically disable things when using
+        # patterns such as (#if QMK_MAJOR > 19).
+        return 0, 0, 0
 
     # output is major.minor.patch-<whatever>
     versions = output.stdout.strip().split("-")[0]

--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -144,3 +144,15 @@ def git_get_qmk_hash():
         return None
 
     return output.stdout.strip()
+
+def git_get_qmk_major_minor_patch():
+    output = cli.run(['git', 'describe', '--tags'])
+    if output.returncode != 0:
+        # we dont want to return numbers here, as it would make stuff like (#if QMK_MAJOR > 19)
+        # to compile just fine, and run into undefined behaviours
+        # instead, making it a string should break compilation
+        return "NA", "NA", "NA"
+
+    # output is major.minor.patch-<whatever>
+    versions = output.stdout.strip().split("-")[0]
+    return map(int, versions.split("."))


### PR DESCRIPTION
## Description

Adds new defines that can be used to check the version of the codebase being used (not 100% reliable as im pretty sure you can update your code without getting the git's tag updated)
```c
#define QMK_MAJOR 0
#define QMK_MINOR 20
#define QMK_PATCH 5
#define __QMK__ 20005

// when skipping git
#define QMK_MAJOR 0
#define QMK_MINOR 0
#define QMK_PATCH 0
#define __QMK__ 0
```

As already explained in the code's comments, defaulted them to  `0` such that checks like `#if QMK_MAJOR > 0` never pass 

* Also refactored a little bit so that code doesn't look gross with a multiline string

PS: Im not too happy with the `__QMK__` name nor the naming clash with `QMK_VERSION`, any suggestions?


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://discord.com/channels/440868230475677696/440868230475677698/1095475979197096117

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
