### PR TITLE
[Keymap] Update brauner preonic layout

### DIFF
--- a/keyboards/preonic/keymaps/brauner/config.h
+++ b/keyboards/preonic/keymaps/brauner/config.h
@@ -25,6 +25,7 @@
 #define MUSIC_MASK (keycode != KC_NO)
 
 #define PERMISSVE_HOLD
+#define HOLD_ON_OTHER_KEY_PRESS_PER_KEY
 
 #define LEADER_PER_KEY_TIMING
 

--- a/keyboards/preonic/keymaps/brauner/keymap.c
+++ b/keyboards/preonic/keymaps/brauner/keymap.c
@@ -279,6 +279,18 @@ static inline bool toggle_layer(enum preonic_layers layer, keyrecord_t *record) 
     return false;
 }
 
+bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case MOD_TAP_LSFT_ENT:
+        case MOD_TAP_LSFT_ESC:
+            /* Immediately select the hold action when another key is pressed. */
+            return true;
+        default:
+            /* Do not select the hold action when another key is pressed. */
+            return false;
+    }
+}
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case QWERTY:


### PR DESCRIPTION
Adapt to changes that make `IGNORE_MOD_TAP_INTERRUPT` the default.