### PR TITLE
bootmagic mods covering the case when swapped mods are pressed at the same time

### DIFF
--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -123,39 +123,25 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
 
 __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
     if (keymap_config.swap_lalt_lgui) {
-        if ((mod & MOD_RGUI) == MOD_LGUI) {
-            mod &= ~MOD_LGUI;
-            mod |= MOD_LALT;
-        } else if ((mod & MOD_RALT) == MOD_LALT) {
-            mod &= ~MOD_LALT;
-            mod |= MOD_LGUI;
+        // if they're both set or both unset, no need to do anything
+        if (((mod & MOD_LALT) == MOD_LALT) ^ ((mod & MOD_LGUI) == MOD_LGUI)) {
+           // we know only 1 is set, XOR with ORd mask to flip the set one
+           mod ^= (MOD_LALT | MOD_LGUI);
         }
     }
     if (keymap_config.swap_ralt_rgui) {
-        if ((mod & MOD_RGUI) == MOD_RGUI) {
-            mod &= ~MOD_RGUI;
-            mod |= MOD_RALT;
-        } else if ((mod & MOD_RALT) == MOD_RALT) {
-            mod &= ~MOD_RALT;
-            mod |= MOD_RGUI;
+        if (((mod & MOD_RALT) == MOD_RALT) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
+           mod ^= (MOD_RALT | MOD_RGUI);
         }
     }
     if (keymap_config.swap_lctl_lgui) {
-        if ((mod & MOD_RGUI) == MOD_LGUI) {
-            mod &= ~MOD_LGUI;
-            mod |= MOD_LCTL;
-        } else if ((mod & MOD_RCTL) == MOD_LCTL) {
-            mod &= ~MOD_LCTL;
-            mod |= MOD_LGUI;
+        if (((mod & MOD_LCTL) == MOD_LCTL) ^ ((mod & MOD_LGUI) == MOD_LGUI)) {
+           mod ^= (MOD_LCTL | MOD_LGUI);
         }
     }
     if (keymap_config.swap_rctl_rgui) {
-        if ((mod & MOD_RGUI) == MOD_RGUI) {
-            mod &= ~MOD_RGUI;
-            mod |= MOD_RCTL;
-        } else if ((mod & MOD_RCTL) == MOD_RCTL) {
-            mod &= ~MOD_RCTL;
-            mod |= MOD_RGUI;
+        if (((mod & MOD_RCTL) == MOD_RCTL) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
+           mod ^= (MOD_RCTL | MOD_RGUI);
         }
     }
     if (keymap_config.no_gui) {

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -122,39 +122,38 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
  */
 
 __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
-
     /**
-    * Note: The right hand MOD variables (MOD_RALT, MOD_RGUI, MOD_RSFT, MOD_RCTL)
-    * are not 1-bit bitmasks like their left-handed counterparts. They have 2 bits
-    * set, so some of the usual bitwise operator tricks need to be modified 
-    * to take this into account
-    */
+     * Note: The right hand MOD variables (MOD_RALT, MOD_RGUI, MOD_RSFT, MOD_RCTL)
+     * are not 1-bit bitmasks like their left-handed counterparts. They have 2 bits
+     * set, so some of the usual bitwise operator tricks need to be modified
+     * to take this into account
+     */
     if (keymap_config.swap_lalt_lgui) {
         /** If both modifiers pressed or neither pressed, do nothing
-        * Otherwise swap the values
-        * Note: The left mods are ANDed with the right-hand values to check
-        * if they were pressed with the right hand bit set
-        */
+         * Otherwise swap the values
+         * Note: The left mods are ANDed with the right-hand values to check
+         * if they were pressed with the right hand bit set
+         */
         if (((mod & MOD_RALT) == MOD_LALT) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
-           mod ^= (MOD_LALT | MOD_LGUI);
+            mod ^= (MOD_LALT | MOD_LGUI);
         }
     }
     if (keymap_config.swap_ralt_rgui) {
         if (((mod & MOD_RALT) == MOD_RALT) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-           /* lefthand values to preserve the right hand bit */
-           mod ^= (MOD_LALT  | MOD_LGUI );
+            /* lefthand values to preserve the right hand bit */
+            mod ^= (MOD_LALT | MOD_LGUI);
         }
     }
     if (keymap_config.swap_lctl_lgui) {
         /* left mods ANDed with right-hand values to check for right hand bit */
         if (((mod & MOD_RCTL) == MOD_LCTL) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
-           mod ^= (MOD_LCTL | MOD_LGUI);
+            mod ^= (MOD_LCTL | MOD_LGUI);
         }
     }
     if (keymap_config.swap_rctl_rgui) {
         if (((mod & MOD_RCTL) == MOD_RCTL) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-           /* lefthand values to preserve the right hand bit */
-           mod ^= (MOD_LCTL | MOD_LGUI );
+            /* lefthand values to preserve the right hand bit */
+            mod ^= (MOD_LCTL | MOD_LGUI);
         }
     }
     if (keymap_config.no_gui) {

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -122,26 +122,38 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
  */
 
 __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
+
+    /**
+    * Note: The right hand MOD variables (MOD_RALT, MOD_RGUI, MOD_RSFT, MOD_RCTL)
+    * are not 1-bit bitmasks like their left-handed counterparts. They have 2 bits
+    * set, so some of the usual bitwise operator tricks need to be modified 
+    * to take this into account
+    */
     if (keymap_config.swap_lalt_lgui) {
-        // if they're both set or both unset, no need to do anything
-        if (((mod & MOD_LALT) == MOD_LALT) ^ ((mod & MOD_LGUI) == MOD_LGUI)) {
-           // we know only 1 is set, XOR with ORd mask to flip the set one
+        // If both modifiers pressed or neither pressed, do nothing
+        // Otherwise swap the values
+        // Note: The left mods are ANDed with the right-hand values to check
+        // if they were pressed with the right hand bit set
+        if (((mod & MOD_RALT) == MOD_LALT) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
            mod ^= (MOD_LALT | MOD_LGUI);
         }
     }
     if (keymap_config.swap_ralt_rgui) {
         if (((mod & MOD_RALT) == MOD_RALT) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-           mod ^= (MOD_RALT | MOD_RGUI);
+           // lefthand values to preserve the right hand bit
+           mod ^= (MOD_LALT  | MOD_LGUI );
         }
     }
     if (keymap_config.swap_lctl_lgui) {
-        if (((mod & MOD_LCTL) == MOD_LCTL) ^ ((mod & MOD_LGUI) == MOD_LGUI)) {
+        // left mods ANDed with right-hand values to check for right hand bit
+        if (((mod & MOD_RCTL) == MOD_LCTL) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
            mod ^= (MOD_LCTL | MOD_LGUI);
         }
     }
     if (keymap_config.swap_rctl_rgui) {
         if (((mod & MOD_RCTL) == MOD_RCTL) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-           mod ^= (MOD_RCTL | MOD_RGUI);
+           // lefthand values to preserve the right hand bit
+           mod ^= (MOD_LCTL | MOD_LGUI );
         }
     }
     if (keymap_config.no_gui) {

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -130,29 +130,30 @@ __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
     * to take this into account
     */
     if (keymap_config.swap_lalt_lgui) {
-        // If both modifiers pressed or neither pressed, do nothing
-        // Otherwise swap the values
-        // Note: The left mods are ANDed with the right-hand values to check
-        // if they were pressed with the right hand bit set
+        /** If both modifiers pressed or neither pressed, do nothing
+        * Otherwise swap the values
+        * Note: The left mods are ANDed with the right-hand values to check
+        * if they were pressed with the right hand bit set
+        */
         if (((mod & MOD_RALT) == MOD_LALT) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
            mod ^= (MOD_LALT | MOD_LGUI);
         }
     }
     if (keymap_config.swap_ralt_rgui) {
         if (((mod & MOD_RALT) == MOD_RALT) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-           // lefthand values to preserve the right hand bit
+           /* lefthand values to preserve the right hand bit */
            mod ^= (MOD_LALT  | MOD_LGUI );
         }
     }
     if (keymap_config.swap_lctl_lgui) {
-        // left mods ANDed with right-hand values to check for right hand bit
+        /* left mods ANDed with right-hand values to check for right hand bit */
         if (((mod & MOD_RCTL) == MOD_LCTL) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
            mod ^= (MOD_LCTL | MOD_LGUI);
         }
     }
     if (keymap_config.swap_rctl_rgui) {
         if (((mod & MOD_RCTL) == MOD_RCTL) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-           // lefthand values to preserve the right hand bit
+           /* lefthand values to preserve the right hand bit */
            mod ^= (MOD_LCTL | MOD_LGUI );
         }
     }

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -123,10 +123,8 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
 
 __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
     /**
-     * Note: The right hand MOD variables (MOD_RALT, MOD_RGUI, MOD_RSFT, MOD_RCTL)
-     * are not 1-bit bitmasks like their left-handed counterparts. They have 2 bits
-     * set, so some of the usual bitwise operator tricks need to be modified
-     * to take this into account
+     * Note: This function is for the 5-bit packed mods, NOT the full 8-bit mods. 
+     * More info about the mods can be seen in modifiers.h.
      */
     if (keymap_config.swap_lalt_lgui) {
         /** If both modifiers pressed or neither pressed, do nothing

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -123,7 +123,7 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
 
 __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
     /**
-     * Note: This function is for the 5-bit packed mods, NOT the full 8-bit mods. 
+     * Note: This function is for the 5-bit packed mods, NOT the full 8-bit mods.
      * More info about the mods can be seen in modifiers.h.
      */
     if (keymap_config.swap_lalt_lgui) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The `mod_config` function would swap modifiers as specified in the `keymap_config` object, but if the swapped modifiers were pressed at the same time (eg if you swapped ctrl and gui but pressed them both together) it would only apply one of the modifiers instead of both.

I refactored a bit to try and keep the simple bitwise operations that were there before.

I also added some comments to explain some of the code since some of it looks like copy-paste typos (comparing RALT to LALT for instance) but is actually intentional. 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ x] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
