### PR TITLE
Xiudi XD004: rename LAYOUT_all to LAYOUT_ortho_1x4

### DIFF
--- a/keyboards/xiudi/xd004/info.json
+++ b/keyboards/xiudi/xd004/info.json
@@ -21,8 +21,11 @@
             ["D3", "D0", "C4", "B4"]
         ]
     },
+    "layout_aliases": {
+        "LAYOUT_all": "LAYOUT_ortho_1x4"
+    },
     "layouts": {
-        "LAYOUT_all": {
+        "LAYOUT_ortho_1x4": {
             "layout": [
                 {"label": "L", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "O", "matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/xiudi/xd004/info.json
+++ b/keyboards/xiudi/xd004/info.json
@@ -24,10 +24,10 @@
     "layouts": {
         "LAYOUT_all": {
             "layout": [
-                {"x": 0, "y": 0, "matrix": [0, 0]},
-                {"x": 1, "y": 0, "matrix": [0, 1]},
-                {"x": 2, "y": 0, "matrix": [0, 2]},
-                {"x": 3, "y": 0, "matrix": [0, 3]}
+                {"label": "L", "matrix": [0, 0], "x": 0, "y": 0},
+                {"label": "O", "matrix": [0, 1], "x": 1, "y": 0},
+                {"label": "V", "matrix": [0, 2], "x": 2, "y": 0},
+                {"label": "E", "matrix": [0, 3], "x": 3, "y": 0}
             ]
         }
     }

--- a/keyboards/xiudi/xd004/keymaps/default/keymap.c
+++ b/keyboards/xiudi/xd004/keymaps/default/keymap.c
@@ -3,6 +3,6 @@
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     // 0: Base Layer
-    LAYOUT_all(KC_L, KC_O, KC_V, KC_E),
+    LAYOUT_ortho_1x4(KC_L, KC_O, KC_V, KC_E),
 
 };

--- a/keyboards/xiudi/xd004/keymaps/narze/keymap.c
+++ b/keyboards/xiudi/xd004/keymaps/narze/keymap.c
@@ -19,6 +19,6 @@
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     // 0: Base Layer
-    LAYOUT_all(HYPR(KC_F2), HYPR(KC_F1), LCTL(KC_B), LCTL(KC_X)),
+    LAYOUT_ortho_1x4(HYPR(KC_F2), HYPR(KC_F1), LCTL(KC_B), LCTL(KC_X)),
 
 };

--- a/keyboards/xiudi/xd004/keymaps/system_and_media/keymap.c
+++ b/keyboards/xiudi/xd004/keymaps/system_and_media/keymap.c
@@ -25,13 +25,13 @@ enum custom_keycodes {  // Make sure have the awesome keycode ready
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     // 0: Base Layer
-    [_BASE] = LAYOUT_all(LT(_SYSTEM, KC_F5), C(G(KC_LEFT)), C(G(KC_RIGHT)), LT(_VOLUME, KC_F7)),
+    [_BASE] = LAYOUT_ortho_1x4(LT(_SYSTEM, KC_F5), C(G(KC_LEFT)), C(G(KC_RIGHT)), LT(_VOLUME, KC_F7)),
 
     // 1: System actions
-    [_SYSTEM] = LAYOUT_all(_______, SUPER_ALT_F4, G(KC_D), G(KC_L)),
+    [_SYSTEM] = LAYOUT_ortho_1x4(_______, SUPER_ALT_F4, G(KC_D), G(KC_L)),
 
     // 2: Volume actions
-    [_VOLUME] = LAYOUT_all(KC_MEDIA_NEXT_TRACK, KC_AUDIO_VOL_DOWN, KC_AUDIO_VOL_UP, _______),
+    [_VOLUME] = LAYOUT_ortho_1x4(KC_MEDIA_NEXT_TRACK, KC_AUDIO_VOL_DOWN, KC_AUDIO_VOL_UP, _______),
 
 };
 


### PR DESCRIPTION
## Description

[title]

cc @narze - This PR changes the layout macro reference in your keymap, but there aren't any logic changes here.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

```
⚠ xiudi/xd004/v1: "LAYOUT_all" should be "LAYOUT" unless additional layouts are provided.
```

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
