### PR TITLE
[Core] Add a dynamic_macro_stop_recording(void) function.

### DIFF
--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -173,6 +173,9 @@ static keyrecord_t *macro_pointer = NULL;
  * 1,2 - either macro 1 or 2 is being recorded */
 static uint8_t macro_id = 0;
 
+/**
+  * If a dynamic macro is currently being recorded, stop recording.
+  */
 void dynamic_macro_stop_recording(void) {
     switch (macro_id) {
     case 1:

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -177,12 +177,12 @@ static uint8_t macro_id = 0;
   * If a dynamic macro is currently being recorded, stop recording. */
 void dynamic_macro_stop_recording(void) {
     switch (macro_id) {
-    case 1:
-      dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
-      break;
-    case 2:
-      dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
-    break;
+        case 1:
+          dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
+          break;
+        case 2:
+          dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
+          break;
     }
     macro_id = 0;
 }

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -151,6 +151,30 @@ void dynamic_macro_record_end(keyrecord_t *macro_buffer, keyrecord_t *macro_poin
     *macro_end = macro_pointer;
 }
 
+/* Both macros use the same buffer but read/write on different
+ * ends of it.
+ *
+ * Macro1 is written left-to-right starting from the beginning of
+ * the buffer.
+ *
+ * Macro2 is written right-to-left starting from the end of the
+ * buffer.
+ *
+ * &macro_buffer   macro_end
+ *  v                   v
+ * +------------------------------------------------------------+
+ * |>>>>>> MACRO1 >>>>>>      <<<<<<<<<<<<< MACRO2 <<<<<<<<<<<<<|
+ * +------------------------------------------------------------+
+ *                           ^                                 ^
+ *                         r_macro_end                  r_macro_buffer
+ *
+ * During the recording when one macro encounters the end of the
+ * other macro, the recording is stopped. Apart from this, there
+ * are no arbitrary limits for the macros' length in relation to
+ * each other: for example one can either have two medium sized
+ * macros or one long macro and one short macro. Or even one empty
+ * and one using the whole buffer.
+ */
 static keyrecord_t macro_buffer[DYNAMIC_MACRO_SIZE];
 
 /* Pointer to the first buffer element after the first macro.
@@ -198,31 +222,6 @@ void dynamic_macro_stop_recording(void) {
  *   }
  */
 bool process_dynamic_macro(uint16_t keycode, keyrecord_t *record) {
-    /* Both macros use the same buffer but read/write on different
-     * ends of it.
-     *
-     * Macro1 is written left-to-right starting from the beginning of
-     * the buffer.
-     *
-     * Macro2 is written right-to-left starting from the end of the
-     * buffer.
-     *
-     * &macro_buffer   macro_end
-     *  v                   v
-     * +------------------------------------------------------------+
-     * |>>>>>> MACRO1 >>>>>>      <<<<<<<<<<<<< MACRO2 <<<<<<<<<<<<<|
-     * +------------------------------------------------------------+
-     *                           ^                                 ^
-     *                         r_macro_end                  r_macro_buffer
-     *
-     * During the recording when one macro encounters the end of the
-     * other macro, the recording is stopped. Apart from this, there
-     * are no arbitrary limits for the macros' length in relation to
-     * each other: for example one can either have two medium sized
-     * macros or one long macro and one short macro. Or even one empty
-     * and one using the whole buffer.
-     */
-
     if (macro_id == 0) {
         /* No macro recording in progress. */
         if (!record->event.pressed) {

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -174,8 +174,7 @@ static keyrecord_t *macro_pointer = NULL;
 static uint8_t macro_id = 0;
 
 /**
-  * If a dynamic macro is currently being recorded, stop recording.
-  */
+  * If a dynamic macro is currently being recorded, stop recording. */
 void dynamic_macro_stop_recording(void) {
     switch (macro_id) {
     case 1:

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -178,11 +178,11 @@ static uint8_t macro_id = 0;
 void dynamic_macro_stop_recording(void) {
     switch (macro_id) {
         case 1:
-          dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
-          break;
+            dynamic_macro_record_end(macro_buffer, macro_pointer, +1, &macro_end);
+            break;
         case 2:
-          dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
-          break;
+            dynamic_macro_record_end(r_macro_buffer, macro_pointer, -1, &r_macro_end);
+            break;
     }
     macro_id = 0;
 }

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -198,8 +198,8 @@ static keyrecord_t *macro_pointer = NULL;
 static uint8_t macro_id = 0;
 
 /**
-  * If a dynamic macro is currently being recorded, stop recording.
-  */
+ * If a dynamic macro is currently being recorded, stop recording.
+ */
 void dynamic_macro_stop_recording(void) {
     switch (macro_id) {
         case 1:

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -198,7 +198,8 @@ static keyrecord_t *macro_pointer = NULL;
 static uint8_t macro_id = 0;
 
 /**
-  * If a dynamic macro is currently being recorded, stop recording. */
+  * If a dynamic macro is currently being recorded, stop recording.
+  */
 void dynamic_macro_stop_recording(void) {
     switch (macro_id) {
         case 1:

--- a/quantum/process_keycode/process_dynamic_macro.h
+++ b/quantum/process_keycode/process_dynamic_macro.h
@@ -39,3 +39,4 @@ void dynamic_macro_record_start_user(int8_t direction);
 void dynamic_macro_play_user(int8_t direction);
 void dynamic_macro_record_key_user(int8_t direction, keyrecord_t *record);
 void dynamic_macro_record_end_user(int8_t direction);
+void dynamic_macro_stop_recording(void);


### PR DESCRIPTION
## Description

This PR refactors the code used to stop recording a dynamic macro into it's own new function, void dynamic_macro_stop_recording(void), allowing users to programmatically end the recording of a dynamic macro.

An example of how this could be useful is that it would allow the user to, in their keymap, change the behavior of the QK_DYNAMIC_MACRO_PLAY_* keys to behave more like Emacs' key macros - where hitting the play 'key' while recording will stop recording and immediately play back the key macro, without requiring the user first perform a separate key stroke to explicitly end recording - by adding a case like this example to their process_record_user function:

```c
  case QK_DYNAMIC_MACRO_PLAY_1:
  case QK_DYNAMIC_MACRO_PLAY_2:
    if (record->event.pressed)
      dynamic_macro_stop_recording();
    return true;
```

Other users may be able to imagine other situations where they'd like to programmattically end the recording of a dynamic macro (on a timer, perhaps, in case they start recording and then go AFK and forget to end the recording of their macro?).

On my local system, this change does not appear to change the size of the firmware produced.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [X] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None.

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
