### PR TITLE
WinKeys Mini Winni: rename LAYOUT_all to LAYOUT_ortho_2x4

### DIFF
--- a/keyboards/winkeys/mini_winni/info.json
+++ b/keyboards/winkeys/mini_winni/info.json
@@ -1,7 +1,7 @@
 {
     "keyboard_name": "Mini Winni",
     "manufacturer": "WinKeys",
-    "maintainer": "Matthew Dias",
+    "maintainer": "matthewdias",
     "usb": {
         "vid": "0x574B",
         "pid": "0x7770",

--- a/keyboards/winkeys/mini_winni/info.json
+++ b/keyboards/winkeys/mini_winni/info.json
@@ -18,8 +18,11 @@
     "ws2812": {
         "pin": "E6"
     },
+    "layout_aliases": {
+        "LAYOUT_all": "LAYOUT_ortho_2x4"
+    },
     "layouts": {
-        "LAYOUT_all": {
+        "LAYOUT_ortho_2x4": {
             "layout": [
                 {"label": "F1", "x": 0, "y": 0, "matrix": [0, 0]},
                 {"label": "F2", "x": 1, "y": 0, "matrix": [0, 1]},

--- a/keyboards/winkeys/mini_winni/info.json
+++ b/keyboards/winkeys/mini_winni/info.json
@@ -21,14 +21,15 @@
     "layouts": {
         "LAYOUT_all": {
             "layout": [
-                {"x": 0, "y": 0, "matrix": [0, 0]},
-                {"x": 1, "y": 0, "matrix": [0, 1]},
-                {"x": 2, "y": 0, "matrix": [0, 2]},
-                {"x": 3, "y": 0, "matrix": [0, 3]},
-                {"x": 0, "y": 1, "matrix": [1, 0]},
-                {"x": 1, "y": 1, "matrix": [1, 1]},
-                {"x": 2, "y": 1, "matrix": [1, 2]},
-                {"x": 3, "y": 1, "matrix": [1, 3]}
+                {"label": "F1", "x": 0, "y": 0, "matrix": [0, 0]},
+                {"label": "F2", "x": 1, "y": 0, "matrix": [0, 1]},
+                {"label": "F3", "x": 2, "y": 0, "matrix": [0, 2]},
+                {"label": "F4", "x": 3, "y": 0, "matrix": [0, 3]},
+
+                {"label": "F5", "x": 0, "y": 1, "matrix": [1, 0]},
+                {"label": "F6", "x": 1, "y": 1, "matrix": [1, 1]},
+                {"label": "F7", "x": 2, "y": 1, "matrix": [1, 2]},
+                {"label": "F8", "x": 3, "y": 1, "matrix": [1, 3]}
             ]
         }
     }

--- a/keyboards/winkeys/mini_winni/keymaps/default/keymap.c
+++ b/keyboards/winkeys/mini_winni/keymaps/default/keymap.c
@@ -19,22 +19,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-	[0] = LAYOUT_all(
+	[0] = LAYOUT_ortho_2x4(
 		KC_F1,  KC_F2,  KC_F3,  KC_F4,  
 		KC_F5,  KC_F6,  KC_F7,  KC_F8
 	),
 
-	[1] = LAYOUT_all(
+	[1] = LAYOUT_ortho_2x4(
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 	),
 
-	[2] = LAYOUT_all(
+	[2] = LAYOUT_ortho_2x4(
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 	),
 
-	[3] = LAYOUT_all(
+	[3] = LAYOUT_ortho_2x4(
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 	)

--- a/keyboards/winkeys/mini_winni/keymaps/via/keymap.c
+++ b/keyboards/winkeys/mini_winni/keymaps/via/keymap.c
@@ -19,22 +19,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-	[0] = LAYOUT_all(
+	[0] = LAYOUT_ortho_2x4(
 		KC_F1,  KC_F2,  KC_F3,  KC_F4,  
 		KC_F5,  KC_F6,  KC_F7,  KC_F8
 	),
 
-	[1] = LAYOUT_all(
+	[1] = LAYOUT_ortho_2x4(
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 	),
 
-	[2] = LAYOUT_all(
+	[2] = LAYOUT_ortho_2x4(
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 	),
 
-	[3] = LAYOUT_all(
+	[3] = LAYOUT_ortho_2x4(
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, 
 		KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 	)


### PR DESCRIPTION
## Description

[title]

Also updates `info.json` to reference the maintainer's GitHub username.

cc @matthewdias (keyboard maintainer)


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

```
⚠ winkeys/mini_winni: "LAYOUT_all" should be "LAYOUT" unless additional layouts are provided.
```

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
