### PR TITLE
Add option for auto mouse movement threshold

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -643,6 +643,7 @@ There are a few ways to control the auto mouse feature with both `config.h` opti
 | `AUTO_MOUSE_TIME`                   | (Optional) Time layer remains active after activation                 | _ideally_ (250-1000) |     _ms_    |                   `650 ms` |
 | `AUTO_MOUSE_DELAY`                  | (Optional) Lockout time after non-mouse key is pressed                | _ideally_ (100-1000) |     _ms_    | `TAPPING_TERM` or `200 ms` |
 | `AUTO_MOUSE_DEBOUNCE`               | (Optional) Time delay from last activation to next update             | _ideally_ (10 - 100) |     _ms_    |                    `25 ms` |
+| `AUTO_MOUSE_THRESHOLD`              | (Optional) Amount of mouse movement required to switch layers         | 0 -                  |     _px_    |                    `10 px` |
 
 ### Adding mouse keys
 

--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -643,7 +643,7 @@ There are a few ways to control the auto mouse feature with both `config.h` opti
 | `AUTO_MOUSE_TIME`                   | (Optional) Time layer remains active after activation                 | _ideally_ (250-1000) |     _ms_    |                   `650 ms` |
 | `AUTO_MOUSE_DELAY`                  | (Optional) Lockout time after non-mouse key is pressed                | _ideally_ (100-1000) |     _ms_    | `TAPPING_TERM` or `200 ms` |
 | `AUTO_MOUSE_DEBOUNCE`               | (Optional) Time delay from last activation to next update             | _ideally_ (10 - 100) |     _ms_    |                    `25 ms` |
-| `AUTO_MOUSE_THRESHOLD`              | (Optional) Amount of mouse movement required to switch layers         | 0 -                  |     _px_    |                    `10 px` |
+| `AUTO_MOUSE_THRESHOLD`              | (Optional) Amount of mouse movement required to switch layers         | 0 -                  |   _units_   |                 `10 units` |
 
 ### Adding mouse keys
 

--- a/quantum/pointing_device/pointing_device_auto_mouse.c
+++ b/quantum/pointing_device/pointing_device_auto_mouse.c
@@ -217,7 +217,11 @@ void auto_mouse_layer_off(void) {
  * @return bool of pointing_device activation
  */
 __attribute__((weak)) bool auto_mouse_activation(report_mouse_t mouse_report) {
-    return mouse_report.x != 0 || mouse_report.y != 0 || mouse_report.h != 0 || mouse_report.v != 0 || mouse_report.buttons;
+    auto_mouse_context.total_mouse_movement.x += mouse_report.x;
+    auto_mouse_context.total_mouse_movement.y += mouse_report.y;
+    auto_mouse_context.total_mouse_movement.h += mouse_report.h;
+    auto_mouse_context.total_mouse_movement.v += mouse_report.v;
+    return abs(auto_mouse_context.total_mouse_movement.x) > AUTO_MOUSE_THRESHOLD || abs(auto_mouse_context.total_mouse_movement.y) > AUTO_MOUSE_THRESHOLD || abs(auto_mouse_context.total_mouse_movement.h) > AUTO_MOUSE_THRESHOLD || abs(auto_mouse_context.total_mouse_movement.v) > AUTO_MOUSE_THRESHOLD || mouse_report.buttons;
 }
 
 /**
@@ -235,14 +239,16 @@ void pointing_device_task_auto_mouse(report_mouse_t mouse_report) {
     // update activation and reset debounce
     auto_mouse_context.status.is_activated = auto_mouse_activation(mouse_report);
     if (is_auto_mouse_active()) {
-        auto_mouse_context.timer.active = timer_read();
-        auto_mouse_context.timer.delay  = 0;
+        auto_mouse_context.total_mouse_movement = (total_mouse_movement_t){.x = 0, .y = 0, .h = 0, .v = 0};
+        auto_mouse_context.timer.active         = timer_read();
+        auto_mouse_context.timer.delay          = 0;
         if (!layer_state_is((AUTO_MOUSE_TARGET_LAYER))) {
             layer_on((AUTO_MOUSE_TARGET_LAYER));
         }
     } else if (layer_state_is((AUTO_MOUSE_TARGET_LAYER)) && timer_elapsed(auto_mouse_context.timer.active) > auto_mouse_context.config.timeout) {
         layer_off((AUTO_MOUSE_TARGET_LAYER));
         auto_mouse_context.timer.active = 0;
+        auto_mouse_context.total_mouse_movement = (total_mouse_movement_t){.x = 0, .y = 0, .h = 0, .v = 0};
     }
 }
 

--- a/quantum/pointing_device/pointing_device_auto_mouse.c
+++ b/quantum/pointing_device/pointing_device_auto_mouse.c
@@ -17,6 +17,7 @@
 
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
 
+#    include <stdlib.h>
 #    include <string.h>
 #    include "pointing_device_auto_mouse.h"
 #    include "debug.h"

--- a/quantum/pointing_device/pointing_device_auto_mouse.c
+++ b/quantum/pointing_device/pointing_device_auto_mouse.c
@@ -247,7 +247,7 @@ void pointing_device_task_auto_mouse(report_mouse_t mouse_report) {
         }
     } else if (layer_state_is((AUTO_MOUSE_TARGET_LAYER)) && timer_elapsed(auto_mouse_context.timer.active) > auto_mouse_context.config.timeout) {
         layer_off((AUTO_MOUSE_TARGET_LAYER));
-        auto_mouse_context.timer.active = 0;
+        auto_mouse_context.timer.active         = 0;
         auto_mouse_context.total_mouse_movement = (total_mouse_movement_t){.x = 0, .y = 0, .h = 0, .v = 0};
     }
 }

--- a/quantum/pointing_device/pointing_device_auto_mouse.h
+++ b/quantum/pointing_device/pointing_device_auto_mouse.h
@@ -42,8 +42,17 @@
 #ifndef AUTO_MOUSE_DEBOUNCE
 #    define AUTO_MOUSE_DEBOUNCE 25
 #endif
+#ifndef AUTO_MOUSE_THRESHOLD
+#    define AUTO_MOUSE_THRESHOLD 10
+#endif
 
 /* data structure */
+typedef struct {
+    mouse_xy_report_t x;
+    mouse_xy_report_t y;
+    int8_t            v;
+    int8_t            h;
+} total_mouse_movement_t;
 typedef struct {
     struct {
         bool     is_enabled;
@@ -60,6 +69,7 @@ typedef struct {
         bool   is_toggled;
         int8_t mouse_key_tracker;
     } status;
+    total_mouse_movement_t total_mouse_movement;
 } auto_mouse_context_t;
 
 /* ----------Set up and control------------------------------------------------------------------------------ */


### PR DESCRIPTION
Add a threshold for a minimum amount of mouse movement before activating the auto mouse layer. Right now, any movement at all triggers the mouse layer. I have a BastardKB Charybdis and I've noticed that I often nudge the trackball when pressing other keys.

## Description

Adds a new configuration option for the auto mouse feature `AUTO_MOUSE_THRESHOLD`. If the mouse is bumped by a distance below this threshold, the auto mouse layer is not activated. The mouse distance is accumulated over multiple events in case a single mouse event does not move the mouse over this threshold (it would have to be a relatively quick movement).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #21396

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.  (It's just a draft PR. I will update the docs if we move forward)
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
