### PR TITLE
[Core] RGB matrix ws2812 update

### DIFF
--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -426,11 +426,17 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 
 // LED color buffer
 LED_TYPE rgb_matrix_ws2812_array[RGB_MATRIX_LED_COUNT];
+bool ws2812_dirty = false;
 
-static void init(void) {}
+static void init(void) {
+    ws2812_dirty = false;
+}
 
 static void flush(void) {
-    ws2812_setleds(rgb_matrix_ws2812_array, RGB_MATRIX_LED_COUNT);
+    if (ws2812_dirty) {
+        ws2812_setleds(rgb_matrix_ws2812_array, RGB_MATRIX_LED_COUNT);
+        ws2812_dirty = false;
+    }
 }
 
 // Set an led in the buffer to a color
@@ -448,6 +454,13 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
     }
 #    endif
 
+    if (rgb_matrix_ws2812_array[i].r == r &&
+        rgb_matrix_ws2812_array[i].g == g &&
+        rgb_matrix_ws2812_array[i].b == b){
+        return;
+    }
+
+    ws2812_dirty = true;
     rgb_matrix_ws2812_array[i].r = r;
     rgb_matrix_ws2812_array[i].g = g;
     rgb_matrix_ws2812_array[i].b = b;

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -454,9 +454,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
     }
 #    endif
 
-    if (rgb_matrix_ws2812_array[i].r == r &&
-        rgb_matrix_ws2812_array[i].g == g &&
-        rgb_matrix_ws2812_array[i].b == b){
+    if (rgb_matrix_ws2812_array[i].r == r && rgb_matrix_ws2812_array[i].g == g && rgb_matrix_ws2812_array[i].b == b) {
         return;
     }
 

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -458,7 +458,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
         return;
     }
 
-    ws2812_dirty = true;
+    ws2812_dirty                 = true;
     rgb_matrix_ws2812_array[i].r = r;
     rgb_matrix_ws2812_array[i].g = g;
     rgb_matrix_ws2812_array[i].b = b;

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -426,7 +426,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 
 // LED color buffer
 LED_TYPE rgb_matrix_ws2812_array[RGB_MATRIX_LED_COUNT];
-bool ws2812_dirty = false;
+bool     ws2812_dirty = false;
 
 static void init(void) {
     ws2812_dirty = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Goes with https://github.com/qmk/qmk_firmware/pull/21134 . This change makes it so that the WS2812 doesn't update every cycle if no RGB LEDs have updated colour. (mainly for static and bitbang applications)

**Untested because I don't have any WS2812 only rgb matrix boards**

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* WS2812 don't update every RGB Matrix cycle

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
