### PR TITLE
Fix ili9xxx inversion opcode entry

### DIFF
--- a/drivers/painter/ili9xxx/qp_ili9xxx_opcodes.h
+++ b/drivers/painter/ili9xxx/qp_ili9xxx_opcodes.h
@@ -19,8 +19,8 @@
 #define ILI9XXX_CMD_SLEEP_OFF 0x11          // Exist sleep mode
 #define ILI9XXX_CMD_PARTIAL_ON 0x12         // Enter partial mode
 #define ILI9XXX_CMD_PARTIAL_OFF 0x13        // Exit partial mode
-#define ILI9XXX_CMD_INVERT_ON 0x20          // Enter inverted mode
-#define ILI9XXX_CMD_INVERT_OFF 0x21         // Exit inverted mode
+#define ILI9XXX_CMD_INVERT_OFF 0x20         // Exit inverted mode
+#define ILI9XXX_CMD_INVERT_ON 0x21          // Enter inverted mode
 #define ILI9XXX_SET_GAMMA 0x26              // Set gamma params
 #define ILI9XXX_CMD_DISPLAY_OFF 0x28        // Disable display
 #define ILI9XXX_CMD_DISPLAY_ON 0x29         // Enable display


### PR DESCRIPTION
## Description

Found error with inversion cmds in ili9xxx opcode list when troubleshooting issue with ili9341 that needs inversion. 

Low impact since it's not actually used currently. Verified against datasheets for 9163, 9341, and 9488. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* discord

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
