### PR TITLE
Add *_MATRIX_LED_COUNT generation

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -71,6 +71,7 @@
     "LED_MATRIX_SPLIT": {"info_key": "led_matrix.split_count", "value_type": "array.int"},
     "LED_MATRIX_TIMEOUT": {"info_key": "led_matrix.timeout", "value_type": "int"},
     "LED_MATRIX_VAL_STEP": {"info_key": "led_matrix.val_steps", "value_type": "int"},
+    "LED_MATRIX_LED_COUNT": {"info_key": "led_matrix.led_count", "value_type": "int", "to_json": false},
 
     // LUFA Bootloader
     "QMK_ESC_INPUT": {"info_key": "qmk_lufa_bootloader.esc_input"},
@@ -109,6 +110,7 @@
     "RGB_MATRIX_SPLIT": {"info_key": "rgb_matrix.split_count", "value_type": "array.int"},
     "RGB_MATRIX_TIMEOUT": {"info_key": "rgb_matrix.timeout", "value_type": "int"},
     "RGB_MATRIX_VAL_STEP": {"info_key": "rgb_matrix.val_steps", "value_type": "int"},
+    "RGB_MATRIX_LED_COUNT": {"info_key": "rgb_matrix.led_count", "value_type": "int", "to_json": false},
 
     // RGBLight
     "RGBLED_NUM": {"info_key": "rgblight.led_count", "value_type": "int"},

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -38,6 +38,10 @@ def _strip_api_content(info_json):
     if 'matrix_pins' in info_json:
         info_json.pop('matrix_size', None)
 
+    for feature in ['rgb_matrix', 'led_matrix']:
+        if info_json.get(feature, {}).get("layout", None):
+            info_json[feature].pop('led_count', None)
+
     return info_json
 
 

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -706,6 +706,9 @@ def _extract_led_config(info_data, keyboard):
             except Exception as e:
                 _log_warning(info_data, f'led_config: {file.name}: {e}')
 
+        if info_data[feature].get("layout", None) and not info_data[feature].get("led_count", None):
+            info_data[feature]["led_count"] = len(info_data[feature]["layout"])
+
     return info_data
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
~~Current hitting preprocessor isues:~~
```
⚠ acheron/apollo/87h/gamma: RGB_MATRIX_LED_COUNT->rgb_matrix.led_count: invalid literal for int() with base 10: 'DRIVER_1_LED_TOTAL'
⚠ aeboards/satellite/rev1: RGB_MATRIX_LED_COUNT->rgb_matrix.led_count: invalid literal for int() with base 10: 'ISSI_DRIVER_TOTAL'
```

~~Parsing is currently disabled due to the above issue. A 2nd pass will refactor keyboards, but this at least allows dd configuration in the short term.~~

Parsing is no longer important as the value is generated only from the length of the LED array.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
