### PR TITLE
Fixed WB32 MCU remote wakeup issue

### DIFF
--- a/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
@@ -73,22 +73,11 @@ void __early_init(void) {
   wb32_clock_init();
   wb32_gpio_init();
 }
+
 /**
  * @brief   Board-specific initialization code.
  * @note    You can add your board-specific code here.
  */
 void boardInit(void) {
 
-}
-
-void restart_usb_driver(USBDriver *usbp) {
-#if USB_SUSPEND_WAKEUP_DELAY > 0
-    // Some hubs, kvm switches, and monitors do
-    // weird things, with USB device state bouncing
-    // around wildly on wakeup, yielding race
-    // conditions that can corrupt the keyboard state.
-    //
-    // Pause for a while to let things settle...
-    chThdSleepMilliseconds(USB_SUSPEND_WAKEUP_DELAY);
-#endif
 }

--- a/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
@@ -89,6 +89,6 @@ void restart_usb_driver(USBDriver *usbp) {
     // conditions that can corrupt the keyboard state.
     //
     // Pause for a while to let things settle...
-    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+    chThdSleepMilliseconds(USB_SUSPEND_WAKEUP_DELAY);
 #endif
 }

--- a/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_F3G71XX/board/board.c
@@ -82,5 +82,13 @@ void boardInit(void) {
 }
 
 void restart_usb_driver(USBDriver *usbp) {
-  // Do nothing. Restarting the USB driver on these boards breaks it.
+#if USB_SUSPEND_WAKEUP_DELAY > 0
+    // Some hubs, kvm switches, and monitors do
+    // weird things, with USB device state bouncing
+    // around wildly on wakeup, yielding race
+    // conditions that can corrupt the keyboard state.
+    //
+    // Pause for a while to let things settle...
+    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#endif
 }

--- a/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
@@ -73,22 +73,11 @@ void __early_init(void) {
   wb32_clock_init();
   wb32_gpio_init();
 }
+
 /**
  * @brief   Board-specific initialization code.
  * @note    You can add your board-specific code here.
  */
 void boardInit(void) {
 
-}
-
-void restart_usb_driver(USBDriver *usbp) {
-#if USB_SUSPEND_WAKEUP_DELAY > 0
-    // Some hubs, kvm switches, and monitors do
-    // weird things, with USB device state bouncing
-    // around wildly on wakeup, yielding race
-    // conditions that can corrupt the keyboard state.
-    //
-    // Pause for a while to let things settle...
-    chThdSleepMilliseconds(USB_SUSPEND_WAKEUP_DELAY);
-#endif
 }

--- a/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
@@ -89,6 +89,6 @@ void restart_usb_driver(USBDriver *usbp) {
     // conditions that can corrupt the keyboard state.
     //
     // Pause for a while to let things settle...
-    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+    chThdSleepMilliseconds(USB_SUSPEND_WAKEUP_DELAY);
 #endif
 }

--- a/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
+++ b/platforms/chibios/boards/GENERIC_WB32_FQ95XX/board/board.c
@@ -82,5 +82,13 @@ void boardInit(void) {
 }
 
 void restart_usb_driver(USBDriver *usbp) {
-  // Do nothing. Restarting the USB driver on these boards breaks it.
+#if USB_SUSPEND_WAKEUP_DELAY > 0
+    // Some hubs, kvm switches, and monitors do
+    // weird things, with USB device state bouncing
+    // around wildly on wakeup, yielding race
+    // conditions that can corrupt the keyboard state.
+    //
+    // Pause for a while to let things settle...
+    wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#endif
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

There are some computers that need to add a wait implementation when remote wakeup

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
