### PR TITLE
Vertex/angle65 WS2812 pin fix

### DIFF
--- a/keyboards/vertex/angle65/config.h
+++ b/keyboards/vertex/angle65/config.h
@@ -28,7 +28,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_EFFECT_RGB_TEST
 #define RGBLIGHT_EFFECT_ALTERNATING
 #define RGBLIGHT_EFFECT_TWINKLE
-#define WS2812_DI_PIN B15
 #define RGBLED_NUM 9
 #define WS2812_SPI SPID2
 #define WS2812_SPI_MOSI_PAL_MODE 5

--- a/keyboards/vertex/angle65/config.h
+++ b/keyboards/vertex/angle65/config.h
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_EFFECT_RGB_TEST
 #define RGBLIGHT_EFFECT_ALTERNATING
 #define RGBLIGHT_EFFECT_TWINKLE
-#define RGB_DI_PIN B15
+#define WS2812_DI_PIN B15
 #define RGBLED_NUM 9
 #define WS2812_SPI SPID2
 #define WS2812_SPI_MOSI_PAL_MODE 5

--- a/keyboards/vertex/angle65/info.json
+++ b/keyboards/vertex/angle65/info.json
@@ -20,6 +20,9 @@
         "caps_lock": "C13",
         "on_state": 0
     },
+    "ws2812": {
+        "pin": "B15"
+    },
     "layouts": {
         "LAYOUT": {
             "layout":[


### PR DESCRIPTION
## Description

Follow up to #20514 — use `WS2812_DI_PIN` on develop branch.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
