### PR TITLE
add VIA support for LED Matrix

### DIFF
--- a/quantum/via.c
+++ b/quantum/via.c
@@ -31,7 +31,7 @@
 #include "eeprom.h"
 #include "version.h" // for QMK_BUILDDATE used in EEPROM magic
 
-#if defined(RGB_MATRIX_ENABLE)
+#if (defined(RGB_MATRIX_ENABLE) || defined(LED_MATRIX_ENABLE))
 #    include <lib/lib8tion/lib8tion.h>
 #endif
 
@@ -141,6 +141,9 @@ __attribute__((weak)) void via_set_device_indication(uint8_t value) {
 #if defined(RGB_MATRIX_ENABLE)
     rgb_matrix_toggle_noeeprom();
 #endif // RGB_MATRIX_ENABLE
+#if defined(LED_MATRIX_ENABLE)
+    led_matrix_toggle_noeeprom();
+#endif // LED_MATRIX_ENABLE
 #if defined(AUDIO_ENABLE)
     if (value == 0) {
         wait_ms(10);
@@ -194,6 +197,7 @@ __attribute__((weak)) void via_custom_value_command_kb(uint8_t *data, uint8_t le
 //      id_qmk_backlight_channel    ->  via_qmk_backlight_command()
 //      id_qmk_rgblight_channel     ->  via_qmk_rgblight_command()
 //      id_qmk_rgb_matrix_channel   ->  via_qmk_rgb_matrix_command()
+//      id_qmk_led_matrix_channel   ->  via_qmk_led_matrix_command()
 //      id_qmk_audio_channel        ->  via_qmk_audio_command()
 //
 __attribute__((weak)) void via_custom_value_command(uint8_t *data, uint8_t length) {
@@ -219,7 +223,14 @@ __attribute__((weak)) void via_custom_value_command(uint8_t *data, uint8_t lengt
         via_qmk_rgb_matrix_command(data, length);
         return;
     }
-#endif // RGBLIGHT_ENABLE
+#endif // RGB_MATRIX_ENABLE
+
+#if defined(LED_MATRIX_ENABLE)
+    if (*channel_id == id_qmk_led_matrix_channel) {
+        via_qmk_led_matrix_command(data, length);
+        return;
+    }
+#endif // LED_MATRIX_ENABLE
 
 #if defined(AUDIO_ENABLE)
     if (*channel_id == id_qmk_audio_channel) {
@@ -691,6 +702,90 @@ void via_qmk_rgb_matrix_save(void) {
 }
 
 #endif // RGB_MATRIX_ENABLE
+
+#if defined(LED_MATRIX_ENABLE)
+
+#    if !defined(LED_MATRIX_MAXIMUM_BRIGHTNESS) || LED_MATRIX_MAXIMUM_BRIGHTNESS > UINT8_MAX
+#        undef LED_MATRIX_MAXIMUM_BRIGHTNESS
+#        define LED_MATRIX_MAXIMUM_BRIGHTNESS UINT8_MAX
+#    endif
+
+void via_qmk_led_matrix_command(uint8_t *data, uint8_t length) {
+    // data = [ command_id, channel_id, value_id, value_data ]
+    uint8_t *command_id        = &(data[0]);
+    uint8_t *value_id_and_data = &(data[2]);
+
+    switch (*command_id) {
+        case id_custom_set_value: {
+            via_qmk_led_matrix_set_value(value_id_and_data);
+            break;
+        }
+        case id_custom_get_value: {
+            via_qmk_led_matrix_get_value(value_id_and_data);
+            break;
+        }
+        case id_custom_save: {
+            via_qmk_led_matrix_save();
+            break;
+        }
+        default: {
+            *command_id = id_unhandled;
+            break;
+        }
+    }
+}
+
+void via_qmk_led_matrix_get_value(uint8_t *data) {
+    // data = [ value_id, value_data ]
+    uint8_t *value_id   = &(data[0]);
+    uint8_t *value_data = &(data[1]);
+
+    switch (*value_id) {
+        case id_qmk_led_matrix_brightness: {
+            value_data[0] = ((uint16_t)led_matrix_get_val() * UINT8_MAX) / LED_MATRIX_MAXIMUM_BRIGHTNESS;
+            break;
+        }
+        case id_qmk_led_matrix_effect: {
+            value_data[0] = led_matrix_is_enabled() ? led_matrix_get_mode() : 0;
+            break;
+        }
+        case id_qmk_led_matrix_effect_speed: {
+            value_data[0] = led_matrix_get_speed();
+            break;
+        }
+    }
+}
+
+void via_qmk_led_matrix_set_value(uint8_t *data) {
+    // data = [ value_id, value_data ]
+    uint8_t *value_id   = &(data[0]);
+    uint8_t *value_data = &(data[1]);
+    switch (*value_id) {
+        case id_qmk_led_matrix_brightness: {
+            led_matrix_set_val_noeeprom(scale8(value_data[0], LED_MATRIX_MAXIMUM_BRIGHTNESS));
+            break;
+        }
+        case id_qmk_led_matrix_effect: {
+            if (value_data[0] == 0) {
+                led_matrix_disable_noeeprom();
+            } else {
+                led_matrix_enable_noeeprom();
+                led_matrix_mode_noeeprom(value_data[0]);
+            }
+            break;
+        }
+        case id_qmk_led_matrix_effect_speed: {
+            led_matrix_set_speed_noeeprom(value_data[0]);
+            break;
+        }
+    }
+}
+
+void via_qmk_led_matrix_save(void) {
+    eeconfig_update_led_matrix();
+}
+
+#endif // LED_MATRIX_ENABLE
 
 #if defined(AUDIO_ENABLE)
 

--- a/quantum/via.h
+++ b/quantum/via.h
@@ -109,6 +109,7 @@ enum via_channel_id {
     id_qmk_rgblight_channel   = 2,
     id_qmk_rgb_matrix_channel = 3,
     id_qmk_audio_channel      = 4,
+    id_qmk_led_matrix_channel = 5,
 };
 
 enum via_qmk_backlight_value {
@@ -128,6 +129,12 @@ enum via_qmk_rgb_matrix_value {
     id_qmk_rgb_matrix_effect       = 2,
     id_qmk_rgb_matrix_effect_speed = 3,
     id_qmk_rgb_matrix_color        = 4,
+};
+
+enum via_qmk_led_matrix_value {
+    id_qmk_led_matrix_brightness   = 1,
+    id_qmk_led_matrix_effect       = 2,
+    id_qmk_led_matrix_effect_speed = 3,
 };
 
 enum via_qmk_audio_value {
@@ -180,6 +187,13 @@ void via_qmk_rgb_matrix_command(uint8_t *data, uint8_t length);
 void via_qmk_rgb_matrix_set_value(uint8_t *data);
 void via_qmk_rgb_matrix_get_value(uint8_t *data);
 void via_qmk_rgb_matrix_save(void);
+#endif
+
+#if defined(LED_MATRIX_ENABLE)
+void via_qmk_led_matrix_command(uint8_t *data, uint8_t length);
+void via_qmk_led_matrix_set_value(uint8_t *data);
+void via_qmk_led_matrix_get_value(uint8_t *data);
+void via_qmk_led_matrix_save(void);
 #endif
 
 #if defined(AUDIO_ENABLE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds led matrix functions for via's lighting system, base on #16086 

Tested on [mechlovin/zed65/mono_led](https://github.com/mechlovin/PCB/tree/master/Zed65/Mono-LED/Dolch65/Backlight-VIA-control) and mechlovin/olly/octagon.
Thanks.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
