### PR TITLE
ez_maker/directpins/promicro: Fix bootloader mismatch

### DIFF
--- a/keyboards/ez_maker/directpins/promicro/info.json
+++ b/keyboards/ez_maker/directpins/promicro/info.json
@@ -2,7 +2,7 @@
     "manufacturer": "Zach White",
     "keyboard_name": "DirectPins ProMicro",
     "maintainer": "skullydazed",
-    "bootloader": "atmel-dfu",
+    "development_board": "promicro",
     "features": {
         "bootmagic": true,
         "extrakey": true,
@@ -22,7 +22,6 @@
             ["B5", "B6"]
         ]
     },
-    "processor": "atmega32u4",
     "usb": {
         "device_version": "0.0.1",
         "pid": "0x2320",


### PR DESCRIPTION
## Description

The configuration for the `ez_maker/directpins/promicro` board had `"bootloader": "atmel-dfu"` for some reason; this broke `qmk flash` for people who actually tried to use that code on a Pro Micro.  Set `"development_board": "promicro"` instead, so that the `caterina` bootloader and other settings appropriate for a Pro Micro would be used.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* `qmk flash -kb ez_maker/directpins/promicro -km default` did not work with a Pro Micro board due to the bootloader mismatch.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
