### PR TITLE
[QP] New `qp_scrolling_text` function

### DIFF
--- a/docs/quantum_painter.md
+++ b/docs/quantum_painter.md
@@ -853,8 +853,8 @@ void keyboard_post_init_kb(void) {
 #### ** Draw Scrolling Text **
 
 ```c
-deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay);
-deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint32_t delay);
+deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint32_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
 ```
 
 The `qp_scrolling_text` and `qp_scrolling_text_recolor` functions animate the supplied string to the screen at the given location using the font supplied, drawing `n_chars` chars each time, moving the text one position to the left every `delay` milliseconds, with the latter function allowing for monochrome-based fonts to be recolored.

--- a/docs/quantum_painter.md
+++ b/docs/quantum_painter.md
@@ -32,18 +32,19 @@ Supported devices:
 
 ## Quantum Painter Configuration :id=quantum-painter-config
 
-| Option                                   | Default | Purpose                                                                                                                                                                                      |
-|------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `QUANTUM_PAINTER_DISPLAY_TIMEOUT`        | `30000` | This controls the amount of time (in milliseconds) that all displays will remain on after the last user input. If set to `0`, the display will remain on indefinitely.                       |
-| `QUANTUM_PAINTER_TASK_THROTTLE`          | `1`     | This controls the amount of time (in milliseconds) that the Quantum Painter internal task will wait between each execution. Affects animations, display timeout, and LVGL timing if enabled. |
-| `QUANTUM_PAINTER_NUM_IMAGES`             | `8`     | The maximum number of images/animations that can be loaded at any one time.                                                                                                                  |
-| `QUANTUM_PAINTER_NUM_FONTS`              | `4`     | The maximum number of fonts that can be loaded at any one time.                                                                                                                              |
-| `QUANTUM_PAINTER_CONCURRENT_ANIMATIONS`  | `4`     | The maximum number of animations that can be executed at the same time.                                                                                                                      |
-| `QUANTUM_PAINTER_LOAD_FONTS_TO_RAM`      | `FALSE` | Whether or not fonts should be loaded to RAM. Relevant for fonts stored in off-chip persistent storage, such as external flash.                                                              |
-| `QUANTUM_PAINTER_PIXDATA_BUFFER_SIZE`    | `32`    | The limit of the amount of pixel data that can be transmitted in one transaction to the display. Higher values require more RAM on the MCU.                                                  |
-| `QUANTUM_PAINTER_SUPPORTS_256_PALETTE`   | `FALSE` | If 256-color palettes are supported. Requires significantly more RAM on the MCU.                                                                                                             |
-| `QUANTUM_PAINTER_SUPPORTS_NATIVE_COLORS` | `FALSE` | If native color range is supported. Requires significantly more RAM on the MCU.                                                                                                              |
-| `QUANTUM_PAINTER_DEBUG`                  | _unset_ | Prints out significant amounts of debugging information to CONSOLE output. Significant performance degradation, use only for debugging.                                                      |
+| Option                                       | Default | Purpose                                                                                                                                                                                      |
+|----------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `QUANTUM_PAINTER_DISPLAY_TIMEOUT`            | `30000` | This controls the amount of time (in milliseconds) that all displays will remain on after the last user input. If set to `0`, the display will remain on indefinitely.                       |
+| `QUANTUM_PAINTER_TASK_THROTTLE`              | `1`     | This controls the amount of time (in milliseconds) that the Quantum Painter internal task will wait between each execution. Affects animations, display timeout, and LVGL timing if enabled. |
+| `QUANTUM_PAINTER_NUM_IMAGES`                 | `8`     | The maximum number of images/animations that can be loaded at any one time.                                                                                                                  |
+| `QUANTUM_PAINTER_NUM_FONTS`                  | `4`     | The maximum number of fonts that can be loaded at any one time.                                                                                                                              |
+| `QUANTUM_PAINTER_CONCURRENT_ANIMATIONS`      | `4`     | The maximum number of animations that can be executed at the same time.                                                                                                                      |
+| `QUANTUM_PAINTER_CONCURRENT_SCROLLING_TEXTS` | `4`     | The maximum number of scrolling texts that can be executed at the same time.                                                                                                                 |
+| `QUANTUM_PAINTER_LOAD_FONTS_TO_RAM`          | `FALSE` | Whether or not fonts should be loaded to RAM. Relevant for fonts stored in off-chip persistent storage, such as external flash.                                                              |
+| `QUANTUM_PAINTER_PIXDATA_BUFFER_SIZE`        | `32`    | The limit of the amount of pixel data that can be transmitted in one transaction to the display. Higher values require more RAM on the MCU.                                                  |
+| `QUANTUM_PAINTER_SUPPORTS_256_PALETTE`       | `FALSE` | If 256-color palettes are supported. Requires significantly more RAM on the MCU.                                                                                                             |
+| `QUANTUM_PAINTER_SUPPORTS_NATIVE_COLORS`     | `FALSE` | If native color range is supported. Requires significantly more RAM on the MCU.                                                                                                              |
+| `QUANTUM_PAINTER_DEBUG`                      | _unset_ | Prints out significant amounts of debugging information to CONSOLE output. Significant performance degradation, use only for debugging.                                                      |
 
 Drivers have their own set of configurable options, and are described in their respective sections.
 
@@ -848,6 +849,23 @@ void keyboard_post_init_kb(void) {
     }
 }
 ```
+
+#### ** Draw Scrolling Text **
+
+```c
+deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay);
+deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+```
+
+The `qp_scrolling_text` and `qp_scrolling_text_recolor` functions animate the supplied string to the screen at the given location using the font supplied, drawing `n_chars` chars each time, moving the text one position to the left every `delay` milliseconds, with the latter function allowing for monochrome-based fonts to be recolored.
+
+#### ** Stop Srolling Text **
+
+```c
+void qp_stop_scrolling_text(deferred_token scrolling_token);
+```
+
+The `qp_stop_scrolling_text` function stops the previously-started animation.
 
 <!-- tabs:end -->
 

--- a/quantum/painter/qp.h
+++ b/quantum/painter/qp.h
@@ -474,7 +474,7 @@ int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, pai
  * @return the \ref deferred_token to use with \ref qp_stop_scrolling_text in order to stop scrolling
  * @return INVALID_DEFERRED_TOKEN if scrolling the text failed
  */
-deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay);
+deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint32_t delay);
 
 /**
  * Draws a scrolling text to the display, recoloring monochrome fonts to the desired foreground/background.
@@ -495,7 +495,7 @@ deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y
  * @return the \ref deferred_token to use with \ref qp_stop_scrolling_text in order to stop scrolling
  * @return INVALID_DEFERRED_TOKEN if scrolling the text failed
  */
-deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint32_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
 
 /**
  * Cancels a running scrolling text.

--- a/quantum/painter/qp.h
+++ b/quantum/painter/qp.h
@@ -64,6 +64,14 @@
 #    define QUANTUM_PAINTER_CONCURRENT_ANIMATIONS 4
 #endif // QUANTUM_PAINTER_CONCURRENT_ANIMATIONS
 
+#ifndef QUANTUM_PAINTER_CONCURRENT_SCROLLING_TEXTS
+/**
+ * @def This controls the maximum number of scrolling texts that Quantum Painter can play simultaneously. Increasing this
+ *      number in order to play more scrolling texts at the same time increases the amount of RAM required.
+ */
+#    define QUANTUM_PAINTER_CONCURRENT_SCROLLING_TEXTS 4
+#endif // QUANTUM_PAINTER_CONCURRENT_SCROLLING_TEXTS
+
 #ifndef QUANTUM_PAINTER_PIXDATA_BUFFER_SIZE
 /**
  * @def This controls the maximum size of the pixel data buffer used for single blocks of transmission. Larger buffers
@@ -452,6 +460,49 @@ int16_t qp_drawtext(painter_device_t device, uint16_t x, uint16_t y, painter_fon
  * @return the width (in pixels) used when drawing the specified string
  */
 int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+
+/**
+ * Draws a scrolling text to the display.
+ *
+ * @param device[in] the handle of the device to control
+ * @param x[in] the x-position where the text should be drawn onto the device
+ * @param y[in] the y-position where the text should be drawn onto the device
+ * @param font[in] the handle of the font
+ * @param str[in] the string to draw
+ * @param n_chars[in] the amount of chars to draw each time
+ * @param delay[in] the time (in ms) between iterations
+ * @return the \ref deferred_token to use with \ref qp_stop_scrolling_text in order to stop scrolling
+ * @return INVALID_DEFERRED_TOKEN if scrolling the text failed
+ */
+deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay);
+
+/**
+ * Draws a scrolling text to the display, recoloring monochrome fonts to the desired foreground/background.
+ *
+ * @param device[in] the handle of the device to control
+ * @param x[in] the x-position where the text should be drawn onto the device
+ * @param y[in] the y-position where the text should be drawn onto the device
+ * @param font[in] the handle of the font
+ * @param str[in] the string to draw
+ * @param n_chars[in] the amount of chars to draw each time
+ * @param delay[in] the time (in ms) between iterations
+ * @param hue_fg[in] the foreground hue to use, with 0-360 mapped to 0-255
+ * @param sat_fg[in] the foreground saturation to use, with 0-100% mapped to 0-255
+ * @param val_fg[in] the foreground value to use, with 0-100% mapped to 0-255
+ * @param hue_bg[in] the background hue to use, with 0-360 mapped to 0-255
+ * @param sat_bg[in] the background saturation to use, with 0-100% mapped to 0-255
+ * @param val_bg[in] the background value to use, with 0-100% mapped to 0-255
+ * @return the \ref deferred_token to use with \ref qp_stop_scrolling_text in order to stop scrolling
+ * @return INVALID_DEFERRED_TOKEN if scrolling the text failed
+ */
+deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
+
+/**
+ * Cancels a running scrolling text.
+ *
+ * @param scrolling_token[in] the scrolling token returned by \ref qp_scrolling_text, or \ref qp_scrolling_text_recolor.
+ */
+void qp_stop_scrolling_text(deferred_token scrolling_token);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum Painter Drivers

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -525,7 +525,7 @@ static bool qp_render_scrolling_text_state(scrolling_text_state_t *state) {
     // update position
     if (ret) {
         ++state->char_number;
-        if (state->char_number == len + state->spaces + 1) {
+        if (state->char_number == len + state->spaces) {
             state->char_number = 0;
         }
     }

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -1,4 +1,5 @@
 // Copyright 2021 Nick Brassel (@tzarc)
+// Copyright 2023 Pablo Martinez (@elpekenin) <elpekenin@elpekenin.dev>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <quantum.h>

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -465,7 +465,7 @@ int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, pai
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum Painter External API: qp_scrolling_text
 
-deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay) {
+deferred_token qp_scrolling_text(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint32_t delay) {
     return qp_scrolling_text_recolor(device, x, y, font, str, n_chars, delay, 0, 0, 255, 0, 0, 0);
 }
 
@@ -479,7 +479,7 @@ typedef struct scrolling_text_state_t {
     painter_font_handle_t font;
     const char *          str;
     uint8_t               n_chars; // Chars being drawn each time
-    uint16_t              delay;
+    uint32_t              delay;
     uint8_t               char_number; // Current positon
     uint8_t               spaces; // Whitespaces between string repetition
     qp_pixel_t            fg;
@@ -544,7 +544,7 @@ static uint32_t scrolling_text_callback(uint32_t trigger_time, void *cb_arg) {
     return ret ? state->delay : 0;
 }
 
-deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint16_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg) {
+deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t n_chars, uint32_t delay, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg) {
     qp_dprintf("qp_scrolling_text_recolor: entry\n");
 
     scrolling_text_state_t *scrolling_state = NULL;
@@ -603,4 +603,12 @@ void qp_stop_scrolling_text(deferred_token scrolling_token) {
             return;
         }
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter Core API: qp_internal_scrolling_text_tick
+
+void qp_internal_scrolling_text_tick(void) {
+    static uint32_t last_scrolling_text_exec = 0;
+    deferred_exec_advanced_task(scrolling_text_executors, QUANTUM_PAINTER_CONCURRENT_SCROLLING_TEXTS, &last_scrolling_text_exec);
 }

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -478,7 +478,7 @@ typedef struct scrolling_text_state_t {
     uint16_t              x;
     uint16_t              y;
     painter_font_handle_t font;
-    const char *          str;
+    char *                str;
     uint8_t               n_chars; // Chars being drawn each time
     uint32_t              delay;
     uint8_t               char_number; // Current positon
@@ -563,19 +563,18 @@ deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, ui
     // make a copy of the string, to prevent issues if the original variable is removed
     // note: input is expected to end in null terminator
     uint8_t len = strlen(str) + 1; // add one to also allocate/copy the terminator
-    char *copied_str = malloc(len);
-    if (copied_str == NULL) {
+    scrolling_state->str = malloc(len);
+    if (scrolling_state->str == NULL) {
         qp_dprintf("qp_scrolling_text_recolor: fail (could not allocate)\n");
         return false;
     }
-    memcpy(copied_str, str, len);
+    memcpy(scrolling_state->str, str, len);
 
     // Prepare the scrolling state
     scrolling_state->device      = device;
     scrolling_state->x           = x;
     scrolling_state->y           = y;
     scrolling_state->font        = font;
-    scrolling_state->str         = copied_str;
     scrolling_state->n_chars     = n_chars;
     scrolling_state->delay       = delay;
     scrolling_state->char_number = 0;
@@ -610,7 +609,7 @@ void qp_stop_scrolling_text(deferred_token scrolling_token) {
         if (scrolling_text_states[i].defer_token == scrolling_token) {
             cancel_deferred_exec_advanced(scrolling_text_executors, QUANTUM_PAINTER_CONCURRENT_SCROLLING_TEXTS, scrolling_token);
             scrolling_text_states[i].device = NULL;
-            free((void *)scrolling_text_states[i].str);
+            free(scrolling_text_states[i].str);
             return;
         }
     }

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -562,7 +562,7 @@ deferred_token qp_scrolling_text_recolor(painter_device_t device, uint16_t x, ui
 
     // make a copy of the string, to prevent issues if the original variable is removed
     // note: input is expected to end in null terminator
-    uint8_t len = strlen(str) + 1; // add one to also allocate/copy the terminator
+    uint8_t len          = strlen(str) + 1; // add one to also allocate/copy the terminator
     scrolling_state->str = malloc(len);
     if (scrolling_state->str == NULL) {
         qp_dprintf("qp_scrolling_text_recolor: fail (could not allocate)\n");

--- a/quantum/painter/qp_draw_text.c
+++ b/quantum/painter/qp_draw_text.c
@@ -482,7 +482,7 @@ typedef struct scrolling_text_state_t {
     uint8_t               n_chars; // Chars being drawn each time
     uint32_t              delay;
     uint8_t               char_number; // Current positon
-    uint8_t               spaces; // Whitespaces between string repetition
+    uint8_t               spaces;      // Whitespaces between string repetition
     qp_pixel_t            fg;
     qp_pixel_t            bg;
     deferred_token        defer_token;
@@ -518,7 +518,6 @@ static bool qp_render_scrolling_text_state(scrolling_text_state_t *state) {
         }
     }
 
-
     // draw it
     bool ret = qp_drawtext_recolor(state->device, state->x, state->y, state->font, slice, state->fg.hsv888.h, state->fg.hsv888.s, state->fg.hsv888.v, state->bg.hsv888.h, state->bg.hsv888.s, state->bg.hsv888.v);
     free((void *)slice); // de-allocate after use
@@ -536,7 +535,7 @@ static bool qp_render_scrolling_text_state(scrolling_text_state_t *state) {
 
 static uint32_t scrolling_text_callback(uint32_t trigger_time, void *cb_arg) {
     scrolling_text_state_t *state = (scrolling_text_state_t *)cb_arg;
-    bool                    ret = qp_render_scrolling_text_state(state);
+    bool                    ret   = qp_render_scrolling_text_state(state);
     if (!ret) {
         // Setting the device to NULL clears the scrolling slot
         state->device = NULL;

--- a/quantum/painter/qp_internal.c
+++ b/quantum/painter/qp_internal.c
@@ -81,6 +81,10 @@ void qp_internal_task(void) {
     void qp_internal_animation_tick(void);
     qp_internal_animation_tick();
 
+    // Handle scrolling texts
+    void qp_internal_scrolling_text_tick(void);
+    qp_internal_scrolling_text_tick();
+
 #ifdef QUANTUM_PAINTER_LVGL_INTEGRATION_ENABLE
     // Run LVGL ticks
     void qp_lvgl_internal_tick(void);


### PR DESCRIPTION
## Description

New functions for scrolling text, similar to `qp_animate`.

There's some code duplication,
- Maybe we should merge `QUANTUM_PAINTER_CONCURRENT_ANIMATIONS` and `QUANTUM_PAINTER_CONCURRENT_SCROLLING_TEXTS` in a common `QUANTUM_PAINTER_CONCURRENT_TASKS` for anything that may use deferred executors... And have asingle the tables of `deferred_executor_t`'s
- Could probably add a generic function that takes the callback function and the array where to store the state as arguments, so that adding similar functions is easier in the future.

## Types of Changes

- [X] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
