### PR TITLE
KJ-Modify RS40 Configurator Touch-Up

### DIFF
--- a/keyboards/kj_modify/rs40/info.json
+++ b/keyboards/kj_modify/rs40/info.json
@@ -17,7 +17,7 @@
         "rows": ["B13", "A10", "B1", "B10"]
     },
     "processor": "STM32F401",
-    "url": "https://www.aliexpress.com/store/911983021",
+    "url": "https://www.aliexpress.us/item/3256803963501165.html",
     "usb": {
         "device_version": "1.0.0",
         "pid": "0x5253",

--- a/keyboards/kj_modify/rs40/readme.md
+++ b/keyboards/kj_modify/rs40/readme.md
@@ -4,7 +4,7 @@ A compact 40% keyboard with 42 keys.
 
 * Keyboard Maintainer: [Audite Marlow](https://github.com/auditemarlow)
 * Hardware Supported: RS40 PCB
-* Hardware Availability: https://www.aliexpress.com/store/911983021
+* Hardware Availability: [KJ-Modify Store on AliExpress](https://www.aliexpress.us/item/3256803963501165.html)
 
 Make example for this keyboard (after setting up your build environment):
 


### PR DESCRIPTION
## Description

Removes a key overlap in the Configurator rendering.
![kj_modify_rs40_default](https://github.com/qmk/qmk_firmware/assets/18669334/b0c11c12-3b14-4040-9231-1e6e131abd68)

cc @AuditeMarlow (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
