### PR TITLE
Akko Top40: correct layout data

### DIFF
--- a/keyboards/akko/top40/info.json
+++ b/keyboards/akko/top40/info.json
@@ -176,9 +176,9 @@
                 { "label": "Ctrl", "matrix": [3, 0], "x": 0, "y": 3, "w": 1.25 },
                 { "label": "Win", "matrix": [3, 1], "x": 1.25, "y": 3, "w": 1.25 },
                 { "label": "Alt", "matrix": [3, 2], "x": 2.5, "y": 3, "w": 1.25 },
-                { "label": "Space", "matrix": [3, 4], "x": 3.75, "y": 3, "w": 6.25 },
+                { "label": "Space", "matrix": [3, 4], "x": 3.75, "y": 3, "w": 2.25 },
                 { "label": "Space", "matrix": [3, 6], "x": 6, "y": 3, "w": 2.75 },
-                { "label": "Fn", "matrix": [3, 8], "x": 8.75, "y": 3, "w": 1.25 },
+                { "label": "Fn", "matrix": [3, 8], "x": 8.75, "y": 3 },
                 { "label": "Left", "matrix": [3, 9], "x": 9.75, "y": 3 },
                 { "label": "Down", "matrix": [3, 10], "x": 10.75, "y": 3 },
                 { "label": "Right", "matrix": [3, 11], "x": 11.75, "y": 3 }


### PR DESCRIPTION
## Description

Corrects a key overlap issue in Configurator.
![image](https://github.com/qmk/qmk_firmware/assets/18669334/804dfaea-5447-4fe1-b88f-4a4d42f2a33f)

cc @jonylee1986 (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
