### PR TITLE
`qmk find`: Fix handling of functions in filters

### DIFF
--- a/lib/python/qmk/search.py
+++ b/lib/python/qmk/search.py
@@ -80,9 +80,9 @@ def search_keymap_targets(keymap='default', filters=[], print_vals=[]):
 
                     if value is not None:
                         if func_name == 'length':
-                            valid_keymaps = filter(lambda e: key in e[2] and len(e[2].get(key)) == int(value), valid_keymaps)
+                            valid_keymaps = filter(lambda e, key=key, value=value: key in e[2] and len(e[2].get(key)) == int(value), valid_keymaps)
                         elif func_name == 'contains':
-                            valid_keymaps = filter(lambda e: key in e[2] and value in e[2].get(key), valid_keymaps)
+                            valid_keymaps = filter(lambda e, key=key, value=value: key in e[2] and value in e[2].get(key), valid_keymaps)
                         else:
                             cli.log.warning(f'Unrecognized filter expression: {function_match.group(0)}')
                             continue
@@ -90,9 +90,9 @@ def search_keymap_targets(keymap='default', filters=[], print_vals=[]):
                         cli.log.info(f'Filtering on condition: {{fg_green}}{func_name}{{fg_reset}}({{fg_cyan}}{key}{{fg_reset}}, {{fg_cyan}}{value}{{fg_reset}})...')
                     else:
                         if func_name == 'exists':
-                            valid_keymaps = filter(lambda e: key in e[2], valid_keymaps)
+                            valid_keymaps = filter(lambda e, key=key: key in e[2], valid_keymaps)
                         elif func_name == 'absent':
-                            valid_keymaps = filter(lambda e: key not in e[2], valid_keymaps)
+                            valid_keymaps = filter(lambda e, key=key: key not in e[2], valid_keymaps)
                         else:
                             cli.log.warning(f'Unrecognized filter expression: {function_match.group(0)}')
                             continue


### PR DESCRIPTION
## Description

Functions in filters did not work properly except when used in the last (or only) filter.  The problem was caused by the peculiarity of the `lambda` behavior in Python — any variables from the outer scope are captured only by reference, therefore any subsequent reassignment of those variables is propagated to all lambdas created earlier in the same scope.  Together with the laziness of `filter()` (it returns an iterator which performs filtering on demand) this resulted in all function filters using the values of the `key` and `value` variables which correspond to the last filter in the sequence, therefore the result of filtering was wrong if some filter with a function was not the last one in the sequence.

Apparently the shortest way to make a Python lambda capture some variables by value is to add arguments with default values for such variables (default values are evaluated when the lambda is created, and any subsequent reassignments in the outer scope no longer changes them). This makes filters with functions work properly even when such filters are not at the last position in the sequence.

------

An alternate solution is to wrap all `filter()` calls with `list()` to force immediate evaluation — in that case the fact that `lambda` captures variables from the outer scope by reference does not matter, because the lambda is invoked only while those variables still have the expected values.  However, in this case the actual problem (the need to capture values instead of references) is not immediately obvious from the code.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

These commands gave different results (the first one correctly printed some keyboard names matching the specified filters, while the second one, which differs only in the order of `-f` options, did not print anything):
```sh
qmk find -f 'split.enabled=true' -f 'features.rgblight=true' -f 'absent(rgblight.split_count)'
qmk find -f 'absent(rgblight.split_count)' -f 'split.enabled=true' -f 'features.rgblight=true'
```
With the change in this PR both commands give the same result.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
