### PR TITLE
Revert "bootmagic mods covering the case when swapped mods are pressed at the same time (#21320)"

### DIFF
--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -122,36 +122,40 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
  */
 
 __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
-    /**
-     * Note: This function is for the 5-bit packed mods, NOT the full 8-bit mods.
-     * More info about the mods can be seen in modifiers.h.
-     */
     if (keymap_config.swap_lalt_lgui) {
-        /** If both modifiers pressed or neither pressed, do nothing
-         * Otherwise swap the values
-         * Note: The left mods are ANDed with the right-hand values to check
-         * if they were pressed with the right hand bit set
-         */
-        if (((mod & MOD_RALT) == MOD_LALT) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
-            mod ^= (MOD_LALT | MOD_LGUI);
+        if ((mod & MOD_RGUI) == MOD_LGUI) {
+            mod &= ~MOD_LGUI;
+            mod |= MOD_LALT;
+        } else if ((mod & MOD_RALT) == MOD_LALT) {
+            mod &= ~MOD_LALT;
+            mod |= MOD_LGUI;
         }
     }
     if (keymap_config.swap_ralt_rgui) {
-        if (((mod & MOD_RALT) == MOD_RALT) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-            /* lefthand values to preserve the right hand bit */
-            mod ^= (MOD_LALT | MOD_LGUI);
+        if ((mod & MOD_RGUI) == MOD_RGUI) {
+            mod &= ~MOD_RGUI;
+            mod |= MOD_RALT;
+        } else if ((mod & MOD_RALT) == MOD_RALT) {
+            mod &= ~MOD_RALT;
+            mod |= MOD_RGUI;
         }
     }
     if (keymap_config.swap_lctl_lgui) {
-        /* left mods ANDed with right-hand values to check for right hand bit */
-        if (((mod & MOD_RCTL) == MOD_LCTL) ^ ((mod & MOD_RGUI) == MOD_LGUI)) {
-            mod ^= (MOD_LCTL | MOD_LGUI);
+        if ((mod & MOD_RGUI) == MOD_LGUI) {
+            mod &= ~MOD_LGUI;
+            mod |= MOD_LCTL;
+        } else if ((mod & MOD_RCTL) == MOD_LCTL) {
+            mod &= ~MOD_LCTL;
+            mod |= MOD_LGUI;
         }
     }
     if (keymap_config.swap_rctl_rgui) {
-        if (((mod & MOD_RCTL) == MOD_RCTL) ^ ((mod & MOD_RGUI) == MOD_RGUI)) {
-            /* lefthand values to preserve the right hand bit */
-            mod ^= (MOD_LCTL | MOD_LGUI);
+        if ((mod & MOD_RGUI) == MOD_RGUI) {
+            mod &= ~MOD_RGUI;
+            mod |= MOD_RCTL;
+        } else if ((mod & MOD_RCTL) == MOD_RCTL) {
+            mod &= ~MOD_RCTL;
+            mod |= MOD_RGUI;
         }
     }
     if (keymap_config.no_gui) {


### PR DESCRIPTION
## Description

This reverts commit ea87936b11a4396d607077d2ebb62e62c57c46a6.

Should not have gone to `master`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
