### PR TITLE
[Bug][Keyboard] Fix key display on Corne OLED

### DIFF
--- a/keyboards/crkbd/crkbd.c
+++ b/keyboards/crkbd/crkbd.c
@@ -91,7 +91,7 @@ static void set_keylog(uint16_t keycode, keyrecord_t *record) {
     }
 
     // update keylog
-    key_name = code_to_name[keycode];
+    key_name = pgm_read_byte(&code_to_name[keycode]);
     last_row = record->event.key.row;
     last_col = record->event.key.col;
 }


### PR DESCRIPTION
## Description

When merging/moving the oled code for the corne, I was not paying close enough attention.  r2g oled code didn't use progmem for the code to name array, but other code did.  Some mix and matching happened. 

Discovered when talking on discord (not directly about corne). 

Tested on hardware, to verify works correctly. 

## Types of Changes

- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
