### PR TITLE
MisterKnife Knife66 ISO Layout Additions II

### DIFF
--- a/keyboards/misterknife/knife66_iso/info.json
+++ b/keyboards/misterknife/knife66_iso/info.json
@@ -20,8 +20,7 @@
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
     "layout_aliases": {
-        "LAYOUT_all": "LAYOUT_split_space_split_bs",
-        "LAYOUT_625u_space": "LAYOUT_625u_space_split_bs"
+        "LAYOUT_all": "LAYOUT_split_space_split_bs"
     },
     "layouts": {
         "LAYOUT_split_space": {

--- a/keyboards/misterknife/knife66_iso/info.json
+++ b/keyboards/misterknife/knife66_iso/info.json
@@ -19,8 +19,11 @@
     "diode_direction": "COL2ROW",
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
+    "layout_aliases": {
+        "LAYOUT_all": "LAYOUT_split_space_split_bs"
+    },
     "layouts": {
-        "LAYOUT_all": {
+        "LAYOUT_split_space_split_bs": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/misterknife/knife66_iso/info.json
+++ b/keyboards/misterknife/knife66_iso/info.json
@@ -193,6 +193,88 @@
                 {"label": "\u2192", "matrix": [4, 13], "x": 15.25, "y": 4.25}
             ]
         },
+        "LAYOUT_625u_space": {
+            "layout": [
+                {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
+                {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},
+                {"label": "2", "matrix": [0, 2], "x": 2, "y": 0},
+                {"label": "3", "matrix": [0, 3], "x": 3, "y": 0},
+                {"label": "4", "matrix": [0, 4], "x": 4, "y": 0},
+                {"label": "5", "matrix": [0, 5], "x": 5, "y": 0},
+                {"label": "6", "matrix": [0, 6], "x": 6, "y": 0},
+                {"label": "7", "matrix": [0, 7], "x": 7, "y": 0},
+                {"label": "8", "matrix": [0, 8], "x": 8, "y": 0},
+                {"label": "9", "matrix": [0, 9], "x": 9, "y": 0},
+                {"label": "0", "matrix": [0, 10], "x": 10, "y": 0},
+                {"label": "-", "matrix": [0, 11], "x": 11, "y": 0},
+                {"label": "=", "matrix": [0, 12], "x": 12, "y": 0},
+                {"label": "Backspace", "matrix": [0, 13], "x": 13, "y": 0, "w": 2},
+
+                {"label": "Home", "matrix": [1, 14], "x": 15.5, "y": 0},
+
+                {"label": "Tab", "matrix": [1, 0], "x": 0, "y": 1, "w": 1.5},
+                {"label": "Q", "matrix": [1, 1], "x": 1.5, "y": 1},
+                {"label": "W", "matrix": [1, 2], "x": 2.5, "y": 1},
+                {"label": "E", "matrix": [1, 3], "x": 3.5, "y": 1},
+                {"label": "R", "matrix": [1, 4], "x": 4.5, "y": 1},
+                {"label": "T", "matrix": [1, 5], "x": 5.5, "y": 1},
+                {"label": "Y", "matrix": [1, 6], "x": 6.5, "y": 1},
+                {"label": "U", "matrix": [1, 7], "x": 7.5, "y": 1},
+                {"label": "I", "matrix": [1, 8], "x": 8.5, "y": 1},
+                {"label": "O", "matrix": [1, 9], "x": 9.5, "y": 1},
+                {"label": "P", "matrix": [1, 10], "x": 10.5, "y": 1},
+                {"label": "[", "matrix": [1, 11], "x": 11.5, "y": 1},
+                {"label": "]", "matrix": [1, 12], "x": 12.5, "y": 1},
+
+                {"label": "End", "matrix": [2, 14], "x": 15.5, "y": 1},
+
+                {"label": "Ctrl", "matrix": [2, 0], "x": 0, "y": 2, "w": 1.75},
+                {"label": "A", "matrix": [2, 1], "x": 1.75, "y": 2},
+                {"label": "S", "matrix": [2, 2], "x": 2.75, "y": 2},
+                {"label": "D", "matrix": [2, 3], "x": 3.75, "y": 2},
+                {"label": "F", "matrix": [2, 4], "x": 4.75, "y": 2},
+                {"label": "G", "matrix": [2, 5], "x": 5.75, "y": 2},
+                {"label": "H", "matrix": [2, 6], "x": 6.75, "y": 2},
+                {"label": "J", "matrix": [2, 7], "x": 7.75, "y": 2},
+                {"label": "K", "matrix": [2, 8], "x": 8.75, "y": 2},
+                {"label": "L", "matrix": [2, 9], "x": 9.75, "y": 2},
+                {"label": ";", "matrix": [2, 10], "x": 10.75, "y": 2},
+                {"label": "'", "matrix": [2, 11], "x": 11.75, "y": 2},
+                {"label": "\\", "matrix": [2, 12], "x": 12.75, "y": 2},
+                {"label": "Enter", "matrix": [1, 13], "x": 13.75, "y": 1, "w": 1.25, "h": 2},
+
+                {"label": "Page Up", "matrix": [3, 14], "x": 15.5, "y": 2},
+
+                {"label": "Shift", "matrix": [3, 0], "x": 0, "y": 3, "w": 1.25},
+                {"label": "`", "matrix": [3, 1], "x": 1.25, "y": 3},
+                {"label": "Z", "matrix": [3, 2], "x": 2.25, "y": 3},
+                {"label": "X", "matrix": [3, 3], "x": 3.25, "y": 3},
+                {"label": "C", "matrix": [3, 4], "x": 4.25, "y": 3},
+                {"label": "V", "matrix": [3, 5], "x": 5.25, "y": 3},
+                {"label": "B", "matrix": [3, 6], "x": 6.25, "y": 3},
+                {"label": "N", "matrix": [3, 7], "x": 7.25, "y": 3},
+                {"label": "M", "matrix": [3, 8], "x": 8.25, "y": 3},
+                {"label": ",", "matrix": [3, 9], "x": 9.25, "y": 3},
+                {"label": ".", "matrix": [3, 10], "x": 10.25, "y": 3},
+                {"label": "/", "matrix": [3, 11], "x": 11.25, "y": 3},
+                {"label": "Shift", "matrix": [3, 12], "x": 12.25, "y": 3, "w": 1.75},
+
+                {"label": "\u2191", "matrix": [3, 13], "x": 14.25, "y": 3.25},
+
+                {"label": "Page Down", "matrix": [4, 14], "x": 15.5, "y": 3},
+
+                {"label": "Ctrl", "matrix": [4, 0], "x": 0, "y": 4, "w": 1.25},
+                {"label": "GUI", "matrix": [4, 1], "x": 2.25, "y": 4},
+                {"label": "Alt", "matrix": [4, 2], "x": 3.25, "y": 4, "w": 1.25},
+                {"label": "Space", "matrix": [4, 7], "x": 4.5, "y": 4, "w": 6.25},
+                {"label": "Fn", "matrix": [4, 9], "x": 10.75, "y": 4},
+                {"label": "Ctrl", "matrix": [4, 10], "x": 11.75, "y": 4, "w": 1.25},
+
+                {"label": "\u2190", "matrix": [4, 11], "x": 13.25, "y": 4.25},
+                {"label": "\u2193", "matrix": [4, 12], "x": 14.25, "y": 4.25},
+                {"label": "\u2192", "matrix": [4, 13], "x": 15.25, "y": 4.25}
+            ]
+        },
         "LAYOUT_625u_space_split_bs": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},

--- a/keyboards/misterknife/knife66_iso/info.json
+++ b/keyboards/misterknife/knife66_iso/info.json
@@ -20,7 +20,8 @@
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
     "layout_aliases": {
-        "LAYOUT_all": "LAYOUT_split_space_split_bs"
+        "LAYOUT_all": "LAYOUT_split_space_split_bs",
+        "LAYOUT_625u_space": "LAYOUT_625u_space_split_bs"
     },
     "layouts": {
         "LAYOUT_split_space_split_bs": {
@@ -108,7 +109,7 @@
                 {"label": "\u2192", "matrix": [4, 13], "x": 15.25, "y": 4.25}
             ]
         },
-        "LAYOUT_625u_space": {
+        "LAYOUT_625u_space_split_bs": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/misterknife/knife66_iso/info.json
+++ b/keyboards/misterknife/knife66_iso/info.json
@@ -24,6 +24,90 @@
         "LAYOUT_625u_space": "LAYOUT_625u_space_split_bs"
     },
     "layouts": {
+        "LAYOUT_split_space": {
+            "layout": [
+                {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
+                {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},
+                {"label": "2", "matrix": [0, 2], "x": 2, "y": 0},
+                {"label": "3", "matrix": [0, 3], "x": 3, "y": 0},
+                {"label": "4", "matrix": [0, 4], "x": 4, "y": 0},
+                {"label": "5", "matrix": [0, 5], "x": 5, "y": 0},
+                {"label": "6", "matrix": [0, 6], "x": 6, "y": 0},
+                {"label": "7", "matrix": [0, 7], "x": 7, "y": 0},
+                {"label": "8", "matrix": [0, 8], "x": 8, "y": 0},
+                {"label": "9", "matrix": [0, 9], "x": 9, "y": 0},
+                {"label": "0", "matrix": [0, 10], "x": 10, "y": 0},
+                {"label": "-", "matrix": [0, 11], "x": 11, "y": 0},
+                {"label": "=", "matrix": [0, 12], "x": 12, "y": 0},
+                {"label": "Backspace", "matrix": [0, 13], "x": 13, "y": 0, "w": 2},
+
+                {"label": "Home", "matrix": [1, 14], "x": 15.5, "y": 0},
+
+                {"label": "Tab", "matrix": [1, 0], "x": 0, "y": 1, "w": 1.5},
+                {"label": "Q", "matrix": [1, 1], "x": 1.5, "y": 1},
+                {"label": "W", "matrix": [1, 2], "x": 2.5, "y": 1},
+                {"label": "E", "matrix": [1, 3], "x": 3.5, "y": 1},
+                {"label": "R", "matrix": [1, 4], "x": 4.5, "y": 1},
+                {"label": "T", "matrix": [1, 5], "x": 5.5, "y": 1},
+                {"label": "Y", "matrix": [1, 6], "x": 6.5, "y": 1},
+                {"label": "U", "matrix": [1, 7], "x": 7.5, "y": 1},
+                {"label": "I", "matrix": [1, 8], "x": 8.5, "y": 1},
+                {"label": "O", "matrix": [1, 9], "x": 9.5, "y": 1},
+                {"label": "P", "matrix": [1, 10], "x": 10.5, "y": 1},
+                {"label": "[", "matrix": [1, 11], "x": 11.5, "y": 1},
+                {"label": "]", "matrix": [1, 12], "x": 12.5, "y": 1},
+
+                {"label": "End", "matrix": [2, 14], "x": 15.5, "y": 1},
+
+                {"label": "Ctrl", "matrix": [2, 0], "x": 0, "y": 2, "w": 1.75},
+                {"label": "A", "matrix": [2, 1], "x": 1.75, "y": 2},
+                {"label": "S", "matrix": [2, 2], "x": 2.75, "y": 2},
+                {"label": "D", "matrix": [2, 3], "x": 3.75, "y": 2},
+                {"label": "F", "matrix": [2, 4], "x": 4.75, "y": 2},
+                {"label": "G", "matrix": [2, 5], "x": 5.75, "y": 2},
+                {"label": "H", "matrix": [2, 6], "x": 6.75, "y": 2},
+                {"label": "J", "matrix": [2, 7], "x": 7.75, "y": 2},
+                {"label": "K", "matrix": [2, 8], "x": 8.75, "y": 2},
+                {"label": "L", "matrix": [2, 9], "x": 9.75, "y": 2},
+                {"label": ";", "matrix": [2, 10], "x": 10.75, "y": 2},
+                {"label": "'", "matrix": [2, 11], "x": 11.75, "y": 2},
+                {"label": "#", "matrix": [2, 12], "x": 12.75, "y": 2},
+                {"label": "Enter", "matrix": [1, 13], "x": 13.75, "y": 1, "w": 1.25, "h": 2},
+
+                {"label": "Page Up", "matrix": [3, 14], "x": 15.5, "y": 2},
+
+                {"label": "Shift", "matrix": [3, 0], "x": 0, "y": 3, "w": 1.25},
+                {"label": "\\", "matrix": [3, 1], "x": 1.25, "y": 3},
+                {"label": "Z", "matrix": [3, 2], "x": 2.25, "y": 3},
+                {"label": "X", "matrix": [3, 3], "x": 3.25, "y": 3},
+                {"label": "C", "matrix": [3, 4], "x": 4.25, "y": 3},
+                {"label": "V", "matrix": [3, 5], "x": 5.25, "y": 3},
+                {"label": "B", "matrix": [3, 6], "x": 6.25, "y": 3},
+                {"label": "N", "matrix": [3, 7], "x": 7.25, "y": 3},
+                {"label": "M", "matrix": [3, 8], "x": 8.25, "y": 3},
+                {"label": ",", "matrix": [3, 9], "x": 9.25, "y": 3},
+                {"label": ".", "matrix": [3, 10], "x": 10.25, "y": 3},
+                {"label": "/", "matrix": [3, 11], "x": 11.25, "y": 3},
+                {"label": "Shift", "matrix": [3, 12], "x": 12.25, "y": 3, "w": 1.75},
+
+                {"label": "\u2191", "matrix": [3, 13], "x": 14.25, "y": 3.25},
+
+                {"label": "Page Down", "matrix": [4, 14], "x": 15.5, "y": 3},
+
+                {"label": "Ctrl", "matrix": [4, 0], "x": 0, "y": 4, "w": 1.25},
+                {"label": "GUI", "matrix": [4, 1], "x": 2.25, "y": 4},
+                {"label": "Alt", "matrix": [4, 2], "x": 3.25, "y": 4, "w": 1.25},
+                {"label": "Space", "matrix": [4, 4], "x": 4.5, "y": 4, "w": 2.25},
+                {"label": "Space", "matrix": [4, 7], "x": 6.75, "y": 4, "w": 2.75},
+                {"label": "Alt", "matrix": [4, 8], "x": 9.5, "y": 4, "w": 1.25},
+                {"label": "Fn", "matrix": [4, 9], "x": 10.75, "y": 4},
+                {"label": "Ctrl", "matrix": [4, 10], "x": 11.75, "y": 4, "w": 1.25},
+
+                {"label": "\u2190", "matrix": [4, 11], "x": 13.25, "y": 4.25},
+                {"label": "\u2193", "matrix": [4, 12], "x": 14.25, "y": 4.25},
+                {"label": "\u2192", "matrix": [4, 13], "x": 15.25, "y": 4.25}
+            ]
+        },
         "LAYOUT_split_space_split_bs": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},

--- a/keyboards/misterknife/knife66_iso/keymaps/default/keymap.c
+++ b/keyboards/misterknife/knife66_iso/keymaps/default/keymap.c
@@ -23,14 +23,14 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_all(
+  [_BASE] = LAYOUT_split_space_split_bs(
     QK_GESC,   KC_1,     KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,  KC_EQL,   KC_DEL, KC_BSPC,  KC_HOME,
     KC_TAB,    KC_Q,     KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC,  KC_RBRC,                    KC_END,
     KC_LCTL,   KC_A,     KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,  KC_BSLS,  KC_ENT,           KC_PGUP,
     KC_LSFT,   KC_GRAVE, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,  KC_RSFT,  KC_UP,            KC_PGDN,
     KC_LCTL,             KC_LGUI, KC_LALT,          LT(1, KC_SPC),    KC_SPC,           KC_RALT, MO(1),   KC_RCTL,  KC_LEFT,  KC_DOWN, KC_RGHT),
 
-  [_FN] = LAYOUT_all(
+  [_FN] = LAYOUT_split_space_split_bs(
     KC_TRNS,   KC_F1,    KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_TRNS, KC_TRNS, RGB_TOG,
     KC_TRNS,   KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_MPLY,  KC_MPRV,  KC_MNXT,                    RGB_MOD,
     KC_TRNS,   KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_LEFT, KC_DOWN,  KC_UP,    KC_RIGHT, KC_TRNS,  KC_TRNS,  KC_INS,   KC_TRNS,          RGB_SPI,

--- a/keyboards/misterknife/knife66_iso/keymaps/default_625u_space_split_bs/keymap.c
+++ b/keyboards/misterknife/knife66_iso/keymaps/default_625u_space_split_bs/keymap.c
@@ -23,14 +23,14 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_625u_space(
+  [_BASE] = LAYOUT_625u_space_split_bs(
     QK_GESC, KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_DEL, KC_BSPC,  KC_HOME,
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,                   KC_END,
     KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,           KC_PGUP,
     KC_LSFT, KC_GRV,  KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT, KC_UP,            KC_PGDN,
     KC_LCTL,          KC_LGUI, KC_LALT,                            KC_SPC,                    MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT),
 
-  [_FN] = LAYOUT_625u_space(
+  [_FN] = LAYOUT_625u_space_split_bs(
     _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______, RGB_TOG,
     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_MPLY, KC_MPRV, KC_MNXT,                   RGB_MOD,
     _______, _______, _______, _______, _______, _______, KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, _______, _______, KC_INS,  _______,          RGB_SPI,


### PR DESCRIPTION
## Description

Even though it was documented in my previous PR, I failed to offer the choice of 2u or Split Backspace.

- rename `LAYOUT_all` to `LAYOUT_split_space_split_bs`
- rename `LAYOUT_625u_space` to `LAYOUT_625u_space_split_bs`
- adds new `LAYOUT_split_space` and `LAYOUT_625u_space` (both with 2u Backspace)

cc @afewyards (keyboard maintainer)


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
