### PR TITLE
planck/rev7: Fix build without AUDIO_ENABLE

### DIFF
--- a/keyboards/planck/rev7/matrix.c
+++ b/keyboards/planck/rev7/matrix.c
@@ -19,6 +19,7 @@
 #include "hal_pal.h"
 #include "hal_pal_lld.h"
 #include "quantum.h"
+#include <math.h>
 
 // STM32-specific watchdog config calculations
 // timeout = 31.25us * PR * (RL + 1)


### PR DESCRIPTION
## Description

The watchdog code in `matrix.c` needs `#include <math.h>`; it broke with `AUDIO_ENABLE = no`, because `quantum.h` no longer included `<math.h>` implicitly.  Adding `#include <math.h>` fixes build of some user keymaps which have `AUDIO_ENABLE = no`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Build failures with `AUDIO_ENABLE = no`, e.g., CI build failure for #21344.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
