### PR TITLE
usbpd_stm32g4: Configure UCPD before disabling the dead battery mode

### DIFF
--- a/platforms/chibios/drivers/usbpd_stm32g4.c
+++ b/platforms/chibios/drivers/usbpd_stm32g4.c
@@ -22,8 +22,6 @@
 
 // Initialises the USBPD subsystem
 __attribute__((weak)) void usbpd_init(void) {
-    // Disable dead-battery signals
-    PWR->CR3 |= PWR_CR3_UCPD_DBDIS;
     // Enable the clock for the UCPD1 peripheral
     RCC->APB1ENR2 |= RCC_APB1ENR2_UCPD1EN;
 
@@ -46,6 +44,11 @@ __attribute__((weak)) void usbpd_init(void) {
     CR |= UCPD_CR_ANAMODE | UCPD_CR_CCENABLE_Msk;
     // Apply the changes
     UCPD1->CR = CR;
+
+    // Disable dead-battery signals only after UCPD1 is configured to ensure
+    // that the transition does not go through any intermediate state without
+    // any pull-down resistance.
+    PWR->CR3 |= PWR_CR3_UCPD_DBDIS;
 }
 
 // Gets the current state of the USBPD allowance


### PR DESCRIPTION
## Description

The UCPD peripheral initially comes up in the “dead battery” mode, in which it supplies the Rd pull-downs on the CC1 and CC2 lines without any explicit configuration if the DBCC pins are wired appropriately.  The dead battery mode must be disabled to use the full functionality of UCPD; however, disabling the dead battery mode must be done only after the UCPD peripheral has been configured in the desired mode, so that the transition between modes happens without going through a state with no pull-down resistance on the CC lines.  Fix the code to respect the required initialization order.

The required init order is actually documented in the STM32G431 Reference Manual (46.4.6):

> After power arrives and the MCU boots, the desired behavior (for example source) must be programmed into ANAMODE and ANASUBMODE[1:0] before setting the UCPD1_DBDIS bit of the PWR_CR3 register to remove dead battery pull-down resistor and allow the values just programmed to take effect.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
