### PR TITLE
`qmk format-json`: Expose full key path and respect `sort_keys`

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -256,7 +256,7 @@ Formats a JSON file in a (mostly) human-friendly way. Will usually correctly det
 **Usage**:
 
 ```
-qmk format-json [--no-sort] [-f FORMAT] <json_file>
+qmk format-json [-f FORMAT] <json_file>
 ```
 
 ## `qmk info`

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -256,7 +256,7 @@ Formats a JSON file in a (mostly) human-friendly way. Will usually correctly det
 **Usage**:
 
 ```
-qmk format-json [-f FORMAT] <json_file>
+qmk format-json [--no-sort] [-f FORMAT] <json_file>
 ```
 
 ## `qmk info`

--- a/lib/python/qmk/cli/c2json.py
+++ b/lib/python/qmk/cli/c2json.py
@@ -57,7 +57,7 @@ def c2json(cli):
         cli.args.output.parent.mkdir(parents=True, exist_ok=True)
         if cli.args.output.exists():
             cli.args.output.replace(cli.args.output.parent / (cli.args.output.name + '.bak'))
-        cli.args.output.write_text(json.dumps(keymap_json, cls=InfoJSONEncoder))
+        cli.args.output.write_text(json.dumps(keymap_json, cls=InfoJSONEncoder, sort_keys=True))
 
         if not cli.args.quiet:
             cli.log.info('Wrote keymap to %s.', cli.args.output)

--- a/lib/python/qmk/cli/format/json.py
+++ b/lib/python/qmk/cli/format/json.py
@@ -15,7 +15,6 @@ from qmk.path import normpath
 
 @cli.argument('json_file', arg_only=True, type=normpath, help='JSON file to format')
 @cli.argument('-f', '--format', choices=['auto', 'keyboard', 'keymap'], default='auto', arg_only=True, help='JSON formatter to use (Default: autodetect)')
-@cli.argument('--no-sort', action='store_true', arg_only=True, help='Do not sort keys.')
 @cli.subcommand('Generate an info.json file for a keyboard.', hidden=False if cli.config.user.developer else True)
 def format_json(cli):
     """Format a json file.
@@ -63,4 +62,4 @@ def format_json(cli):
                 json_file['layers'][layer_num] = current_layer
 
     # Display the results
-    print(json.dumps(json_file, cls=json_encoder, sort_keys=not cli.args.no_sort))
+    print(json.dumps(json_file, cls=json_encoder, sort_keys=True))

--- a/lib/python/qmk/cli/format/json.py
+++ b/lib/python/qmk/cli/format/json.py
@@ -15,6 +15,7 @@ from qmk.path import normpath
 
 @cli.argument('json_file', arg_only=True, type=normpath, help='JSON file to format')
 @cli.argument('-f', '--format', choices=['auto', 'keyboard', 'keymap'], default='auto', arg_only=True, help='JSON formatter to use (Default: autodetect)')
+@cli.argument('--no-sort', action='store_true', arg_only=True, help='Do not sort keys.')
 @cli.subcommand('Generate an info.json file for a keyboard.', hidden=False if cli.config.user.developer else True)
 def format_json(cli):
     """Format a json file.
@@ -62,4 +63,4 @@ def format_json(cli):
                 json_file['layers'][layer_num] = current_layer
 
     # Display the results
-    print(json.dumps(json_file, cls=json_encoder))
+    print(json.dumps(json_file, cls=json_encoder, sort_keys=not cli.args.no_sort))

--- a/lib/python/qmk/cli/generate/info_json.py
+++ b/lib/python/qmk/cli/generate/info_json.py
@@ -76,7 +76,7 @@ def generate_info_json(cli):
     # Build the info.json file
     kb_info_json = info_json(cli.config.generate_info_json.keyboard)
     strip_info_json(kb_info_json)
