### PR TITLE
[Bugfix] LVGL bindings wrong offset math

### DIFF
--- a/quantum/painter/lvgl/qp_lvgl.c
+++ b/quantum/painter/lvgl/qp_lvgl.c
@@ -112,9 +112,6 @@ bool qp_lvgl_attach(painter_device_t device) {
     uint16_t panel_width, panel_height, offset_x, offset_y;
     qp_get_geometry(selected_display, &panel_width, &panel_height, NULL, &offset_x, &offset_y);
 
-    panel_width -= offset_x;
-    panel_height -= offset_y;
-
     // Setting up display driver
     static lv_disp_drv_t disp_drv;     /*Descriptor of a display driver*/
     lv_disp_drv_init(&disp_drv);       /*Basic initialization*/


### PR DESCRIPTION
## Description

QP-LVGL glue code has an bug. It computes panel size to be sent to LVGL as `width - offset_x` (and same for y), but that subtraction is not needed since the size is already the area in which we can draw, not size + offset (which doesnt even make much sense anyway).

## Types of Changes

- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://discord.com/channels/440868230475677696/440868230475677698/1115565012644274236

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
