### PR TITLE
Fixup head reference for CI keyboard count verification

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,7 +88,7 @@ jobs:
         QMK_KEYBOARDS_BASE_COUNT=$(qmk list-keyboards | wc -l)
 
         # Get the keyboard list and count for the PR
-        git checkout -f ${{ github.head_ref }}
+        git checkout -f ${{ github.ref }}
         git merge --no-commit --squash ${{ github.base_ref }}
         QMK_KEYBOARDS_PR=$(qmk list-keyboards)
         QMK_KEYBOARDS_PR_COUNT=$(qmk list-keyboards | wc -l)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,7 +88,7 @@ jobs:
         QMK_KEYBOARDS_BASE_COUNT=$(qmk list-keyboards | wc -l)
 
         # Get the keyboard list and count for the PR
-        git checkout -f ${{ github.ref }}
+        git checkout -f --detach ${{ github.sha }}
         git merge --no-commit --squash ${{ github.base_ref }}
         QMK_KEYBOARDS_PR=$(qmk list-keyboards)
         QMK_KEYBOARDS_PR_COUNT=$(qmk list-keyboards | wc -l)


### PR DESCRIPTION
## Description

Fixes #21246.

`github.ref` points at `refs/pull/<pr_number>/merge` -- see https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
