### PR TITLE
[Core] Optimisation - Add RGB LED colour set check in drivers

### DIFF
--- a/drivers/led/aw20216.c
+++ b/drivers/led/aw20216.c
@@ -145,6 +145,11 @@ void AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     aw_led led;
     memcpy_P(&led, (&g_aw_leds[index]), sizeof(led));
 
+    if (g_pwm_buffer[led.driver][led.r] == red &&
+        g_pwm_buffer[led.driver][led.g] == green &&
+        g_pwm_buffer[led.driver][led.b] == blue) {
+        return;
+    }
     g_pwm_buffer[led.driver][led.r]          = red;
     g_pwm_buffer[led.driver][led.g]          = green;
     g_pwm_buffer[led.driver][led.b]          = blue;

--- a/drivers/led/aw20216.c
+++ b/drivers/led/aw20216.c
@@ -145,9 +145,7 @@ void AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     aw_led led;
     memcpy_P(&led, (&g_aw_leds[index]), sizeof(led));
 
-    if (g_pwm_buffer[led.driver][led.r] == red &&
-        g_pwm_buffer[led.driver][led.g] == green &&
-        g_pwm_buffer[led.driver][led.b] == blue) {
+    if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
         return;
     }
     g_pwm_buffer[led.driver][led.r]          = red;

--- a/drivers/led/ckled2001-simple.c
+++ b/drivers/led/ckled2001-simple.c
@@ -151,6 +151,9 @@ void CKLED2001_set_value(int index, uint8_t value) {
     if (index >= 0 && index < LED_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_ckled2001_leds[index]), sizeof(led));
 
+        if (g_pwm_buffer[led.driver][led.v] == value) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }

--- a/drivers/led/ckled2001.c
+++ b/drivers/led/ckled2001.c
@@ -150,9 +150,7 @@ void CKLED2001_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_ckled2001_leds[index]), sizeof(led));
 
-        if (g_pwm_buffer[led.driver][led.r] == red &&
-            g_pwm_buffer[led.driver][led.g] == green &&
-            g_pwm_buffer[led.driver][led.b] == blue) {
+        if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
         g_pwm_buffer[led.driver][led.r]          = red;

--- a/drivers/led/ckled2001.c
+++ b/drivers/led/ckled2001.c
@@ -150,6 +150,11 @@ void CKLED2001_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_ckled2001_leds[index]), sizeof(led));
 
+        if (g_pwm_buffer[led.driver][led.r] == red &&
+            g_pwm_buffer[led.driver][led.g] == green &&
+            g_pwm_buffer[led.driver][led.b] == blue) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;

--- a/drivers/led/issi/is31fl3218.c
+++ b/drivers/led/issi/is31fl3218.c
@@ -72,6 +72,12 @@ void IS31FL3218_init(void) {
 }
 
 void IS31FL3218_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
+    if (g_pwm_buffer[index * 3 + 0]  == red &&
+        g_pwm_buffer[index * 3 + 1]  == green &&
+        g_pwm_buffer[index * 3 + 2]  == blue
+        ) {
+        return;
+    }
     g_pwm_buffer[index * 3 + 0]  = red;
     g_pwm_buffer[index * 3 + 1]  = green;
     g_pwm_buffer[index * 3 + 2]  = blue;

--- a/drivers/led/issi/is31fl3218.c
+++ b/drivers/led/issi/is31fl3218.c
@@ -72,10 +72,7 @@ void IS31FL3218_init(void) {
 }
 
 void IS31FL3218_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
