### PR TITLE
Left Control is now ESC when tapped

### DIFF
--- a/keyboards/lily58/keymaps/gaston/keymap.c
+++ b/keyboards/lily58/keymaps/gaston/keymap.c
@@ -26,6 +26,7 @@ enum layer_number {
 
 #define EN_LOWER LT(_LOWER, KC_SPC)
 #define EN_MOUSE MO(_MOUSE)
+#define MT_CESC LCTL_T(KC_ESC)
 
 /* See the readme.md file for an ASCII representation of this keymap. */
 
@@ -34,13 +35,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_QWERTY] = LAYOUT(
     KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,                       KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC,
     KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                       KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_MINS,
-    KC_LCTL, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,                       KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+    MT_CESC, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,                       KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
     KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    EN_MOUSE,KC_EQL,   KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT,
                                KC_RALT, KC_LALT, KC_LGUI, EN_LOWER,EN_LOWER, KC_LBRC, KC_RBRC, KC_BSLS
 ),
 
 [_LOWER] = LAYOUT(
-    KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                     KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
+    KC_TRNS,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                     KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
     KC_TRNS, XXXXXXX, KC_MUTE, KC_VOLD, KC_VOLU, XXXXXXX,                   KC_HOME, KC_PGDN, KC_PGUP, KC_END,  XXXXXXX, KC_F12,
     KC_TRNS, XXXXXXX, KC_MPRV, KC_MPLY, KC_MNXT, XXXXXXX,                   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, XXXXXXX, XXXXXXX,
     KC_TRNS, XXXXXXX, XXXXXXX, KC_BRID, KC_BRIU, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, KC_INS,  KC_DEL,  XXXXXXX, XXXXXXX, XXXXXXX,

--- a/keyboards/lily58/keymaps/gaston/readme.md
+++ b/keyboards/lily58/keymaps/gaston/readme.md
@@ -10,6 +10,7 @@ The main characteristics of this keymap are:
   * The main thumb buttons are spaces when tapped and enable the LOWER layer
     when held.
   * Vim style arrow keys.
+  * Left Control is ESC when tapped.
   * Left and right ALT in case you need different behaviors. (For example, the
     default Option and readline's Alt behavior in macOS.)
 * The LOWER layer has mostly meta keys.
@@ -23,7 +24,7 @@ The main characteristics of this keymap are:
 |------+------+------+------+------+------|                    |------+------+------+------+------+------|
 | TAB  |   Q  |   W  |   E  |   R  |   T  |                    |   Y  |   U  |   I  |   O  |   P  |  -   |
 |------+------+------+------+------+------|                    |------+------+------+------+------+------|
-|LCTRL |   A  |   S  |   D  |   F  |   G  |-------.    ,-------|   H  |   J  |   K  |   L  |   ;  |  '   |
+|C_ESC |   A  |   S  |   D  |   F  |   G  |-------.    ,-------|   H  |   J  |   K  |   L  |   ;  |  '   |
 |------+------+------+------+------+------| MOUSE |    |    =  |------+------+------+------+------+------|
 | LSFT |   Z  |   X  |   C  |   V  |   B  |-------|    |-------|   N  |   M  |   ,  |   .  |   /  | ENT  |
 `-----------------------------------------/  LT   /     \  LT   \----------------------------------------'
@@ -36,7 +37,7 @@ The main characteristics of this keymap are:
 
 ```plain
 ,-----------------------------------------.                    ,-----------------------------------------.
-| ESC  |  F1  |  F2  |  F3  |  F4  |  F5  |                    |  F6  |  F7  |  F8  |  F9  | F10  | F11  |
+| TRNS |  F1  |  F2  |  F3  |  F4  |  F5  |                    |  F6  |  F7  |  F8  |  F9  | F10  | F11  |
 |------+------+------+------+------+------|                    |------+------+------+------+------+------|
 | TRNS |      | MUTE | VOLD | VOLU |      |                    | HOME | PGDN | PGUP | END  |      | F12  |
 |------+------+------+------+------+------|                    |------+------+------+------+------+------|


### PR DESCRIPTION
## Description

Updates the custom Lily58 keymap to make the left CTRL key work with tap-hold. When tapped it's ESC and when held it's LCTRL.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
