### PR TITLE
[Bug] Fix compilation error introduced by #20669

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -200,7 +200,7 @@ void process_hand_swap(keyevent_t *event) {
         }
     }
 #    ifdef ENCODER_MAP_ENABLE
-    else if (IS_ENCODEREVENT(*event) && pos.row == KEYLOC_ENCODER_CW || pos.row == KEYLOC_ENCODER_CCW) {
+    else if (IS_ENCODEREVENT(*event) && (pos.row == KEYLOC_ENCODER_CW || pos.row == KEYLOC_ENCODER_CCW)) {
         static uint8_t encoder_swap_state[((NUM_ENCODERS) + (CHAR_BIT)-1) / (CHAR_BIT)];
         size_t         index   = pos.col;
         bool           do_swap = should_swap_hands(index, encoder_swap_state, event->pressed);


### PR DESCRIPTION

## Description

is encoderevent check in #30669 introduced a warning/error: 
```
Compiling: quantum/action.c                                                                        quantum/action.c: In function 'process_hand_swap':
quantum/action.c:203:38: error: suggest parentheses around '&&' within '||' [-Werror=parentheses]
  203 |     else if (IS_ENCODEREVENT(*event) && pos.row == KEYLOC_ENCODER_CW || pos.row == KEYLOC_ENCODER_CCW) {
cc1: all warnings being treated as errors
```

This fixes that, by wrapping the cw/ccw check in parentheses. 

## Types of Changes

- [x] Core
- [x] Bugfix


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
