### PR TITLE
Quantum PWM

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -184,6 +184,11 @@ ifeq ($(strip $(QUANTUM_PAINTER_ENABLE)), yes)
     include $(QUANTUM_DIR)/painter/rules.mk
 endif
 
+QUANTUM_PWM_ENABLE ?= no
+ ifeq ($(strip $(QUANTUM_PWM_ENABLE)), yes)
+     include $(QUANTUM_DIR)/pwm/rules.mk
+ endif
+
 VALID_EEPROM_DRIVER_TYPES := vendor custom transient i2c spi wear_leveling legacy_stm32_flash
 EEPROM_DRIVER ?= vendor
 ifeq ($(filter $(EEPROM_DRIVER),$(VALID_EEPROM_DRIVER_TYPES)),)

--- a/docs/quantum_pwm.md
+++ b/docs/quantum_pwm.md
@@ -1,0 +1,297 @@
+# Quantum PWP :id=quantum-pwm
+
+Quantum PWM is the standardised API for PWM devices. It currently includes support for software PWM (at the matrix scan rate) and hardware PWM using pin alternate functions and/or callback functions.
+
+There is not yet support for Quantum PWM on AVR-based boards, but an AVR driver can be added in the future. Quantum PWM intended to be extensible to support a wide variety of PWM devices (e.g. controlling an I2C-based PWM chip).
+
+Quantum PWM drivers typically generate effects by way of driving hardware pins and/or through callback functions. Pin assignments and callback functions can be assigned NULL if they are unused.
+
+Certain implementations (like software-based PWM) have no ability to directly drive pins, such that any pin-driving functionality must be implemented by the callback functions.
+
+The two main callback functions are the trigger callback (which occurs when the PWM threnshold is met) and a periodic callback (which occurs at the PWM period rate, equivalent to the 100% duty cycle point). Certain implementations (like an I2C-based PWM chip) may not be able to generate callbacks due to technical limitations.
+
+
+To enable overall Quantum PWM to be built into your firmware, add the following to `rules.mk`:
+
+```make
+QUANTUM_PWM_ENABLE = yes
+QUANTUM_PWM_DRIVERS += ......
+```
+
+You will also likely need to select an appropriate driver in `rules.mk`, which is listed below.
+
+!> Quantum PWM is not currently integrated with system-level operations such as when the keyboard goes into suspend. Users will need to handle this manually at the current time.
+
+Supported devices:
+
+| PWM Type     | Driver                                   |
+|--------------|------------------------------------------|
+| Software     | `QUANTUM_PWM_DRIVERS += software_pwm`    |
+| Integrated   | `QUANTUM_PWM_DRIVERS += integrated_pwm`  |
+
+## Quantum PWM Configuration :id=quantum-pwm-config
+
+| Option                                            | Default | Purpose                                                                                                                                      |
+|---------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `QUANTUM_PWM_TASK_THROTTLE`                       | `1`     | This controls the amount of time (in milliseconds) that the Quantum PWM internal task will wait between each execution.                      |
+| `QUANTUM_PWM_DEBUG`                               | _unset_ | Prints out significant amounts of debugging information to CONSOLE output. Significant performance degradation, use only for debugging.      |
+
+
+Drivers have their own set of configurable options, and are described in their respective sections.
+
+## Quantum PWM Drivers :id=quantum-pwm-drivers
+
+<!-- tabs:start -->
+
+
+### ** Software **
+
+The software PWM driver runs at the matrix scan rate, which can vary and may be slow to the point of unusable for certain applications. While a frequency value can be assigned, it is disregarded by this driver.
+
+The software PWM driver can only generate trigger and periodic callbacks; there no mechanism to automatically drive output pins aside from using the callback functions.
+
+<!-- tabs:start -->
+
+#### ** Software PWM **
+
+Enabling support for the Software PWM in Quantum PWM is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PWM_ENABLE = yes
+QUANTUM_PWM_DRIVERS += software_pwm
+```
+
+(Instead of `QUANTUM_PWM_ENABLE = yes`, you may instead add `"quantum_pwm": true` in the list of features in info.json)
+
+Creating a software PWM device in firmware can then be done with the following API:
+
+```c
+pwm_device_t make_software_pwm_device(void (*trigger_callback)(void), void (*period_callback)(void));
+```
+
+The device handle returned from the `make_software_pwm_device` function can be used to perform all other PWM operations.
+
+The maximum number of displays can be configured by changing the following in your `config.h` (default is 1):
+
+```c
+// 3 PWM devices:
+#define SOFTWARE_PWM_NUM_DEVICES 3
+```
+
+<!-- tabs:end -->
+
+### ** Integrated PWM **
+
+Many microcontrollers have internal timers which can be used for PWM purposes. These timers can often to drive output pins directly and/or generate callbacks.
+
+If the microcontroller requires timers to be enabled for PWM, that should be done before using integrated PWM capabilities. These drivers will only configure pin settings and PWM settings. If the microcontroller has DMA capabilities, DMA can configured to work with PWM sources, but should be configured outside of Quantum PWM.
+
+<!-- tabs:start -->
+
+#### ** ChibiOS Integrated PWM **
+
+Enabling support for integrated PWM in Quantum PWM is done by adding the following to `rules.mk`:
+
+```make
+QUANTUM_PWM_ENABLE = yes
+QUANTUM_PWM_DRIVERS += integrated_pwm
+```
+
+(Instead of `QUANTUM_PWM_ENABLE = yes`, you may instead add `"quantum_pwm": true` in the list of features in info.json)
+Creating an integrated PWM device in firmware can then be done with the following API:
+
+```c
+pwm_device_t make_integrated_pwm_device(ch_integrated_pwm_config_t pwm_config, ch_integrated_pwm_pin_t *integrated_pwm_pin, void (*trigger_callback)(void), void (*period_callback)(void));
+```
+
+The device handle returned from the `make_integrated_pwm_device` function can be used to perform all other PWM operations. The integrated_pwm_pin, trigger_callback, and period_callback arguments can individually be assigned NULL if they are not needed.
+
+The maximum number of PWM devices can be configured by changing the following in your `config.h` (default is 1, limit is currently 16 max):
+
+```c
+// 3 PWM devices:
+#define INTEGRATED_PWM_NUM_DEVICES 3
+```
+
+The ChibiOS driver API also includes two helper functions that make it simple to create (and reuse, if desired) the `pwm_config` and `integrated_pwm_pin`:
+
+```c
+ch_integrated_pwm_pin_t make_ch_integrated_pwm_pin(pin_t pwm_pin, iomode_t pal_mode);
+ch_integrated_pwm_config_t make_ch_integrated_pwm_config(PWMDriver *pwm_driver, pwmchannel_t channel, uint32_t pwm_timer_frequency, pwmcnt_t pwm_period, bool on_state_is_high, bool complementary_output);
+```
+
+In `make_ch_integrated_pwm_pin`, the `pal_mode` argument will be applied directly to the pin so as to allow ORing of modes. This means that for many microcontrollers (like GPIO_V2 microcontrollers), the alternate funtion mode indicated in the datasheet will need to have PAL_MODE_ALTERNATE() applied, like this:
+
+```c
+ch_integrated_pwm_pin_t mypwm_pin = make_ch_integrated_pwm_pin(B10, PAL_MODE_ALTERNATE(1));
+```
+
+For the `pwm_timer_frequency` argument in `make_ch_integrated_pwm_config`, the clock frequency for the timer should be used in units of Hz. This is typically divisor of the system clock frequency; as per ChibiOS documentation, the behavoir undefined if an invalid clock frequency is specified.
+
+For the `pwm_period` argument in `make_ch_integrated_pwm_config`, the period should be specified in number of ticks of the PWM clock. After the specified number of ticks have elapsed, if periodic callbacks are enabled, the `period_callback` will be called.
+
+pwm_period
+<!-- tabs:end -->
+
+## Quantum PWM API :id=quantum-pwm-api
+
+All APIs require a `pwm_device_t` object as their first parameter -- this object comes from the specific device initialisation, and instructions on creating it can be found in each driver's respective section.
+
+To use any of the APIs, you need to include `qpwm.h`:
+```c
+#include <qpwm.h>
+```
+
+<!-- tabs:start -->
+
+### ** General Notes **
+
+The units for frequency is in Hertz. Duty cycle is expressed as a perecentage out of 100.00% (precision smaller than hundredths of a percent are ignored).
+
+Quantum PWM has no awareness of CIE lighting curves. If CIE ligthing curves are needed they must be implemented by the caller.
+
+Callback functions must accept no arguments and return no values.
+
+
+### ** Device Control **
+
+<!-- tabs:start -->
+
+#### ** PWM Initialisation **
+
+
+
+
+/**
+ * Sets the trigger callback for the PWM device. 
+ *
+ * @param device[in] the handle of the device to control
+ * @param trigger_callback[in] the callback function to execute upon triggering
+ * @return true if setting the callback function succeeded
+ * @return false if setting the callback function failed
+ */
+
+
+
+/**
+ * Sets the period callback for the PWM device. 
+ *
+ * @param device[in] the handle of the device to control
+ * @param period_callback[in] the callback function to execute upon PWM period elapsing
+ * @return true if setting the callback function succeeded
+ * @return false if setting the callback function failed
+ */
+bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback);
+
+
+```c
+bool qpwm_init(pwm_device_t device);
+```
+
+The `qpwm_init` function is used to initialise a PWM device after it has been created.
+
+```c
+static pwm_device_t backlight_pwm;
+void keyboard_post_init_kb(void) {
+    backlight_pwm = qpwm_make_.......;         // Create the backlight pwm
+    qpwm_init(backlight_pwm, );   // Initialise the backlight pwm
+}
+```
+
+#### ** PWM Power **
+
+```c
+bool qpwm_power(pwm_device_t device, bool power_on);
+```
+
+The `qpwm_power` function instructs the PWM device as to whether or not the PWM should be running.
+
+```c
+static uint8_t last_backlight = 255;
+void backlight_set(uint8_t backlight_pwm_level) {
+    if (backlight_pwm_level == 0) {
+        qpwm_power(backlight_pwm, false);
+    } else {}
+        qpwm_power(backlight_pwm, true);
+    }
+}
+
+```
+
+#### ** Set Frequency **
+
+```c
+bool qpwm_set_frequency(pwm_device_t device, float frequency);
+```
+
+The `qpwm_set_frequency` function sets the frequency at which the PWM should run. The units of frequency is in Hertz.
+
+#### ** Set Duty Cycle **
+
+```c
+bool qpwm_set_duty_cycle(pwm_device_t device, float duty);
+```
+
+The `qpwm_set_duty_cycle` function sets the duty cycle for the PWM device. The duty cycle is expressed as a percentage, and ranges from 0.00% to 100.00%
+
+```c
+void update_backlight_pwm(float pwm_duty_cycle) {
+    qpwm_set_duty_cycle(backlight_pwm, pwm_duty_cycle);
+}
+```
+
+<!-- tabs:end -->
+
+### ** Assigning Callbacks **
+
+Callback functions can be assigned at the time the PWM device is created, and/or later be assigned different functions (or `NULL`).
+
+<!-- tabs:start -->
+
+#### ** Set Trigger Callback **
+
+```c
+bool qpwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback);
+```
+
+The `qpwm_set_trigger_callback` can be used to assign a callback function to be called when the PWM is triggered at the target duty cycle.
+
+```c
+void b6_high(void) {
+    writePinHigh(B6);
+)
+
+void trigger_pin_B6_high(void) {
+    qpwm_set_trigger_callback(backlight_pwm, b6_high);
+}
+
+void trigger_pin_disable(void) {
+    qpwm_set_trigger_callback(backlight_pwm, NULL);
+}
+```
+
+#### ** Set Period Callback **
+
+```c
+bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback);
+```
+
+The `qpwm_set_period_callback` can be used to assign a callback function to be called when the PWM period elapses.
+
+```c
+void b6_low(void) {
+    writePinLow(B6);
+}
+
+void period_pin_B6_low(void) {
+    qpwm_set_period_callback(backlight_pwm, b6_low);
+}
+
+void trigger_pin_disable(void) {
+    qpwm_set_period_callback(backlight_pwm, NULL);
+}
+```
+
+<!-- tabs:end -->
+
+<!-- tabs:end -->

--- a/docs/quantum_pwm.md
+++ b/docs/quantum_pwm.md
@@ -159,31 +159,6 @@ Callback functions must accept no arguments and return no values.
 
 #### ** PWM Initialisation **
 
-
-
-
-/**
- * Sets the trigger callback for the PWM device. 
- *
- * @param device[in] the handle of the device to control
- * @param trigger_callback[in] the callback function to execute upon triggering
- * @return true if setting the callback function succeeded
- * @return false if setting the callback function failed
- */
-
-
-
-/**
- * Sets the period callback for the PWM device. 
- *
- * @param device[in] the handle of the device to control
- * @param period_callback[in] the callback function to execute upon PWM period elapsing
- * @return true if setting the callback function succeeded
- * @return false if setting the callback function failed
- */
-bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback);
-
-
 ```c
 bool qpwm_init(pwm_device_t device);
 ```

--- a/docs/quantum_pwm.md
+++ b/docs/quantum_pwm.md
@@ -262,7 +262,7 @@ void period_pin_B6_low(void) {
     qpwm_set_period_callback(backlight_pwm, b6_low);
 }
 
-void trigger_pin_disable(void) {
+void period_pin_disable(void) {
     qpwm_set_period_callback(backlight_pwm, NULL);
 }
 ```

