### PR TITLE
feat, docs: WB32 flashing

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -322,6 +322,29 @@ Flashing sequence:
 3. Flash a .bin file
 4. Reset the device into application mode (may be done automatically)
 
+## WB32 DFU
+
+Some keyboards produced for several commercial brands (GMMK, Akko, MonsGeek, Inland) use this bootloader. The `wb32-dfu-updater` utility is bundled with [QMK MSYS](https://msys.qmk.fm/) and [Glorious's build of QMK Toolbox](https://www.gloriousgaming.com/blogs/guides-resources/gmmk-2-qmk-installation-guide). If neither of these flashing methods is available for your OS, you will likely need to [compile the CLI version from source](https://github.com/WestberryTech/wb32-dfu-updater).
+
+The `info.json` setting for this bootloader is `wb32-dfu`.
+
+Compatible flashers:
+
+* [Glorious's build of QMK Toolbox](https://www.gloriousgaming.com/blogs/guides-resources/gmmk-2-qmk-installation-guide) (recommended GUI)
+* [wb32-dfu-updater_cli](https://github.com/WestberryTech/wb32-dfu-updater) / `:flash` target in QMK (recommended command line)
+  ```
+  wb32-dfu-updater_cli -t -s 0x8000000 -D <filename>
+  ```
+
+Flashing sequence:
+
+1. Enter the bootloader using any of the following methods:
+    * Tap the `QK_BOOT` keycode
+    * Press the `RESET` button on the PCB
+2. Wait for the OS to detect the device
+3. Flash a .bin file
+4. Reset the device into application mode (may be done automatically)
+
 ## tinyuf2
 
 Keyboards may opt into supporting the tinyuf2 bootloader. This is currently only supported on F303/F401/F411.

--- a/lib/python/qmk/constants.py
+++ b/lib/python/qmk/constants.py
@@ -82,6 +82,7 @@ BOOTLOADER_VIDS_PIDS = {
     },
     'apm32-dfu': {("314b", "0106")},
     'gd32v-dfu': {("28e9", "0189")},
+    'wb32-dfu': {("342d", "dfa0")},
     'bootloadhid': {("16c0", "05df")},
     'usbasploader': {("16c0", "05dc")},
     'usbtinyisp': {("1782", "0c9f")},

--- a/lib/python/qmk/flashers.py
+++ b/lib/python/qmk/flashers.py
@@ -96,7 +96,7 @@ def _find_bootloader():
                             details = 'halfkay'
                         else:
                             details = 'qmk-hid'
-                    elif bl == 'stm32-dfu' or bl == 'apm32-dfu' or bl == 'gd32v-dfu' or bl == 'kiibohd':
+                    elif bl in {'apm32-dfu', 'gd32v-dfu', 'kiibohd', 'stm32-dfu'}:
                         details = (vid, pid)
                     else:
                         details = None
@@ -181,9 +181,18 @@ def _flash_dfu_util(details, file):
         cli.run(['dfu-util', '-a', '0', '-d', f'{details[0]}:{details[1]}', '-s', '0x08000000:leave', '-D', file], capture_output=False)
 
 
+def _flash_wb32_dfu_updater(file):
+    if shutil.which('wb32-dfu-updater_cli'):
+        cmd = 'wb32-dfu-updater_cli'
+    else:
+        return True
+
+    cli.run([cmd, '-t', '-s', '0x08000000', '-D', file], capture_output=False)
+
+
 def _flash_isp(mcu, programmer, file):
     programmer = 'usbasp' if programmer == 'usbasploader' else 'usbtiny'
-    # Check if the provide mcu has an avrdude-specific name, otherwise pass on what the user provided
+    # Check if the provided mcu has an avrdude-specific name, otherwise pass on what the user provided
     mcu = AVRDUDE_MCU.get(mcu, mcu)
     cli.run(['avrdude', '-p', mcu, '-c', programmer, '-U', f'flash:w:{file}:i'], capture_output=False)
 
@@ -211,8 +220,11 @@ def flasher(mcu, file):
                 return (True, "Please make sure 'teensy_loader_cli' or 'hid_bootloader_cli' is available on your system.")
         else:
             return (True, "Specifying the MCU with '-m' is necessary for HalfKay/HID bootloaders!")
-    elif bl == 'stm32-dfu' or bl == 'apm32-dfu' or bl == 'gd32v-dfu' or bl == 'kiibohd':
+    elif bl in {'apm32-dfu', 'gd32v-dfu', 'kiibohd', 'stm32-dfu'}:
         _flash_dfu_util(details, file)
+    elif bl == 'wb32-dfu':
+        if _flash_wb32_dfu_updater(file):
+            return (True, "Please make sure 'wb32-dfu-updater_cli' is available on your system.")
     elif bl == 'usbasploader' or bl == 'usbtinyisp':
         if mcu:
             _flash_isp(mcu, bl, file)


### PR DESCRIPTION
## Description

Attempts to make `qmk flash path/to/binary.bin` work for WB32, and adds documentation about flashing source code through the CLI (...as it will not work for non-MSYS users OOTB)

There are also some very minor formatting changes to `flashers.py`.

**I do not own any WB32 boards and cannot fully test this.**
Perhaps @itarze, @jonylee1986 or one of the users who has run into this problem can provide feedback/test.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

#21216

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