-    if (g_pwm_buffer[index * 3 + 0]  == red &&
-        g_pwm_buffer[index * 3 + 1]  == green &&
-        g_pwm_buffer[index * 3 + 2]  == blue
-        ) {
+    if (g_pwm_buffer[index * 3 + 0] == red && g_pwm_buffer[index * 3 + 1] == green && g_pwm_buffer[index * 3 + 2] == blue) {
         return;
     }
     g_pwm_buffer[index * 3 + 0]  = red;

--- a/drivers/led/issi/is31fl3731-simple.c
+++ b/drivers/led/issi/is31fl3731-simple.c
@@ -196,6 +196,10 @@ void IS31FL3731_set_value(int index, uint8_t value) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
         // Subtract 0x24 to get the second index of g_pwm_buffer
+
+        if (g_pwm_buffer[led.driver][led.v - 0x24] == value) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.v - 0x24]   = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -184,6 +184,12 @@ void IS31FL3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
         // Subtract 0x24 to get the second index of g_pwm_buffer
+        if (g_pwm_buffer[led.driver][led.r - 0x24] == red &&
+            g_pwm_buffer[led.driver][led.g - 0x24] == green &&
+            g_pwm_buffer[led.driver][led.b - 0x24] == blue
+        ) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.r - 0x24]   = red;
         g_pwm_buffer[led.driver][led.g - 0x24]   = green;
         g_pwm_buffer[led.driver][led.b - 0x24]   = blue;

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -184,10 +184,7 @@ void IS31FL3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
         // Subtract 0x24 to get the second index of g_pwm_buffer
