### PR TITLE
Implement UF2 device type id extension tag

### DIFF
--- a/builddefs/common_rules.mk
+++ b/builddefs/common_rules.mk
@@ -152,6 +152,7 @@ endif
 # To produce a UF2 file in your build, add to your keyboard's rules.mk:
 #      FIRMWARE_FORMAT = uf2
 UF2CONV = $(TOP_DIR)/util/uf2conv.py
+UF2CONV_ARGS ?=
 UF2_FAMILY ?= 0x0
 
 # Compiler flags to generate dependency files.
@@ -219,7 +220,7 @@ gccversion :
 	@$(BUILD_CMD)
 
 %.uf2: %.elf
-	$(eval CMD=$(HEX) $< $(BUILD_DIR)/$(TARGET).tmp && $(UF2CONV) $(BUILD_DIR)/$(TARGET).tmp --output $@ --convert --family $(UF2_FAMILY) >/dev/null 2>&1)
+	$(eval CMD=$(HEX) $< $(BUILD_DIR)/$(TARGET).tmp && $(UF2CONV) $(UF2CONV_ARGS) $(BUILD_DIR)/$(TARGET).tmp --output $@ --convert --family $(UF2_FAMILY) >/dev/null 2>&1)
 	#@$(SILENT) || printf "$(MSG_EXECUTING) '$(CMD)':\n"
 	@$(SILENT) || printf "$(MSG_UF2) $@" | $(AWK_CMD)
 	@$(BUILD_CMD)

--- a/util/uf2conv.py
+++ b/util/uf2conv.py
@@ -151,10 +151,15 @@ class Block:
         flags = 0x0
         if familyid:
             flags |= 0x2000
+        if devicetype:
+            flags |= 0x8000
         hd = struct.pack("<IIIIIIII",
             UF2_MAGIC_START0, UF2_MAGIC_START1,
             flags, self.addr, 256, blockno, numblocks, familyid)
         hd += self.bytes[0:256]
+        if devicetype:
+            hd += bytearray(b'\x08\x29\xa7\xc8')
+            hd += bytearray(devicetype.to_bytes(4, 'little'))
         while len(hd) < 512 - 4:
             hd += b"\x00"
         hd += struct.pack("<I", UF2_MAGIC_END)
@@ -283,6 +288,8 @@ def main():
     parser.add_argument('-f', '--family', dest='family', type=str,
                         default="0x0",
                         help='specify familyID - number or name (default: 0x0)')
+    parser.add_argument('-t' , '--device-type', dest='devicetype', type=str,
+                        help='specify deviceTypeID extension tag - number')
     parser.add_argument('-o', '--output', metavar="FILE", dest='output', type=str,
                         help='write output to named file; defaults to "flash.uf2" or "flash.bin" where sensible')
     parser.add_argument('-d', '--device', dest="device_path",
@@ -311,6 +318,9 @@ def main():
             familyid = int(args.family, 0)
         except ValueError:
             error("Family ID needs to be a number or one of: " + ", ".join(families.keys()))
+
+    global devicetype
+    devicetype = int(args.devicetype, 0) if args.devicetype else None
 
     if args.list:
         list_drives()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Adds support for `0xc8a729 - device type identifier` - <https://github.com/microsoft/uf2#extension-tags>.

This functionality will be used with `adafruit/tinyuf2` to resolve some potential bricking scenarios with an upcoming product launch. The issue is that to reject "bad" self-update files, we also need to add the magic flags to QMK firmware files too.

The intention is to upstream compatibility in the long term, both to `microsoft/uf2` and `adafruit/tinyuf2`.
As discussed on Discord, in the short term we were okay accepting this change based on its changeset size, and the long term intentions.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
