### PR TITLE
[Bug] Fix compilation issues with PS/2 driver on F4x1 controllers

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -809,9 +809,9 @@ endif
 
 ifeq ($(strip $(PS2_MOUSE_ENABLE)), yes)
     PS2_ENABLE := yes
+    MOUSE_ENABLE := yes
     SRC += ps2_mouse.c
     OPT_DEFS += -DPS2_MOUSE_ENABLE
-    MOUSE_ENABLE := yes
 endif
 
 VALID_PS2_DRIVER_TYPES := busywait interrupt usart vendor

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -811,7 +811,7 @@ ifeq ($(strip $(PS2_MOUSE_ENABLE)), yes)
     PS2_ENABLE := yes
     SRC += ps2_mouse.c
     OPT_DEFS += -DPS2_MOUSE_ENABLE
-    OPT_DEFS += -DMOUSE_ENABLE
+    MOUSE_ENABLE := yes
 endif
 
 VALID_PS2_DRIVER_TYPES := busywait interrupt usart vendor

--- a/drivers/ps2/ps2_interrupt.c
+++ b/drivers/ps2/ps2_interrupt.c
@@ -47,6 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
 // chibiOS headers
 #    include "ch.h"
 #    include "hal.h"
+#    include "gpio.h"
 #endif
 
 #include "ps2.h"

--- a/platforms/chibios/drivers/ps2/ps2_io.c
+++ b/platforms/chibios/drivers/ps2/ps2_io.c
@@ -4,6 +4,7 @@
 // chibiOS headers
 #include "ch.h"
 #include "hal.h"
+#include "gpio.h"
 
 /* Check port settings for clock and data line */
 #if !(defined(PS2_CLOCK_PIN))


### PR DESCRIPTION
## Description

> ./keyboards/cantor/keymaps/test/config.h:10:23: error: 'A8' undeclared (first use in this function)

"gpio.h" fixes the issue. Not sure the exact cause, so not sure this is the right fix. 

Also, didn't properly enable the mouse endpoint. Was fine on AVR, but ChibiOS errors out on endpoint descriptors if mousekey or pointing device wasn't also enabled. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* https://www.reddit.com/r/olkb/comments/12iyda4/help_qmk_ps2_mouse_and_arm_processor/

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
