### PR TITLE
Refactor kinetic mouse key feature

### DIFF
--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -101,7 +101,7 @@ This is an extension of the accelerated mode. The kinetic mode uses a quadratic 
 Tips:
 
 * The smoothness of the cursor movement depends on the `MOUSEKEY_INTERVAL` setting. The shorter the interval is set the smoother the movement will be.  Setting the value too low makes the cursor unresponsive.  Lower settings are possible if the micro processor is fast enough. For example: At an interval of `8` milliseconds, `125` movements per second will be initiated.  With a base speed of `1000` each movement will move the cursor by `8` pixels.
-* Mouse wheel movements are implemented differently from cursor movements. While it's okay for the cursor to move multiple pixels at once for the mouse wheel this would lead to jerky movements. Instead, the mouse wheel operates at step size `2`. Setting mouse wheel speed is done by adjusting the number of wheel movements per second.
+* Mouse wheel movements are implemented differently from cursor movements. While it's okay for the cursor to move multiple pixels at once for the mouse wheel this would lead to jerky movements. Instead, the mouse wheel operates at step size `1`. Setting mouse wheel speed is done by adjusting the number of wheel movements per second.
 
 ### Constant mode
 

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -192,37 +192,46 @@ const uint16_t mk_initial_speed     = MOUSEKEY_INITIAL_SPEED;
 static uint8_t move_unit(void) {
     uint16_t speed = mk_initial_speed;
 
-    if (mousekey_accel & ((1 << 0) | (1 << 2))) {
-        speed = mousekey_accel & (1 << 2) ? mk_accelerated_speed : mk_decelerated_speed;
+    if (mousekey_accel & (1 << 0)) {
+        speed = mk_decelerated_speed;
+    } else if (mousekey_accel & (1 << 2)) {
+        speed = mk_accelerated_speed;
     } else if (mousekey_repeat && mouse_timer) {
         const uint16_t time_elapsed = timer_elapsed(mouse_timer) / 50;
         speed                       = mk_initial_speed + MOUSEKEY_MOVE_DELTA * time_elapsed + (MOUSEKEY_MOVE_DELTA * time_elapsed * time_elapsed) / 2;
-
-        speed = speed > mk_base_speed ? mk_base_speed : speed;
+        if (speed > mk_base_speed) {
+            speed = mk_base_speed;
+        }
     }
-
     /* convert speed to USB mouse speed 1 to 127 */
     speed = (uint8_t)(speed / (1000U / mk_interval));
-    speed = speed < 1 ? 1 : speed;
 
-    return speed > MOUSEKEY_MOVE_MAX ? MOUSEKEY_MOVE_MAX : speed;
+    if (speed > MOUSEKEY_MOVE_MAX) {
+        speed = MOUSEKEY_MOVE_MAX;
+    } else if (speed < 1) {
+        speed = 1;
+    }
+    return speed;
 }
 
 static uint8_t wheel_unit(void) {
     uint16_t speed = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS;
 
-    if (mousekey_accel & ((1 << 0) | (1 << 2))) {
-        speed = mousekey_accel & (1 << 2) ? MOUSEKEY_WHEEL_ACCELERATED_MOVEMENTS : MOUSEKEY_WHEEL_DECELERATED_MOVEMENTS;
+    if (mousekey_accel & (1 << 0)) {
+        speed = MOUSEKEY_WHEEL_DECELERATED_MOVEMENTS;
+    } else if (mousekey_accel & (1 << 2)) {
+        speed = MOUSEKEY_WHEEL_ACCELERATED_MOVEMENTS;
     } else if (mousekey_wheel_repeat && mouse_timer) {
         if (mk_wheel_interval != MOUSEKEY_WHEEL_BASE_MOVEMENTS) {
             const uint16_t time_elapsed = timer_elapsed(mouse_timer) / 50;
             speed                       = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS + 1 * time_elapsed + (1 * time_elapsed * time_elapsed) / 2;
         }
-        speed = speed > MOUSEKEY_WHEEL_BASE_MOVEMENTS ? MOUSEKEY_WHEEL_BASE_MOVEMENTS : speed;
+        if (speed > MOUSEKEY_WHEEL_BASE_MOVEMENTS) {
+            speed = MOUSEKEY_WHEEL_BASE_MOVEMENTS;
+        }
     }
     mk_wheel_interval = 1000U / speed;
-
-    return (uint8_t)speed > MOUSEKEY_WHEEL_INITIAL_MOVEMENTS ? 2 : 1;
+    return 1;
 }
 
 #        endif /* #ifndef MK_KINETIC_SPEED */

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -175,7 +175,7 @@ static uint8_t wheel_unit(void) {
 /*
  * Kinetic movement  acceleration algorithm
  *
- *  current speed = I + A * T/50 + A * 0.5 * T^2 | maximum B
+ *  current speed = I + A * T/50 + A * (T/50)^2 * 1/2 | maximum B
  *
  * T: time since the mouse movement started
  * E: mouse events per second (set through MOUSEKEY_INTERVAL, UHK sends 250, the
@@ -196,7 +196,7 @@ static uint8_t move_unit(void) {
         speed = mousekey_accel & (1 << 2) ? mk_accelerated_speed : mk_decelerated_speed;
     } else if (mousekey_repeat && mouse_timer) {
         const uint16_t time_elapsed = timer_elapsed(mouse_timer) / 50;
-        speed                       = mk_initial_speed + MOUSEKEY_MOVE_DELTA * time_elapsed + MOUSEKEY_MOVE_DELTA * 0.5 * time_elapsed * time_elapsed;
+        speed                       = mk_initial_speed + MOUSEKEY_MOVE_DELTA * time_elapsed + (MOUSEKEY_MOVE_DELTA * time_elapsed * time_elapsed) / 2;
 
         speed = speed > mk_base_speed ? mk_base_speed : speed;
     }
@@ -216,7 +216,7 @@ static uint8_t wheel_unit(void) {
     } else if (mousekey_wheel_repeat && mouse_timer) {
         if (mk_wheel_interval != MOUSEKEY_WHEEL_BASE_MOVEMENTS) {
             const uint16_t time_elapsed = timer_elapsed(mouse_timer) / 50;
-            speed                       = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS + 1 * time_elapsed + 1 * 0.5 * time_elapsed * time_elapsed;
+            speed                       = MOUSEKEY_WHEEL_INITIAL_MOVEMENTS + 1 * time_elapsed + (1 * time_elapsed * time_elapsed) / 2;
         }
         speed = speed > MOUSEKEY_WHEEL_BASE_MOVEMENTS ? MOUSEKEY_WHEEL_BASE_MOVEMENTS : speed;
     }


### PR DESCRIPTION
## Description

* Use division by integer

Replace multiplication of fractional decimal numbers with division by integer to avoid floating point operations. This change will reduce compiled firmware size.

* Refactor if-else statements

Simplify duplicate `if` conditions and refactor ternary statements for consistency with the rest of the file.

* Revert kinetic wheel workaround

Revert mouse key wheel step size to `1` because stuck mouse wheel issue was fixed in #17493.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
