### PR TITLE
Adds a way to separate tab from AUTO_SHIFT_SPECIAL.

### DIFF
--- a/docs/feature_auto_shift.md
+++ b/docs/feature_auto_shift.md
@@ -133,7 +133,17 @@ groups in the below fallback switch.
 ### NO_AUTO_SHIFT_SPECIAL (simple define)
 
 Do not Auto Shift special keys, which include -\_, =+, [{, ]}, ;:, '", ,<, .>,
-and /?
+/?, and the KC_TAB.
+
+### NO_AUTO_SHIFT_TAB (simple define)
+
+Do not Auto Shift KC_TAB but leave Auto Shift enabled for the other special
+characters.
+
+### NO_AUTO_SHIFT_SYMBOLS (simple define)
+
+Do not Auto Shift symbol keys, which include -\_, =+, [{, ]}, ;:, '", ,<, .>,
+and /?.
 
 ### NO_AUTO_SHIFT_NUMERIC (simple define)
 
@@ -143,9 +153,13 @@ Do not Auto Shift numeric keys, zero through nine.
 
 Do not Auto Shift alpha characters, which include A through Z.
 
+### AUTO_SHIFT_ENTER (simple define)
+
+Auto Shift the enter key.
+
 ### Auto Shift Per Key
 
-There are functions that allows you to determine which keys shold be autoshifted, much like the tap-hold keys.
+There are functions that allows you to determine which keys should be autoshifted, much like the tap-hold keys.
 
 The first of these, used to simply add a key to Auto Shift, is `get_custom_auto_shifted_key`:
 
@@ -172,9 +186,15 @@ bool get_auto_shifted_key(uint16_t keycode, keyrecord_t *record) {
         case KC_1 ... KC_0:
 #    endif
 #    ifndef NO_AUTO_SHIFT_SPECIAL
+#    ifndef NO_AUTO_SHIFT_TAB
         case KC_TAB:
-        case KC_MINUS ... KC_SLASH:
-        case KC_NONUS_BACKSLASH:
+#    endif
+#    ifndef NO_AUTO_SHIFT_SYMBOLS
+        case AUTO_SHIFT_SYMBOLS:
+#    endif
+#    endif
+#    ifdef AUTO_SHIFT_ENTER
+        case KC_ENT:
 #    endif
             return true;
     }
@@ -191,6 +211,25 @@ Enables keyrepeat.
 ### AUTO_SHIFT_NO_AUTO_REPEAT (simple define)
 
 Disables automatically keyrepeating when `AUTO_SHIFT_TIMEOUT` is exceeded.
+
+
+### AUTO_SHIFT_ALPHA (predefined key group)
+
+A predefined group of keys representing A through Z.
+
+### AUTO_SHIFT_NUMERIC (predefined key group)
+
+A predefined group of keys representing 0 through 9. Note, these are defined as
+1 through 0 since that is the order they normally appear in.
+
+### AUTO_SHIFT_SYMBOLS (predefined key group)
+
+A predefined group of keys representing symbolic characters which include -\_, =+, [{, ]}, ;:, '", ,<, .>,
+and /?.
+
+### AUTO_SHIFT_SPECIAL (predefined key group)
+
+A predefined group of keys that combines AUTO_SHIFT_SYMBOLS and KC_TAB.
 
 ## Custom Shifted Values
 

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -75,12 +75,12 @@ __attribute__((weak)) bool get_auto_shifted_key(uint16_t keycode, keyrecord_t *r
         case AUTO_SHIFT_NUMERIC:
 #    endif
 #    ifndef NO_AUTO_SHIFT_SPECIAL
-#    ifndef NO_AUTO_SHIFT_TAB
+#        ifndef NO_AUTO_SHIFT_TAB
         case KC_TAB:
-#    endif
-#    ifndef NO_AUTO_SHIFT_SYMBOLS
+#        endif
+#        ifndef NO_AUTO_SHIFT_SYMBOLS
         case AUTO_SHIFT_SYMBOLS:
-#    endif
+#        endif
 #    endif
 #    ifdef AUTO_SHIFT_ENTER
         case KC_ENT:

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -75,7 +75,15 @@ __attribute__((weak)) bool get_auto_shifted_key(uint16_t keycode, keyrecord_t *r
         case AUTO_SHIFT_NUMERIC:
 #    endif
 #    ifndef NO_AUTO_SHIFT_SPECIAL
-        case AUTO_SHIFT_SPECIAL:
+#    ifndef NO_AUTO_SHIFT_TAB
+        case KC_TAB:
+#    endif
+#    ifndef NO_AUTO_SHIFT_SYMBOLS
+        case AUTO_SHIFT_SYMBOLS:
+#    endif
+#    endif
+#    ifdef AUTO_SHIFT_ENTER
+        case KC_ENT:
 #    endif
             return true;
     }

--- a/quantum/process_keycode/process_auto_shift.h
+++ b/quantum/process_keycode/process_auto_shift.h
@@ -28,10 +28,14 @@
 // clang-format off
 #define AUTO_SHIFT_ALPHA KC_A ... KC_Z
 #define AUTO_SHIFT_NUMERIC KC_1 ... KC_0
+#define AUTO_SHIFT_SYMBOLS          \
+             KC_MINUS ... KC_SLASH: \
+        case KC_NONUS_BACKSLASH
+
+// Kept to avoid breaking existing keymaps.
 #define AUTO_SHIFT_SPECIAL          \
              KC_TAB:                \
-        case KC_MINUS ... KC_SLASH: \
-        case KC_NONUS_BACKSLASH
+        case AUTO_SHIFT_SYMBOLS
 // clang-format on
 
 bool process_auto_shift(uint16_t keycode, keyrecord_t *record);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

The goal is to add a means of enabling all of the other special characters while disabling Auto Shift on tab. While I was at it, this adds documentation to the predefined character groups used to setup `get_auto_shifted_key` so that you don't have to go digging through .h files for them.

This also relates back to https://github.com/qmk/qmk_firmware/issues/13469 in that I added a flag to specifically enable enter .. though the need for it is arguable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Potentially https://github.com/qmk/qmk_firmware/issues/13469

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
