### PR TITLE
add azerty_fr keymap for kprepublic/bm60hsrgb_iso/rev1 

### DIFF
--- a/keyboards/kprepublic/bm60hsrgb_iso/rev1/keymaps/azerty_fr/keymap.c
+++ b/keyboards/kprepublic/bm60hsrgb_iso/rev1/keymaps/azerty_fr/keymap.c
@@ -1,0 +1,36 @@
+/* Copyright 2020 markva
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "keymap_extras/keymap_french.h"
+#include "keymap_extras/sendstring_french.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT_60_iso_arrow(
+        KC_ESC,  FR_AMPR,  FR_EACU, FR_DQUO, FR_QUOT, FR_LPRN, FR_MINS, FR_EGRV, FR_UNDS, FR_CCED, FR_AGRV, FR_RPRN, FR_EQL, KC_BSPC,
+        KC_TAB,  FR_A,    FR_Z,    FR_E,    FR_R,    FR_T,    FR_Y,    FR_U,    FR_I,    FR_O,    FR_P,    FR_CIRC,  FR_DLR,
+        KC_CAPS, FR_Q,    FR_S,    FR_D,    FR_F,    FR_G,    FR_H,    FR_J,    FR_K,    FR_L,    FR_M,    FR_UGRV, FR_ASTR,  KC_ENT,
+        KC_LSFT, FR_LABK, FR_W,    FR_X,    FR_C,    FR_V,    FR_B,    FR_N,    FR_COMM, FR_SCLN, FR_COLN, KC_RSFT, KC_UP,   FR_EXLM,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                    KC_RALT, MO(1),   KC_LEFT, KC_DOWN, KC_RGHT
+    ),
+    [1] = LAYOUT_60_iso_arrow(
+        QK_BOOT,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
+        _______, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______, _______, KC_PSCR, KC_INS,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, DM_PLY1, DM_PLY2, DM_REC1, DM_REC2, DM_RSTP,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_PGUP, _______,
+        _______, _______, _______,                            _______,                   _______, _______, KC_HOME, KC_PGDN, KC_END
+    ),
+};

--- a/keyboards/kprepublic/bm60hsrgb_iso/rev1/keymaps/azerty_fr/rules.mk
+++ b/keyboards/kprepublic/bm60hsrgb_iso/rev1/keymaps/azerty_fr/rules.mk
@@ -1,0 +1,1 @@
+#DYNAMIC_MACRO_ENABLE = yes

--- a/keyboards/kprepublic/bm60hsrgb_iso/rev1/readme.md
+++ b/keyboards/kprepublic/bm60hsrgb_iso/rev1/readme.md
@@ -1,4 +1,4 @@
-# BM60HSRGB_ISO/rev2
+# BM60HSRGB_ISO/rev1
 
 ![BM60HSRGB_ISO](https://i.imgur.com/i3gk2vql.jpg)
 


### PR DESCRIPTION
Add a keymap for french AZERTY layout on KPRepublic bm60hsrgb_iso/rev1 keyboard
Update readme file for rev1 to match keyboard rev (rev2 -> rev1)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
