### PR TITLE
support boards with APM32 instead of the STM32

### DIFF
--- a/keyboards/durgod/k310/base/rules.mk
+++ b/keyboards/durgod/k310/base/rules.mk
@@ -1,7 +1,9 @@
+# Wildcard to allow APM32 MCU
+DFU_SUFFIX_ARGS = -v FFFF -p FFFF
+
 # Build Options
 #   change yes to no to disable
 #
-DFU_SUFFIX_ARGS = -v FFFF -p FFFF
 BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
 MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control

--- a/keyboards/durgod/k310/base/rules.mk
+++ b/keyboards/durgod/k310/base/rules.mk
@@ -1,6 +1,7 @@
 # Build Options
 #   change yes to no to disable
 #
+DFU_SUFFIX_ARGS = -v FFFF -p FFFF
 BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
 MOUSEKEY_ENABLE = no        # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control


### PR DESCRIPTION
Will still work with STM32, but allows APM32 chips to be flashed as well

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
