### PR TITLE
Generate `make` dependency file during build for info.json's etc.

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -343,6 +343,15 @@ $(KEYBOARD_OUTPUT)/src/default_keyboard.h: $(INFO_JSON_FILES)
 
 generated-files: $(KEYBOARD_OUTPUT)/src/info_config.h $(KEYBOARD_OUTPUT)/src/default_keyboard.c $(KEYBOARD_OUTPUT)/src/default_keyboard.h
 
+generated-files: $(KEYMAP_OUTPUT)/src/info_deps.d
+
+$(KEYMAP_OUTPUT)/src/info_deps.d:
+	@$(SILENT) || printf "$(MSG_GENERATING) $@" | $(AWK_CMD)
+	$(eval CMD=$(QMK_BIN) generate-make-dependencies -kb $(KEYBOARD) -km $(KEYMAP) -o $(KEYMAP_OUTPUT)/src/info_deps.d)
+	@$(BUILD_CMD)
+
+-include $(KEYMAP_OUTPUT)/src/info_deps.d
+
 .INTERMEDIATE : generated-files
 
 # Userspace setup and definitions

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -57,6 +57,7 @@ subcommands = [
     'qmk.cli.generate.keyboard_h',
     'qmk.cli.generate.keycodes',
     'qmk.cli.generate.keycodes_tests',
+    'qmk.cli.generate.make_dependencies',
     'qmk.cli.generate.rgb_breathe_table',
     'qmk.cli.generate.rules_mk',
     'qmk.cli.generate.version_h',

--- a/lib/python/qmk/cli/generate/make_dependencies.py
+++ b/lib/python/qmk/cli/generate/make_dependencies.py
@@ -1,0 +1,56 @@
+"""Used by the make system to generate dependency lists for each of the generated files.
+"""
+from pathlib import Path
+from milc import cli
+
+from argcomplete.completers import FilesCompleter
+
+from qmk.commands import dump_lines
+from qmk.constants import QMK_FIRMWARE
+from qmk.keyboard import keyboard_completer, keyboard_folder
+from qmk.keymap import keymap_completer, locate_keymap
+from qmk.path import normpath, FileType
+
+
+@cli.argument('filename', nargs='?', arg_only=True, type=FileType('r'), completer=FilesCompleter('.json'), help='A configurator export JSON.')
+@cli.argument('-o', '--output', arg_only=True, type=normpath, help='File to write to')
+@cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
+@cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, required=True, help='Keyboard to generate dependency file for.')
+@cli.argument('-km', '--keymap', completer=keymap_completer, help='The keymap to build a firmware for. Ignored when a configurator export is supplied.')
+@cli.subcommand('Generates the list of dependencies associated with a keyboard build and its generated files.', hidden=True)
+def generate_make_dependencies(cli):
+    """Generates the list of dependent info.json, rules.mk, and config.h files for a keyboard.
+    """
+    interesting_files = [
+        'info.json',
+        'keymap.json',
+        'rules.mk',
+        'post_rules.mk',
+        'config.h',
+        'post_config.h',
+    ]
+
+    found_files = []
+
+    # Walk up the keyboard's directory tree looking for the files we're interested in
+    keyboards_root = Path('keyboards')
+    parent_path = Path('keyboards') / cli.args.keyboard
+    while parent_path != keyboards_root:
+        for file in interesting_files:
+            test_path = parent_path / file
+            if test_path.exists():
+                found_files.append(test_path)
+        parent_path = parent_path.parent
+
+    # Find the keymap and include any of the interesting files
+    if cli.args.keymap is not None:
+        km = locate_keymap(cli.args.keyboard, cli.args.keymap)
+        if km is not None:
+            for file in interesting_files:
+                found_files.extend(km.parent.glob(f'**/{file}'))
+
+    # If we have a matching userspace, include those too
+    for file in interesting_files:
+        found_files.extend((QMK_FIRMWARE / 'users' / cli.args.keymap).glob(f'**/{file}'))
+
+    dump_lines(cli.args.output, [f'generated-files: {found.resolve()}\n' for found in found_files])


### PR DESCRIPTION
## Description

This adds automated generation of a `make` dependency file, specifically tying the `generated-files` target to each of the "interesting" files that contribute to codegen (listed in `interesting_files`).

Upshot is, changes to `info.json` or any of the other metadata files should now properly trigger rebuilds.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
