### PR TITLE
[Core] Added the option to caluculate precise diagonal speed of a mouse cursor

### DIFF
--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -75,11 +75,6 @@ Diagonal movement speed calculation may not be accurate when step size and maxim
 #define MOUSEKEY_PRECISE_DIAGONAL_MOVE
 ```
 
-Under the method above, the result is always rounded toward zero. So for pursuing most precision, add the following line to `config.h`. This computes the nearest integer value and rounds halfway cases away from zero.
-```c
-#define MOUSEKEY_PRECISE_DIAGONAL_MOVE_2
-```
-
 Tips:
 
 * Setting `MOUSEKEY_DELAY` too low makes the cursor unresponsive. Setting it too high makes small movements difficult.

--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -70,11 +70,6 @@ This is the default mode. You can adjust the cursor and scrolling acceleration u
 |`MOUSEKEY_WHEEL_MAX_SPEED`  |8      |Maximum number of scroll steps per scroll action         |
 |`MOUSEKEY_WHEEL_TIME_TO_MAX`|40     |Time until maximum scroll speed is reached               |
 
-Diagonal movement speed calculation may not be accurate when step size and maximum cursor speed are configured to low values. To improve the accuracy of diagonal movement calculation, add the following in your keymap's `config.h` file:
-```c
-#define MOUSEKEY_PRECISE_DIAGONAL_MOVE
-```
-
 Tips:
 
 * Setting `MOUSEKEY_DELAY` too low makes the cursor unresponsive. Setting it too high makes small movements difficult.

--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -58,17 +58,18 @@ Configuration options that are times, intervals or delays are given in milliseco
 
 This is the default mode. You can adjust the cursor and scrolling acceleration using the following settings in your keymap’s `config.h` file:
 
-|Define                      |Default|Description                                              |
-|----------------------------|-------|---------------------------------------------------------|
-|`MOUSEKEY_DELAY`            |10     |Delay between pressing a movement key and cursor movement|
-|`MOUSEKEY_INTERVAL`         |20     |Time between cursor movements in milliseconds            |
-|`MOUSEKEY_MOVE_DELTA`       |8      |Step size                                                |
-|`MOUSEKEY_MAX_SPEED`        |10     |Maximum cursor speed at which acceleration stops         |
-|`MOUSEKEY_TIME_TO_MAX`      |30     |Time until maximum cursor speed is reached               |
-|`MOUSEKEY_WHEEL_DELAY`      |10     |Delay between pressing a wheel key and wheel movement    |
-|`MOUSEKEY_WHEEL_INTERVAL`   |80     |Time between wheel movements                             |
-|`MOUSEKEY_WHEEL_MAX_SPEED`  |8      |Maximum number of scroll steps per scroll action         |
-|`MOUSEKEY_WHEEL_TIME_TO_MAX`|40     |Time until maximum scroll speed is reached               |
+|Define                          |Default        |Description                                              |
+|--------------------------------|---------------|---------------------------------------------------------|
+|`MOUSEKEY_DELAY`                |10             |Delay between pressing a movement key and cursor movement|
+|`MOUSEKEY_INTERVAL`             |20             |Time between cursor movements in milliseconds            |
+|`MOUSEKEY_MOVE_DELTA`           |8              |Step size                                                |
+|`MOUSEKEY_MAX_SPEED`            |10             |Maximum cursor speed at which acceleration stops         |
+|`MOUSEKEY_TIME_TO_MAX`          |30             |Time until maximum cursor speed is reached               |
+|`MOUSEKEY_WHEEL_DELAY`          |10             |Delay between pressing a wheel key and wheel movement    |
+|`MOUSEKEY_WHEEL_INTERVAL`       |80             |Time between wheel movements                             |
+|`MOUSEKEY_WHEEL_MAX_SPEED`      |8              |Maximum number of scroll steps per scroll action         |
+|`MOUSEKEY_WHEEL_TIME_TO_MAX`    |40             |Time until maximum scroll speed is reached               |
+|`MOUSEKEY_PRECISE_DIAGONAL_MOVE`|**Not defined**|Precisely caluculated diagonal cursor speed              |
 
 Tips:
 

--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -58,17 +58,17 @@ Configuration options that are times, intervals or delays are given in milliseco
 
 This is the default mode. You can adjust the cursor and scrolling acceleration using the following settings in your keymap’s `config.h` file:
 
-|Define                          |Default|Description                                              |
-|--------------------------------|-------|---------------------------------------------------------|
-|`MOUSEKEY_DELAY`                |10     |Delay between pressing a movement key and cursor movement|
-|`MOUSEKEY_INTERVAL`             |20     |Time between cursor movements in milliseconds            |
-|`MOUSEKEY_MOVE_DELTA`           |8      |Step size                                                |
-|`MOUSEKEY_MAX_SPEED`            |10     |Maximum cursor speed at which acceleration stops         |
-|`MOUSEKEY_TIME_TO_MAX`          |30     |Time until maximum cursor speed is reached               |
-|`MOUSEKEY_WHEEL_DELAY`          |10     |Delay between pressing a wheel key and wheel movement    |
-|`MOUSEKEY_WHEEL_INTERVAL`       |80     |Time between wheel movements                             |
-|`MOUSEKEY_WHEEL_MAX_SPEED`      |8      |Maximum number of scroll steps per scroll action         |
-|`MOUSEKEY_WHEEL_TIME_TO_MAX`    |40     |Time until maximum scroll speed is reached               |
+|Define                      |Default|Description                                              |
+|----------------------------|-------|---------------------------------------------------------|
+|`MOUSEKEY_DELAY`            |10     |Delay between pressing a movement key and cursor movement|
+|`MOUSEKEY_INTERVAL`         |20     |Time between cursor movements in milliseconds            |
+|`MOUSEKEY_MOVE_DELTA`       |8      |Step size                                                |
+|`MOUSEKEY_MAX_SPEED`        |10     |Maximum cursor speed at which acceleration stops         |
+|`MOUSEKEY_TIME_TO_MAX`      |30     |Time until maximum cursor speed is reached               |
+|`MOUSEKEY_WHEEL_DELAY`      |10     |Delay between pressing a wheel key and wheel movement    |
+|`MOUSEKEY_WHEEL_INTERVAL`   |80     |Time between wheel movements                             |
+|`MOUSEKEY_WHEEL_MAX_SPEED`  |8      |Maximum number of scroll steps per scroll action         |
+|`MOUSEKEY_WHEEL_TIME_TO_MAX`|40     |Time until maximum scroll speed is reached               |
 
 Diagonal movement speed calculation may not be accurate when step size and maximum cursor speed are configured to low values. To improve the accuracy of diagonal movement calculation, add the following in your keymap's `config.h` file:
 ```c