-    info_json_text = json.dumps(kb_info_json, indent=4, cls=InfoJSONEncoder)
+    info_json_text = json.dumps(kb_info_json, indent=4, cls=InfoJSONEncoder, sort_keys=True)
 
     if cli.args.output:
         # Write to a file

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -200,7 +200,7 @@ def info(cli):
 
     # Output in the requested format
     if cli.args.format == 'json':
-        print(json.dumps(kb_info_json, cls=InfoJSONEncoder))
+        print(json.dumps(kb_info_json, cls=InfoJSONEncoder, sort_keys=True))
         return True
     elif cli.args.format == 'text':
         print_dotted_output(kb_info_json)

--- a/lib/python/qmk/cli/migrate.py
+++ b/lib/python/qmk/cli/migrate.py
@@ -75,7 +75,7 @@ def migrate(cli):
 
     # Finally write out updated info.json
     cli.log.info(f'  Updating {target_info}')
-    target_info.write_text(json.dumps(info_data.to_dict(), cls=InfoJSONEncoder))
+    target_info.write_text(json.dumps(info_data.to_dict(), cls=InfoJSONEncoder, sort_keys=True))
 
     cli.log.info(f'{{fg_green}}Migration of keyboard {{fg_cyan}}{cli.args.keyboard}{{fg_green}} complete!{{fg_reset}}')
     cli.log.info(f"Verify build with {{fg_yellow}}qmk compile -kb {cli.args.keyboard} -km default{{fg_reset}}.")

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -102,7 +102,7 @@ def augment_community_info(src, dest):
         item["matrix"] = [int(item["y"]), int(item["x"])]
 
     # finally write out the updated info.json
-    dest.write_text(json.dumps(info, cls=InfoJSONEncoder))
+    dest.write_text(json.dumps(info, cls=InfoJSONEncoder, sort_keys=True))
 
 
 def _question(*args, **kwargs):

--- a/lib/python/qmk/cli/via2json.py
+++ b/lib/python/qmk/cli/via2json.py
@@ -141,5 +141,5 @@ def via2json(cli):
     # Generate the keymap.json
     keymap_json = generate_json(cli.args.keymap, cli.args.keyboard, keymap_layout, keymap_data, macro_data)
 
-    keymap_lines = [json.dumps(keymap_json, cls=KeymapJSONEncoder)]
+    keymap_lines = [json.dumps(keymap_json, cls=KeymapJSONEncoder, sort_keys=True)]
     dump_lines(cli.args.output, keymap_lines, cli.args.quiet)

--- a/lib/python/qmk/importers.py
+++ b/lib/python/qmk/importers.py
@@ -91,7 +91,7 @@ def import_keymap(keymap_data):
     keyboard_keymap.parent.mkdir(parents=True, exist_ok=True)
 
     # Dump out all those lovely files
-    keyboard_keymap.write_text(json.dumps(keymap_data, cls=KeymapJSONEncoder))
+    keyboard_keymap.write_text(json.dumps(keymap_data, cls=KeymapJSONEncoder, sort_keys=True))
 
     return (kb_name, km_name)
 
@@ -139,8 +139,8 @@ def import_keyboard(info_data, keymap_data=None):
     temp = json_load(keyboard_info)
     deep_update(temp, info_data)
 
-    keyboard_info.write_text(json.dumps(temp, cls=InfoJSONEncoder))
-    keyboard_keymap.write_text(json.dumps(keymap_data, cls=KeymapJSONEncoder))
+    keyboard_info.write_text(json.dumps(temp, cls=InfoJSONEncoder, sort_keys=True))
+    keyboard_keymap.write_text(json.dumps(keymap_data, cls=KeymapJSONEncoder, sort_keys=True))
 
     return kb_name
 

--- a/lib/python/qmk/json_encoders.py
+++ b/lib/python/qmk/json_encoders.py
@@ -27,39 +27,41 @@ class QMKJSONEncoder(json.JSONEncoder):
 
         return float(obj)
 
