### PR TITLE
Move `pre_process_record_kb()` before `process_combo()`

### DIFF
--- a/docs/understanding_qmk.md
+++ b/docs/understanding_qmk.md
@@ -129,9 +129,9 @@ The `process_record()` function itself is deceptively simple, but hidden within 
 
 * [`void action_exec(keyevent_t event)`](https://github.com/qmk/qmk_firmware/blob/325da02e57fe7374e77b82cb00360ba45167e25c/quantum/action.c#L78-L140)
     * [`void pre_process_record_quantum(keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/325da02e57fe7374e77b82cb00360ba45167e25c/quantum/quantum.c#L204)
-      * [`bool process_combo(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/325da02e57fe7374e77b82cb00360ba45167e25c/quantum/process_keycode/process_combo.c#L521)
       * [`bool pre_process_record_kb(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/27119fa77e8a1b95fff80718d3db4f3e32849298/quantum/quantum.c#L117)
         * [`bool pre_process_record_user(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/27119fa77e8a1b95fff80718d3db4f3e32849298/quantum/quantum.c#L121)
+      * [`bool process_combo(uint16_t keycode, keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/325da02e57fe7374e77b82cb00360ba45167e25c/quantum/process_keycode/process_combo.c#L521)
   * [`void process_record(keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/325da02e57fe7374e77b82cb00360ba45167e25c/quantum/action.c#L254)
     * [`bool process_record_quantum(keyrecord_t *record)`](https://github.com/qmk/qmk_firmware/blob/325da02e57fe7374e77b82cb00360ba45167e25c/quantum/quantum.c#L224)
       * [Map this record to a keycode](https://github.com/qmk/qmk_firmware/blob/325da02e57fe7374e77b82cb00360ba45167e25c/quantum/quantum.c#L225)

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -211,12 +211,11 @@ uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache) {
 /* Get keycode, and then process pre tapping functionality */
 bool pre_process_record_quantum(keyrecord_t *record) {
     uint16_t keycode = get_record_keycode(record, true);
+    return pre_process_record_kb(keycode, record) &&
 #ifdef COMBO_ENABLE
-    if (!(process_combo(keycode, record))) {
-        return false;
-    }
+           process_combo(keycode, record) &&
 #endif
-    return pre_process_record_kb(keycode, record);
+           true;
 }
 
 /* Get keycode, and then call keyboard function */


### PR DESCRIPTION
## Description

Fix up #20584 to call `pre_process_record_kb()` (and therefore `pre_process_record_user()`) before `process_combo()`.

Adding the `pre_process_record_kb()` call after `process_combo()` is problematic — `pre_process_record_kb()` will miss any events which might be a part of some combo: https://github.com/qmk/qmk_firmware/pull/20584#issuecomment-1549138142.  Calling `pre_process_record_kb()` before the combo code would result in a much more logical behavior (`pre_process_record_kb()` receives all events for raw key or encoder actions before any other processing, including combos).

If we ever need a callback that runs after the combo processing, but before the tapping code, it would need to be called in more places (e.g., in two places where the combo code currently calls `action_tapping_process()`); but that probably could wait until some real user of such callback appears.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
