### PR TITLE
Set minimum middle column value

### DIFF
--- a/quantum/rgb_matrix/animations/pixel_fractal_anim.h
+++ b/quantum/rgb_matrix/animations/pixel_fractal_anim.h
@@ -7,7 +7,11 @@ RGB_MATRIX_EFFECT(PIXEL_FRACTAL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 static bool PIXEL_FRACTAL(effect_params_t* params) {
-#        define MID_COL MATRIX_COLS / 2
+#        if MATRIX_COLS < 2
+#            define MID_COL 1
+#        else
+#            define MID_COL MATRIX_COLS / 2
+#        endif
     static bool     led[MATRIX_ROWS][MID_COL];
     static uint32_t wait_timer = 0;
 


### PR DESCRIPTION
## Description

Set a minimum middle column value of `1` to avoid integer rounding to zero on division when `MATRIX_COLS` is less than 2

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Reported by @drashna on Discord when effect was tested with `MATRIX_COLS` = `1`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
