### PR TITLE
Fix `test_json2c_no_json()`

### DIFF
--- a/keyboards/handwired/pytest/basic/info.json
+++ b/keyboards/handwired/pytest/basic/info.json
@@ -2,7 +2,7 @@
     "layouts": {
         "LAYOUT_custom": {
             "layout": [
-                { "label": "KC_Q", "matrix": [0, 0], "x": 0, "y": 0 }
+                {"label": "KC_Q", "matrix": [0, 0], "x": 0, "y": 0}
             ]
         }
     }

--- a/keyboards/handwired/pytest/config.h
+++ b/keyboards/handwired/pytest/config.h
@@ -1,6 +1,0 @@
-#pragma once
-
-
-#define MATRIX_COL_PINS { F4 }
-#define MATRIX_ROW_PINS { F5 }
-#define DIODE_DIRECTION COL2ROW

--- a/keyboards/handwired/pytest/info.json
+++ b/keyboards/handwired/pytest/info.json
@@ -7,6 +7,11 @@
         "pid": "0x6465",
         "device_version": "0.0.1"
     },
+    "matrix_pins": {
+        "cols": ["F4"],
+        "rows": ["F5"]
+    },
+    "diode_direction": "COL2ROW",
     "processor": "atmega32u4",
     "bootloader": "atmel-dfu",
     "layout_aliases": {

--- a/keyboards/handwired/pytest/macro/info.json
+++ b/keyboards/handwired/pytest/macro/info.json
@@ -1,10 +1,10 @@
 {
-  "maintainer": "qmk",
-  "layouts": {
-    "LAYOUT_custom": {
-      "layout": [
-        { "label": "KC_Q", "matrix": [0, 0], "x": 0, "y": 0 }
-      ]
+    "maintainer": "qmk",
+    "layouts": {
+        "LAYOUT_custom": {
+            "layout": [
+                {"label": "KC_Q", "matrix": [0, 0], "x": 0, "y": 0}
+            ]
+        }
     }
-  }
 }

--- a/lib/python/qmk/tests/minimal_info.json
+++ b/lib/python/qmk/tests/minimal_info.json
@@ -4,7 +4,7 @@
     "layouts": {
         "LAYOUT": {
             "layout": [
-                { "label": "KC_A", "matrix": [0, 0], "x": 0, "y": 0 }
+                {"label": "KC_A", "matrix": [0, 0], "x": 0, "y": 0}
             ]
         }
     }

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -168,7 +168,7 @@ def test_json2c_wrong_json():
 
 
 def test_json2c_no_json():
-    result = check_subcommand('json2c', 'keyboards/handwired/pytest/config.h')
+    result = check_subcommand('json2c', 'keyboards/handwired/pytest/basic/keymaps/default/keymap.c')
     check_returncode(result, [1])
     assert 'Invalid JSON encountered' in result.stdout
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This particular test fails when given an empty file of any kind, as the hjson loader will emit `{}`. Same for a config.h file with only preprocessor statements, since `#` is considered a comment.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
