### PR TITLE
Allow force flush of oled display.

### DIFF
--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -200,8 +200,12 @@ oled_rotation_t oled_init_user(oled_rotation_t rotation);
 // Clears the display buffer, resets cursor position to 0, and sets the buffer to dirty for rendering
 void oled_clear(void);
 
-// Renders the dirty chunks of the buffer to oled display
-void oled_render(void);
+// Alias to olde_render_dirty to avoid a change in api. 
+#define oled_render() oled_render_dirty(false)
+
+// Renders all dirty blocks to the display at one time or a subset depending on the value of
+// all.
+void oled_render_dirty(bool all);
 
 // Moves cursor to character position indicated by column and line, wraps if out of bounds
 // Max column denoted by 'oled_max_chars()' and max lines by 'oled_max_lines()' functions

--- a/drivers/oled/ssd1306_sh1106.c
+++ b/drivers/oled/ssd1306_sh1106.c
@@ -290,7 +290,7 @@ static void rotate_90(const uint8_t *src, uint8_t *dest) {
     }
 }
 
-void oled_render(void) {
+void oled_render_dirty(bool all) {
     // Do we have work to do?
     oled_dirty &= OLED_ALL_BLOCKS_MASK;
     if (!oled_dirty || !oled_initialized || oled_scrolling) {
@@ -302,7 +302,7 @@ void oled_render(void) {
 
     uint8_t update_start  = 0;
     uint8_t num_processed = 0;
-    while (oled_dirty && num_processed++ < OLED_UPDATE_PROCESS_LIMIT) { // render all dirty blocks (up to the configured limit)
+    while (oled_dirty && (num_processed++ < OLED_UPDATE_PROCESS_LIMIT || all)) { // render all dirty blocks (up to the configured limit)
         // Find next dirty block
         while (!(oled_dirty & ((OLED_BLOCK_TYPE)1 << update_start))) {
             ++update_start;


### PR DESCRIPTION
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

API copmatible refactoring of the oled_render function that allows callers to forcibly render all dirty
blocks instead of allowing the oled_task function to render them asynchronously. This is mostly useful
when want to display a logo/message/graphic right before rebooting into a bootloader or other state
where the MCU will be unable to finish flushing blocks to the display.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