--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -58,18 +58,22 @@ Configuration options that are times, intervals or delays are given in milliseco
 
 This is the default mode. You can adjust the cursor and scrolling acceleration using the following settings in your keymap’s `config.h` file:
 
-|Define                          |Default        |Description                                              |
-|--------------------------------|---------------|---------------------------------------------------------|
-|`MOUSEKEY_DELAY`                |10             |Delay between pressing a movement key and cursor movement|
-|`MOUSEKEY_INTERVAL`             |20             |Time between cursor movements in milliseconds            |
-|`MOUSEKEY_MOVE_DELTA`           |8              |Step size                                                |
-|`MOUSEKEY_MAX_SPEED`            |10             |Maximum cursor speed at which acceleration stops         |
-|`MOUSEKEY_TIME_TO_MAX`          |30             |Time until maximum cursor speed is reached               |
-|`MOUSEKEY_WHEEL_DELAY`          |10             |Delay between pressing a wheel key and wheel movement    |
-|`MOUSEKEY_WHEEL_INTERVAL`       |80             |Time between wheel movements                             |
-|`MOUSEKEY_WHEEL_MAX_SPEED`      |8              |Maximum number of scroll steps per scroll action         |
-|`MOUSEKEY_WHEEL_TIME_TO_MAX`    |40             |Time until maximum scroll speed is reached               |
-|`MOUSEKEY_PRECISE_DIAGONAL_MOVE`|**Not defined**|Precisely caluculated diagonal cursor speed              |
+|Define                          |Default|Description                                              |
+|--------------------------------|-------|---------------------------------------------------------|
+|`MOUSEKEY_DELAY`                |10     |Delay between pressing a movement key and cursor movement|
+|`MOUSEKEY_INTERVAL`             |20     |Time between cursor movements in milliseconds            |
+|`MOUSEKEY_MOVE_DELTA`           |8      |Step size                                                |
+|`MOUSEKEY_MAX_SPEED`            |10     |Maximum cursor speed at which acceleration stops         |
+|`MOUSEKEY_TIME_TO_MAX`          |30     |Time until maximum cursor speed is reached               |
+|`MOUSEKEY_WHEEL_DELAY`          |10     |Delay between pressing a wheel key and wheel movement    |
+|`MOUSEKEY_WHEEL_INTERVAL`       |80     |Time between wheel movements                             |
+|`MOUSEKEY_WHEEL_MAX_SPEED`      |8      |Maximum number of scroll steps per scroll action         |
+|`MOUSEKEY_WHEEL_TIME_TO_MAX`    |40     |Time until maximum scroll speed is reached               |
+
+Diagonal movement speed calculation may not be accurate when step size and maximum cursor speed are configured to low values. To improve the accuracy of diagonal movement calculation, add the following in your keymap's `config.h` file:
+```c
+#define MOUSEKEY_PRECISE_DIAGONAL_MOVE
+```
 
 Tips:
 

