### PR TITLE
Reset `matrix_need_update` properly in eager debouncing algorithms

### DIFF
--- a/quantum/debounce/asym_eager_defer_pk.c
+++ b/quantum/debounce/asym_eager_defer_pk.c
@@ -144,6 +144,8 @@ static void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[],
 static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows) {
     debounce_counter_t *debounce_pointer = debounce_counters;
 
+    matrix_need_update = false;
+
     for (uint8_t row = 0; row < num_rows; row++) {
         matrix_row_t delta = raw[row] ^ cooked[row];
         for (uint8_t col = 0; col < MATRIX_COLS; col++) {

--- a/quantum/debounce/sym_eager_pk.c
+++ b/quantum/debounce/sym_eager_pk.c
@@ -125,6 +125,7 @@ static void update_debounce_counters(uint8_t num_rows, uint8_t elapsed_time) {
 
 // upload from raw_matrix to final matrix;
 static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows) {
+    matrix_need_update                   = false;
     debounce_counter_t *debounce_pointer = debounce_counters;
     for (uint8_t row = 0; row < num_rows; row++) {
         matrix_row_t delta        = raw[row] ^ cooked[row];

--- a/quantum/debounce/sym_eager_pr.c
+++ b/quantum/debounce/sym_eager_pr.c
@@ -119,6 +119,7 @@ static void update_debounce_counters(uint8_t num_rows, uint8_t elapsed_time) {
 
 // upload from raw_matrix to final matrix;
 static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows) {
+    matrix_need_update                   = false;
     debounce_counter_t *debounce_pointer = debounce_counters;
     for (uint8_t row = 0; row < num_rows; row++) {
         matrix_row_t existing_row = cooked[row];


### PR DESCRIPTION
doing this PR before it gets forgotten again. Fixes the significant performance drop when using one of the affected debounce algorithms.
example: `6400` matrix scan rates slow down to `5800` when a key is pressed and doesn't recover. Same test on another board, `1700`-> `1450`. With this patch the scan rate is consistent and stable.
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
The `matrix_need_update` variable needs to be reset to `false` in `transfer_matrix_values()`, otherwise that function continues to be invoked for every scanning loop (forever with `sym_eager_pk` and `sym_eager_pk`, or until some key gets released with `asym_eager_defer_pk`), and the scanning rate gets much lower because of all that useless work.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
