### PR TITLE
[Bug] Fix issue with Repeat Key-Combo test

### DIFF
--- a/tests/repeat_key/repeat_key_combo/test.mk
+++ b/tests/repeat_key/repeat_key_combo/test.mk
@@ -16,3 +16,4 @@
 REPEAT_KEY_ENABLE = yes
 
 COMBO_ENABLE = yes
+INTROSPECTION_KEYMAP_C = test_combos.c

--- a/tests/repeat_key/repeat_key_combo/test_combos.c
+++ b/tests/repeat_key/repeat_key_combo/test_combos.c
@@ -1,0 +1,8 @@
+// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// Copyright 2023 @filterpaper
+// Copyright 2023 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+
+const uint16_t xy_combo[] PROGMEM = {KC_X, KC_Y, COMBO_END};
+combo_t        key_combos[]       = {COMBO(xy_combo, KC_Q)};

--- a/tests/repeat_key/repeat_key_combo/test_repeat_key_combo.cpp
+++ b/tests/repeat_key/repeat_key_combo/test_repeat_key_combo.cpp
@@ -24,13 +24,6 @@ using ::testing::InSequence;
 
 namespace {
 
-extern "C" {
-// Define a combo: KC_X + KC_Y = KC_Q.
-const uint16_t xy_combo[] PROGMEM = {KC_X, KC_Y, COMBO_END};
-combo_t        key_combos[]       = {COMBO(xy_combo, KC_Q)};
-uint16_t       COMBO_LEN          = sizeof(key_combos) / sizeof(*key_combos);
-} // extern "C"
-
 class RepeatKey : public TestFixture {};
 
 // Tests repeating a combo, KC_X + KC_Y = KC_Q, by typing


### PR DESCRIPTION
## Description

Repeat Key PR didn't have combo introspection changes, so once both were merged, unit tests starting failing.

This fixes that. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