--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -75,6 +75,11 @@ Diagonal movement speed calculation may not be accurate when step size and maxim
 #define MOUSEKEY_PRECISE_DIAGONAL_MOVE
 ```
 
+Under the method above, the result is always rounded toward zero. So for pursuing most precision, add the following line to `config.h`. This computes the nearest integer value and rounds halfway cases away from zero.
+```c
+#define MOUSEKEY_PRECISE_DIAGONAL_MOVE_2
+```
+
 Tips:
 
 * Setting `MOUSEKEY_DELAY` too low makes the cursor unresponsive. Setting it too high makes small movements difficult.

--- a/docs/ja/feature_mouse_keys.md
+++ b/docs/ja/feature_mouse_keys.md
@@ -72,7 +72,6 @@ MOUSEKEY_ENABLE = yes
 | `MOUSEKEY_WHEEL_INTERVAL` | 100 | ホイールの動きの間の時間 |
 | `MOUSEKEY_WHEEL_MAX_SPEED` | 8 | スクロールアクションごとのスクロールステップの最大数 |
 | `MOUSEKEY_WHEEL_TIME_TO_MAX` | 40 | 最大スクロール速度に達するまでの時間 |
-| `MOUSEKEY_PRECISE_DIAGONAL_MOVE` | **定義なし** | 正確に計算された斜めに移動する際のカーソル速度 |
 
 斜めのカーソル速度はステップの大きさや最大カーソル速度を低く設定した際に精度よく計算されません。
 気になる場合、以下の行を各キーマップの `config.h` に追加してください。

--- a/docs/ja/feature_mouse_keys.md
+++ b/docs/ja/feature_mouse_keys.md
@@ -65,6 +65,7 @@ MOUSEKEY_ENABLE = yes
 |----------------------------|-------|---------------------------------------------------------|
 | `MOUSEKEY_DELAY` | 300 | 移動キーを押してからカーソルが移動するまでの遅延 |
 | `MOUSEKEY_INTERVAL` | 50 | カーソル移動間の時間 |
+| `MOUSEKEY_MOVE_DELTA` | 8 | ステップの大きさ |
 | `MOUSEKEY_MAX_SPEED` | 10 | 加速が停止する最大のカーソル速度 |
 | `MOUSEKEY_TIME_TO_MAX` | 20 | 最大カーソル速度に達するまでの時間 |
 | `MOUSEKEY_WHEEL_DELAY` | 300 | ホイールキーを押してからホイールが動くまでの遅延 |
@@ -72,6 +73,13 @@ MOUSEKEY_ENABLE = yes
 | `MOUSEKEY_WHEEL_MAX_SPEED` | 8 | スクロールアクションごとのスクロールステップの最大数 |
 | `MOUSEKEY_WHEEL_TIME_TO_MAX` | 40 | 最大スクロール速度に達するまでの時間 |
 | `MOUSEKEY_PRECISE_DIAGONAL_MOVE` | **定義なし** | 正確に計算された斜めに移動する際のカーソル速度 |
+
+斜めのカーソル速度はステップの大きさや最大カーソル速度を低く設定した際に精度よく計算されません。
+気になる場合、以下の行を各キーマップの `config.h` に追加してください。
+
+```c
+#define MOUSEKEY_PRECISE_DIAGONAL_MOVE
+```
 
 ヒント:
 

--- a/docs/ja/feature_mouse_keys.md
+++ b/docs/ja/feature_mouse_keys.md
@@ -73,13 +73,6 @@ MOUSEKEY_ENABLE = yes
 | `MOUSEKEY_WHEEL_MAX_SPEED` | 8 | スクロールアクションごとのスクロールステップの最大数 |
 | `MOUSEKEY_WHEEL_TIME_TO_MAX` | 40 | 最大スクロール速度に達するまでの時間 |
 
-斜めのカーソル速度はステップの大きさや最大カーソル速度を低く設定した際に精度よく計算されません。
-気になる場合、以下の行を各キーマップの `config.h` に追加してください。
-
-```c
-#define MOUSEKEY_PRECISE_DIAGONAL_MOVE
-```
-
 ヒント:
 
 * `MOUSEKEY_DELAY` の設定が低すぎるとカーソルが応答しなくなります。設定が高すぎると小さな動きが難しくなります。

--- a/docs/ja/feature_mouse_keys.md
+++ b/docs/ja/feature_mouse_keys.md
@@ -71,6 +71,7 @@ MOUSEKEY_ENABLE = yes
 | `MOUSEKEY_WHEEL_INTERVAL` | 100 | ホイールの動きの間の時間 |
 | `MOUSEKEY_WHEEL_MAX_SPEED` | 8 | スクロールアクションごとのスクロールステップの最大数 |
 | `MOUSEKEY_WHEEL_TIME_TO_MAX` | 40 | 最大スクロール速度に達するまでの時間 |
+| `MOUSEKEY_PRECISE_DIAGONAL_MOVE` | **定義なし** | 正確に計算された斜めに移動する際のカーソル速度 |
 
 ヒント:
 

--- a/docs/ja/feature_mouse_keys.md
+++ b/docs/ja/feature_mouse_keys.md
@@ -81,6 +81,11 @@ MOUSEKEY_ENABLE = yes
 #define MOUSEKEY_PRECISE_DIAGONAL_MOVE
 ```
 
