### PR TITLE
Fix English word list retrieval in qmk generate-autocorrect-data

### DIFF
--- a/lib/python/qmk/cli/generate/autocorrect_data.py
+++ b/lib/python/qmk/cli/generate/autocorrect_data.py
@@ -66,15 +66,10 @@ def parse_file(file_name: str) -> List[Tuple[str, str]]:
         import english_words
         correct_words = english_words.get_english_words_set(['web2'], lower=True, alpha=True)
     except AttributeError:
-        try:
-            from english_words import english_words_lower_alpha_set as correct_words
-        except:
-            if not cli.args.quiet:
-                cli.echo('Autocorrection will falsely trigger when a typo is a substring of a correctly spelled word.')
-                cli.echo('Failed to load the english_words package. Try updating the english_words package and rerun this script:')
-                cli.echo('  {fg_cyan}python3 -m pip install english_words --upgrade')
-            # Use a minimal word list as a fallback.
-            correct_words = ('information', 'available', 'international', 'language', 'loosest', 'reference', 'wealthier', 'entertainment', 'association', 'provides', 'technology', 'statehood')
+        from english_words import english_words_lower_alpha_set as correct_words
+        if not cli.args.quiet:
+            cli.echo('The english_words package is outdated, update by running:')
+            cli.echo('  {fg_cyan}python3 -m pip install english_words --upgrade')
     except ImportError:
         if not cli.args.quiet:
             cli.echo('Autocorrection will falsely trigger when a typo is a substring of a correctly spelled word.')

--- a/lib/python/qmk/cli/generate/autocorrect_data.py
+++ b/lib/python/qmk/cli/generate/autocorrect_data.py
@@ -63,7 +63,18 @@ def parse_file(file_name: str) -> List[Tuple[str, str]]:
   """
 
     try:
-        from english_words import english_words_lower_alpha_set as correct_words
+        import english_words
+        correct_words = english_words.get_english_words_set(['web2'], lower=True, alpha=True)
+    except AttributeError:
+        try:
+            from english_words import english_words_lower_alpha_set as correct_words
+        except:
+            if not cli.args.quiet:
+                cli.echo('Autocorrection will falsely trigger when a typo is a substring of a correctly spelled word.')
+                cli.echo('Failed to load the english_words package. Try updating the english_words package and rerun this script:')
+                cli.echo('  {fg_cyan}python3 -m pip install english_words --upgrade')
+            # Use a minimal word list as a fallback.
+            correct_words = ('information', 'available', 'international', 'language', 'loosest', 'reference', 'wealthier', 'entertainment', 'association', 'provides', 'technology', 'statehood')
     except ImportError:
         if not cli.args.quiet:
             cli.echo('Autocorrection will falsely trigger when a typo is a substring of a correctly spelled word.')


### PR DESCRIPTION
## Description

The english_words package has breaking changes in v2.0 which results in the failure to load the English dictionary and an error indicating the english_words package should be installed for the functionality to work. This PR implements support for either v1 or v2 of the english_words package.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #20914

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).