### PR TITLE
CLI: Improve keymap folder resolution

### DIFF
--- a/lib/python/qmk/cli/new/keymap.py
+++ b/lib/python/qmk/cli/new/keymap.py
@@ -5,7 +5,7 @@ import shutil
 from milc import cli
 from milc.questions import question
 
-from qmk.path import is_keyboard, keymap
+from qmk.path import is_keyboard, keymaps, keymap
 from qmk.git import git_get_username
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.keyboard import keyboard_completer, keyboard_folder
@@ -50,9 +50,9 @@ def new_keymap(cli):
         return False
 
     # generate keymap paths
-    km_path = keymap(kb_name)
-    keymap_path_default = km_path / 'default'
-    keymap_path_new = km_path / user_name
+    keymaps_dirs = keymaps(kb_name)
+    keymap_path_default = keymap(kb_name, 'default')
+    keymap_path_new = keymaps_dirs[0] / user_name
 
     if not keymap_path_default.exists():
         cli.log.error(f'Default keymap {{fg_cyan}}{keymap_path_default}{{fg_reset}} does not exist!')

--- a/lib/python/qmk/importers.py
+++ b/lib/python/qmk/importers.py
@@ -5,7 +5,7 @@ import json
 
 from qmk.git import git_get_username
 from qmk.json_schema import validate
-from qmk.path import keyboard, keymap
+from qmk.path import keyboard, keymaps
 from qmk.constants import MCU2BOOTLOADER, LEGACY_KEYCODES
 from qmk.json_encoders import InfoJSONEncoder, KeymapJSONEncoder
 from qmk.json_schema import deep_update, json_load
@@ -84,7 +84,7 @@ def import_keymap(keymap_data):
     kb_name = keymap_data['keyboard']
     km_name = keymap_data['keymap']
 
-    km_folder = keymap(kb_name) / km_name
+    km_folder = keymaps(kb_name)[0] / km_name
     keyboard_keymap = km_folder / 'keymap.json'
 
     # This is the deepest folder in the expected tree

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -379,7 +379,7 @@ def write_json(keyboard, keymap, layout, layers, macros=None):
     """
     keymap_json = generate_json(keyboard, keymap, layout, layers, macros=None)
     keymap_content = json.dumps(keymap_json)
-    keymap_file = qmk.path.keymap(keyboard) / keymap / 'keymap.json'
+    keymap_file = qmk.path.keymaps(keyboard)[0] / keymap / 'keymap.json'
 
     return write_file(keymap_file, keymap_content)
 
@@ -406,7 +406,7 @@ def write(keymap_json):
             A list of macros for this keymap.
     """
     keymap_content = generate_c(keymap_json)
-    keymap_file = qmk.path.keymap(keymap_json['keyboard']) / keymap_json['keymap'] / 'keymap.c'
+    keymap_file = qmk.path.keymaps(keymap_json['keyboard'])[0] / keymap_json['keymap'] / 'keymap.c'
 
     return write_file(keymap_file, keymap_content)
 

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -36,8 +36,8 @@ def keyboard(keyboard_name):
     return Path('keyboards') / keyboard_name
 
 
-def keymap(keyboard_name):
-    """Locate the correct directory for storing a keymap.
+def keymaps(keyboard_name):
+    """Returns all of the `keymaps/` directories for a given keyboard.
 
     Args:
 
@@ -45,15 +45,34 @@ def keymap(keyboard_name):
             The name of the keyboard. Example: clueboard/66/rev3
     """
     keyboard_folder = keyboard(keyboard_name)
+    found_dirs = []
 
     for _ in range(MAX_KEYBOARD_SUBFOLDERS):
         if (keyboard_folder / 'keymaps').exists():
-            return (keyboard_folder / 'keymaps').resolve()
+            found_dirs.append((keyboard_folder / 'keymaps').resolve())
 
         keyboard_folder = keyboard_folder.parent
 
+    if len(found_dirs) > 0:
+        return found_dirs
+
     logging.error('Could not find the keymaps directory!')
     raise NoSuchKeyboardError('Could not find keymaps directory for: %s' % keyboard_name)
+
+
+def keymap(keyboard_name, keymap_name):
+    """Locate the directory of a given keymap.
+
+    Args:
+
+        keyboard_name
+            The name of the keyboard. Example: clueboard/66/rev3
+        keymap_name
+            The name of the keymap. Example: default
+    """
+    for keymap_dir in keymaps(keyboard_name):
+        if (keymap_dir / keymap_name).exists():
+            return (keymap_dir / keymap_name).resolve()
 
 
 def normpath(path):

--- a/lib/python/qmk/tests/test_qmk_path.py
+++ b/lib/python/qmk/tests/test_qmk_path.py
@@ -5,8 +5,8 @@ import qmk.path
 
 
 def test_keymap_pytest_basic():
-    path = qmk.path.keymap('handwired/pytest/basic')
-    assert path.samefile('keyboards/handwired/pytest/basic/keymaps')
+    path = qmk.path.keymap('handwired/pytest/basic', 'default')
+    assert path.samefile('keyboards/handwired/pytest/basic/keymaps/default')
 
 
 def test_normpath():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Renamed `qmk.path.keymap()` to `keymaps()` and changed return value to a list of all found `keymaps/` directories for the given keyboard
- `keymap()` now takes a keyboard name and keymap name, and returns the path if it exists

This fixes an issue with `qmk new-keymap`: for example, attempting to create a new keymap for a board such as `crkbd/rev1` fails as there is no `default` keymap under rev1's `keymaps/` directory. Now it should grab the keymap folder from parent level and copy it down.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