+上記の方法の場合、結果の端数は常に切り捨てられます。四捨五入を行うためには以下の行を `config.h` に追加してください。
+```c
+#define MOUSEKEY_PRECISE_DIAGONAL_MOVE_2
+```
+
 ヒント:
 
 * `MOUSEKEY_DELAY` の設定が低すぎるとカーソルが応答しなくなります。設定が高すぎると小さな動きが難しくなります。

--- a/docs/ja/feature_mouse_keys.md
+++ b/docs/ja/feature_mouse_keys.md
@@ -81,11 +81,6 @@ MOUSEKEY_ENABLE = yes
 #define MOUSEKEY_PRECISE_DIAGONAL_MOVE
 ```
 
-上記の方法の場合、結果の端数は常に切り捨てられます。四捨五入を行うためには以下の行を `config.h` に追加してください。
-```c
-#define MOUSEKEY_PRECISE_DIAGONAL_MOVE_2
-```
-
 ヒント:
 
 * `MOUSEKEY_DELAY` の設定が低すぎるとカーソルが応答しなくなります。設定が高すぎると小さな動きが難しくなります。

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -28,14 +28,12 @@
 
 static inline int8_t times_inv_sqrt2(int8_t x) {
 #ifdef MOUSEKEY_PRECISE_DIAGONAL_MOVE
-    // 46341/65536 is very near to 1/sqrt(2)
-    // 0.70710754                  0.707106781
-    return (x < 0 ? -1 : 1) * scale16(x < 0 ? -x : x, 46341);
-#elif defined MOUSEKEY_PRECISE_DIAGONAL_MOVE_2
+    // 46341/65536 is very close to 1/sqrt(2)
+    // 0.70710754                   0.707106781
     return round((x < 0 ? -1 : 1) * scale16(x < 0 ? -x : x, 46341));
 #else
-    // 181/256 is also pretty close to 1/sqrt(2)
-    // 0.70703125
+    // 181/256 is pretty close to 1/sqrt(2)
+    // 0.70703125                 0.707106781
     // 1 too small for x=99 and x=198
     // This ends up being a mult and discard lower 8 bits
     return (x * 181) >> 8;

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -29,7 +29,11 @@ static inline int8_t times_inv_sqrt2(int8_t x) {
     // 0.70703125                 0.707106781
     // 1 too small for x=99 and x=198
     // This ends up being a mult and discard lower 8 bits
+#ifdef MOUSEKEY_PRECISE_DIAGONAL_MOVE
+    return x * 0.707106781;
+#else
     return (x * 181) >> 8;
+#endif
 }
 
 static report_mouse_t mouse_report = {0};

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -32,7 +32,7 @@ static inline int8_t times_inv_sqrt2(int8_t x) {
     // 0.70710754                  0.707106781
     return (x < 0 ? -1 : 1) * scale16(x < 0 ? -x : x, 46341);
 #elif defined MOUSEKEY_PRECISE_DIAGONAL_MOVE_2
-    return round(x * 0.707106781);
+    return round((x < 0 ? -1 : 1) * scale16(x < 0 ? -x : x, 46341));
 #else
     // 181/256 is also pretty close to 1/sqrt(2)
     // 0.70703125

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -23,15 +23,18 @@
 #include "print.h"
 #include "debug.h"
 #include "mousekey.h"
+#include "lib/lib8tion/lib8tion.h"
 
 static inline int8_t times_inv_sqrt2(int8_t x) {
-    // 181/256 is pretty close to 1/sqrt(2)
-    // 0.70703125                 0.707106781
+#ifdef MOUSEKEY_PRECISE_DIAGONAL_MOVE
+    // 46341/65536 is very near to 1/sqrt(2)
+    // 0.70710754                  0.707106781
+    return (x < 0 ? -1 : 1) * scale16(x < 0 ? -x : x, 46341);
+#else
+    // 181/256 is also pretty close to 1/sqrt(2)
+    // 0.70703125
     // 1 too small for x=99 and x=198
     // This ends up being a mult and discard lower 8 bits
-#ifdef MOUSEKEY_PRECISE_DIAGONAL_MOVE
-    return x * 0.707106781;
-#else
     return (x * 181) >> 8;
 #endif
 }

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <math.h>
 #include "keycode.h"
 #include "host.h"
 #include "timer.h"
@@ -30,6 +31,8 @@ static inline int8_t times_inv_sqrt2(int8_t x) {
     // 46341/65536 is very near to 1/sqrt(2)
     // 0.70710754                  0.707106781
     return (x < 0 ? -1 : 1) * scale16(x < 0 ? -x : x, 46341);
+#elif defined MOUSEKEY_PRECISE_DIAGONAL_MOVE_2
+    return round(x * 0.707106781);
 #else
     // 181/256 is also pretty close to 1/sqrt(2)
     // 0.70703125

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -17,27 +17,23 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <math.h>
 #include "keycode.h"
 #include "host.h"
 #include "timer.h"
 #include "print.h"
 #include "debug.h"
 #include "mousekey.h"
-#include "lib/lib8tion/lib8tion.h"
 
 static inline int8_t times_inv_sqrt2(int8_t x) {
-#ifdef MOUSEKEY_PRECISE_DIAGONAL_MOVE
-    // 46341/65536 is very close to 1/sqrt(2)
-    // 0.70710754                   0.707106781
-    return round((x < 0 ? -1 : 1) * scale16(x < 0 ? -x : x, 46341));
-#else
-    // 181/256 is pretty close to 1/sqrt(2)
-    // 0.70703125                 0.707106781
-    // 1 too small for x=99 and x=198
-    // This ends up being a mult and discard lower 8 bits
-    return (x * 181) >> 8;
-#endif
+    // 181/256 (0.70703125) is used as an approximation for 1/sqrt(2)
+    // because it is close to the exact value which is 0.707106781
+    int16_t  n = x * 181;
+    uint16_t d = 256;
+    // To ensure that the integer result is rounded accurately after
+    // division, check the sign of the numerator
+    // If negative, subtract half of the denominator before dividing
+    // Otherwise, add half of the denominator before dividing
+    return (n < 0) ? (n - d / 2) / d : (n + d / 2) / d;
 }
 
 static report_mouse_t mouse_report = {0};


### PR DESCRIPTION
## Description

Under the status quo, diagonal movement speed is caluculated by using bitwise operation. It sometimes causes an error whose amount is unacceptable. For example, when setting MOUSEKEY_MAX_SPEED and MOUSEKEY_MOVE_DELTA low like 1 and 3 each, the amounts of movement are below.

| Direction | x | y | v | h |
| :-: | :-: | :-: | :-: | :-: |
| ↗ | 2 | -3 | 0 | 0 |
| ↖ | -3 | -3 | 0 | 0 |
| ↘ | 2 | 2 | 0 | 0 |
| ↙ | -3 | 2 | 0 | 0 |

To fix this, I added the option to enable precise caluculation by defining MOUSEKEY_PRECISE_DIAGONAL_MOVE.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* none

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