-    def encode_dict_single_line(self, obj):
-        return "{" + ", ".join(f"{self.encode(key)}: {self.encode(element)}" for key, element in sorted(obj.items(), key=self.sort_layout)) + "}"
+    def encode_dict_single_line(self, obj, path):
+        """Encode a dict-like object onto a single line.
+        """
+        return "{" + ", ".join(f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in sorted(obj.items(), key=self.sort_layout)) + "}"
 
-    def encode_list(self, obj, key=None):
+    def encode_list(self, obj, path):
         """Encode a list-like object.
         """
         if self.primitives_only(obj):
-            return "[" + ", ".join(self.encode(element) for element in obj) + "]"
+            return "[" + ", ".join(self.encode(value, path + [index]) for index, value in enumerate(obj)) + "]"
 
         else:
             self.indentation_level += 1
 
-            if key in ('layout', 'rotary'):
-                # These are part of a layout or led/encoder config, put them on a single line.
-                output = [self.indent_str + self.encode_dict_single_line(element) for element in obj]
+            if path[-1] in ('layout', 'rotary'):
+                # These are part of a LED layout or encoder config, put them on a single line
+                output = [self.indent_str + self.encode_dict_single_line(value, path + [index]) for index, value in enumerate(obj)]
             else:
-                output = [self.indent_str + self.encode(element) for element in obj]
+                output = [self.indent_str + self.encode(value, path + [index]) for index, value in enumerate(obj)]
 
             self.indentation_level -= 1
 
             return "[\n" + ",\n".join(output) + "\n" + self.indent_str + "]"
 
