### PR TITLE
Rart45: rename LAYOUT_all to LAYOUT

### DIFF
--- a/keyboards/rart/rart45/info.json
+++ b/keyboards/rart/rart45/info.json
@@ -1,89 +1,89 @@
 {
-  "keyboard_name": "Rart45",
-  "manufacturer": "Alabahuy",
-  "url": "",
-  "maintainer": "Alabahuy",
-  "usb": {
-    "vid": "0x414C",
-    "pid": "0x0045",
-    "device_version": "0.0.1"
-  },
-  "matrix_pins": {
-    "cols": ["D6", "D4", "B2", "B5", "B4", "B3"],
-    "rows": ["D1", "C2", "C1", "B1", "D0", "C3", "C0", "D7", "B0"]
-  },
-  "diode_direction": "COL2ROW",
-  "indicators": {
-    "caps_lock": "D5",
-    "on_state": 0
-  },
-  "processor": "atmega328p",
-  "bootloader": "usbasploader",
-  "layouts": {
-    "LAYOUT_all": {
-      "layout": [
-        {"matrix": [0, 0], "x": 0, "y": 0},
-        {"matrix": [4, 0], "x": 1, "y": 0},
-        {"matrix": [0, 1], "x": 2, "y": 0},
-        {"matrix": [4, 1], "x": 3, "y": 0},
-        {"matrix": [0, 2], "x": 4, "y": 0},
-        {"matrix": [4, 2], "x": 5, "y": 0},
+    "keyboard_name": "Rart45",
+    "manufacturer": "Alabahuy",
+    "url": "",
+    "maintainer": "Alabahuy",
+    "usb": {
+        "vid": "0x414C",
+        "pid": "0x0045",
+        "device_version": "0.0.1"
+    },
+    "matrix_pins": {
+        "cols": ["D6", "D4", "B2", "B5", "B4", "B3"],
+        "rows": ["D1", "C2", "C1", "B1", "D0", "C3", "C0", "D7", "B0"]
+    },
+    "diode_direction": "COL2ROW",
+    "indicators": {
+        "caps_lock": "D5",
+        "on_state": 0
+    },
+    "processor": "atmega328p",
+    "bootloader": "usbasploader",
+    "layouts": {
+        "LAYOUT_all": {
+            "layout": [
+                {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
+                {"label": "1", "matrix": [4, 0], "x": 1, "y": 0},
+                {"label": "2", "matrix": [0, 1], "x": 2, "y": 0},
+                {"label": "3", "matrix": [4, 1], "x": 3, "y": 0},
+                {"label": "4", "matrix": [0, 2], "x": 4, "y": 0},
+                {"label": "5", "matrix": [4, 2], "x": 5, "y": 0},
 
-        {"matrix": [0, 3], "x": 7, "y": 0},
-        {"matrix": [4, 3], "x": 8, "y": 0},
-        {"matrix": [0, 4], "x": 9, "y": 0},
-        {"matrix": [4, 4], "x": 10, "y": 0},
-        {"matrix": [0, 5], "x": 11, "y": 0},
-        {"matrix": [4, 5], "x": 12, "y": 0},
+                {"label": "6", "matrix": [0, 3], "x": 7, "y": 0},
+                {"label": "7", "matrix": [4, 3], "x": 8, "y": 0},
+                {"label": "8", "matrix": [0, 4], "x": 9, "y": 0},
+                {"label": "9", "matrix": [4, 4], "x": 10, "y": 0},
+                {"label": "0", "matrix": [0, 5], "x": 11, "y": 0},
+                {"label": "Delete", "matrix": [4, 5], "x": 12, "y": 0},
 
-        {"matrix": [1, 0], "x": 0, "y": 1},
-        {"matrix": [5, 0], "x": 1, "y": 1},
-        {"matrix": [1, 1], "x": 2, "y": 1},
-        {"matrix": [5, 1], "x": 3, "y": 1},
-        {"matrix": [1, 2], "x": 4, "y": 1},
-        {"matrix": [5, 2], "x": 5, "y": 1},
+                {"label": "Tab", "matrix": [1, 0], "x": 0, "y": 1},
+                {"label": "Q", "matrix": [5, 0], "x": 1, "y": 1},
+                {"label": "W", "matrix": [1, 1], "x": 2, "y": 1},
+                {"label": "E", "matrix": [5, 1], "x": 3, "y": 1},
+                {"label": "R", "matrix": [1, 2], "x": 4, "y": 1},
+                {"label": "T", "matrix": [5, 2], "x": 5, "y": 1},
 
-        {"matrix": [1, 3], "x": 7, "y": 1},
-        {"matrix": [5, 3], "x": 8, "y": 1},
-        {"matrix": [1, 4], "x": 9, "y": 1},
-        {"matrix": [5, 4], "x": 10, "y": 1},
-        {"matrix": [1, 5], "x": 11, "y": 1},
-        {"matrix": [5, 5], "x": 12, "y": 1},
+                {"label": "Y", "matrix": [1, 3], "x": 7, "y": 1},
+                {"label": "U", "matrix": [5, 3], "x": 8, "y": 1},
+                {"label": "I", "matrix": [1, 4], "x": 9, "y": 1},
+                {"label": "O", "matrix": [5, 4], "x": 10, "y": 1},
+                {"label": "P", "matrix": [1, 5], "x": 11, "y": 1},
+                {"label": "Backspace", "matrix": [5, 5], "x": 12, "y": 1},
 
-        {"matrix": [2, 0], "x": 0, "y": 2},
-        {"matrix": [6, 0], "x": 1, "y": 2},
-        {"matrix": [2, 1], "x": 2, "y": 2},
-        {"matrix": [6, 1], "x": 3, "y": 2},
-        {"matrix": [2, 2], "x": 4, "y": 2},
-        {"matrix": [6, 2], "x": 5, "y": 2},
+                {"label": "Esc", "matrix": [2, 0], "x": 0, "y": 2},
+                {"label": "A", "matrix": [6, 0], "x": 1, "y": 2},
+                {"label": "S", "matrix": [2, 1], "x": 2, "y": 2},
+                {"label": "D", "matrix": [6, 1], "x": 3, "y": 2},
+                {"label": "F", "matrix": [2, 2], "x": 4, "y": 2},
+                {"label": "G", "matrix": [6, 2], "x": 5, "y": 2},
 
-        {"matrix": [2, 3], "x": 7, "y": 2},
-        {"matrix": [6, 3], "x": 8, "y": 2},
-        {"matrix": [2, 4], "x": 9, "y": 2},
-        {"matrix": [6, 4], "x": 10, "y": 2},
-        {"matrix": [2, 5], "x": 11, "y": 2},
-        {"matrix": [6, 5], "x": 12, "y": 2},
+                {"label": "H", "matrix": [2, 3], "x": 7, "y": 2},
+                {"label": "J", "matrix": [6, 3], "x": 8, "y": 2},
+                {"label": "K", "matrix": [2, 4], "x": 9, "y": 2},
+                {"label": "L", "matrix": [6, 4], "x": 10, "y": 2},
+                {"label": ";", "matrix": [2, 5], "x": 11, "y": 2},
+                {"label": "\\", "matrix": [6, 5], "x": 12, "y": 2},
 
-        {"matrix": [3, 0], "x": 0, "y": 3},
-        {"matrix": [7, 0], "x": 1, "y": 3},
-        {"matrix": [3, 1], "x": 2, "y": 3},
-        {"matrix": [7, 1], "x": 3, "y": 3},
-        {"matrix": [3, 2], "x": 4, "y": 3},
-        {"matrix": [7, 2], "x": 5, "y": 3},
+                {"label": "Shift", "matrix": [3, 0], "x": 0, "y": 3},
+                {"label": "Z", "matrix": [7, 0], "x": 1, "y": 3},
+                {"label": "X", "matrix": [3, 1], "x": 2, "y": 3},
+                {"label": "C", "matrix": [7, 1], "x": 3, "y": 3},
+                {"label": "V", "matrix": [3, 2], "x": 4, "y": 3},
+                {"label": "B", "matrix": [7, 2], "x": 5, "y": 3},
 
-        {"matrix": [3, 3], "x": 7, "y": 3},
-        {"matrix": [7, 3], "x": 8, "y": 3},
-        {"matrix": [3, 4], "x": 9, "y": 3},
-        {"matrix": [7, 4], "x": 10, "y": 3},
-        {"matrix": [3, 5], "x": 11, "y": 3},
-        {"matrix": [7, 5], "x": 12, "y": 3},
+                {"label": "N", "matrix": [3, 3], "x": 7, "y": 3},
+                {"label": "M", "matrix": [7, 3], "x": 8, "y": 3},
+                {"label": ",", "matrix": [3, 4], "x": 9, "y": 3},
+                {"label": ".", "matrix": [7, 4], "x": 10, "y": 3},
+                {"label": "/", "matrix": [3, 5], "x": 11, "y": 3},
+                {"label": "Enter", "matrix": [7, 5], "x": 12, "y": 3},
 
-        {"matrix": [8, 0], "x": 2.875, "y": 4, "w": 1.25},
-        {"matrix": [8, 1], "x": 4.125, "y": 4, "w": 1.25},
-        {"matrix": [8, 2], "x": 5.375, "y": 4, "w": 2.25},
-        {"matrix": [8, 3], "x": 7.625, "y": 4, "w": 1.25},
-        {"matrix": [8, 4], "x": 8.875, "y": 4, "w": 1.25}
-      ]
+                {"label": "Ctrl", "matrix": [8, 0], "x": 2.875, "y": 4, "w": 1.25},
+                {"label": "Fn", "matrix": [8, 1], "x": 4.125, "y": 4, "w": 1.25},
+                {"label": "Space", "matrix": [8, 2], "x": 5.375, "y": 4, "w": 2.25},
+                {"label": "Fn2", "matrix": [8, 3], "x": 7.625, "y": 4, "w": 1.25},
+                {"label": "Alt", "matrix": [8, 4], "x": 8.875, "y": 4, "w": 1.25}
+            ]
+        }
     }
-  }
 }

--- a/keyboards/rart/rart45/info.json
+++ b/keyboards/rart/rart45/info.json
@@ -19,8 +19,11 @@
     },
     "processor": "atmega328p",
     "bootloader": "usbasploader",
+    "layout_aliases": {
+        "LAYOUT_all": "LAYOUT"
+    },
     "layouts": {
-        "LAYOUT_all": {
+        "LAYOUT": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "1", "matrix": [4, 0], "x": 1, "y": 0},

--- a/keyboards/rart/rart45/keymaps/default/keymap.c
+++ b/keyboards/rart/rart45/keymaps/default/keymap.c
@@ -16,7 +16,7 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-  [0] = LAYOUT_all(
+  [0] = LAYOUT(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,    
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
         KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_BSLS,
@@ -24,7 +24,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                    KC_LCTL, MO(1),       KC_SPC,       MO(2),   KC_LALT
   ),
 
-  [1] = LAYOUT_all(
+  [1] = LAYOUT(
         KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
@@ -32,7 +32,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                    KC_LCTL, _______,     KC_SPC,       _______, KC_LALT        
   ),
 
-  [2] = LAYOUT_all(
+  [2] = LAYOUT(
         QK_BOOT,   KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,

--- a/keyboards/rart/rart45/keymaps/via/keymap.c
+++ b/keyboards/rart/rart45/keymaps/via/keymap.c
@@ -16,7 +16,7 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-  [0] = LAYOUT_all(
+  [0] = LAYOUT(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,    
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
         KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_BSLS,
@@ -24,7 +24,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                    KC_LCTL, MO(1),       KC_SPC,       MO(2),   KC_LALT
   ),
 
-  [1] = LAYOUT_all(
+  [1] = LAYOUT(
         KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
@@ -32,7 +32,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                    KC_LCTL, _______,     KC_SPC,       _______, KC_LALT        
   ),
 
-  [2] = LAYOUT_all(
+  [2] = LAYOUT(
         QK_BOOT,   KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
@@ -40,7 +40,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                    KC_LCTL, _______,     KC_SPC,       _______, KC_LALT   
   ),  
 
-  [3] = LAYOUT_all(
+  [3] = LAYOUT(
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,


### PR DESCRIPTION
## Description

- rename `LAYOUT_all` to `LAYOUT` (only one layout supported)

cc @alabahuy (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
