### PR TITLE
Implement option to define mod mask to trigger alt repeat key

### DIFF
--- a/quantum/process_keycode/process_repeat_key.c
+++ b/quantum/process_keycode/process_repeat_key.c
@@ -96,6 +96,17 @@ bool process_repeat_key(uint16_t keycode, keyrecord_t* record) {
     }
 
     if (keycode == QK_REPEAT_KEY) {
+#ifndef NO_ALT_REPEAT_KEY
+#ifdef ALT_REPEAT_MASK
+        uint8_t mod = get_mods();
+        if(mod & ALT_REPEAT_MASK) {
+            del_mods(ALT_REPEAT_MASK);
+            alt_repeat_key_invoke(&record->event);
+            set_mods(mod);
+            return false;
+        }
+#endif // SHIFT_ALT_REPEAT_KEY
+#endif // NO_ALT_REPEAT_KEY
         repeat_key_invoke(&record->event);
         return false;
 #ifndef NO_ALT_REPEAT_KEY

--- a/quantum/process_keycode/process_repeat_key.c
+++ b/quantum/process_keycode/process_repeat_key.c
@@ -97,15 +97,15 @@ bool process_repeat_key(uint16_t keycode, keyrecord_t* record) {
 
     if (keycode == QK_REPEAT_KEY) {
 #ifndef NO_ALT_REPEAT_KEY
-#ifdef ALT_REPEAT_MASK
+#	ifdef ALT_REPEAT_MASK
         uint8_t mod = get_mods();
-        if(mod & ALT_REPEAT_MASK) {
+        if (mod & ALT_REPEAT_MASK) {
             del_mods(ALT_REPEAT_MASK);
             alt_repeat_key_invoke(&record->event);
             set_mods(mod);
             return false;
         }
-#endif // SHIFT_ALT_REPEAT_KEY
+#	endif // ALT_REPEAT_MASK
 #endif // NO_ALT_REPEAT_KEY
         repeat_key_invoke(&record->event);
         return false;

--- a/quantum/process_keycode/process_repeat_key.c
+++ b/quantum/process_keycode/process_repeat_key.c
@@ -97,7 +97,7 @@ bool process_repeat_key(uint16_t keycode, keyrecord_t* record) {
 
     if (keycode == QK_REPEAT_KEY) {
 #ifndef NO_ALT_REPEAT_KEY
-#	ifdef ALT_REPEAT_MASK
+#    ifdef ALT_REPEAT_MASK
         uint8_t mod = get_mods();
         if (mod & ALT_REPEAT_MASK) {
             del_mods(ALT_REPEAT_MASK);
@@ -105,8 +105,8 @@ bool process_repeat_key(uint16_t keycode, keyrecord_t* record) {
             set_mods(mod);
             return false;
         }
-#	endif // ALT_REPEAT_MASK
-#endif // NO_ALT_REPEAT_KEY
+#    endif // ALT_REPEAT_MASK
+#endif     // NO_ALT_REPEAT_KEY
         repeat_key_invoke(&record->event);
         return false;
 #ifndef NO_ALT_REPEAT_KEY


### PR DESCRIPTION
Added define for ALT_REPEAT_MASK, as a mod bit mask value such as MOD_BIT(KC_RSFT) that when active will cause QK_REP to send the alternate repeat key instead of the standard repeat key.

First PR so let me know what I can do to tidy things up. Looked at writing unit tests for the function but I am a bit lost on how to set up tests with and without a particular define present. Unsure if the addition is large enough to merit adding to the documentation regarding it as well, but if it is I'd be happy to write something up for the docs.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] ? My change requires a change to the documentation.
- [ ] ? I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
