### PR TITLE
[Keyboard] Allow changing keychron DIP in rules.mk

### DIFF
--- a/keyboards/keychron/q1/q1.c
+++ b/keyboards/keychron/q1/q1.c
@@ -25,6 +25,8 @@ const matrix_row_t matrix_mask[] = {
     0b0111111111111111,
 };
 
+#ifdef DIP_SWITCH_ENABLE
+
 #ifndef MAC_DIP_LAYER
 #define MAC_DIP_LAYER 0
 #endif
@@ -33,8 +35,6 @@ const matrix_row_t matrix_mask[] = {
 #define WIN_DIP_LAYER 2
 #endif
 
-
-#ifdef DIP_SWITCH_ENABLE
 
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}

--- a/keyboards/keychron/q1/q1.c
+++ b/keyboards/keychron/q1/q1.c
@@ -25,12 +25,21 @@ const matrix_row_t matrix_mask[] = {
     0b0111111111111111,
 };
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
+
 #ifdef DIP_SWITCH_ENABLE
 
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q10/q10.c
+++ b/keyboards/keychron/q10/q10.c
@@ -27,12 +27,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q11/q11.c
+++ b/keyboards/keychron/q11/q11.c
@@ -36,12 +36,21 @@ const matrix_row_t matrix_mask[] = {
 };
 
 #ifdef DIP_SWITCH_ENABLE
+
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 0 : 2));
+        default_layer_set(1UL << (active ? MAC_DIP_LAYER : WIN_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q12/q12.c
+++ b/keyboards/keychron/q12/q12.c
@@ -25,14 +25,24 @@ const matrix_row_t matrix_mask[] = {
     0b111111111111111111,
     0b111111111111101111,
 };
+
 // clang-format on
 #ifdef DIP_SWITCH_ENABLE
+
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q2/q2.c
+++ b/keyboards/keychron/q2/q2.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q3/q3.c
+++ b/keyboards/keychron/q3/q3.c
@@ -32,12 +32,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q4/q4.c
+++ b/keyboards/keychron/q4/q4.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q5/q5.c
+++ b/keyboards/keychron/q5/q5.c
@@ -27,12 +27,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q6/q6.c
+++ b/keyboards/keychron/q6/q6.c
@@ -27,12 +27,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q60/q60.c
+++ b/keyboards/keychron/q60/q60.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q65/q65.c
+++ b/keyboards/keychron/q65/q65.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q7/q7.c
+++ b/keyboards/keychron/q7/q7.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q8/q8.c
+++ b/keyboards/keychron/q8/q8.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/q9/q9.c
+++ b/keyboards/keychron/q9/q9.c
@@ -25,10 +25,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/s1/s1.c
+++ b/keyboards/keychron/s1/s1.c
@@ -27,10 +27,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v1/v1.c
+++ b/keyboards/keychron/v1/v1.c
@@ -27,12 +27,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v10/v10.c
+++ b/keyboards/keychron/v10/v10.c
@@ -27,12 +27,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v2/v2.c
+++ b/keyboards/keychron/v2/v2.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v3/v3.c
+++ b/keyboards/keychron/v3/v3.c
@@ -31,12 +31,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 0 : 2));
+        default_layer_set(1UL << (active ? MAC_DIP_LAYER : WIN_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v4/v4.c
+++ b/keyboards/keychron/v4/v4.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v5/v5.c
+++ b/keyboards/keychron/v5/v5.c
@@ -27,12 +27,20 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v6/v6.c
+++ b/keyboards/keychron/v6/v6.c
@@ -27,15 +27,23 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 2
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) {
         return false;
     }
     if (index == 0) {
 #    if defined(OS_SWITCH_REVERT)
-        default_layer_set(1UL << (!active ? 2 : 0));
+        default_layer_set(1UL << (!active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
 #    else
-        default_layer_set(1UL << (active ? 2 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
 #    endif
     }
     return true;

--- a/keyboards/keychron/v7/v7.c
+++ b/keyboards/keychron/v7/v7.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }

--- a/keyboards/keychron/v8/v8.c
+++ b/keyboards/keychron/v8/v8.c
@@ -26,10 +26,18 @@ const matrix_row_t matrix_mask[] = {
 
 #ifdef DIP_SWITCH_ENABLE
 
+#ifndef MAC_DIP_LAYER
+#define MAC_DIP_LAYER 0
+#endif
+
+#ifndef WIN_DIP_LAYER
+#define WIN_DIP_LAYER 1
+#endif
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
-        default_layer_set(1UL << (active ? 1 : 0));
+        default_layer_set(1UL << (active ? WIN_DIP_LAYER : MAC_DIP_LAYER));
     }
     return true;
 }


### PR DESCRIPTION
Change keychron firmwares to use a preprocessor macro to determine which layer to switch to in each position of the DIP switch. 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Add two preprocessor macros that define which layer to set to default when the DIP switch is changed on Keychron keyboards (`WIN_DIP_LAYER` an `MAC_DIP_LAYER`).

This way, individual keyboard layouts can define these in their `rules.mk` if they don't want to use the default (see for example [my keyboard layout](https://github.com/jakergrossman/qmk_firmware/commit/52838d2cdb7bb4bc877b592916850528f4f8848a) where I wanted to have dvorak in one position and qwerty in another.) With the existing code I would have had to modify the keyboard's `q11.c` to achieve what I wanted, with this I just have to add lines to _that specific layout's_ rules.mk.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage (I only have Q11, but I compiled every layout for every keychron board so I don't foresee an issue)).
