### PR TITLE
Revert use of legacy wear leveling driver now ChibiOS is fixed

### DIFF
--- a/keyboards/mode/m75s/rules.mk
+++ b/keyboards/mode/m75s/rules.mk
@@ -10,8 +10,6 @@ NKRO_ENABLE = no            # Enable N-Key Rollover
 BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = legacy
 LTO_ENABLE = yes
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread

--- a/keyboards/teleport/native/rules.mk
+++ b/keyboards/teleport/native/rules.mk
@@ -2,7 +2,3 @@ RGB_MATRIX_ENABLE = yes
 RGB_MATRIX_CUSTOM_KB = yes
 
 DEFAULT_FOLDER = teleport/native/iso
-
-# Temporary workaround while waiting fixes of F411xC flash size definitions
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = legacy

--- a/platforms/chibios/mcu_selection.mk
+++ b/platforms/chibios/mcu_selection.mk
@@ -361,10 +361,6 @@ ifneq ($(findstring STM32F401, $(MCU)),)
 
   # Bootloader address for STM32 DFU
   STM32_BOOTLOADER_ADDRESS ?= 0x1FFF0000
-
-  # Revert to legacy wear-leveling driver until ChibiOS's EFL driver is fixed with 128kB and 384kB variants.
-  EEPROM_DRIVER ?= wear_leveling
-  WEAR_LEVELING_DRIVER ?= legacy
 endif
 
 ifneq ($(findstring STM32F405, $(MCU)),)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
ChibiOS bump in this cycle allows us to remove the previously added workarounds.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
