### PR TITLE
Add next tapping record user callback

### DIFF
--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -544,4 +544,13 @@ static void debug_waiting_buffer(void) {
     ac_dprintf("}\n");
 }
 
+/**
+ * @brief Get next tapping record from buffer
+ *
+ * @return keyrecord_t
+ */
+keyrecord_t get_next_tapping_record(void) {
+    return waiting_buffer[waiting_buffer_tail];
+}
+
 #endif

--- a/quantum/action_tapping.h
+++ b/quantum/action_tapping.h
@@ -35,9 +35,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define WAITING_BUFFER_SIZE 8
 
 #ifndef NO_ACTION_TAPPING
-uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache);
-uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache);
-void     action_tapping_process(keyrecord_t record);
+uint16_t    get_record_keycode(keyrecord_t *record, bool update_layer_cache);
+uint16_t    get_event_keycode(keyevent_t event, bool update_layer_cache);
+void        action_tapping_process(keyrecord_t record);
+keyrecord_t get_next_tapping_record(void);
 #endif
 
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add a new `get_next_tapping_record()` function that allows user space read access to the next buffered tapping key. This can provide more granular control to tap-hold decision function based on that key.


Example:
```c
bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) {
    keyrecord_t next = get_next_tapping_record();
    // row > 3 on a 3x5_2 split is the right side
    // enable permissive hold for left-shift with right-side keys
    if (keycode == LSFT_T(KC_A) && next.event.key.row > 3 && next.event.pressed) {
        return true;
    }
    return false;
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
