### PR TITLE
Verify max one keyboard addition during CI.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,7 @@ jobs:
         echo '${{ steps.file_changes.outputs.all_changed_files}}'
 
     - name: Run qmk lint
+      if: always()
       shell: 'bash {0}'
       run: |
         QMK_CHANGES=$(echo -e '${{ steps.file_changes.outputs.all_changed_files}}' | sed 's/ /\n/g')
@@ -72,3 +73,30 @@ jobs:
             exit 255
         fi
         exit $exit_code
+
+    - name: Verify at most one added keyboard
+      if: always()
+      shell: 'bash {0}'
+      run: |
+        git reset --hard ${{ github.head_ref }}
+        git clean -xfd
+
+        # Get the keyboard list and count for the target branch
+        git checkout -f ${{ github.base_ref }}
+        QMK_KEYBOARDS_BASE=$(qmk list-keyboards)
+        QMK_KEYBOARDS_BASE_COUNT=$(qmk list-keyboards | wc -l)
+
+        # Get the keyboard list and count for the PR
+        git checkout -f ${{ github.head_ref }}
+        QMK_KEYBOARDS_PR=$(qmk list-keyboards)
+        QMK_KEYBOARDS_PR_COUNT=$(qmk list-keyboards | wc -l)
+
+        echo "::group::Keyboards changes in this PR"
+        diff -d -U 0 <(echo $left_side) <(echo $right_side) | grep -vE '^(---|\+\+\+|@@)' | sed -e 's@^-@Removed: @g' -e 's@^+@  Added: @g'
+        echo "::endgroup::"
+
+        if [[ $QMK_KEYBOARDS_PR_COUNT -gt $(($QMK_KEYBOARDS_BASE_COUNT + 1)) ]]; then
+            echo "More than one keyboard added in this PR -- see the PR Checklist."
+            echo "::error::More than one keyboard added in this PR -- see the PR Checklist."
+            exit 1
+        fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,21 +78,23 @@ jobs:
       if: always()
       shell: 'bash {0}'
       run: |
-        git reset --hard ${{ github.head_ref }}
+        git reset --hard
         git clean -xfd
 
         # Get the keyboard list and count for the target branch
         git checkout -f ${{ github.base_ref }}
+        git pull --ff-only
         QMK_KEYBOARDS_BASE=$(qmk list-keyboards)
         QMK_KEYBOARDS_BASE_COUNT=$(qmk list-keyboards | wc -l)
 
         # Get the keyboard list and count for the PR
         git checkout -f ${{ github.head_ref }}
+        git merge --no-commit --squash ${{ github.base_ref }}
         QMK_KEYBOARDS_PR=$(qmk list-keyboards)
         QMK_KEYBOARDS_PR_COUNT=$(qmk list-keyboards | wc -l)
 
         echo "::group::Keyboards changes in this PR"
-        diff -d -U 0 <(echo $left_side) <(echo $right_side) | grep -vE '^(---|\+\+\+|@@)' | sed -e 's@^-@Removed: @g' -e 's@^+@  Added: @g'
+        diff -d -U 0 <(echo "$QMK_KEYBOARDS_BASE") <(echo "$QMK_KEYBOARDS_PR") | grep -vE '^(---|\+\+\+|@@)' | sed -e 's@^-@Removed: @g' -e 's@^+@  Added: @g'
         echo "::endgroup::"
 
         if [[ $QMK_KEYBOARDS_PR_COUNT -gt $(($QMK_KEYBOARDS_BASE_COUNT + 1)) ]]; then


### PR DESCRIPTION
## Description

- Checks the before and after counts of the number of keyboards in the repository, ensuring that a maximum increase of 1 is present in the PR.
- Lists the added/removed keyboards in the CI run output.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