--- a/drivers/pwm/integrated/qpwm_integrated.c
+++ b/drivers/pwm/integrated/qpwm_integrated.c
@@ -1,0 +1,5 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qpwm_internal.h"
+#include "qpwm_integrated.h"

--- a/drivers/pwm/integrated/qpwm_integrated.h
+++ b/drivers/pwm/integrated/qpwm_integrated.h
@@ -11,4 +11,3 @@
 typedef struct integrated_pwm_device_t {
     pwm_driver_t base;
 } integrated_pwm_device_t;
-

--- a/drivers/pwm/integrated/qpwm_integrated.h
+++ b/drivers/pwm/integrated/qpwm_integrated.h
@@ -1,0 +1,14 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "qpwm_internal.h"
+
+////////////////////////////////////////////////////////////////////
+// Quantum PWM configurables (add to your keyboard's config.h)
+
+typedef struct integrated_pwm_device_t {
+    pwm_driver_t base;
+} integrated_pwm_device_t;
+

--- a/drivers/pwm/software/qpwm_software.c
+++ b/drivers/pwm/software/qpwm_software.c
@@ -7,7 +7,7 @@
 
 typedef struct software_pwm_device_t {
     pwm_driver_t base;
-    
+
     software_pwm_update_task_func_t update_task_func;
 
     bool enabled;
@@ -17,7 +17,6 @@ typedef struct software_pwm_device_t {
 // Driver storage
 software_pwm_device_t software_pwm_drivers[SOFTWARE_PWM_NUM_DEVICES] = {0};
 
-
 // Init control
 bool software_pwm_init(pwm_device_t device) {
     return true;
@@ -25,31 +24,31 @@ bool software_pwm_init(pwm_device_t device) {
 
 // Power control
 bool software_pwm_power(pwm_device_t device, bool power_on) {
-    software_pwm_device_t *driver = (software_pwm_device_t *) device;
-    driver->enabled = power_on;
-    if (driver->base.period_callback) {    
-        driver->base.period_callback();  // Return to the baseline state
+    software_pwm_device_t *driver = (software_pwm_device_t *)device;
+    driver->enabled               = power_on;
+    if (driver->base.period_callback) {
+        driver->base.period_callback(); // Return to the baseline state
     }
     return true;
 }
 
 // Frequency control
 bool software_pwm_set_frequency(pwm_device_t device, float frequency) {
-    pwm_driver_t *driver = (pwm_driver_t *) device;
-    driver->frequency = frequency;
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+    driver->frequency    = frequency;
     return true;
 }
 
 // PWM duty cycle control
 bool software_pwm_set_duty_cycle(pwm_device_t device, float duty_cycle) {
-    pwm_driver_t *driver = (pwm_driver_t *) device;
-    driver->duty_cycle = duty_cycle;
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+    driver->duty_cycle   = duty_cycle;
     return true;
 }
 
 // PWM trigger callback assignment
 bool software_pwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback) {
-    pwm_driver_t *driver = (pwm_driver_t *) device;
+    pwm_driver_t *driver     = (pwm_driver_t *)device;
     driver->trigger_callback = trigger_callback;
     return true;
 }
@@ -60,8 +59,6 @@ bool software_pwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t
     driver->period_callback = period_callback;
     return true;
 }
-
-
 
 void software_pwm_update_task_func(pwm_device_t device, uint8_t tick) {
     software_pwm_device_t *driver = (software_pwm_device_t *)device;
@@ -87,20 +84,20 @@ void software_pwm_update_task_func(pwm_device_t device, uint8_t tick) {
             0b0111111111111111,
             0b1111111111111111,
         };
-      
-        index = floor(driver->base.duty_cycle*17.0/100.0);
+
+        index = floor(driver->base.duty_cycle * 17.0 / 100.0);
         if (index > 16) {
             index = 16;
         }
-        if(duty_table[index] & ((uint16_t)1 << (tick % 16))) {
-            // driver->trigger_func(); 
+        if (duty_table[index] & ((uint16_t)1 << (tick % 16))) {
+            // driver->trigger_func();
             if (driver->base.trigger_callback) {
-                driver->base.trigger_callback();  
+                driver->base.trigger_callback();
             }
         } else {
             // driver->period_func();
             if (driver->base.period_callback) {
-                driver->base.period_callback(); 
+                driver->base.period_callback();
             }
         }
     }
@@ -110,12 +107,12 @@ void software_pwm_update_task_func(pwm_device_t device, uint8_t tick) {
 // Driver vtable
 
 const pwm_driver_vtable_t software_pwm_driver_vtable = {
-        .init                  = software_pwm_init,
-        .power                 = software_pwm_power,
-        .set_frequency         = software_pwm_set_frequency,
-        .set_duty_cycle        = software_pwm_set_duty_cycle, 
-        .set_trigger_callback  = software_pwm_set_trigger_callback, 
-        .set_period_callback   = software_pwm_set_period_callback, 
+    .init                  = software_pwm_init,
+    .power                 = software_pwm_power,
+    .set_frequency         = software_pwm_set_frequency,
+    .set_duty_cycle        = software_pwm_set_duty_cycle,
+    .set_trigger_callback  = software_pwm_set_trigger_callback,
+    .set_period_callback   = software_pwm_set_period_callback, 
 };
 
 // Factory function for creating a handle to the PWM device
@@ -123,12 +120,12 @@ pwm_device_t make_software_pwm_device(void (*trigger_callback)(void), void (*per
     for (uint32_t i = 0; i < SOFTWARE_PWM_NUM_DEVICES; ++i) {
         software_pwm_device_t *driver = &software_pwm_drivers[i];
         if (!driver->base.driver_vtable) {
-            driver->base.driver_vtable = (const pwm_driver_vtable_t *)&software_pwm_driver_vtable;
-            driver->base.frequency = 0;         /* unused in this implementation */
-            driver->base.duty_cycle = 50;       /* default to 50% duty cycle upon creation */
-            driver->base.period_callback = (pwm_driver_callback_t)period_callback;
+            driver->base.driver_vtable    = (const pwm_driver_vtable_t *)&software_pwm_driver_vtable;
+            driver->base.frequency        = 0;  /* unused in this implementation */
+            driver->base.duty_cycle       = 50; /* default to 50% duty cycle upon creation */
+            driver->base.period_callback  = (pwm_driver_callback_t)period_callback;
             driver->base.trigger_callback = (pwm_driver_callback_t)trigger_callback;
-            driver->update_task_func = (software_pwm_update_task_func_t)software_pwm_update_task_func;
+            driver->update_task_func      = (software_pwm_update_task_func_t)software_pwm_update_task_func;
 
             if (!qpwm_internal_register_device((pwm_device_t)driver)) {
                 memset(driver, 0, sizeof(software_pwm_device_t));

--- a/drivers/pwm/software/qpwm_software.c
+++ b/drivers/pwm/software/qpwm_software.c
@@ -55,7 +55,7 @@ bool software_pwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_
 
 // PWM period callback assignment
 bool software_pwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback) {
-    pwm_driver_t *driver = (pwm_driver_t *) device;
+    pwm_driver_t *driver    = (pwm_driver_t *)device;
     driver->period_callback = period_callback;
     return true;
 }
@@ -107,12 +107,12 @@ void software_pwm_update_task_func(pwm_device_t device, uint8_t tick) {
 // Driver vtable
 
 const pwm_driver_vtable_t software_pwm_driver_vtable = {
-    .init                  = software_pwm_init,
-    .power                 = software_pwm_power,
-    .set_frequency         = software_pwm_set_frequency,
-    .set_duty_cycle        = software_pwm_set_duty_cycle,
-    .set_trigger_callback  = software_pwm_set_trigger_callback,
-    .set_period_callback   = software_pwm_set_period_callback, 
+    .init                 = software_pwm_init,
+    .power                = software_pwm_power,
+    .set_frequency        = software_pwm_set_frequency,
+    .set_duty_cycle       = software_pwm_set_duty_cycle,
+    .set_trigger_callback = software_pwm_set_trigger_callback,
+    .set_period_callback  = software_pwm_set_period_callback,
 };
 
 // Factory function for creating a handle to the PWM device

--- a/drivers/pwm/software/qpwm_software.c
+++ b/drivers/pwm/software/qpwm_software.c
@@ -27,7 +27,6 @@ bool software_pwm_init(pwm_device_t device) {
 bool software_pwm_power(pwm_device_t device, bool power_on) {
     software_pwm_device_t *driver = (software_pwm_device_t *) device;
     driver->enabled = power_on;
-    //driver->period_func(); 
     if (driver->base.period_callback) {    
         driver->base.period_callback();  // Return to the baseline state
     }

--- a/drivers/pwm/software/qpwm_software.c
+++ b/drivers/pwm/software/qpwm_software.c
@@ -1,0 +1,156 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qpwm_internal.h"
+#include "qpwm_software.h"
+#include <math.h>
+
+typedef struct software_pwm_device_t {
+    pwm_driver_t base;
+    
+    software_pwm_update_task_func_t update_task_func;
+
+    bool enabled;
+
+} software_pwm_device_t;
+
+// Driver storage
+software_pwm_device_t software_pwm_drivers[SOFTWARE_PWM_NUM_DEVICES] = {0};
+
+
+// Init control
+bool software_pwm_init(pwm_device_t device) {
+    return true;
+}
+
+// Power control
+bool software_pwm_power(pwm_device_t device, bool power_on) {
+    software_pwm_device_t *driver = (software_pwm_device_t *) device;
+    driver->enabled = power_on;
+    //driver->period_func(); 
+    if (driver->base.period_callback) {    
+        driver->base.period_callback();  // Return to the baseline state
+    }
+    return true;
+}
+
+// Frequency control
+bool software_pwm_set_frequency(pwm_device_t device, float frequency) {
+    pwm_driver_t *driver = (pwm_driver_t *) device;
+    driver->frequency = frequency;
+    return true;
+}
+
+// PWM duty cycle control
+bool software_pwm_set_duty_cycle(pwm_device_t device, float duty_cycle) {
+    pwm_driver_t *driver = (pwm_driver_t *) device;
+    driver->duty_cycle = duty_cycle;
+    return true;
+}
+
+// PWM trigger callback assignment
+bool software_pwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback) {
+    pwm_driver_t *driver = (pwm_driver_t *) device;
+    driver->trigger_callback = trigger_callback;
+    return true;
+}
+
+// PWM period callback assignment
+bool software_pwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback) {
+    pwm_driver_t *driver = (pwm_driver_t *) device;
+    driver->period_callback = period_callback;
+    return true;
+}
+
+
+
+void software_pwm_update_task_func(pwm_device_t device, uint8_t tick) {
+    software_pwm_device_t *driver = (software_pwm_device_t *)device;
+    if (driver->enabled) {
+        uint8_t index;
+
+        static const uint16_t duty_table[] = {
+            0b0000000000000000,
+            0b1000000000000000,
+            0b1000000010000000,
+            0b1000001000010000,
+            0b1000100010001000,
+            0b1001000100100100,
+            0b1001001001001001,
+            0b1010100101010100,
+            0b1010101010101010,
+            0b0101011010101011,
+            0b0110110110110110,
+            0b0110111011011011,
+            0b0111011101110111,
+            0b0111110111101111,
+            0b0111111101111111,
+            0b0111111111111111,
+            0b1111111111111111,
+        };
+      
+        index = floor(driver->base.duty_cycle*17.0/100.0);
+        if (index > 16) {
+            index = 16;
+        }
+        if(duty_table[index] & ((uint16_t)1 << (tick % 16))) {
+            // driver->trigger_func(); 
+            if (driver->base.trigger_callback) {
+                driver->base.trigger_callback();  
+            }
+        } else {
+            // driver->period_func();
+            if (driver->base.period_callback) {
+                driver->base.period_callback(); 
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Driver vtable
+
+const pwm_driver_vtable_t software_pwm_driver_vtable = {
+        .init                  = software_pwm_init,
+        .power                 = software_pwm_power,
+        .set_frequency         = software_pwm_set_frequency,
+        .set_duty_cycle        = software_pwm_set_duty_cycle, 
+        .set_trigger_callback  = software_pwm_set_trigger_callback, 
+        .set_period_callback   = software_pwm_set_period_callback, 
+};
+
+// Factory function for creating a handle to the PWM device
+pwm_device_t make_software_pwm_device(void (*trigger_callback)(void), void (*period_callback)(void)) {
+    for (uint32_t i = 0; i < SOFTWARE_PWM_NUM_DEVICES; ++i) {
+        software_pwm_device_t *driver = &software_pwm_drivers[i];
+        if (!driver->base.driver_vtable) {
+            driver->base.driver_vtable = (const pwm_driver_vtable_t *)&software_pwm_driver_vtable;
+            driver->base.frequency = 0;         /* unused in this implementation */
+            driver->base.duty_cycle = 50;       /* default to 50% duty cycle upon creation */
+            driver->base.period_callback = (pwm_driver_callback_t)period_callback;
+            driver->base.trigger_callback = (pwm_driver_callback_t)trigger_callback;
+            driver->update_task_func = (software_pwm_update_task_func_t)software_pwm_update_task_func;
+
+            if (!qpwm_internal_register_device((pwm_device_t)driver)) {
+                memset(driver, 0, sizeof(software_pwm_device_t));
+                return NULL;
+            }
+
+            return (pwm_device_t)driver;
+        }
+    }
+    return NULL;
+}
+
+__attribute__((weak)) void qpwm_internal_update_tick(void) {
+    static uint8_t current_tick = 0;
+    for (uint32_t i = 0; i < SOFTWARE_PWM_NUM_DEVICES; ++i) {
+        software_pwm_device_t *driver = &software_pwm_drivers[i];
+        if (driver) {
+            if (driver->update_task_func) {
+                driver->update_task_func(driver, current_tick);
+            }
+        }
+    }
+    current_tick++;
+}

--- a/drivers/pwm/software/qpwm_software.h
+++ b/drivers/pwm/software/qpwm_software.h
@@ -1,0 +1,40 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "qpwm_internal.h"
+
+////////////////////////////////////////////////////////////////////
+// Quantum PWM configurables (add to your keyboard's config.h)
+
+#ifndef SOFTWARE_PWM_NUM_DEVICES
+#    define SOFTWARE_PWM_NUM_DEVICES 1
+#endif //SOFTWARE_PWM_NUM_DEVICES
+
+#define QUANTUM_PWM_UPDATE_TASK
+void qpwm_internal_update_tick(void);
+
+//typedef void (*software_pwm_callback_func_t)(void);
+typedef void (*software_pwm_update_task_func_t)(pwm_device_t device, uint8_t tick);
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM software device factories and helpers
+
+
+#ifdef QUANTUM_PWM_SOFTWARE_PWM_ENABLE
+/**
+ * Factory function for creating a handle to the PWM device.
+ *
+ * NOTE: This PWM can only be used to trigger callback functions.
+ * Any pin state changes must be implemented in the assigned callback
+ * functions
+ * 
+ * @param pwm_config[in] configures the PWM (e.g. frequency, duty cycle)
+ * @param hardware_pwm_pin[in] optional output pin specification
+ * @return the device handle used with all routines in Quantum PWM
+ */
+pwm_device_t make_software_pwm_device(void (*trigger_callback)(void), void (*period_callback)(void));
+
+#endif // QUANTUM_PWM_SOFTWARE_PWM_ENABLE

--- a/drivers/pwm/software/qpwm_software.h
+++ b/drivers/pwm/software/qpwm_software.h
@@ -10,18 +10,15 @@
 
 #ifndef SOFTWARE_PWM_NUM_DEVICES
 #    define SOFTWARE_PWM_NUM_DEVICES 1
-#endif //SOFTWARE_PWM_NUM_DEVICES
+#endif // SOFTWARE_PWM_NUM_DEVICES
 
 #define QUANTUM_PWM_UPDATE_TASK
 void qpwm_internal_update_tick(void);
 
-//typedef void (*software_pwm_callback_func_t)(void);
 typedef void (*software_pwm_update_task_func_t)(pwm_device_t device, uint8_t tick);
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum PWM software device factories and helpers
-
 
 #ifdef QUANTUM_PWM_SOFTWARE_PWM_ENABLE
 /**
@@ -30,7 +27,7 @@ typedef void (*software_pwm_update_task_func_t)(pwm_device_t device, uint8_t tic
  * NOTE: This PWM can only be used to trigger callback functions.
  * Any pin state changes must be implemented in the assigned callback
  * functions
- * 
+ *
  * @param pwm_config[in] configures the PWM (e.g. frequency, duty cycle)
  * @param hardware_pwm_pin[in] optional output pin specification
  * @return the device handle used with all routines in Quantum PWM

--- a/platforms/chibios/drivers/pwm.c
+++ b/platforms/chibios/drivers/pwm.c
@@ -4,7 +4,7 @@
 #include "qpwm_internal.h"
 #include "pwm.h"
 
-//Improves readability
+// Improves readability
 #define CH_INTEGRATED_PWM_DRIVER_PTR ((driver->ch_integrated_pwm_config).pwm_driver)
 #define CH_INTEGRATED_PWM_CONFIG ((driver->ch_integrated_pwm_config).pwmCFG)
 #define CH_INTEGRATED_PWM_CHANNEL ((driver->ch_integrated_pwm_config).channel)
@@ -15,11 +15,11 @@
 // Common
 
 typedef struct ch_integrated_pwm_device_t {
-    pwm_driver_t base;
-    ch_integrated_pwm_pin_t *ch_integrated_pwm_pin;
+    pwm_driver_t               base;
+    ch_integrated_pwm_pin_t *  ch_integrated_pwm_pin;
     ch_integrated_pwm_config_t ch_integrated_pwm_config;
-    bool pwm_started;
-    uint32_t driver_index;
+    bool                       pwm_started;
+    uint32_t                   driver_index;
 
     void (*trigger_callback)(void);
     void (*period_callback)(void);
@@ -33,18 +33,18 @@ ch_integrated_pwm_device_t ch_integrated_pwm_drivers[INTEGRATED_PWM_NUM_DEVICES]
 // These functions are used for the PWM driver callbacks directly, which
 // requires accepting a (ChibiOS-specific) PWMDriver* argument. The only job
 // of these callback functions is to redirect the call to a non-Chibios-specific
-// callback function typed as void (*_callback)(void).  
-#define MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(index) \
-void ch_integrated_pwm_trigger_callback##index(PWMDriver *pwmp) { \
-    (void)pwmp; \
-    ch_integrated_pwm_drivers[index].trigger_callback(); \
-}
+// callback function typed as void (*_callback)(void).
+#define MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(index)                \
+    void ch_integrated_pwm_trigger_callback##index(PWMDriver *pwmp) { \
+        (void)pwmp;                                                   \
+        ch_integrated_pwm_drivers[index].trigger_callback();          \
+    }
 
-#define MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(index) \
-void ch_integrated_pwm_period_callback##index(PWMDriver *pwmp) { \
-    (void)pwmp; \
-    ch_integrated_pwm_drivers[index].period_callback(); \
-} 
+#define MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(index)                \
+    void ch_integrated_pwm_period_callback##index(PWMDriver *pwmp) { \
+        (void)pwmp;                                                  \
+        ch_integrated_pwm_drivers[index].period_callback();          \
+    }
 
 #define MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK_FN_NAME(index) ch_integrated_pwm_trigger_callback##index
 #define MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK_FN_NAME(index) ch_integrated_pwm_period_callback##index
@@ -115,119 +115,117 @@ MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(15);
 MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(15);
 #endif
 
-
 // Store the callback function pointers in an array so they can be accessed by index value
 pwmcallback_t ch_integrated_pwm_trigger_callbacks[INTEGRATED_PWM_NUM_DEVICES] = {
-    #if INTEGRATED_PWM_NUM_DEVICES > 0
+#if INTEGRATED_PWM_NUM_DEVICES > 0
     ch_integrated_pwm_trigger_callback0,
-    #else
+#else
     0
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 1
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 1
     ch_integrated_pwm_trigger_callback1,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 2
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 2
     ch_integrated_pwm_trigger_callback2,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 3
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 3
     ch_integrated_pwm_trigger_callback3,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 4
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 4
     ch_integrated_pwm_trigger_callback4,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 5
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 5
     ch_integrated_pwm_trigger_callback5,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 6
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 6
     ch_integrated_pwm_trigger_callback6,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 7
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 7
     ch_integrated_pwm_trigger_callback7,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 8
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 8
     ch_integrated_pwm_trigger_callback8,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 9
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 9
     ch_integrated_pwm_trigger_callback9,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 10
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 10
     ch_integrated_pwm_trigger_callback10,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 11
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 11
     ch_integrated_pwm_trigger_callback11,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 12
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 12
     ch_integrated_pwm_trigger_callback12,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 13
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 13
     ch_integrated_pwm_trigger_callback13,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 14
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 14
     ch_integrated_pwm_trigger_callback14,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 15
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 15
     ch_integrated_pwm_trigger_callback15,
-    #endif
+#endif
 };
 
-
 pwmcallback_t ch_integrated_pwm_period_callbacks[INTEGRATED_PWM_NUM_DEVICES] = {
-    #if INTEGRATED_PWM_NUM_DEVICES > 0
+#if INTEGRATED_PWM_NUM_DEVICES > 0
     ch_integrated_pwm_period_callback0,
-    #else
+#else
     0
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 1
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 1
     ch_integrated_pwm_period_callback1,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 2
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 2
     ch_integrated_pwm_period_callback2,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 3
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 3
     ch_integrated_pwm_period_callback3,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 4
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 4
     ch_integrated_pwm_period_callback4,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 5
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 5
     ch_integrated_pwm_period_callback5,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 6
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 6
     ch_integrated_pwm_period_callback6,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 7
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 7
     ch_integrated_pwm_period_callback7,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 8
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 8
     ch_integrated_pwm_period_callback8,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 9
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 9
     ch_integrated_pwm_period_callback9,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 10
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 10
     ch_integrated_pwm_period_callback10,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 11
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 11
     ch_integrated_pwm_period_callback11,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 12
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 12
     ch_integrated_pwm_period_callback12,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 13
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 13
     ch_integrated_pwm_period_callback13,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 14
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 14
     ch_integrated_pwm_period_callback14,
-    #endif
-    #if INTEGRATED_PWM_NUM_DEVICES > 15
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 15
     ch_integrated_pwm_period_callback15,
-    #endif
+#endif
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Initialization
 __attribute__((weak)) bool ch_integrated_pwm_init(pwm_device_t device) {
-    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *)device;
     if (driver->ch_integrated_pwm_pin != NULL) {
         palSetPadMode(PAL_PORT(CH_INTEGRATED_PWM_PIN), PAL_PAD(CH_INTEGRATED_PWM_PIN), CH_INTEGRATED_PWM_PIN_PAL_MODE);
     }
@@ -239,7 +237,7 @@ __attribute__((weak)) bool ch_integrated_pwm_init(pwm_device_t device) {
 
 // Power control
 bool ch_integrated_pwm_power(pwm_device_t device, bool power_on) {
-    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *)device;
     pwmStop((driver->ch_integrated_pwm_config).pwm_driver);
     driver->pwm_started = false;
     if (power_on) {
@@ -247,9 +245,8 @@ bool ch_integrated_pwm_power(pwm_device_t device, bool power_on) {
         driver->pwm_started = true;
 
         chSysLockFromISR();
-        pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), \
-                          PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle*100.0)));
-        
+        pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle * 100.0)));
+
         if (CH_INTEGRATED_PWM_CONFIG.channels[CH_INTEGRATED_PWM_CHANNEL - 1].callback) {
             pwmEnableChannelNotificationI(CH_INTEGRATED_PWM_DRIVER_PTR, CH_INTEGRATED_PWM_CHANNEL - 1);
         }
@@ -264,8 +261,8 @@ bool ch_integrated_pwm_power(pwm_device_t device, bool power_on) {
 
 // PWM period control
 bool ch_integrated_pwm_set_period(pwm_device_t device, uint32_t period) {
-    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
-    
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *)device;
+
     if (period == 0) {
         return true;
     }
@@ -274,15 +271,14 @@ bool ch_integrated_pwm_set_period(pwm_device_t device, uint32_t period) {
 
     if (driver->pwm_started == false) {
         // PWM not running, update configuration data only
-        CH_INTEGRATED_PWM_CONFIG.period = period;
+        CH_INTEGRATED_PWM_CONFIG.period      = period;
         CH_INTEGRATED_PWM_DRIVER_PTR->period = period;
         return true;
     }
 
     chSysLockFromISR();
     pwmChangePeriodI(CH_INTEGRATED_PWM_DRIVER_PTR, period);
-    pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (pwmchnmsk_t)(CH_INTEGRATED_PWM_CHANNEL - 1), \
-                      PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle*100.0)));
+    pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (pwmchnmsk_t)(CH_INTEGRATED_PWM_CHANNEL - 1), PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle * 100.0)));
     chSysUnlockFromISR();
 
     return true;
@@ -290,7 +286,7 @@ bool ch_integrated_pwm_set_period(pwm_device_t device, uint32_t period) {
 
 // PWM frequency control
 bool ch_integrated_pwm_set_frequency(pwm_device_t device, float frequency) {
-    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *)device;
     if (frequency <= 0.0) {
         return true;
     }
@@ -299,23 +295,22 @@ bool ch_integrated_pwm_set_frequency(pwm_device_t device, float frequency) {
 
     if (driver->pwm_started == false) {
         // PWM not running, update configuration data only
-        CH_INTEGRATED_PWM_CONFIG.period = (CH_INTEGRATED_PWM_CONFIG.frequency / frequency ); // (timer clock frequency / PWM frequency)
+        CH_INTEGRATED_PWM_CONFIG.period      = (CH_INTEGRATED_PWM_CONFIG.frequency / frequency ); // (timer clock frequency / PWM frequency)
         CH_INTEGRATED_PWM_DRIVER_PTR->period = CH_INTEGRATED_PWM_CONFIG.period;
         return true;
     }
 
     chSysLockFromISR();
     pwmChangePeriodI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CONFIG.frequency / frequency ));
-    pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), \
-                      PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle*100.0)));
+    pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle * 100.0)));
     chSysUnlockFromISR();
     return true;
 }
 
 // PWM duty cycle control
 bool ch_integrated_pwm_set_duty_cycle(pwm_device_t device, float duty_cycle) {
-    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
-    driver->base.duty_cycle = duty_cycle;
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *)device;
+    driver->base.duty_cycle            = duty_cycle;
 
     if (driver->pwm_started == false) {
         // PWM not running, nothing else to do
@@ -324,24 +319,21 @@ bool ch_integrated_pwm_set_duty_cycle(pwm_device_t device, float duty_cycle) {
 
     chSysLockFromISR();
     if (duty_cycle == 0) {
-        pwmDisableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, \
-                          (CH_INTEGRATED_PWM_CHANNEL - 1));
+        pwmDisableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1));
         if (driver->trigger_callback) {
             // If callbacks are being used, the 0% duty cycle state is equivalent to
             // being perpetually post-triggered, so execute the trigger callback to
             // leave things in the correct state. However, this generally may be
             // insufficient when using callbacks becuse the period callback will continue to
             // execute even if the channel is disabled. Unlike the hardware PWM mode (for
-            // which the hardware will suppress periodic events from affecting the assigned 
+            // which the hardware will suppress periodic events from affecting the assigned
             // pin when the channel is disabled), the periodic callback function will continue
             // to be called until the PWM is stopped by qpwm_power(my_qpm_device, false) or by
             // setting the periodic callback function to NULL.
             driver->trigger_callback();
         }
     } else {
-        pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, \
-                         (CH_INTEGRATED_PWM_CHANNEL - 1), \
-                         PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint32_t)(duty_cycle*100.0)));
+        pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint32_t)(duty_cycle * 100.0)));
     }
     chSysUnlockFromISR();
     return true;
@@ -349,8 +341,8 @@ bool ch_integrated_pwm_set_duty_cycle(pwm_device_t device, float duty_cycle) {
 
 // PWM trigger callback assignment
 bool ch_integrated_pwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback) {
-    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
-    driver->trigger_callback = trigger_callback;
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *)device;
+    driver->trigger_callback           = trigger_callback;
     if (trigger_callback) {
         CH_INTEGRATED_PWM_CONFIG.channels[CH_INTEGRATED_PWM_CHANNEL - 1].callback = ch_integrated_pwm_trigger_callbacks[driver->driver_index];
     } else {
@@ -364,8 +356,8 @@ bool ch_integrated_pwm_set_trigger_callback(pwm_device_t device, pwm_driver_call
 // same PWM driver), setting the period callback for one PWM device will affect all the period callback for all
 // PWM devices sharing that driver. There is only one period callback allowed per PWM driver.
 bool ch_integrated_pwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback) {
-    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
-    driver->period_callback = period_callback;
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *)device;
+    driver->period_callback            = period_callback;
     if (period_callback) {
         CH_INTEGRATED_PWM_CONFIG.callback = ch_integrated_pwm_period_callbacks[driver->driver_index];
     } else {
@@ -374,17 +366,16 @@ bool ch_integrated_pwm_set_period_callback(pwm_device_t device, pwm_driver_callb
     return true;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Driver vtable
 
 const pwm_driver_vtable_t integrated_pwm_driver_vtable = {
-        .init                   = ch_integrated_pwm_init,
-        .power                  = ch_integrated_pwm_power,
-        .set_frequency          = ch_integrated_pwm_set_frequency,
-        .set_duty_cycle         = ch_integrated_pwm_set_duty_cycle, 
-        .set_trigger_callback   = ch_integrated_pwm_set_trigger_callback, 
-        .set_period_callback    = ch_integrated_pwm_set_period_callback, 
+    .init                   = ch_integrated_pwm_init,
+    .power                  = ch_integrated_pwm_power,
+    .set_frequency          = ch_integrated_pwm_set_frequency,
+    .set_duty_cycle         = ch_integrated_pwm_set_duty_cycle,
+    .set_trigger_callback   = ch_integrated_pwm_set_trigger_callback,
+    .set_period_callback    = ch_integrated_pwm_set_period_callback,
 };
 
 // Factory function for creating a handle to the PWM device
@@ -392,13 +383,13 @@ pwm_device_t make_integrated_pwm_device(ch_integrated_pwm_config_t pwm_config, c
     for (uint32_t i = 0; i < INTEGRATED_PWM_NUM_DEVICES; ++i) {
         ch_integrated_pwm_device_t *driver = &ch_integrated_pwm_drivers[i];
         if (!driver->base.driver_vtable) {
-            driver->base.driver_vtable = (const pwm_driver_vtable_t *)&integrated_pwm_driver_vtable;
+            driver->base.driver_vtable       = (const pwm_driver_vtable_t *)&integrated_pwm_driver_vtable;
             driver->ch_integrated_pwm_config = pwm_config;
-            driver->ch_integrated_pwm_pin = integrated_pwm_pin;
-            driver->base.frequency = pwm_config.pwmCFG.frequency / pwm_config.pwmCFG.period;
-            driver->base.duty_cycle = 50;       /* default to 50% duty cycle upon creation */
-            driver->driver_index = i;
-            driver->pwm_started = false;
+            driver->ch_integrated_pwm_pin    = integrated_pwm_pin;
+            driver->base.frequency           = pwm_config.pwmCFG.frequency / pwm_config.pwmCFG.period;
+            driver->base.duty_cycle          = 50; /* default to 50% duty cycle upon creation */
+            driver->driver_index             = i;
+            driver->pwm_started              = false;
 
             ch_integrated_pwm_set_trigger_callback((pwm_device_t)driver, trigger_callback);
             ch_integrated_pwm_set_period_callback((pwm_device_t)driver, period_callback);
@@ -413,7 +404,6 @@ pwm_device_t make_integrated_pwm_device(ch_integrated_pwm_config_t pwm_config, c
     }
     return NULL;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ChibiOS-specific Helper Functions
@@ -430,15 +420,13 @@ ch_integrated_pwm_config_t make_ch_integrated_pwm_config(PWMDriver *pwm_driver, 
     if (complementary_output) {
         if (on_state_is_high) {
             pwmCFG.channels[channel - 1].mode = PWM_COMPLEMENTARY_OUTPUT_ACTIVE_LOW;
-        }
-        else {
+        } else {
             pwmCFG.channels[channel - 1].mode = PWM_COMPLEMENTARY_OUTPUT_ACTIVE_HIGH;
         }
     } else {
         if (on_state_is_high) {
             pwmCFG.channels[channel - 1].mode = PWM_OUTPUT_ACTIVE_HIGH;
-        }
-        else {
+        } else {
             pwmCFG.channels[channel - 1].mode = PWM_OUTPUT_ACTIVE_LOW;
         }
     }
@@ -446,8 +434,8 @@ ch_integrated_pwm_config_t make_ch_integrated_pwm_config(PWMDriver *pwm_driver, 
     ch_integrated_pwm_config_t ch_integrated_pwm_config;
 
     ch_integrated_pwm_config.pwm_driver = pwm_driver;
-    ch_integrated_pwm_config.pwmCFG = pwmCFG;
-    ch_integrated_pwm_config.channel = channel;
+    ch_integrated_pwm_config.pwmCFG     = pwmCFG;
+    ch_integrated_pwm_config.channel    = channel;
 
     return ch_integrated_pwm_config;
 }
@@ -460,6 +448,6 @@ ch_integrated_pwm_pin_t make_ch_integrated_pwm_pin(pin_t pin, iomode_t pal_mode)
     ch_integrated_pwm_pin_t ch_pwm_pin;
     ch_pwm_pin.pin = pin;
     ch_pwm_pin.pal_mode = pal_mode;
-    
+
     return ch_pwm_pin;
 }

--- a/platforms/chibios/drivers/pwm.c
+++ b/platforms/chibios/drivers/pwm.c
@@ -1,0 +1,465 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qpwm_internal.h"
+#include "pwm.h"
+
+//Improves readability
+#define CH_INTEGRATED_PWM_DRIVER_PTR ((driver->ch_integrated_pwm_config).pwm_driver)
+#define CH_INTEGRATED_PWM_CONFIG ((driver->ch_integrated_pwm_config).pwmCFG)
+#define CH_INTEGRATED_PWM_CHANNEL ((driver->ch_integrated_pwm_config).channel)
+#define CH_INTEGRATED_PWM_PIN ((driver->ch_integrated_pwm_pin)->pin)
+#define CH_INTEGRATED_PWM_PIN_PAL_MODE ((driver->ch_integrated_pwm_pin)->pal_mode)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Common
+
+typedef struct ch_integrated_pwm_device_t {
+    pwm_driver_t base;
+    ch_integrated_pwm_pin_t *ch_integrated_pwm_pin;
+    ch_integrated_pwm_config_t ch_integrated_pwm_config;
+    bool pwm_started;
+    uint32_t driver_index;
+
+    void (*trigger_callback)(void);
+    void (*period_callback)(void);
+
+} ch_integrated_pwm_device_t;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Driver and callback storage
+ch_integrated_pwm_device_t ch_integrated_pwm_drivers[INTEGRATED_PWM_NUM_DEVICES] = {0};
+
+// These functions are used for as the PWM driver callbacks directly, which
+// requires accepting a (Chibios-specific) PWMDriver* argument. The only job
+// of these callback functions is to redirect the call to a non-Chibios-specific
+// callback function typed as void (*_callback)(void).  
+#define MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(index) \
+void ch_integrated_pwm_trigger_callback##index(PWMDriver *pwmp) { \
+    (void)pwmp; \
+    ch_integrated_pwm_drivers[index].trigger_callback(); \
+}
+
+#define MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(index) \
+void ch_integrated_pwm_period_callback##index(PWMDriver *pwmp) { \
+    (void)pwmp; \
+    ch_integrated_pwm_drivers[index].period_callback(); \
+} 
+
+#define MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK_FN_NAME(index) ch_integrated_pwm_trigger_callback##index
+#define MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK_FN_NAME(index) ch_integrated_pwm_period_callback##index
+
+// Generate the trigger callbacks and periodic callbacks for each PWM device (as-needed)
+#if INTEGRATED_PWM_NUM_DEVICES > 0
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(0);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(0);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 1
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(1);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(1);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 2
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(2);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(2);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 3
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(3);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(3);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 4
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(4);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(4);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 5
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(5);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(5);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 6
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(6);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(6);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 7
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(7);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(7);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 8
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(8);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(8);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 9
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(9);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(9);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 10
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(10);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(10);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 11
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(11);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(11);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 12
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(12);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(12);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 13
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(13);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(13);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 14
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(14);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(14);
+#endif
+#if INTEGRATED_PWM_NUM_DEVICES > 15
+MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(15);
+MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(15);
+#endif
+
+
+// Driver and callback storage
+pwmcallback_t ch_integrated_pwm_trigger_callbacks[INTEGRATED_PWM_NUM_DEVICES] = {
+    #if INTEGRATED_PWM_NUM_DEVICES > 0
+    ch_integrated_pwm_trigger_callback0,
+    #else
+    0
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 1
+    ch_integrated_pwm_trigger_callback1,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 2
+    ch_integrated_pwm_trigger_callback2,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 3
+    ch_integrated_pwm_trigger_callback3,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 4
+    ch_integrated_pwm_trigger_callback4,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 5
+    ch_integrated_pwm_trigger_callback5,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 6
+    ch_integrated_pwm_trigger_callback6,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 7
+    ch_integrated_pwm_trigger_callback7,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 8
+    ch_integrated_pwm_trigger_callback8,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 9
+    ch_integrated_pwm_trigger_callback9,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 10
+    ch_integrated_pwm_trigger_callback10,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 11
+    ch_integrated_pwm_trigger_callback11,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 12
+    ch_integrated_pwm_trigger_callback12,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 13
+    ch_integrated_pwm_trigger_callback13,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 14
+    ch_integrated_pwm_trigger_callback14,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 15
+    ch_integrated_pwm_trigger_callback15,
+    #endif
+};
+
+
+pwmcallback_t ch_integrated_pwm_period_callbacks[INTEGRATED_PWM_NUM_DEVICES] = {
+    #if INTEGRATED_PWM_NUM_DEVICES > 0
+    ch_integrated_pwm_period_callback0,
+    #else
+    0
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 1
+    ch_integrated_pwm_period_callback1,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 2
+    ch_integrated_pwm_period_callback2,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 3
+    ch_integrated_pwm_period_callback3,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 4
+    ch_integrated_pwm_period_callback4,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 5
+    ch_integrated_pwm_period_callback5,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 6
+    ch_integrated_pwm_period_callback6,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 7
+    ch_integrated_pwm_period_callback7,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 8
+    ch_integrated_pwm_period_callback8,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 9
+    ch_integrated_pwm_period_callback9,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 10
+    ch_integrated_pwm_period_callback10,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 11
+    ch_integrated_pwm_period_callback11,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 12
+    ch_integrated_pwm_period_callback12,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 13
+    ch_integrated_pwm_period_callback13,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 14
+    ch_integrated_pwm_period_callback14,
+    #endif
+    #if INTEGRATED_PWM_NUM_DEVICES > 15
+    ch_integrated_pwm_period_callback15,
+    #endif
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Initialization
+__attribute__((weak)) bool ch_integrated_pwm_init(pwm_device_t device) {
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    if (driver->ch_integrated_pwm_pin != NULL) {
+        palSetPadMode(PAL_PORT(CH_INTEGRATED_PWM_PIN), PAL_PAD(CH_INTEGRATED_PWM_PIN), CH_INTEGRATED_PWM_PIN_PAL_MODE);
+    }
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM API implementations
+
+// Power control
+bool ch_integrated_pwm_power(pwm_device_t device, bool power_on) {
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    pwmStop((driver->ch_integrated_pwm_config).pwm_driver);
+    driver->pwm_started = false;
+    if (power_on) {
+        pwmStart(CH_INTEGRATED_PWM_DRIVER_PTR, &CH_INTEGRATED_PWM_CONFIG);
+        driver->pwm_started = true;
+
+        chSysLockFromISR();
+        pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), \
+                          PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle*100.0)));
+        
+        if (CH_INTEGRATED_PWM_CONFIG.channels[CH_INTEGRATED_PWM_CHANNEL - 1].callback) {
+            pwmEnableChannelNotificationI(CH_INTEGRATED_PWM_DRIVER_PTR, CH_INTEGRATED_PWM_CHANNEL - 1);
+        }
+        if (CH_INTEGRATED_PWM_CONFIG.callback) {
+            pwmEnablePeriodicNotificationI(CH_INTEGRATED_PWM_DRIVER_PTR);
+        }
+        chSysUnlockFromISR();
+    }
+
+    return true;
+}
+
+// PWM period control
+bool ch_integrated_pwm_set_period(pwm_device_t device, uint32_t period) {
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    
+    if (period == 0) {
+        return true;
+    }
+
+    driver->base.frequency = CH_INTEGRATED_PWM_CONFIG.frequency / period; // (timer clock frequency / number of ticks)
+
+    if (driver->pwm_started == false) {
+        // PWM not running, update configuration data only
+        CH_INTEGRATED_PWM_CONFIG.period = period;
+        CH_INTEGRATED_PWM_DRIVER_PTR->period = period;
+        return true;
+    }
+
+    chSysLockFromISR();
+    pwmChangePeriodI(CH_INTEGRATED_PWM_DRIVER_PTR, period);
+    pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (pwmchnmsk_t)(CH_INTEGRATED_PWM_CHANNEL - 1), \
+                      PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle*100.0)));
+    chSysUnlockFromISR();
+
+    return true;
+}
+
+// PWM frequency control
+bool ch_integrated_pwm_set_frequency(pwm_device_t device, float frequency) {
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    if (frequency <= 0.0) {
+        return true;
+    }
+
+    driver->base.frequency = frequency;
+
+    if (driver->pwm_started == false) {
+        // PWM not running, update configuration data only
+        CH_INTEGRATED_PWM_CONFIG.period = (CH_INTEGRATED_PWM_CONFIG.frequency / frequency ); // (timer clock frequency / PWM frequency)
+        CH_INTEGRATED_PWM_DRIVER_PTR->period = CH_INTEGRATED_PWM_CONFIG.period;
+        return true;
+    }
+
+    chSysLockFromISR();
+    pwmChangePeriodI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CONFIG.frequency / frequency ));
+    pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), \
+                      PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle*100.0)));
+    chSysUnlockFromISR();
+    return true;
+}
+
+// PWM duty cycle control
+bool ch_integrated_pwm_set_duty_cycle(pwm_device_t device, float duty_cycle) {
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    driver->base.duty_cycle = duty_cycle;
+
+    if (driver->pwm_started == false) {
+        // PWM not running, nothing else to do
+        return true;
+    }
+
+    chSysLockFromISR();
+    if (duty_cycle == 0) {
+        pwmDisableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, \
+                          (CH_INTEGRATED_PWM_CHANNEL - 1));
+        if (driver->trigger_callback) {
+            // If callbacks are being used, the 0% duty cycle state is equivalent to
+            // being perpetually post-triggered, so execute the trigger callback to
+            // leave things in the correct state. However, this generally may be
+            // insufficient when using callbacks becuse the period callback will continue to
+            // execute even if the channel is disabled. Unlike the hardware PWM mode (for
+            // which the hardware will suppress periodic events from affecting the assigned 
+            // pin when the channel is disabled), the periodic callback function will continue
+            // to be called until the PWM is stopped by qpwm_power(my_qpm_device, false) or by
+            // setting the periodic callback function to NULL.
+            driver->trigger_callback();
+        }
+    } else {
+        pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, \
+                         (CH_INTEGRATED_PWM_CHANNEL - 1), \
+                         PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint32_t)(duty_cycle*100.0)));
+    }
+    chSysUnlockFromISR();
+    return true;
+}
+
+// PWM trigger callback assignment
+bool ch_integrated_pwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback) {
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    driver->trigger_callback = trigger_callback;
+    if (trigger_callback) {
+        CH_INTEGRATED_PWM_CONFIG.channels[CH_INTEGRATED_PWM_CHANNEL - 1].callback = ch_integrated_pwm_trigger_callbacks[driver->driver_index];
+    } else {
+        CH_INTEGRATED_PWM_CONFIG.channels[CH_INTEGRATED_PWM_CHANNEL - 1].callback = NULL;
+    }
+    return true;
+}
+
+// PWM period callback assignment
+// NOTE: If multiple ChibiOS PWM devices share the PWM driver (for example, using multiple channels within the
+// same PWM driver), setting the period callback for one PWM device will affect all the period callback for all
+// PWM devices sharing that driver. There is only one period callback allowed per PWM driver.
+bool ch_integrated_pwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback) {
+    ch_integrated_pwm_device_t *driver = (ch_integrated_pwm_device_t *) device;
+    driver->period_callback = period_callback;
+    if (period_callback) {
+        CH_INTEGRATED_PWM_CONFIG.callback = ch_integrated_pwm_period_callbacks[driver->driver_index];
+    } else {
+        CH_INTEGRATED_PWM_CONFIG.callback = NULL;
+    }
+    return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Driver vtable
+
+const pwm_driver_vtable_t integrated_pwm_driver_vtable = {
+        .init                   = ch_integrated_pwm_init,
+        .power                  = ch_integrated_pwm_power,
+        .set_frequency          = ch_integrated_pwm_set_frequency,
+        .set_duty_cycle         = ch_integrated_pwm_set_duty_cycle, 
+        .set_trigger_callback   = ch_integrated_pwm_set_trigger_callback, 
+        .set_period_callback    = ch_integrated_pwm_set_period_callback, 
+};
+
+// Factory function for creating a handle to the PWM device
+pwm_device_t make_integrated_pwm_device(ch_integrated_pwm_config_t pwm_config, ch_integrated_pwm_pin_t *integrated_pwm_pin, void (*trigger_callback)(void), void (*period_callback)(void)) {
+    for (uint32_t i = 0; i < INTEGRATED_PWM_NUM_DEVICES; ++i) {
+        ch_integrated_pwm_device_t *driver = &ch_integrated_pwm_drivers[i];
+        if (!driver->base.driver_vtable) {
+            driver->base.driver_vtable = (const pwm_driver_vtable_t *)&integrated_pwm_driver_vtable;
+            driver->ch_integrated_pwm_config = pwm_config;
+            driver->ch_integrated_pwm_pin = integrated_pwm_pin;
+            driver->base.frequency = pwm_config.pwmCFG.frequency / pwm_config.pwmCFG.period;
+            driver->base.duty_cycle = 50;       /* default to 50% duty cycle upon creation */
+            driver->driver_index = i;
+            driver->pwm_started = false;
+
+            ch_integrated_pwm_set_trigger_callback((pwm_device_t)driver, trigger_callback);
+            ch_integrated_pwm_set_period_callback((pwm_device_t)driver, period_callback);
+
+            if (!qpwm_internal_register_device((pwm_device_t)driver)) {
+                memset(driver, 0, sizeof(ch_integrated_pwm_device_t));
+                return NULL;
+            }
+
+            return (pwm_device_t)driver;
+        }
+    }
+    return NULL;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ChibiOS-specific Helper Functions
+
+// Helper function that generates a new ch_integrated_pwm_config_t with one channel enabled.
+// The resulting ch_integrated_pwm_config_t can be modified as needed (to enable multiple channels, configure DMA, etc.)
+// A ch_integrated_pwm_config_t can also be made entirely from scratch similar to how this function creates it.
+ch_integrated_pwm_config_t make_ch_integrated_pwm_config(PWMDriver *pwm_driver, pwmchannel_t channel, uint32_t pwm_clock_frequency, pwmcnt_t pwm_period, bool on_state_is_high, bool complementary_output) {
+    PWMConfig pwmCFG = {
+        .frequency = pwm_clock_frequency, /* PWM clock frequency  */
+        .period    = pwm_period,          /* PWM period in counter ticks. e.g. clock frequency is 10KHz, period is 256 ticks then t_period is 25.6ms */
+    };
+
+    if (complementary_output) {
+        if (on_state_is_high) {
+            pwmCFG.channels[channel - 1].mode = PWM_COMPLEMENTARY_OUTPUT_ACTIVE_LOW;
+        }
+        else {
+            pwmCFG.channels[channel - 1].mode = PWM_COMPLEMENTARY_OUTPUT_ACTIVE_HIGH;
+        }
+    } else {
+        if (on_state_is_high) {
+            pwmCFG.channels[channel - 1].mode = PWM_OUTPUT_ACTIVE_HIGH;
+        }
+        else {
+            pwmCFG.channels[channel - 1].mode = PWM_OUTPUT_ACTIVE_LOW;
+        }
+    }
+
+    ch_integrated_pwm_config_t ch_integrated_pwm_config;
+
+    ch_integrated_pwm_config.pwm_driver = pwm_driver;
+    ch_integrated_pwm_config.pwmCFG = pwmCFG;
+    ch_integrated_pwm_config.channel = channel;
+
+    return ch_integrated_pwm_config;
+}
+
+// Helper function that generates a new ch_integrated_pwm_pin_t.
+// NOTE: The pal_mode is applied directly, so if PAL_MODE_ALTERNATE() macro is needed (e.g. for GPIOV2)
+// the macro and other bitwise ORing should be applied in the calling function.
+// A integrated_pwm_config_t can also be made entirely from scratch similar to how this function creates it.
+ch_integrated_pwm_pin_t make_ch_integrated_pwm_pin(pin_t pin, iomode_t pal_mode) {
+    ch_integrated_pwm_pin_t ch_pwm_pin;
+    ch_pwm_pin.pin = pin;
+    ch_pwm_pin.pal_mode = pal_mode;
+    
+    return ch_pwm_pin;
+}

--- a/platforms/chibios/drivers/pwm.c
+++ b/platforms/chibios/drivers/pwm.c
@@ -295,13 +295,13 @@ bool ch_integrated_pwm_set_frequency(pwm_device_t device, float frequency) {
 
     if (driver->pwm_started == false) {
         // PWM not running, update configuration data only
-        CH_INTEGRATED_PWM_CONFIG.period      = (CH_INTEGRATED_PWM_CONFIG.frequency / frequency ); // (timer clock frequency / PWM frequency)
+        CH_INTEGRATED_PWM_CONFIG.period      = (CH_INTEGRATED_PWM_CONFIG.frequency / frequency); // (timer clock frequency / PWM frequency)
         CH_INTEGRATED_PWM_DRIVER_PTR->period = CH_INTEGRATED_PWM_CONFIG.period;
         return true;
     }
 
     chSysLockFromISR();
-    pwmChangePeriodI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CONFIG.frequency / frequency ));
+    pwmChangePeriodI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CONFIG.frequency / frequency));
     pwmEnableChannelI(CH_INTEGRATED_PWM_DRIVER_PTR, (CH_INTEGRATED_PWM_CHANNEL - 1), PWM_PERCENTAGE_TO_WIDTH(CH_INTEGRATED_PWM_DRIVER_PTR, (uint16_t)(driver->base.duty_cycle * 100.0)));
     chSysUnlockFromISR();
     return true;
