### PR TITLE
Fix up `qmk find` when not specifying filters.

### DIFF
--- a/lib/python/qmk/cli/find.py
+++ b/lib/python/qmk/cli/find.py
@@ -19,6 +19,10 @@ from qmk.search import search_keymap_targets
 def find(cli):
     """Search through all keyboards and keymaps for a given search criteria.
     """
+
+    if len(cli.args.filter) == 0 and len(cli.args.print) > 0:
+        cli.log.warning('No filters supplied -- keymaps not parsed, unable to print requested values.')
+
     targets = search_keymap_targets(cli.args.keymap, cli.args.filter, cli.args.print)
     for keyboard, keymap, print_vals in targets:
         print(f'{keyboard}:{keymap}')

--- a/lib/python/qmk/search.py
+++ b/lib/python/qmk/search.py
@@ -61,7 +61,7 @@ def search_keymap_targets(keymap='default', filters=[], print_vals=[]):
             target_list = [(kb, keymap) for kb in filter(lambda kb: kb is not None, pool.starmap(_keymap_exists, [(kb, keymap) for kb in qmk.keyboard.list_keyboards()]))]
 
         if len(filters) == 0:
-            targets = target_list
+            targets = [(kb, km, {}) for kb, km in target_list]
         else:
             cli.log.info('Parsing data for all matching keyboard/keymap combinations...')
             valid_keymaps = [(e[0], e[1], dotty(e[2])) for e in pool.starmap(_load_keymap_info, target_list)]


### PR DESCRIPTION
## Description

When attempting to get `qmk find` to output the list of build targets for a specific keymap, exceptions were being thrown because the printable item list return value was not set during the search operation.

This PR fixes the exception but also provides a warning saying that it can't output the requested printable info if no filters are supplied -- mainly because the json's aren't parsed if not filters are present.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
