### PR TITLE
[Bug] [Core] Fix unintentionally pressed modifiers when key up on using key override

### DIFF
--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -166,12 +166,6 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
 
     deferred_register = 0;
 
-    // Clear the suppressed mods
-    clear_suppressed_override_mods();
-
-    // Unregister the replacement. First remove the weak override mods
-    clear_weak_override_mods();
-
     const key_override_t *const old = active_override;
 
     const uint8_t mod_free_replacement = clear_mods_from(active_override->replacement);
@@ -190,10 +184,16 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
             del_key(mod_free_replacement);
         } else {
             key_override_printf("NOT KEY 1\n");
-            send_keyboard_report();
             unregister_code(mod_free_replacement);
         }
+        send_keyboard_report();
     }
+
+    // Clear the suppressed mods
+    clear_suppressed_override_mods();
+
+    // Unregister the replacement. First remove the weak override mods
+    clear_weak_override_mods();
 
     const uint16_t trigger = active_override->trigger;
 

--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -192,7 +192,7 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
     // Clear the suppressed mods
     clear_suppressed_override_mods();
 
-    // Unregister the replacement. First remove the weak override mods
+    // Unregister the replacement. Then remove the weak override mods
     clear_weak_override_mods();
 
     const uint16_t trigger = active_override->trigger;


### PR DESCRIPTION
## Description

In the status quo, the trigger_mods is repressed before the replacement_key is up like the Picture 1 (SQ). This behavior causes some problems for example overridden arrow keys are unable to navigate search suggestions on YouTube.
My PR solves this issue as Picture 2 (AP).

### Picture 1 (SQ)

![Picture 1 (SQ)](https://github.com/qmk/qmk_firmware/assets/44694396/02fe255f-3e08-49c9-a644-a4ef47dddd72)

### Picture 2 (AP)

![Picture 2 (AP)](https://github.com/qmk/qmk_firmware/assets/44694396/47b9bb2d-7ca8-4e74-b35d-e3cbba6d3735)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* nothing

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
