### PR TITLE
Acheron Elongate Delta: rename LAYOUT_all to LAYOUT

### DIFF
--- a/keyboards/acheron/elongate/delta/info.json
+++ b/keyboards/acheron/elongate/delta/info.json
@@ -24,8 +24,11 @@
     },
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
+    "layout_aliases": {
+        "LAYOUT_all": "LAYOUT"
+    },
     "layouts": {
-        "LAYOUT_all": {
+        "LAYOUT": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/acheron/elongate/delta/keymaps/default/keymap.c
+++ b/keyboards/acheron/elongate/delta/keymaps/default/keymap.c
@@ -17,25 +17,25 @@
 #define SPC_L2 LT(2, KC_SPACE)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[0] = LAYOUT_all( /* Base */
+[0] = LAYOUT( /* Base */
     KC_ESC , KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,  KC_KP_7,  KC_KP_8, KC_KP_9,
     KC_TAB , KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,             KC_ENTER, KC_KP_4,  KC_KP_5, KC_KP_6,
     KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, MO(1)  , KC_UP,    KC_KP_1,  KC_KP_2, KC_KP_3,
     KC_LCTL, KC_LWIN, KC_LALT,          SPC_L2,                    KC_SPC,           KC_RALT, KC_LEFT, KC_DOWN,  KC_RIGHT, KC_KP_0, KC_DOT
 ),
-[1] = LAYOUT_all( /* Base */
+[1] = LAYOUT( /* Base */
     KC_F1,   KC_F2,   KC_F2,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_LBRC, KC_RBRC, KC_MINS,  KC_EQL,  KC_NUM,  KC_SCRL, KC_CAPS,
     KC_CAPS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,           KC_RSFT, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_SCLN, KC_QUOT, KC_SLSH, KC_TRNS,  KC_PGUP, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,                   KC_SPC,           KC_TRNS, KC_HOME,  KC_PGDN, KC_END , KC_TRNS, KC_TRNS
 ),
-[2] = LAYOUT_all( /* Base */                                    
+[2] = LAYOUT( /* Base */                                    
     QK_BOOT  , KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS , KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS , KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS,          RGB_TOG, RGB_MOD,  RGB_RMOD, RGB_M_T, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS ,                   KC_SPC,           KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 ),
-[3] = LAYOUT_all( /* Base */                                    
+[3] = LAYOUT( /* Base */                                    
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS,          KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,

--- a/keyboards/acheron/elongate/delta/keymaps/via/keymap.c
+++ b/keyboards/acheron/elongate/delta/keymaps/via/keymap.c
@@ -17,25 +17,25 @@
 #define SPC_L2 LT(2, KC_SPACE)
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-[0] = LAYOUT_all( /* Base */
+[0] = LAYOUT( /* Base */
     KC_ESC , KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,  KC_KP_7,  KC_KP_8, KC_KP_9,
     KC_TAB , KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,             KC_ENTER, KC_KP_4,  KC_KP_5, KC_KP_6,
     KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, MO(1)  , KC_UP,    KC_KP_1,  KC_KP_2, KC_KP_3,
     KC_LCTL, KC_LWIN, KC_LALT,          SPC_L2,                    KC_SPC,           KC_RALT, KC_LEFT, KC_DOWN,  KC_RIGHT, KC_KP_0, KC_DOT
 ),
-[1] = LAYOUT_all( /* Base */
+[1] = LAYOUT( /* Base */
     KC_F1,   KC_F2,   KC_F2,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_LBRC, KC_RBRC, KC_MINS,  KC_EQL,  KC_NUM,  KC_SCRL, KC_CAPS,
     KC_CAPS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,           KC_RSFT, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_SCLN, KC_QUOT, KC_SLSH, KC_TRNS,  KC_PGUP, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,                   KC_SPC,           KC_TRNS, KC_HOME,  KC_PGDN, KC_END , KC_TRNS, KC_TRNS
 ),
-[2] = LAYOUT_all( /* Base */                                    
+[2] = LAYOUT( /* Base */                                    
     QK_BOOT  , KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS , KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS , KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS,          RGB_TOG, RGB_MOD,  RGB_RMOD, RGB_M_T, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS ,                   KC_SPC,           KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
 ),
-[3] = LAYOUT_all( /* Base */                                    
+[3] = LAYOUT( /* Base */                                    
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
     KC_TRNS,          KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,


### PR DESCRIPTION
## Description

[title]

Keyboard only supports one layout.

cc @Gondolindrim (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

```
⚠ acheron/elongate/delta: "LAYOUT_all" should be "LAYOUT" unless additional layouts are provided.
```

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
