### PR TITLE
Update newbs_getting_started.md QMK CLI install instruction for Apple Silicon Mac users

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -66,7 +66,7 @@ Install the QMK CLI by running:
     
 Install the QMK CLI on an Apple Silicon Mac by running:
 
-    arch -x86_64 brew install qmk/qmk/qmk
+    arch -arm64 brew install qmk/qmk/qmk
 
 ### ** Linux/WSL **
 


### PR DESCRIPTION
Use `arch -arm64 brew install qmk/qmk/qmk` instead of `-x86_64` for Apple Silicon Macs

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Under `[2. Prepare your build environment`,](https://docs.qmk.fm/#/newbs_getting_started?id=set-up-your-environment), the instruction to install the QMK CLI for Apple Silicon Macs contains a flag for x86 architectures which will not work for ARM architectures. Either the command should be specified for x86 systems or contain the `-arm64` flag instead. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Documentation misspecification for Apple Silicon users.

## Checklist
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
