### PR TITLE
Fix backlight sync on suspend_power_down for split keyboards

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -468,7 +468,7 @@ void suspend_power_down_quantum(void) {
 #ifndef NO_SUSPEND_POWER_DOWN
 // Turn off backlight
 #    ifdef BACKLIGHT_ENABLE
-    backlight_set(0);
+    backlight_level_noeeprom(0);
 #    endif
 
 #    ifdef LED_MATRIX_ENABLE

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -412,7 +412,7 @@ static void backlight_handlers_slave(matrix_row_t master_matrix[], matrix_row_t 
     uint8_t backlight_level = split_shmem->backlight_level;
     split_shared_memory_unlock();
 
-    backlight_set(backlight_level);
+    backlight_level_noeeprom(backlight_level);
 }
 
 #    define TRANSACTIONS_BACKLIGHT_MASTER() TRANSACTION_HANDLER_MASTER(backlight)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

With split keyboards, when PC goes to sleep, only master side turns backlight off. 

This happens because `suspend_power_down_quantum` uses `backlight_set` which does not update in-memory config and just turns off pins. Backlight split sync uses the config to get current level value, so we must set it with `backlight_level_noeeprom`.
I also updated handling sync on the slave side to use same function, while technically it's not required for the fix, I think keeping the correct value in config makes sense.
Discussed in discord https://discord.com/channels/440868230475677696/440868230475677698/1112672499780571166

Reproduced and tested on my keyboard.

I put the PR to develop branch as per guidelines, however if you think it can be merged to master since it's a small bugfix, let me know and I can change target branch.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

I found two issues related to that
#19032
#14851

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
