### PR TITLE
Take care of scroll divisor remainders for PS/2 drag scroll

### DIFF
--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -255,7 +255,7 @@ static inline void ps2_mouse_scroll_button_task(report_mouse_t *mouse_report) {
         SCROLL_SENT,
     } scroll_state                     = SCROLL_NONE;
     static uint16_t scroll_button_time = 0;
-    static int16_t scroll_x, scroll_y;
+    static int16_t  scroll_x, scroll_y;
 
     if (PS2_MOUSE_SCROLL_BTN_MASK == (mouse_report->buttons & (PS2_MOUSE_SCROLL_BTN_MASK))) {
         // All scroll buttons are pressed
@@ -269,13 +269,13 @@ static inline void ps2_mouse_scroll_button_task(report_mouse_t *mouse_report) {
 
         // If the mouse has moved, update the report to scroll instead of move the mouse
         if (mouse_report->x || mouse_report->y) {
-            scroll_state    = SCROLL_SENT;
-            scroll_y        += mouse_report->y;
-            scroll_x        += mouse_report->x;
+            scroll_state = SCROLL_SENT;
+            scroll_y += mouse_report->y;
+            scroll_x += mouse_report->x;
             mouse_report->v = -scroll_y / (PS2_MOUSE_SCROLL_DIVISOR_V);
             mouse_report->h = scroll_x / (PS2_MOUSE_SCROLL_DIVISOR_H);
-            scroll_y        += (mouse_report->v * (PS2_MOUSE_SCROLL_DIVISOR_V));
-            scroll_x        -= (mouse_report->h * (PS2_MOUSE_SCROLL_DIVISOR_H));
+            scroll_y += (mouse_report->v * (PS2_MOUSE_SCROLL_DIVISOR_V));
+            scroll_x -= (mouse_report->h * (PS2_MOUSE_SCROLL_DIVISOR_H));
             mouse_report->x = 0;
             mouse_report->y = 0;
 #ifdef PS2_MOUSE_INVERT_H

--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -255,6 +255,7 @@ static inline void ps2_mouse_scroll_button_task(report_mouse_t *mouse_report) {
         SCROLL_SENT,
     } scroll_state                     = SCROLL_NONE;
     static uint16_t scroll_button_time = 0;
+    static int16_t scroll_x, scroll_y;
 
     if (PS2_MOUSE_SCROLL_BTN_MASK == (mouse_report->buttons & (PS2_MOUSE_SCROLL_BTN_MASK))) {
         // All scroll buttons are pressed
@@ -262,13 +263,19 @@ static inline void ps2_mouse_scroll_button_task(report_mouse_t *mouse_report) {
         if (scroll_state == SCROLL_NONE) {
             scroll_button_time = timer_read();
             scroll_state       = SCROLL_BTN;
+            scroll_x           = 0;
+            scroll_y           = 0;
         }
 
         // If the mouse has moved, update the report to scroll instead of move the mouse
         if (mouse_report->x || mouse_report->y) {
             scroll_state    = SCROLL_SENT;
-            mouse_report->v = -mouse_report->y / (PS2_MOUSE_SCROLL_DIVISOR_V);
-            mouse_report->h = mouse_report->x / (PS2_MOUSE_SCROLL_DIVISOR_H);
+            scroll_y        += mouse_report->y;
+            scroll_x        += mouse_report->x;
+            mouse_report->v = -scroll_y / (PS2_MOUSE_SCROLL_DIVISOR_V);
+            mouse_report->h = scroll_x / (PS2_MOUSE_SCROLL_DIVISOR_H);
+            scroll_y        += (mouse_report->v * (PS2_MOUSE_SCROLL_DIVISOR_V));
+            scroll_x        -= (mouse_report->h * (PS2_MOUSE_SCROLL_DIVISOR_H));
             mouse_report->x = 0;
             mouse_report->y = 0;
 #ifdef PS2_MOUSE_INVERT_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Similar to drag scroll implementations elsewhere, accumulate the X & Y coordinates until enough for a wheel tick. Save and apply the remainder towards next wheel tick.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
