### PR TITLE
fix `scheikled` keymap for `dactyl_manuform/4x6`

### DIFF
--- a/keyboards/handwired/dactyl_manuform/4x6/keymaps/scheikled/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/4x6/keymaps/scheikled/keymap.c
@@ -4,7 +4,7 @@
 /* A K.O,Y layout for the Dactyl Manuform 4x6 Keyboard */
 
 #include QMK_KEYBOARD_H
-#include "users/scheiklp/koy_keys_on_quertz_de_latin1.h"
+#include "koy_keys_on_quertz_de_latin1.h"
 
 enum custom_layers {
     _1,

--- a/keyboards/handwired/dactyl_manuform/4x6/keymaps/scheikled/keymap.c
+++ b/keyboards/handwired/dactyl_manuform/4x6/keymaps/scheikled/keymap.c
@@ -4,7 +4,7 @@
 /* A K.O,Y layout for the Dactyl Manuform 4x6 Keyboard */
 
 #include QMK_KEYBOARD_H
-#include "koy_keys_on_quertz_de_latin1.h"
+#include "users/scheiklp/koy_keys_on_quertz_de_latin1.h"
 
 enum custom_layers {
     _1,
@@ -60,5 +60,4 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                                         N_PASTE     , N_UNDO        ,      KC_BSPC , KC_DEL
 
   ),
-
 };

--- a/keyboards/handwired/dactyl_manuform/4x6/keymaps/scheikled/rules.mk
+++ b/keyboards/handwired/dactyl_manuform/4x6/keymaps/scheikled/rules.mk
@@ -8,3 +8,4 @@ COMMAND_ENABLE = no
 NKRO_ENABLE = yes
 RGBLIGHT_ENABLE = yes
 DEBOUNCE_TYPE = asym_eager_defer_pk
+USER_NAME := scheiklp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Amend named keymap to prevent compilation failure

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
