### PR TITLE
teleport/native: switch from wrongly used user to kb function, boost matrix scan rate

### DIFF
--- a/keyboards/teleport/native/ansi/keymaps/perfmode/config.h
+++ b/keyboards/teleport/native/ansi/keymaps/perfmode/config.h
@@ -21,3 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Increase eeprom size to allow for 5 layers */
 #define WEAR_LEVELING_BACKING_SIZE 16384
 #define WEAR_LEVELING_LOGICAL_SIZE 4096
+
+/* Increase debounce, as asym eager seems to lead to chatter with the fast polling rate in some cases */
+#define DEBOUNCE 7

--- a/keyboards/teleport/native/ansi/keymaps/perfmode/keymap.c
+++ b/keyboards/teleport/native/ansi/keymaps/perfmode/keymap.c
@@ -15,6 +15,9 @@
  */
 #include QMK_KEYBOARD_H
 
+// tested and working
+void matrix_io_delay(void) { __asm__ volatile("nop\nnop\nnop\n"); }
+
 enum layers{
     BASE,
     GAME,

--- a/keyboards/teleport/native/ansi/keymaps/perfmode/rules.mk
+++ b/keyboards/teleport/native/ansi/keymaps/perfmode/rules.mk
@@ -1,4 +1,5 @@
 DEBOUNCE_TYPE = asym_eager_defer_pk 
+OPT = 3
 
 VIA_ENABLE = yes
  

--- a/keyboards/teleport/native/ansi/keymaps/perfmode/rules.mk
+++ b/keyboards/teleport/native/ansi/keymaps/perfmode/rules.mk
@@ -1,5 +1,5 @@
 DEBOUNCE_TYPE = asym_eager_defer_pk 
-OPT = 3
+OPT = 2
 
 VIA_ENABLE = yes
  

--- a/keyboards/teleport/native/info.json
+++ b/keyboards/teleport/native/info.json
@@ -16,7 +16,7 @@
     "features": {
         "bootmagic": true,
         "command": false,
-        "console": true,
+        "console": false,
         "extrakey": true,
         "mousekey": true,
         "nkro": true,

--- a/keyboards/teleport/native/info.json
+++ b/keyboards/teleport/native/info.json
@@ -16,10 +16,11 @@
     "features": {
         "bootmagic": true,
         "command": false,
-        "console": false,
+        "console": true,
         "extrakey": true,
         "mousekey": true,
-        "nkro": true
+        "nkro": true,
+        "lto": true
     },
     "diode_direction": "ROW2COL",
     "matrix_pins": {

--- a/keyboards/teleport/native/iso/keymaps/perfmode/config.h
+++ b/keyboards/teleport/native/iso/keymaps/perfmode/config.h
@@ -21,3 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Increase eeprom size to allow for 5 layers */
 #define WEAR_LEVELING_BACKING_SIZE 16384
 #define WEAR_LEVELING_LOGICAL_SIZE 4096
+
+/* Increase debounce, as asym eager seems to lead to chatter with the fast polling rate in some cases */
+#define DEBOUNCE 7

--- a/keyboards/teleport/native/iso/keymaps/perfmode/keymap.c
+++ b/keyboards/teleport/native/iso/keymaps/perfmode/keymap.c
@@ -15,6 +15,9 @@
  */
 #include QMK_KEYBOARD_H
 
+// tested and working
+void matrix_io_delay(void) { __asm__ volatile("nop\nnop\nnop\n"); }
+
 enum layers{
     BASE,
     GAME,

--- a/keyboards/teleport/native/iso/keymaps/perfmode/rules.mk
+++ b/keyboards/teleport/native/iso/keymaps/perfmode/rules.mk
@@ -1,4 +1,5 @@
 DEBOUNCE_TYPE = asym_eager_defer_pk 
+OPT = 3
 
 VIA_ENABLE = yes
  

--- a/keyboards/teleport/native/iso/keymaps/perfmode/rules.mk
+++ b/keyboards/teleport/native/iso/keymaps/perfmode/rules.mk
@@ -1,5 +1,5 @@
 DEBOUNCE_TYPE = asym_eager_defer_pk 
-OPT = 3
+OPT = 2
 
 VIA_ENABLE = yes
  

--- a/keyboards/teleport/native/native.c
+++ b/keyboards/teleport/native/native.c
@@ -20,6 +20,8 @@
 void keyboard_post_init_kb(void) {
     setPinOutput(B9);
     writePinHigh(B9);
+    
+    keyboard_post_init_user();
 }
 
 #ifdef RGB_MATRIX_ENABLE

--- a/keyboards/teleport/native/native.c
+++ b/keyboards/teleport/native/native.c
@@ -17,7 +17,7 @@
 #include "quantum.h"
 
 /* This board has !SDB of the is31 wired to D2. Set high to enable */
-void keyboard_post_init_user(void) {
+void keyboard_post_init_kb(void) {
     setPinOutput(B9);
     writePinHigh(B9);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
This PR makes a few changes to the Native keyboard. First, it enables LTO for all keymaps, and replaces a `keyboard_post_init_user()` function with `keyboard_post_init_kb()` in native.c - as far as I am aware, _user functions should be used in keymaps, _kb functions in board-wide code files.

In addition, on the highly customized "perfmode" keymaps, it will replace the matrix delays with nops and add `OPT=2` to rules.mk. Both together lead to a significant speed-up of matrix scan rates, from about 3 kHz to 13.5 kHz (disabled LEDs, or static LEDs together with PR #21134).

The board was originally tested and working fine with `OPT=3`, but I was told `3` could lead to issues with custom keymaps enabling other features by other users eventually, so decided to play safe and stay at `2`. 13.5 kHz is plenty.

This firmware has been tested over a few days on an ISO board without issues.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Native had _user function in native.c, replaced by _kb function

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
