### PR TITLE
[Bugfix] Check `NULL` pointers on QP

### DIFF
--- a/quantum/painter/lvgl/qp_lvgl.c
+++ b/quantum/painter/lvgl/qp_lvgl.c
@@ -61,7 +61,7 @@ bool qp_lvgl_attach(painter_device_t device) {
     qp_lvgl_detach();
 
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_lvgl_attach: fail (validation_ok == false)\n");
         qp_lvgl_detach();
         return false;

--- a/quantum/painter/qp.c
+++ b/quantum/painter/qp.c
@@ -186,6 +186,11 @@ void qp_set_viewport_offsets(painter_device_t device, uint16_t offset_x, uint16_
     qp_dprintf("qp_set_viewport_offsets: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
 
+    if (!driver) {
+        qp_dprintf("qp_set_viewport_offsets: fail (pointer to NULL)\n");
+        return;
+    }
+
     driver->offset_x = offset_x;
     driver->offset_y = offset_y;
 

--- a/quantum/painter/qp.c
+++ b/quantum/painter/qp.c
@@ -134,8 +134,13 @@ bool qp_flush(painter_device_t device) {
 // Quantum Painter External API: qp_get_geometry
 
 void qp_get_geometry(painter_device_t device, uint16_t *width, uint16_t *height, painter_rotation_t *rotation, uint16_t *offset_x, uint16_t *offset_y) {
-    qp_dprintf("qp_geometry: entry\n");
+    qp_dprintf("qp_get_geometry: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
+
+    if (!driver) {
+        qp_dprintf("qp_get_geometry: fail (pointer to NULL)\n");
+        return;
+    }
 
     switch (driver->rotation) {
         default:
@@ -171,7 +176,7 @@ void qp_get_geometry(painter_device_t device, uint16_t *width, uint16_t *height,
         *offset_y = driver->offset_y;
     }
 
-    qp_dprintf("qp_geometry: ok\n");
+    qp_dprintf("qp_get_geometry: ok\n");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/quantum/painter/qp.c
+++ b/quantum/painter/qp.c
@@ -30,6 +30,11 @@ bool qp_init(painter_device_t device, painter_rotation_t rotation) {
     qp_dprintf("qp_init: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
 
+    if (!driver) {
+        qp_dprintf("qp_init: fail (pointer to NULL)\n");
+        return false;
+    }
+
     driver->validate_ok = false;
     if (!validate_driver_integrity(driver)) {
         qp_dprintf("Failed to validate driver integrity in qp_init\n");
@@ -65,7 +70,7 @@ bool qp_init(painter_device_t device, painter_rotation_t rotation) {
 bool qp_power(painter_device_t device, bool power_on) {
     qp_dprintf("qp_power: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_power: fail (validation_ok == false)\n");
         return false;
     }
@@ -87,7 +92,7 @@ bool qp_power(painter_device_t device, bool power_on) {
 bool qp_clear(painter_device_t device) {
     qp_dprintf("qp_clear: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_clear: fail (validation_ok == false)\n");
         return false;
     }
@@ -109,7 +114,7 @@ bool qp_clear(painter_device_t device) {
 bool qp_flush(painter_device_t device) {
     qp_dprintf("qp_flush: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_flush: fail (validation_ok == false)\n");
         return false;
     }
@@ -188,7 +193,7 @@ void qp_set_viewport_offsets(painter_device_t device, uint16_t offset_x, uint16_
 bool qp_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom) {
     qp_dprintf("qp_viewport: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_viewport: fail (validation_ok == false)\n");
         return false;
     }
@@ -211,7 +216,7 @@ bool qp_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t 
 bool qp_pixdata(painter_device_t device, const void *pixel_data, uint32_t native_pixel_count) {
     qp_dprintf("qp_pixdata: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_pixdata: fail (validation_ok == false)\n");
         return false;
     }

--- a/quantum/painter/qp_comms.c
+++ b/quantum/painter/qp_comms.c
@@ -8,7 +8,7 @@
 
 bool qp_comms_init(painter_device_t device) {
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_comms_init: fail (validation_ok == false)\n");
         return false;
     }
@@ -18,7 +18,7 @@ bool qp_comms_init(painter_device_t device) {
 
 bool qp_comms_start(painter_device_t device) {
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_comms_start: fail (validation_ok == false)\n");
         return false;
     }
@@ -28,7 +28,7 @@ bool qp_comms_start(painter_device_t device) {
 
 void qp_comms_stop(painter_device_t device) {
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_comms_stop: fail (validation_ok == false)\n");
         return;
     }
@@ -38,7 +38,7 @@ void qp_comms_stop(painter_device_t device) {
 
 uint32_t qp_comms_send(painter_device_t device, const void *data, uint32_t byte_count) {
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_comms_send: fail (validation_ok == false)\n");
         return false;
     }

--- a/quantum/painter/qp_draw_circle.c
+++ b/quantum/painter/qp_draw_circle.c
@@ -128,7 +128,7 @@ static bool qp_circle_helper_impl(painter_device_t device, uint16_t centerx, uin
 bool qp_circle(painter_device_t device, uint16_t x, uint16_t y, uint16_t radius, uint8_t hue, uint8_t sat, uint8_t val, bool filled) {
     qp_dprintf("qp_circle: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_circle: fail (validation_ok == false)\n");
         return false;
     }

--- a/quantum/painter/qp_draw_core.c
+++ b/quantum/painter/qp_draw_core.c
@@ -145,7 +145,7 @@ bool qp_internal_load_qgf_palette(qp_stream_t *stream, uint8_t bpp) {
 
 bool qp_setpixel(painter_device_t device, uint16_t x, uint16_t y, uint8_t hue, uint8_t sat, uint8_t val) {
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_setpixel: fail (validation_ok == false)\n");
         return false;
     }
@@ -175,7 +175,7 @@ bool qp_line(painter_device_t device, uint16_t x0, uint16_t y0, uint16_t x1, uin
 
     qp_dprintf("qp_line(%d, %d, %d, %d): entry\n", (int)x0, (int)y0, (int)x1, (int)y1);
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_line: fail (validation_ok == false)\n");
         return false;
     }
@@ -253,7 +253,7 @@ bool qp_internal_fillrect_helper_impl(painter_device_t device, uint16_t left, ui
 bool qp_rect(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom, uint8_t hue, uint8_t sat, uint8_t val, bool filled) {
     qp_dprintf("qp_rect(%d, %d, %d, %d): entry\n", (int)left, (int)top, (int)right, (int)bottom);
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_rect: fail (validation_ok == false)\n");
         return false;
     }

--- a/quantum/painter/qp_draw_ellipse.c
+++ b/quantum/painter/qp_draw_ellipse.c
@@ -62,7 +62,7 @@ static bool qp_ellipse_helper_impl(painter_device_t device, uint16_t centerx, ui
 bool qp_ellipse(painter_device_t device, uint16_t x, uint16_t y, uint16_t sizex, uint16_t sizey, uint8_t hue, uint8_t sat, uint8_t val, bool filled) {
     qp_dprintf("qp_ellipse: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_ellipse: fail (validation_ok == false)\n");
         return false;
     }

--- a/quantum/painter/qp_draw_image.c
+++ b/quantum/painter/qp_draw_image.c
@@ -90,7 +90,7 @@ painter_image_handle_t qp_load_image_mem(const void *buffer) {
 
 bool qp_close_image(painter_image_handle_t image) {
     qgf_image_handle_t *qgf_image = (qgf_image_handle_t *)image;
-    if (!qgf_image->validate_ok) {
+    if (!qgf_image || !qgf_image->validate_ok) {
         qp_dprintf("qp_close_image: fail (invalid image)\n");
         return false;
     }
@@ -210,13 +210,13 @@ static bool qp_drawimage_prepare_frame_for_stream_read(painter_device_t device, 
 static bool qp_drawimage_recolor_impl(painter_device_t device, uint16_t x, uint16_t y, painter_image_handle_t image, int frame_number, qgf_frame_info_t *frame_info, qp_pixel_t fg_hsv888, qp_pixel_t bg_hsv888) {
     qp_dprintf("qp_drawimage_recolor: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_drawimage_recolor: fail (validation_ok == false)\n");
         return false;
     }
 
     qgf_image_handle_t *qgf_image = (qgf_image_handle_t *)image;
-    if (!qgf_image->validate_ok) {
+    if (!qgf_image || !qgf_image->validate_ok) {
         qp_dprintf("qp_drawimage_recolor: fail (invalid image)\n");
         return false;
     }

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -136,7 +136,7 @@ painter_font_handle_t qp_load_font_mem(const void *buffer) {
 
 bool qp_close_font(painter_font_handle_t font) {
     qff_font_handle_t *qff_font = (qff_font_handle_t *)font;
-    if (!qff_font->validate_ok) {
+    if (!qff_font || !qff_font->validate_ok) {
         qp_dprintf("qp_close_font: fail (invalid font)\n");
         return false;
     }
@@ -380,7 +380,7 @@ static inline bool qp_font_code_point_handler_drawglyph(qff_font_handle_t *qff_f
 
 int16_t qp_textwidth(painter_font_handle_t font, const char *str) {
     qff_font_handle_t *qff_font = (qff_font_handle_t *)font;
-    if (!qff_font->validate_ok) {
+    if (!qff_font || !qff_font->validate_ok) {
         qp_dprintf("qp_textwidth: fail (invalid font)\n");
         return false;
     }
@@ -406,13 +406,13 @@ int16_t qp_drawtext(painter_device_t device, uint16_t x, uint16_t y, painter_fon
 int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg) {
     qp_dprintf("qp_drawtext_recolor: entry\n");
     painter_driver_t *driver = (painter_driver_t *)device;
-    if (!driver->validate_ok) {
+    if (!driver || !driver->validate_ok) {
         qp_dprintf("qp_drawtext_recolor: fail (validation_ok == false)\n");
         return 0;
     }
 
     qff_font_handle_t *qff_font = (qff_font_handle_t *)font;
-    if (!qff_font->validate_ok) {
+    if (!qff_font || !qff_font->validate_ok) {
         qp_dprintf("qp_drawtext_recolor: fail (invalid font)\n");
         return false;
     }


### PR DESCRIPTION
## Description

Haven't done an exhaustive review, seems like the codebase is correct in terms of "check before doing things", but the checks didn't account for users providing `NULL` pointers to the functions. Thus MCU would crash when checking `if (!pointer->valid)`, now we do `if (!pointer || !pointer->valid)`

Perhaps should have targeted `master`... 🤔 

Shall i add my name to headers after such a tiny change?

## Types of Changes

- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
