### PR TITLE
GMMK Numpad: correct layout data

### DIFF
--- a/keyboards/gmmk/numpad/info.json
+++ b/keyboards/gmmk/numpad/info.json
@@ -39,7 +39,7 @@
                 {"label": "4", "matrix": [2, 0], "x": 0, "y": 2},
                 {"label": "5", "matrix": [2, 1], "x": 1, "y": 2},
                 {"label": "6", "matrix": [2, 2], "x": 2, "y": 2},
-                {"label": "CALC", "matrix": [2, 3], "x": 3, "y": 2},
+                {"label": "CALC", "matrix": [2, 3], "x": 4.25, "y": 0},
 
                 {"label": "1", "matrix": [3, 0], "x": 0, "y": 3},
                 {"label": "2", "matrix": [3, 1], "x": 1, "y": 3},
@@ -47,7 +47,7 @@
                 {"label": "RET", "matrix": [3, 3], "x": 3, "y": 3, "h": 2},
 
                 {"label": "0", "matrix": [4, 0], "x": 0, "y": 4, "w": 2},
-                {"label": ".", "matrix": [4, 3], "x": 3, "y": 4}
+                {"label": ".", "matrix": [4, 3], "x": 2, "y": 4}
             ]
         }
     }


### PR DESCRIPTION
## Description

Fixes a key overlap issue in the Configurator rendering:
![gmmk_numpad_default](https://github.com/qmk/qmk_firmware/assets/18669334/da00782d-98cf-4b07-9962-b886d9406bcd)

cc @GloriousThrall, @RustedAperture (keyboard maintainers)


## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
