### PR TITLE
[Keyboard] Enable LTO on salicylic acid 7skb to reduce size

### DIFF
--- a/keyboards/salicylic_acid3/7skb/rev1/info.json
+++ b/keyboards/salicylic_acid3/7skb/rev1/info.json
@@ -19,6 +19,9 @@
     "ws2812": {
         "pin": "D3"
     },
+    "build": {
+        "lto": true
+    },
     "processor": "atmega32u4",
     "bootloader": "caterina",
     "layouts": {


### PR DESCRIPTION
## Description

Is compiling ~100 bytes over, and LTO wasn't already enabled

## Types of Changes

- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* tzarc CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
