### PR TITLE
Amend `ryanbaekr` boards by pin definitions

### DIFF
--- a/keyboards/ryanbaekr/rb69/info.json
+++ b/keyboards/ryanbaekr/rb69/info.json
@@ -16,8 +16,8 @@
         "rows": ["D7", "C6", "D4", "D0", "D1"]
     },
     "diode_direction": "COL2ROW",
-    "processor": "atmega32u4",
-    "bootloader": "caterina",
+    "development_board": "elite_c",
+    "pin_compatible": "elite_c",
     "layouts": {
         "LAYOUT": {
             "layout": [

--- a/keyboards/ryanbaekr/rb86/info.json
+++ b/keyboards/ryanbaekr/rb86/info.json
@@ -13,8 +13,8 @@
         "rows": ["B0", "B1", "B2", "B3", "B4", "D7"]
     },
     "diode_direction": "COL2ROW",
-    "processor": "atmega32u4",
-    "bootloader": "caterina",
+    "development_board": "elite_c",
+    "pin_compatible": "elite_c",
     "layout_aliases": {
         "LAYOUT_numpad_6x17": "LAYOUT"
     },

--- a/keyboards/ryanbaekr/rb87/info.json
+++ b/keyboards/ryanbaekr/rb87/info.json
@@ -3,8 +3,8 @@
     "manufacturer": "ryanbaekr",
     "url": "",
     "maintainer": "ryanbaekr",
-    "processor": "atmega32u4",
-    "bootloader": "caterina",
+    "development_board": "elite_c",
+    "pin_compatible": "elite_c",
     "usb": {
         "vid": "0x7262",
         "pid": "0x0087",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

During creation of a now closed PR, noticed a section of ryanbaekr boards that define elite_c pins but have defined "promicro" as their controller. This PR aims to amend this configuration mismatch by changing processor, bootloader, and pin_compatibility to elite_c.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