-        if (g_pwm_buffer[led.driver][led.r - 0x24] == red &&
-            g_pwm_buffer[led.driver][led.g - 0x24] == green &&
-            g_pwm_buffer[led.driver][led.b - 0x24] == blue
-        ) {
+        if (g_pwm_buffer[led.driver][led.r - 0x24] == red && g_pwm_buffer[led.driver][led.g - 0x24] == green && g_pwm_buffer[led.driver][led.b - 0x24] == blue) {
             return;
         }
         g_pwm_buffer[led.driver][led.r - 0x24]   = red;

--- a/drivers/led/issi/is31fl3733-simple.c
+++ b/drivers/led/issi/is31fl3733-simple.c
@@ -196,7 +196,7 @@ void IS31FL3733_set_value(int index, uint8_t value) {
     if (index >= 0 && index < LED_MATRIX_LED_COUNT) {
         is31_led led = g_is31_leds[index];
 
-        if(g_pwm_buffer[led.driver][led.v] == value) {
+        if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
         g_pwm_buffer[led.driver][led.v]          = value;

--- a/drivers/led/issi/is31fl3733-simple.c
+++ b/drivers/led/issi/is31fl3733-simple.c
@@ -196,6 +196,9 @@ void IS31FL3733_set_value(int index, uint8_t value) {
     if (index >= 0 && index < LED_MATRIX_LED_COUNT) {
         is31_led led = g_is31_leds[index];
 
+        if(g_pwm_buffer[led.driver][led.v] == value) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -189,9 +189,7 @@ void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
-        if (g_pwm_buffer[led.driver][led.r] == red &&
-            g_pwm_buffer[led.driver][led.g] == green &&
-            g_pwm_buffer[led.driver][led.b] == blue) {
+        if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
         g_pwm_buffer[led.driver][led.r]          = red;

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -189,6 +189,11 @@ void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
+        if (g_pwm_buffer[led.driver][led.r] == red &&
+            g_pwm_buffer[led.driver][led.g] == green &&
+            g_pwm_buffer[led.driver][led.b] == blue) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -169,6 +169,11 @@ void IS31FL3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
+        if (g_pwm_buffer[led.driver][led.r] == red &&
+            g_pwm_buffer[led.driver][led.g] == green &&
+            g_pwm_buffer[led.driver][led.b] == blue) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -169,9 +169,7 @@ void IS31FL3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
-        if (g_pwm_buffer[led.driver][led.r] == red &&
-            g_pwm_buffer[led.driver][led.g] == green &&
-            g_pwm_buffer[led.driver][led.b] == blue) {
+        if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
         g_pwm_buffer[led.driver][led.r]          = red;

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -176,9 +176,7 @@ void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
-        if (g_pwm_buffer[led.driver][led.r] == red &&
-            g_pwm_buffer[led.driver][led.g] == green &&
-            g_pwm_buffer[led.driver][led.b] == blue) {
+        if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
         g_pwm_buffer[led.driver][led.r]          = red;

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -176,6 +176,11 @@ void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
+        if (g_pwm_buffer[led.driver][led.r] == red &&
+            g_pwm_buffer[led.driver][led.g] == green &&
+            g_pwm_buffer[led.driver][led.b] == blue) {
+            return;
+        }
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -180,10 +180,7 @@ void IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
-        if (g_pwm_buffer[led.driver][led.r] == red &&
-            g_pwm_buffer[led.driver][led.g] == green &&
-            g_pwm_buffer[led.driver][led.b] == blue
-            ) {
+        if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
         g_pwm_buffer_update_required[led.driver] = true;

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -180,10 +180,16 @@ void IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
+        if (g_pwm_buffer[led.driver][led.r] == red &&
+            g_pwm_buffer[led.driver][led.g] == green &&
+            g_pwm_buffer[led.driver][led.b] == blue
+            ) {
+            return;
+        }
+        g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;
-        g_pwm_buffer_update_required[led.driver] = true;
     }
 }
 

--- a/drivers/led/issi/is31flcommon.c
+++ b/drivers/led/issi/is31flcommon.c
@@ -139,9 +139,7 @@ void IS31FL_set_manual_scaling_buffer(void) {
         if (scale.driver >= 0 && scale.driver < RGB_MATRIX_LED_COUNT) {
             is31_led led = g_is31_leds[scale.driver];
 
-            if (g_scaling_buffer[led.driver][led.r] = scale.r &&
-                g_scaling_buffer[led.driver][led.g] = scale.g &&
-                g_scaling_buffer[led.driver][led.b] = scale.b) {
+            if (g_scaling_buffer[led.driver][led.r] = scale.r && g_scaling_buffer[led.driver][led.g] = scale.g && g_scaling_buffer[led.driver][led.b] = scale.b) {
                 return;
             }
             g_scaling_buffer[led.driver][led.r] = scale.r;

--- a/drivers/led/issi/is31flcommon.c
+++ b/drivers/led/issi/is31flcommon.c
@@ -139,6 +139,11 @@ void IS31FL_set_manual_scaling_buffer(void) {
         if (scale.driver >= 0 && scale.driver < RGB_MATRIX_LED_COUNT) {
             is31_led led = g_is31_leds[scale.driver];
 
+            if (g_scaling_buffer[led.driver][led.r] = scale.r &&
+                g_scaling_buffer[led.driver][led.g] = scale.g &&
+                g_scaling_buffer[led.driver][led.b] = scale.b) {
+                return;
+            }
             g_scaling_buffer[led.driver][led.r] = scale.r;
             g_scaling_buffer[led.driver][led.g] = scale.g;
             g_scaling_buffer[led.driver][led.b] = scale.b;
@@ -146,6 +151,9 @@ void IS31FL_set_manual_scaling_buffer(void) {
         if (scale.driver >= 0 && scale.driver < LED_MATRIX_LED_COUNT) {
             is31_led led = g_is31_leds[scale.driver];
 
+            if (g_scaling_buffer[led.driver][led.v] == scale.v) {
+                return;
+            }
             g_scaling_buffer[led.driver][led.v] = scale.v;
 #    endif
             g_scaling_buffer_update_required[led.driver] = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Actually uses the buffer/driver check to see if an i2c/spi flush is required to LED drivers.

Tested on STM32L4 + IS31FL3741 (pachi/rgb/rev2)

Effect Speed default (128)
For reference off is ~8171
<table>
<tr>
 <td>Effect
 <td>Old Scan Rate
 <td>New Scan Rate
<tr>
 <td>Solid Colour
 <td>2926
 <td>8127
<tr>
 <td>Gradient Up/Down
 <td>2858
 <td>8062
<tr>
 <td>Cycle All
 <td>2840
 <td>3594~3998
<tr>
 <td>Cycle Spiral
 <td>2719
 <td>2708
</table>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Prevent static animations to keep pushing i2c/spi commands slowing down overall scan rate

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
