### PR TITLE
[Enhancement] Decouple autocorrect logic

### DIFF
--- a/quantum/process_keycode/process_autocorrect.c
+++ b/quantum/process_keycode/process_autocorrect.c
@@ -57,7 +57,7 @@ void autocorrect_toggle(void) {
 }
 
 /**
- * @brief handler for determining if autocorrect should process keypress
+ * @brief handler for user to override whether autocorrect should process this keypress
  *
  * @param keycode Keycode registered by matrix press, per keymap
  * @param record keyrecord_t structure
@@ -67,6 +67,23 @@ void autocorrect_toggle(void) {
  * @return false Stop processing and escape from autocorrect.
  */
 __attribute__((weak)) bool process_autocorrect_user(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods) {
+    return preprocess_autocorrect(keycode, record, typo_buffer_size, mods);
+}
+
+/**
+ * @brief fallback handler for determining if autocorrect should process this keypress
+ *        can be used by user callback to get the basic keycode being "wrapped"
+ *
+ * NOTE: These values may have been edited by user callback before getting here
+ *
+ * @param keycode Keycode registered by matrix press, per keymap
+ * @param record keyrecord_t structure
+ * @param typo_buffer_size passed along to allow resetting of autocorrect buffer
+ * @param mods allow processing of mod status
+ * @return true Allow autocorection
+ * @return false Stop processing and escape from autocorrect.
+ */
+bool preprocess_autocorrect(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods) {
     // See quantum_keycodes.h for reference on these matched ranges.
     switch (*keycode) {
         // Exclude these keycodes from processing.

--- a/quantum/process_keycode/process_autocorrect.c
+++ b/quantum/process_keycode/process_autocorrect.c
@@ -67,7 +67,7 @@ void autocorrect_toggle(void) {
  * @return false Stop processing and escape from autocorrect.
  */
 __attribute__((weak)) bool process_autocorrect_user(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods) {
-    return preprocess_autocorrect(keycode, record, typo_buffer_size, mods);
+    return process_autocorrect_default_handler(keycode, record, typo_buffer_size, mods);
 }
 
 /**
@@ -83,7 +83,7 @@ __attribute__((weak)) bool process_autocorrect_user(uint16_t *keycode, keyrecord
  * @return true Allow autocorection
  * @return false Stop processing and escape from autocorrect.
  */
-bool preprocess_autocorrect(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods) {
+bool process_autocorrect_default_handler(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods) {
     // See quantum_keycodes.h for reference on these matched ranges.
     switch (*keycode) {
         // Exclude these keycodes from processing.

--- a/quantum/process_keycode/process_autocorrect.h
+++ b/quantum/process_keycode/process_autocorrect.h
@@ -9,6 +9,7 @@
 
 bool process_autocorrect(uint16_t keycode, keyrecord_t *record);
 bool process_autocorrect_user(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods);
+bool preprocess_autocorrect(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods);
 bool apply_autocorrect(uint8_t backspaces, const char *str);
 
 bool autocorrect_is_enabled(void);

--- a/quantum/process_keycode/process_autocorrect.h
+++ b/quantum/process_keycode/process_autocorrect.h
@@ -9,7 +9,7 @@
 
 bool process_autocorrect(uint16_t keycode, keyrecord_t *record);
 bool process_autocorrect_user(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods);
-bool preprocess_autocorrect(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods);
+bool process_autocorrect_default_handler(uint16_t *keycode, keyrecord_t *record, uint8_t *typo_buffer_size, uint8_t *mods);
 bool apply_autocorrect(uint8_t backspaces, const char *str);
 
 bool autocorrect_is_enabled(void);


### PR DESCRIPTION
## Description

Rigth now the weak function contains a lot of functionality that users may want to extend instead of completely override (eg: me 🙃), thus decoupling this into a function, to avoid duplications.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