@@ -370,12 +370,12 @@ bool ch_integrated_pwm_set_period_callback(pwm_device_t device, pwm_driver_callb
 // Driver vtable
 
 const pwm_driver_vtable_t integrated_pwm_driver_vtable = {
-    .init                   = ch_integrated_pwm_init,
-    .power                  = ch_integrated_pwm_power,
-    .set_frequency          = ch_integrated_pwm_set_frequency,
-    .set_duty_cycle         = ch_integrated_pwm_set_duty_cycle,
-    .set_trigger_callback   = ch_integrated_pwm_set_trigger_callback,
-    .set_period_callback    = ch_integrated_pwm_set_period_callback,
+    .init                  = ch_integrated_pwm_init,
+    .power                 = ch_integrated_pwm_power,
+    .set_frequency         = ch_integrated_pwm_set_frequency,
+    .set_duty_cycle        = ch_integrated_pwm_set_duty_cycle,
+    .set_trigger_callback  = ch_integrated_pwm_set_trigger_callback,
+    .set_period_callback   = ch_integrated_pwm_set_period_callback,
 };
 
 // Factory function for creating a handle to the PWM device
@@ -446,7 +446,7 @@ ch_integrated_pwm_config_t make_ch_integrated_pwm_config(PWMDriver *pwm_driver, 
 // A integrated_pwm_config_t can also be made entirely from scratch similar to how this function creates it.
 ch_integrated_pwm_pin_t make_ch_integrated_pwm_pin(pin_t pin, iomode_t pal_mode) {
     ch_integrated_pwm_pin_t ch_pwm_pin;
-    ch_pwm_pin.pin = pin;
+    ch_pwm_pin.pin      = pin;
     ch_pwm_pin.pal_mode = pal_mode;
 
     return ch_pwm_pin;

--- a/platforms/chibios/drivers/pwm.c
+++ b/platforms/chibios/drivers/pwm.c
@@ -30,8 +30,8 @@ typedef struct ch_integrated_pwm_device_t {
 // Driver and callback storage
 ch_integrated_pwm_device_t ch_integrated_pwm_drivers[INTEGRATED_PWM_NUM_DEVICES] = {0};
 
-// These functions are used for as the PWM driver callbacks directly, which
-// requires accepting a (Chibios-specific) PWMDriver* argument. The only job
+// These functions are used for the PWM driver callbacks directly, which
+// requires accepting a (ChibiOS-specific) PWMDriver* argument. The only job
 // of these callback functions is to redirect the call to a non-Chibios-specific
 // callback function typed as void (*_callback)(void).  
 #define MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(index) \
@@ -49,7 +49,7 @@ void ch_integrated_pwm_period_callback##index(PWMDriver *pwmp) { \
 #define MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK_FN_NAME(index) ch_integrated_pwm_trigger_callback##index
 #define MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK_FN_NAME(index) ch_integrated_pwm_period_callback##index
 
-// Generate the trigger callbacks and periodic callbacks for each PWM device (as-needed)
+// Generate unique ChibiOS-compatible trigger callbacks and periodic callbacks for each PWM device (as-needed)
 #if INTEGRATED_PWM_NUM_DEVICES > 0
 MAKE_CH_INTEGRATED_PWM_TRIGGER_CALLBACK(0);
 MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(0);
@@ -116,7 +116,7 @@ MAKE_CH_INTEGRATED_PWM_PERIOD_CALLBACK(15);
 #endif
 
 
-// Driver and callback storage
+// Store the callback function pointers in an array so they can be accessed by index value
 pwmcallback_t ch_integrated_pwm_trigger_callbacks[INTEGRATED_PWM_NUM_DEVICES] = {
     #if INTEGRATED_PWM_NUM_DEVICES > 0
     ch_integrated_pwm_trigger_callback0,

--- a/platforms/chibios/drivers/pwm.h
+++ b/platforms/chibios/drivers/pwm.h
@@ -1,0 +1,56 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "qpwm_internal.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM Peripherap PWM configurables (add to your keyboard's config.h)
+
+#ifndef INTEGRATED_PWM_NUM_DEVICES
+/**
+ * @def This controls the maximum number of integrated PWM devices that Quantum PWM can control with at any one time.
+ *      Increasing this number allows for multiple PWM integrateds to be used.
+ */
+#    define INTEGRATED_PWM_NUM_DEVICES 1
+#endif
+
+_Static_assert((INTEGRATED_PWM_NUM_DEVICES) >= 1 && (INTEGRATED_PWM_NUM_DEVICES) < 16, "INTEGRATED_PWM_NUM_DEVICES must be between 1 and 15");
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM integrated device factories and helpers for ChibiOS
+typedef struct ch_integrated_pwm_pin_t {
+    pin_t pin;
+    iomode_t pal_mode;
+} ch_integrated_pwm_pin_t;
+
+typedef struct ch_integrated_pwm_config_t {
+    PWMDriver *pwm_driver;
+    PWMConfig pwmCFG;
+    pwmchannel_t channel;
+} ch_integrated_pwm_config_t;
+
+
+#ifdef QUANTUM_PWM_INTEGRATED_PWM_ENABLE
+/**
+ * Factory function for creating a handle to the PWM device.
+ *
+ * NOTE: PWM can be used to trigger callback functions or change
+ * an output pin state. If output pins are unused, leave
+ * hardware_pwm_pin as NULL
+ * 
+ * @param pwm_config[in] configures the PWM (e.g. frequency, duty cycle)
+ * @param hardware_pwm_pin[in] optional output pin specification
+ * @return the device handle used with all routines in Quantum PWM
+ */
+pwm_device_t make_integrated_pwm_device(ch_integrated_pwm_config_t pwm_config, ch_integrated_pwm_pin_t *integrated_pwm_pin, void (*trigger_callback)(void), void (*period_callback)(void));
+
+
+// Helper functions
+ch_integrated_pwm_pin_t make_ch_integrated_pwm_pin(pin_t pwm_pin, iomode_t pal_mode);
+
+ch_integrated_pwm_config_t make_ch_integrated_pwm_config(PWMDriver *pwm_driver, pwmchannel_t channel, uint32_t pwm_timer_frequency, pwmcnt_t pwm_period, bool on_state_is_high, bool complementary_output);
+
+#endif // QUANTUM_PWM_INTEGRATED_PWM_ENABLE

--- a/platforms/chibios/drivers/pwm.h
+++ b/platforms/chibios/drivers/pwm.h
@@ -18,20 +18,18 @@
 
 _Static_assert((INTEGRATED_PWM_NUM_DEVICES) >= 1 && (INTEGRATED_PWM_NUM_DEVICES) < 16, "INTEGRATED_PWM_NUM_DEVICES must be between 1 and 15");
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum PWM integrated device factories and helpers for ChibiOS
 typedef struct ch_integrated_pwm_pin_t {
-    pin_t pin;
+    pin_t    pin;
     iomode_t pal_mode;
 } ch_integrated_pwm_pin_t;
 
 typedef struct ch_integrated_pwm_config_t {
-    PWMDriver *pwm_driver;
-    PWMConfig pwmCFG;
+    PWMDriver *  pwm_driver;
+    PWMConfig    pwmCFG;
     pwmchannel_t channel;
 } ch_integrated_pwm_config_t;
-
 
 #ifdef QUANTUM_PWM_INTEGRATED_PWM_ENABLE
 /**
@@ -40,13 +38,12 @@ typedef struct ch_integrated_pwm_config_t {
  * NOTE: PWM can be used to trigger callback functions or change
  * an output pin state. If output pins are unused, leave
  * hardware_pwm_pin as NULL
- * 
+ *
  * @param pwm_config[in] configures the PWM (e.g. frequency, duty cycle)
  * @param hardware_pwm_pin[in] optional output pin specification
  * @return the device handle used with all routines in Quantum PWM
  */
 pwm_device_t make_integrated_pwm_device(ch_integrated_pwm_config_t pwm_config, ch_integrated_pwm_pin_t *integrated_pwm_pin, void (*trigger_callback)(void), void (*period_callback)(void));
-
 
 // Helper functions
 ch_integrated_pwm_pin_t make_ch_integrated_pwm_pin(pin_t pwm_pin, iomode_t pal_mode);

--- a/quantum/main.c
+++ b/quantum/main.c
@@ -65,6 +65,12 @@ int main(void) {
         qp_internal_task();
 #endif
 
+#ifdef QUANTUM_PWM_ENABLE
+         // Run Quantum PWM task
+         void qpwm_internal_task(void);
+         qpwm_internal_task();
+#endif
+
 #ifdef DEFERRED_EXEC_ENABLE
         // Run deferred executions
         void deferred_exec_task(void);

--- a/quantum/main.c
+++ b/quantum/main.c
@@ -66,9 +66,9 @@ int main(void) {
 #endif
 
 #ifdef QUANTUM_PWM_ENABLE
-         // Run Quantum PWM task
-         void qpwm_internal_task(void);
-         qpwm_internal_task();
+        // Run Quantum PWM task
+        void qpwm_internal_task(void);
+        qpwm_internal_task();
 #endif
 
 #ifdef DEFERRED_EXEC_ENABLE

--- a/quantum/pwm/qpwm.c
+++ b/quantum/pwm/qpwm.c
@@ -1,0 +1,114 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <quantum.h>
+#include "qpwm_internal.h"
+
+///////////////////////////////////////////////////////////
+// Internal driver validation
+static bool validate_driver_vtable(pwm_driver_t *driver) {
+    return (driver->driver_vtable && driver->driver_vtable->init && driver->driver_vtable->power && driver->driver_vtable->set_frequency && driver->driver_vtable->set_duty_cycle) ? true : false;
+}
+
+///////////////////////////////////////////////////////////
+// Quantum PWM External API: qpwm_init
+
+bool qpwm_init(pwm_device_t device) {
+    qpwm_dprintf("qpwm_init:entry\n");
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+
+    driver->validate_ok = false;
+    if (!validate_driver_vtable(driver)) {
+        qpwm_dprintf("Failed to validate driver integrity in qpwm_init\n");
+        return false;
+    }
+
+    driver->validate_ok = true;
+
+    bool ret = driver->driver_vtable->init(device);
+    qpwm_dprintf("qpwm_init: %s\n", ret ? "ok" : "fail");
+    return ret;
+}
+
+
+
+///////////////////////////////////////////////////////////
+// Quantum PWM External API: qpwm_power
+
+bool qpwm_power(pwm_device_t device, bool power_on) {
+    qpwm_dprintf("qpwm_power:entry\n");
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+    if (!driver->validate_ok) {
+        qpwm_dprintf("qpwm_power: fail) (validation_ok == false)\n");
+        return false;
+    }
+
+    bool ret = driver->driver_vtable->power(device, power_on);
+    qpwm_dprintf("qpwm_power: %s\n", ret ? "ok" : "fail");
+    return ret;
+}
+
+///////////////////////////////////////////////////////////
+// Quantum PWM External API: qpwm_set_frequency
+
+bool qpwm_set_frequency(pwm_device_t device, float frequency) {
+    qpwm_dprintf("pwm_set_frequency:entry\n");
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+    if (!driver->validate_ok) {
+        qpwm_dprintf("pwm_set_frequency: fail) (validation_ok == false)\n");
+        return false;
+    }
+
+    bool ret = driver->driver_vtable->set_frequency(device, frequency);
+    qpwm_dprintf("pwm_set_frequency: %s\n", ret ? "ok" : "fail");
+    return ret;
+}
+
+///////////////////////////////////////////////////////////
+// Quantum PWM External API: qpwm_set_duty_cycle
+
+bool qpwm_set_duty_cycle(pwm_device_t device, float duty_cycle) {
+    qpwm_dprintf("qpwm_set_duty_cycle:entry\n");
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+    if (!driver->validate_ok) {
+        qpwm_dprintf("qpwm_set_duty_cycle: fail) (validation_ok == false)\n");
+        return false;
+    }
+
+    bool ret = driver->driver_vtable->set_duty_cycle(device, duty_cycle);
+    qpwm_dprintf("qpwm_set_duty_cycle: %s\n", ret ? "ok" : "fail");
+    return ret;
+}
+
+///////////////////////////////////////////////////////////
+// Quantum PWM External API: qpwm_set_trigger_callback
+
+bool qpwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback) {
+    qpwm_dprintf("qpwm_set_trigger_callback:entry\n");
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+    if (!driver->validate_ok) {
+        qpwm_dprintf("qpwm_set_trigger_callback: fail) (validation_ok == false)\n");
+        return false;
+    }
+
+    bool ret = driver->driver_vtable->set_trigger_callback(device, trigger_callback);
+    qpwm_dprintf("qpwm_set_trigger_callback: %s\n", ret ? "ok" : "fail");
+    return ret;
+}
+
+///////////////////////////////////////////////////////////
+// Quantum PWM External API: qpwm_set_period_callback
+
+bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback) {
+    qpwm_dprintf("qpwm_set_period_callback:entry\n");
+    pwm_driver_t *driver = (pwm_driver_t *)device;
+    if (!driver->validate_ok) {
+        qpwm_dprintf("qpwm_set_period_callback: fail) (validation_ok == false)\n");
+        return false;
+    }
+
+    bool ret = driver->driver_vtable->set_period_callback(device, period_callback);
+    qpwm_dprintf("qpwm_set_period_callback: %s\n", ret ? "ok" : "fail");
+    return ret;
+}
+

--- a/quantum/pwm/qpwm.c
+++ b/quantum/pwm/qpwm.c
@@ -30,8 +30,6 @@ bool qpwm_init(pwm_device_t device) {
     return ret;
 }
 
-
-
 ///////////////////////////////////////////////////////////
 // Quantum PWM External API: qpwm_power
 
@@ -111,4 +109,3 @@ bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_
     qpwm_dprintf("qpwm_set_period_callback: %s\n", ret ? "ok" : "fail");
     return ret;
 }
-

--- a/quantum/pwm/qpwm.h
+++ b/quantum/pwm/qpwm.h
@@ -98,7 +98,6 @@ bool qpwm_set_duty_cycle(pwm_device_t device, float duty);
  */
 bool qpwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback);
 
-
 /**
  * Sets the period callback for the PWM device.
  *

--- a/quantum/pwm/qpwm.h
+++ b/quantum/pwm/qpwm.h
@@ -1,0 +1,127 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM global configurables (add to your keyboard's config.h)
+
+#ifndef QUANTUM_PWM_TASK_THROTTLE
+/**
+ * @def This controls the amount of time (in milliseconds) that the Quantum PWM internal task will wait between
+ *      each execution.
+ */
+#    define QUANTUM_PWM_TASK_THROTTLE 1
+#endif // QUANTUM_PWM_TASK_THROTTLE
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM types
+
+/**
+ * @typedef A handle to a Quantum PWM device, such as a hardware peripheral or external I2C PWM chip. Most Quantum PWM
+ *          APIs require this argument in order to perform operations on the PWM device.
+ *         
+ */
+typedef const void *pwm_device_t;
+
+/**
+ * @typedef A function pointer to a Quantum PWM callback. Callback functions of this type may be called 
+ *          whenever PWM event triggers or the PWM period elapses.
+ *         
+ */
+typedef void (*pwm_driver_callback_t)(void);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM External API
+
+/**
+ * Initialize a PWM device.
+ *
+ * @param device[in] the handle of the device to initialize
+ * @return true if initialization succeeded
+ * @return false if initialization failed
+ */
+bool qpwm_init(pwm_device_t device);
+
+/**
+ * Controls whether a PWM device is running or not.
+ *
+ * @param device[in] the handle of the device to control
+ * @param power_on[in] whether or not the device should be on
+ * @return true if controlling the power state succeeded
+ * @return false if controlling the power state failed
+ */
+bool qpwm_power(pwm_device_t device, bool power_on);
+
+/**
+ * Sets the frequency at which the PWM device is running.
+ * Units are in Hz.
+ * 
+ * @note qpwm_set_frequency and qpwm_set_period control the same
+ * variable. Quantum PWM drivers may internally stores this
+ * information as a period to match the underlying settings in
+ * units of clock ticks. Drivers may also allow the period to be written
+ * directly. Some driver implementations have limited frequency range
+ * and/or precision, or may only permit fixed frequency operation. 
+ * set_frequency() applies a "best effort" approach to match the
+ * assigned frequency.
+ *
+ * @param device[in] the handle of the device to control
+ * @param frequency[in] the frequency of the PWM in Hz
+ * @return true if setting the frequency succeeded
+ * @return false if setting the frequency failed
+ */
+bool qpwm_set_frequency(pwm_device_t device, float frequency);
+
+/**
+ * Sets the duty cycle for the PWM device. 
+ * 
+ * @note Duty cycle is a float as a percentage, valid ranges are from 0.00% to 100.00%:
+ *
+ * @param device[in] the handle of the device to control
+ * @param duty[in] the duty cycle of the PWM in percentage
+ * @return true if setting the duty cycle succeeded
+ * @return false if setting the duty cycle failed
+ */
+bool qpwm_set_duty_cycle(pwm_device_t device, float duty);
+
+/**
+ * Sets the trigger callback for the PWM device. 
+ *
+ * @param device[in] the handle of the device to control
+ * @param trigger_callback[in] the callback function to execute upon triggering
+ * @return true if setting the callback function succeeded
+ * @return false if setting the callback function failed
+ */
+bool qpwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigger_callback);
+
+
+/**
+ * Sets the period callback for the PWM device. 
+ *
+ * @param device[in] the handle of the device to control
+ * @param period_callback[in] the callback function to execute upon PWM period elapsing
+ * @return true if setting the callback function succeeded
+ * @return false if setting the callback function failed
+ */
+bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback);
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum PWM Drivers
+
+#ifdef QUANTUM_PWM_INTEGRATED_PWM_ENABLE
+#    include "pwm.h"
+#else // QUANTUM_PWM_INTEGRATED_PWM_ENABLE
+#    define INTEGRATED_PWM_NUM_DEVICES 0
+#endif // QUANTUM_PWM_INTEGRATED_PWM_ENABLE
+
+#ifdef QUANTUM_PWM_SOFTWARE_PWM_ENABLE
+#    include "qpwm_software.h"
+#else // QUANTUM_PWM_SOFTWARE_PWM_ENABLE
+#    define SOFTWARE_PWM_NUM_DEVICES 0
+#endif // QUANTUM_PWM_SOFTWARE_PWM_ENABLE
+

--- a/quantum/pwm/qpwm.h
+++ b/quantum/pwm/qpwm.h
@@ -23,14 +23,14 @@
 /**
  * @typedef A handle to a Quantum PWM device, such as a hardware peripheral or external I2C PWM chip. Most Quantum PWM
  *          APIs require this argument in order to perform operations on the PWM device.
- *         
+ *
  */
 typedef const void *pwm_device_t;
 
 /**
- * @typedef A function pointer to a Quantum PWM callback. Callback functions of this type may be called 
+ * @typedef A function pointer to a Quantum PWM callback. Callback functions of this type may be called
  *          whenever PWM event triggers or the PWM period elapses.
- *         
+ *
  */
 typedef void (*pwm_driver_callback_t)(void);
 
@@ -59,13 +59,13 @@ bool qpwm_power(pwm_device_t device, bool power_on);
 /**
  * Sets the frequency at which the PWM device is running.
  * Units are in Hz.
- * 
+ *
  * @note qpwm_set_frequency and qpwm_set_period control the same
  * variable. Quantum PWM drivers may internally stores this
  * information as a period to match the underlying settings in
  * units of clock ticks. Drivers may also allow the period to be written
  * directly. Some driver implementations have limited frequency range
- * and/or precision, or may only permit fixed frequency operation. 
+ * and/or precision, or may only permit fixed frequency operation.
  * set_frequency() applies a "best effort" approach to match the
  * assigned frequency.
  *
@@ -77,8 +77,8 @@ bool qpwm_power(pwm_device_t device, bool power_on);
 bool qpwm_set_frequency(pwm_device_t device, float frequency);
 
 /**
- * Sets the duty cycle for the PWM device. 
- * 
+ * Sets the duty cycle for the PWM device.
+ *
  * @note Duty cycle is a float as a percentage, valid ranges are from 0.00% to 100.00%:
  *
  * @param device[in] the handle of the device to control
@@ -89,7 +89,7 @@ bool qpwm_set_frequency(pwm_device_t device, float frequency);
 bool qpwm_set_duty_cycle(pwm_device_t device, float duty);
 
 /**
- * Sets the trigger callback for the PWM device. 
+ * Sets the trigger callback for the PWM device.
  *
  * @param device[in] the handle of the device to control
  * @param trigger_callback[in] the callback function to execute upon triggering
@@ -100,7 +100,7 @@ bool qpwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigge
 
 
 /**
- * Sets the period callback for the PWM device. 
+ * Sets the period callback for the PWM device.
  *
  * @param device[in] the handle of the device to control
  * @param period_callback[in] the callback function to execute upon PWM period elapsing
@@ -108,7 +108,6 @@ bool qpwm_set_trigger_callback(pwm_device_t device, pwm_driver_callback_t trigge
  * @return false if setting the callback function failed
  */
 bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_callback);
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum PWM Drivers
@@ -124,4 +123,3 @@ bool qpwm_set_period_callback(pwm_device_t device, pwm_driver_callback_t period_
 #else // QUANTUM_PWM_SOFTWARE_PWM_ENABLE
 #    define SOFTWARE_PWM_NUM_DEVICES 0
 #endif // QUANTUM_PWM_SOFTWARE_PWM_ENABLE
-

--- a/quantum/pwm/qpwm_internal.c
+++ b/quantum/pwm/qpwm_internal.c
@@ -25,7 +25,7 @@ bool qpwm_internal_register_device(pwm_device_t driver) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Quantum Painter Core API: qpwm_internal_task
+// Quantum PWM Core API: qpwm_internal_task
 
 _Static_assert((QUANTUM_PWM_TASK_THROTTLE) >= 0 && (QUANTUM_PWM_TASK_THROTTLE) < 1000, "QUANTUM_PWM_TASK_THROTTLE must be between 0 and 999");
 

--- a/quantum/pwm/qpwm_internal.c
+++ b/quantum/pwm/qpwm_internal.c
@@ -1,0 +1,44 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qpwm_internal.h"
+
+enum {
+    // Work out how many PWM devices we're actually going to be instantiating
+    QPWM_NUM_DEVICES = (INTEGRATED_PWM_NUM_DEVICES) + \
+                       (SOFTWARE_PWM_NUM_DEVICES)
+};
+
+static pwm_device_t qpwm_devices[QPWM_NUM_DEVICES] = {NULL};
+
+bool qpwm_internal_register_device(pwm_device_t driver) {
+    for (uint8_t i = 0; i < QPWM_NUM_DEVICES; i++) {
+        if(qpwm_devices[i] == NULL) {
+            qpwm_devices[i] = driver;
+            return true;
+        }
+    }
+
+    // We should never get here -- someone has screwed up their device counts during config
+    qpwm_dprintf("qpwm_internal_register_device: no more space for devices!\n");
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter Core API: qpwm_internal_task
+
+_Static_assert((QUANTUM_PWM_TASK_THROTTLE) >= 0 && (QUANTUM_PWM_TASK_THROTTLE) < 1000, "QUANTUM_PWM_TASK_THROTTLE must be between 0 and 999");
+
+void qpwm_internal_task(void) {
+
+    static uint32_t last_tick = 0;
+    uint32_t now              = timer_read32();
+    if (TIMER_DIFF_32(now, last_tick) < (QUANTUM_PWM_TASK_THROTTLE)) {
+        return;
+    }
+    last_tick = now;
+#ifdef QUANTUM_PWM_UPDATE_TASK
+    // Run internal update task software-driven PWM
+    qpwm_internal_update_tick();
+#endif
+}

--- a/quantum/pwm/qpwm_internal.c
+++ b/quantum/pwm/qpwm_internal.c
@@ -13,7 +13,7 @@ static pwm_device_t qpwm_devices[QPWM_NUM_DEVICES] = {NULL};
 
 bool qpwm_internal_register_device(pwm_device_t driver) {
     for (uint8_t i = 0; i < QPWM_NUM_DEVICES; i++) {
-        if(qpwm_devices[i] == NULL) {
+        if (qpwm_devices[i] == NULL) {
             qpwm_devices[i] = driver;
             return true;
         }
@@ -30,9 +30,8 @@ bool qpwm_internal_register_device(pwm_device_t driver) {
 _Static_assert((QUANTUM_PWM_TASK_THROTTLE) >= 0 && (QUANTUM_PWM_TASK_THROTTLE) < 1000, "QUANTUM_PWM_TASK_THROTTLE must be between 0 and 999");
 
 void qpwm_internal_task(void) {
-
     static uint32_t last_tick = 0;
-    uint32_t now              = timer_read32();
+    uint32_t        now       = timer_read32();
     if (TIMER_DIFF_32(now, last_tick) < (QUANTUM_PWM_TASK_THROTTLE)) {
         return;
     }

--- a/quantum/pwm/qpwm_internal.h
+++ b/quantum/pwm/qpwm_internal.h
@@ -14,7 +14,9 @@
 #    include <print.h>
 #    define qpwm_dprintf(...) dprintf(__VA_ARGS__)
 #else
-#    define qpwm_dprintf(...)  do { } while (0)
+#    define qpwm_dprintf(...) \
+        do {                  \
+        } while (0)
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/quantum/pwm/qpwm_internal.h
+++ b/quantum/pwm/qpwm_internal.h
@@ -1,0 +1,22 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "quantum.h"
+#include "qpwm.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Helpers
+
+#ifdef QUANTUM_PWM_DEBUG
+#    include <debug.h>
+#    include <print.h>
+#    define qpwm_dprintf(...) dprintf(__VA_ARGS__)
+#else
+#    define qpwm_dprintf(...)  do { } while (0)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Specific internal definitions
+#include <qpwm_internal_driver.h>

--- a/quantum/pwm/qpwm_internal_driver.h
+++ b/quantum/pwm/qpwm_internal_driver.h
@@ -1,0 +1,51 @@
+// Copyright 2023 David Hoelscher (@customMK)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "qpwm_internal.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Driver callbacks
+
+typedef bool (*pwm_driver_init_func)(pwm_device_t device);
+typedef bool (*pwm_driver_power_func)(pwm_device_t device, bool power_on);
+typedef bool (*pwm_driver_set_frequency_func)(pwm_device_t device, float frequency);
+typedef bool (*pwm_driver_set_duty_cycle_func)(pwm_device_t device, float duty);
+typedef bool (*pwm_driver_set_trigger_callback_func)(pwm_device_t device, pwm_driver_callback_t trigger_callback);
+typedef bool (*pwm_driver_set_period_callback_func)(pwm_device_t device, pwm_driver_callback_t period_callback);
+
+
+// Driver vtable definition
+typedef struct pwm_driver_vtable_t {
+    pwm_driver_init_func                 init;
+    pwm_driver_power_func                power;
+    pwm_driver_set_frequency_func        set_frequency; 
+    pwm_driver_set_duty_cycle_func       set_duty_cycle;
+    pwm_driver_set_trigger_callback_func set_trigger_callback;
+    pwm_driver_set_period_callback_func  set_period_callback;    
+} pwm_driver_vtable_t;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Driver base definition
+
+//typedef void (*pwm_driver_callback_t)(void);
+
+typedef struct pwm_driver_t {
+    const pwm_driver_vtable_t *driver_vtable;
+
+    // Flag signifying if validation was successful
+    bool validate_ok;
+
+    float frequency;
+    float duty_cycle;
+
+    pwm_driver_callback_t trigger_callback;
+    pwm_driver_callback_t period_callback;
+    
+} pwm_driver_t;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Device internals
+
+bool qpwm_internal_register_device(pwm_device_t driver);

--- a/quantum/pwm/qpwm_internal_driver.h
+++ b/quantum/pwm/qpwm_internal_driver.h
@@ -15,21 +15,18 @@ typedef bool (*pwm_driver_set_duty_cycle_func)(pwm_device_t device, float duty);
 typedef bool (*pwm_driver_set_trigger_callback_func)(pwm_device_t device, pwm_driver_callback_t trigger_callback);
 typedef bool (*pwm_driver_set_period_callback_func)(pwm_device_t device, pwm_driver_callback_t period_callback);
 
-
 // Driver vtable definition
 typedef struct pwm_driver_vtable_t {
     pwm_driver_init_func                 init;
     pwm_driver_power_func                power;
-    pwm_driver_set_frequency_func        set_frequency; 
+    pwm_driver_set_frequency_func        set_frequency;
     pwm_driver_set_duty_cycle_func       set_duty_cycle;
     pwm_driver_set_trigger_callback_func set_trigger_callback;
-    pwm_driver_set_period_callback_func  set_period_callback;    
+    pwm_driver_set_period_callback_func  set_period_callback;
 } pwm_driver_vtable_t;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Driver base definition
-
-//typedef void (*pwm_driver_callback_t)(void);
 
 typedef struct pwm_driver_t {
     const pwm_driver_vtable_t *driver_vtable;
@@ -42,7 +39,7 @@ typedef struct pwm_driver_t {
 
     pwm_driver_callback_t trigger_callback;
     pwm_driver_callback_t period_callback;
-    
+
 } pwm_driver_t;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/quantum/pwm/rules.mk
+++ b/quantum/pwm/rules.mk
@@ -1,0 +1,42 @@
+# Quantum PWM Configurables
+QUANTUM_PWM_DRIVERS ?=
+
+# The list of permissible drivers that can be listed in QUANTUM_PWM_DRIVERS
+VALID_QUANTUM_PWM_DRIVERS := \
+    integrated_pwm \
+    software_pwm
+
+#-------------------------------------------------------------------------------
+
+OPT_DEFS += -DQUANTUM_PWM_ENABLE
+COMMON_VPATH += $(QUANTUM_DIR)/pwm
+SRC += \
+    $(QUANTUM_DIR)/pwm/qpwm.c \
+    $(QUANTUM_DIR)/pwm/qpwm_internal.c
+
+# Handler for each driver
+define handle_quantum_pwm_driver
+    CURRENT_PWM_DRIVER := $1
+
+    ifeq ($$(filter $$(strip $$(CURRENT_PWM_DRIVER)),$$(VALID_QUANTUM_PWM_DRIVERS)),)
+        $$(error "$$(CURRENT_PWM_DRIVER)" is not a valid Quantum PWM driver)
+
+    else ifeq ($$(strip $$(CURRENT_PWM_DRIVER)),integrated_pwm)
+        QUANTUM_LIB_SRC += pwm.c
+        OPT_DEFS += -DQUANTUM_PWM_INTEGRATED_PWM_ENABLE
+        COMMON_VPATH += \
+            $(DRIVER_PATH)/pwm/integrated
+        SRC += \
+            $(DRIVER_PATH)/pwm/integrated/qpwm_integrated.c
+
+    else ifeq ($$(strip $$(CURRENT_PWM_DRIVER)),software_pwm)
+        OPT_DEFS += -DQUANTUM_PWM_SOFTWARE_PWM_ENABLE
+        COMMON_VPATH += \
+            $(DRIVER_PATH)/pwm/software
+        SRC += \
+            $(DRIVER_PATH)/pwm/software/qpwm_software.c
+    endif
+endef
+
+# Iterate through the listed drivers for the build, including what's necessary
+$(foreach qpwm_driver,$(QUANTUM_PWM_DRIVERS),$(eval $(call handle_quantum_pwm_driver,$(qpwm_driver))))

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -192,6 +192,10 @@ extern layer_state_t layer_state;
 #    include "qp.h"
 #endif
 
+#ifdef QUANTUM_PWM_ENABLE
+#    include "qpwm.h"
+#endif
+
 #ifdef DIP_SWITCH_ENABLE
 #    include "dip_switch.h"
 #endif


### PR DESCRIPTION
## Description

I was using the backlight feature to control switch backlighting, but I wanted to add the ability to independently perform dimming of an LCD backlight. At the moment, QMK's ability to control backlights is limited to a single backlight and is implemented in bespoke manner across platforms, without any sort of abstraction layer in front of them.

To generate a useful backlight abstraction, I realized it would be best to start with a lower-level abstraction layer for PWM which could also then be used in other PWM-driven systems (like audio and WS2812 comms). This would then make it easier to generate abstractions not only for backlighting, but also for audio and WS2812 comms (which are also currently bespoke implementations).

This PR attempts to introduce the "Quantum PWM" API, which is intended to be a frontend for PWM devices, providing a unified API and allowing people to implement a minimal driver implementation to make it compatible with QMK. While this PR currently only includes drivers for software PWM (running at the matrix scan rate) and integrated PWM for ChibiOS platforms, drivers can be added to include any type of PWM, including those on AVR platforms, or even control of I2C-based PWM chips.

Tested on a STM32F411 microcontroller. Overall abstraction methods and organization is inspired by and largely based on Quantum Painter.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
