### PR TITLE
Use unsigned integer for kinetic speed

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -74,7 +74,7 @@ uint8_t mk_time_to_max = MOUSEKEY_TIME_TO_MAX;
 uint8_t mk_wheel_delay = MOUSEKEY_WHEEL_DELAY / 10;
 /* milliseconds between repeated motion events (0-255) */
 #    ifdef MK_KINETIC_SPEED
-float mk_wheel_interval = 1000.0f / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
+uint16_t mk_wheel_interval = 1000U / MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
 #    else
 uint8_t mk_wheel_interval = MOUSEKEY_WHEEL_INTERVAL;
 #    endif
@@ -190,37 +190,37 @@ const uint16_t mk_decelerated_speed = MOUSEKEY_DECELERATED_SPEED;
 const uint16_t mk_initial_speed     = MOUSEKEY_INITIAL_SPEED;
 
 static uint8_t move_unit(void) {
-    float speed = mk_initial_speed;
+    uint16_t speed = mk_initial_speed;
 
     if (mousekey_accel & ((1 << 0) | (1 << 2))) {
         speed = mousekey_accel & (1 << 2) ? mk_accelerated_speed : mk_decelerated_speed;
     } else if (mousekey_repeat && mouse_timer) {
-        const float time_elapsed = timer_elapsed(mouse_timer) / 50;
-        speed                    = mk_initial_speed + MOUSEKEY_MOVE_DELTA * time_elapsed + MOUSEKEY_MOVE_DELTA * 0.5 * time_elapsed * time_elapsed;
+        const uint16_t time_elapsed = timer_elapsed(mouse_timer) / 50;
+        speed                       = mk_initial_speed + MOUSEKEY_MOVE_DELTA * time_elapsed + MOUSEKEY_MOVE_DELTA * 0.5 * time_elapsed * time_elapsed;
 
         speed = speed > mk_base_speed ? mk_base_speed : speed;
     }
 
     /* convert speed to USB mouse speed 1 to 127 */
-    speed = (uint8_t)(speed / (1000.0f / mk_interval));
+    speed = (uint8_t)(speed / (1000U / mk_interval));
     speed = speed < 1 ? 1 : speed;
 
     return speed > MOUSEKEY_MOVE_MAX ? MOUSEKEY_MOVE_MAX : speed;
 }
 
 static uint8_t wheel_unit(void) {
-    float speed = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
+    uint16_t speed = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
 
     if (mousekey_accel & ((1 << 0) | (1 << 2))) {
         speed = mousekey_accel & (1 << 2) ? MOUSEKEY_WHEEL_ACCELERATED_MOVEMENTS : MOUSEKEY_WHEEL_DECELERATED_MOVEMENTS;
     } else if (mousekey_wheel_repeat && mouse_timer) {
         if (mk_wheel_interval != MOUSEKEY_WHEEL_BASE_MOVEMENTS) {
-            const float time_elapsed = timer_elapsed(mouse_timer) / 50;
-            speed                    = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS + 1 * time_elapsed + 1 * 0.5 * time_elapsed * time_elapsed;
+            const uint16_t time_elapsed = timer_elapsed(mouse_timer) / 50;
+            speed                       = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS + 1 * time_elapsed + 1 * 0.5 * time_elapsed * time_elapsed;
         }
         speed = speed > MOUSEKEY_WHEEL_BASE_MOVEMENTS ? MOUSEKEY_WHEEL_BASE_MOVEMENTS : speed;
     }
-    mk_wheel_interval = 1000.0f / speed;
+    mk_wheel_interval = 1000U / speed;
 
     return (uint8_t)speed > MOUSEKEY_WHEEL_INITIAL_MOVEMENTS ? 2 : 1;
 }


### PR DESCRIPTION
## Description

The current kinetic mouse key function uses resource-intensive floating point to compute the quadratic curve speed. But the result is returned as an unsigned 8-bit integer value. The code line where fractional accuracy is important is at the division of `speed = (uint8_t)(speed / (1000.0f / mk_interval));`

This change uses 16-bit integers for the quadratic calculation variables, which are less resource-intensive. The output acceleration curve is almost unchanged with the default `MOUSEKEY_INTERVAL` value.

Truncation is used to round division output to an integer. With higher `MOUSEKEY_INTERVAL` values, rounding appears more accurate using 16-bit integer versus floating point. Example:

`mk_interval = 30`

| speed | (uint8_t)(speed / (1000.0f / mk_interval)) | (uint8_t)(speed / (1000U / mk_interval)) |
|------|----|----|
|  292 |  8 |  9 |
|  484 | 14 | 15 |
| 1060 | 31 | 32 |
| 1660 | 49 | 50 |

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