-    def encode(self, obj, key=None):
-        """Encode keymap.json objects for QMK.
+    def encode(self, obj, path=[]):
+        """Encode JSON objects for QMK.
         """
         if isinstance(obj, Decimal):
             return self.encode_decimal(obj)
 
         elif isinstance(obj, (list, tuple)):
-            return self.encode_list(obj, key)
+            return self.encode_list(obj, path)
 
         elif isinstance(obj, dict):
-            return self.encode_dict(obj, key)
+            return self.encode_dict(obj, path)
 
         else:
             return super().encode(obj)
@@ -80,19 +82,25 @@ class QMKJSONEncoder(json.JSONEncoder):
 class InfoJSONEncoder(QMKJSONEncoder):
     """Custom encoder to make info.json's a little nicer to work with.
     """
-    def encode_dict(self, obj, key):
+    def encode_dict(self, obj, path):
         """Encode info.json dictionaries.
         """
         if obj:
             self.indentation_level += 1
-            output = [self.indent_str + f"{json.dumps(k)}: {self.encode(v, k)}" for k, v in sorted(obj.items(), key=self.sort_dict)]
+
+            items = sorted(obj.items(), key=self.sort_dict) if self.sort_keys else obj.items()
+            output = [self.indent_str + f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in items]
+
             self.indentation_level -= 1
+
             return "{\n" + ",\n".join(output) + "\n" + self.indent_str + "}"
         else:
             return "{}"
 
-    def sort_layout(self, key):
-        key = key[0]
+    def sort_layout(self, item):
+        """Sorts the hashes in a nice way.
+        """
+        key = item[0]
 
         if key == 'label':
             return '00label'
@@ -117,10 +125,10 @@ class InfoJSONEncoder(QMKJSONEncoder):
 
         return key
 
-    def sort_dict(self, key):
+    def sort_dict(self, item):
         """Forces layout to the back of the sort order.
         """
-        key = key[0]
+        key = item[0]
 
         if self.indentation_level == 1:
             if key == 'manufacturer':
@@ -150,19 +158,19 @@ class InfoJSONEncoder(QMKJSONEncoder):
 class KeymapJSONEncoder(QMKJSONEncoder):
     """Custom encoder to make keymap.json's a little nicer to work with.
     """
-    def encode_dict(self, obj, key):
+    def encode_dict(self, obj, path):
         """Encode dictionary objects for keymap.json.
         """
         if obj:
             self.indentation_level += 1
-            output = [self.indent_str + f"{json.dumps(k)}: {self.encode(v, k)}" for k, v in sorted(obj.items(), key=self.sort_dict)]
+            output = [self.indent_str + f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in sorted(obj.items(), key=self.sort_dict)]
             self.indentation_level -= 1
             return "{\n" + ",\n".join(output) + "\n" + self.indent_str + "}"
 
         else:
             return "{}"
 
-    def encode_list(self, obj, k=None):
+    def encode_list(self, obj, path):
         """Encode a list-like object.
         """
         if self.indentation_level == 2:
@@ -196,10 +204,10 @@ class KeymapJSONEncoder(QMKJSONEncoder):
 
             return "[\n" + ",\n".join(output) + "\n" + self.indent_str + "]"
 
-    def sort_dict(self, key):
+    def sort_dict(self, item):
         """Sorts the hashes in a nice way.
         """
-        key = key[0]
+        key = item[0]
 
         if self.indentation_level == 1:
             if key == 'version':

--- a/lib/python/qmk/json_encoders.py
+++ b/lib/python/qmk/json_encoders.py
@@ -27,6 +27,21 @@ class QMKJSONEncoder(json.JSONEncoder):
 
         return float(obj)
 
+    def encode_dict(self, obj, path):
+        """Encode a dict-like object.
+        """
+        if obj:
+            self.indentation_level += 1
+
+            items = sorted(obj.items(), key=self.sort_dict) if self.sort_keys else obj.items()
+            output = [self.indent_str + f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in items]
+
+            self.indentation_level -= 1
+
+            return "{\n" + ",\n".join(output) + "\n" + self.indent_str + "}"
+        else:
+            return "{}"
+
     def encode_dict_single_line(self, obj, path):
         """Encode a dict-like object onto a single line.
         """
@@ -82,21 +97,6 @@ class QMKJSONEncoder(json.JSONEncoder):
 class InfoJSONEncoder(QMKJSONEncoder):
     """Custom encoder to make info.json's a little nicer to work with.
     """
-    def encode_dict(self, obj, path):
-        """Encode info.json dictionaries.
-        """
-        if obj:
-            self.indentation_level += 1
-
-            items = sorted(obj.items(), key=self.sort_dict) if self.sort_keys else obj.items()
-            output = [self.indent_str + f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in items]
-
-            self.indentation_level -= 1
-
-            return "{\n" + ",\n".join(output) + "\n" + self.indent_str + "}"
-        else:
-            return "{}"
-
     def sort_layout(self, item):
         """Sorts the hashes in a nice way.
         """
@@ -132,7 +132,7 @@ class InfoJSONEncoder(QMKJSONEncoder):
 
         if self.indentation_level == 1:
             if key == 'manufacturer':
-                return '10keyboard_name'
+                return '10manufacturer'
 
             elif key == 'keyboard_name':
                 return '11keyboard_name'
@@ -158,18 +158,6 @@ class InfoJSONEncoder(QMKJSONEncoder):
 class KeymapJSONEncoder(QMKJSONEncoder):
     """Custom encoder to make keymap.json's a little nicer to work with.
     """
-    def encode_dict(self, obj, path):
-        """Encode dictionary objects for keymap.json.
-        """
-        if obj:
-            self.indentation_level += 1
-            output = [self.indent_str + f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in sorted(obj.items(), key=self.sort_dict)]
-            self.indentation_level -= 1
-            return "{\n" + ",\n".join(output) + "\n" + self.indent_str + "}"
-
-        else:
-            return "{}"
-
     def encode_list(self, obj, path):
         """Encode a list-like object.
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The info.json encoder now knows the full key path when encoding, instead of just the key name, in the form of an array. One possible application for this would be the ability to differentiate LED layouts from key layouts, possibly allowing further formatting of the latter to separate rows and gaps between keys. This is currently only done by hand and would be reverted by the encoder.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
