### PR TITLE
Improve tap-hold configuration

### DIFF
--- a/keyboards/lily58/keymaps/gaston/config.h
+++ b/keyboards/lily58/keymaps/gaston/config.h
@@ -24,3 +24,4 @@
 
 #define QUICK_TAP_TERM 0
 #define TAPPING_TERM 150 /* ms */
+#define HOLD_ON_OTHER_KEY_PRESS_PER_KEY

--- a/keyboards/lily58/keymaps/gaston/keymap.c
+++ b/keyboards/lily58/keymaps/gaston/keymap.c
@@ -57,3 +57,14 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 )
 
 };
+
+bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case MT_CESC:
+            // Immediately select the hold action when another key is pressed.
+            return true;
+        default:
+            // Do not select the hold action when another key is pressed.
+            return false;
+    }
+}


### PR DESCRIPTION
## Description

Enable hold on other key press for better tap-hold experience.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
