### PR TITLE
Add an emphasis on QMK MSYS terminal

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -120,7 +120,7 @@ NOTE: remember to follow the instructions printed at the end of installation (us
 
 ### ** Windows **
 
-After installing QMK you can set it up with this command:
+Open QMK MSYS and run the following command:
 
     qmk setup
 
@@ -128,7 +128,7 @@ In most situations you will want to answer `y` to all of the prompts.
 
 ### ** macOS **
 
-After installing QMK you can set it up with this command:
+After installing QMK, open Terminal and run the following command:
 
     qmk setup
 
@@ -136,7 +136,7 @@ In most situations you will want to answer `y` to all of the prompts.
 
 ### ** Linux/WSL **
 
-After installing QMK you can set it up with this command:
+After installing QMK, open your preferred terminal app and run the following command:
 
     qmk setup
 
@@ -150,7 +150,7 @@ Luckily, the fix is easy. Run this as your user: `echo 'PATH="$HOME/.local/bin:$
 
 ###  ** FreeBSD **
 
-After installing QMK you can set it up with this command:
+After installing QMK, open your preferred terminal app and run the following command:
 
     qmk setup
 

--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -128,7 +128,7 @@ In most situations you will want to answer `y` to all of the prompts.
 
 ### ** macOS **
 
-After installing QMK, open Terminal and run the following command:
+Open Terminal and run the following command:
 
     qmk setup
 
@@ -136,7 +136,7 @@ In most situations you will want to answer `y` to all of the prompts.
 
 ### ** Linux/WSL **
 
-After installing QMK, open your preferred terminal app and run the following command:
+Open your preferred terminal app and run the following command:
 
     qmk setup
 
@@ -150,7 +150,7 @@ Luckily, the fix is easy. Run this as your user: `echo 'PATH="$HOME/.local/bin:$
 
 ###  ** FreeBSD **
 
-After installing QMK, open your preferred terminal app and run the following command:
+Open your preferred terminal app and run the following command:
 
     qmk setup
 


### PR DESCRIPTION
## Description

Not using MSYS terminal is a frequent user error. This change adds an additional statement to guide users to run the first command in MSYS itself. Edited the same statement for consistency for the other OSes.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
