### PR TITLE
Refactor times inverse of sqrt 2 calculation

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -25,11 +25,15 @@
 #include "mousekey.h"
 
 static inline int8_t times_inv_sqrt2(int8_t x) {
-    // 181/256 is pretty close to 1/sqrt(2)
-    // 0.70703125                 0.707106781
-    // 1 too small for x=99 and x=198
-    // This ends up being a mult and discard lower 8 bits
-    return (x * 181) >> 8;
+    // 181/256 (0.70703125) is used as an approximation for 1/sqrt(2)
+    // because it is close to the exact value which is 0.707106781
+    int16_t n = x * 181, d = 256;
+
+    // To ensure that the integer result is rounded accurately after
+    // division, check the sign of the numerator:
+    // If negative, subtract half of the denominator before dividing
+    // Otherwise, add half of the denominator before dividing
+    return n < 0 ? (n - d / 2) / d : (n + d / 2) / d;
 }
 
 static report_mouse_t mouse_report = {0};

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -27,7 +27,8 @@
 static inline int8_t times_inv_sqrt2(int8_t x) {
     // 181/256 (0.70703125) is used as an approximation for 1/sqrt(2)
     // because it is close to the exact value which is 0.707106781
-    int16_t n = x * 181, d = 256;
+    const int16_t  n = x * 181;
+    const uint16_t d = 256;
 
     // To ensure that the integer result is rounded accurately after
     // division, check the sign of the numerator:


### PR DESCRIPTION
## Description

Diagonal mouse movement is calculated with equal x and y values times 1/sqrt(2). The current function uses bit shifting to divide and then truncates the fractional part to an integer, causing rounding errors.

Example, when x = -7 and y = 7, the current function will return a rounded-down value of `4` instead of `5`, when compared to a rounded floating point multiplication with 1/sqrt(2) (0.707106781):

| x | (x * 181) >> 8 | round(x * 0.707106781) |
|---|----------------|------------------------|
|-7 |     -5         |          -5            |
| 7 |      4         |           5            |

This change uses a simple sign checking ternary operator for the numerator. If negative, subtract half of the denominator before dividing. Otherwise add half of the denominator before dividing. The truncated integer after division will be an accurate rounding that matches floating point operations.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
