### PR TITLE
keymap_extras: remove direct `quantum.h` includes

### DIFF
--- a/quantum/keymap_extras/sendstring_belgian.h
+++ b/quantum/keymap_extras/sendstring_belgian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_belgian.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_bepo.h
+++ b/quantum/keymap_extras/sendstring_bepo.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_bepo.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_brazilian_abnt2.h
+++ b/quantum/keymap_extras/sendstring_brazilian_abnt2.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_brazilian_abnt2.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_canadian_multilingual.h
+++ b/quantum/keymap_extras/sendstring_canadian_multilingual.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_canadian_multilingual.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_colemak.h
+++ b/quantum/keymap_extras/sendstring_colemak.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_colemak.h"
 
 // clang-format off

--- a/quantum/keymap_extras/sendstring_croatian.h
+++ b/quantum/keymap_extras/sendstring_croatian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_croatian.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_czech.h
+++ b/quantum/keymap_extras/sendstring_czech.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_czech.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_danish.h
+++ b/quantum/keymap_extras/sendstring_danish.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_danish.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_dvorak.h
+++ b/quantum/keymap_extras/sendstring_dvorak.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_dvorak.h"
 
 // clang-format off

--- a/quantum/keymap_extras/sendstring_dvorak_fr.h
+++ b/quantum/keymap_extras/sendstring_dvorak_fr.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_dvorak_fr.h"
 
 // clang-format off

--- a/quantum/keymap_extras/sendstring_dvorak_programmer.h
+++ b/quantum/keymap_extras/sendstring_dvorak_programmer.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_dvorak_programmer.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_estonian.h
+++ b/quantum/keymap_extras/sendstring_estonian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_estonian.h"
-#include "quantum"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_finnish.h
+++ b/quantum/keymap_extras/sendstring_finnish.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_finnish.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_french.h
+++ b/quantum/keymap_extras/sendstring_french.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_french.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_french_afnor.h
+++ b/quantum/keymap_extras/sendstring_french_afnor.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_french_afnor.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_french_mac_iso.h
+++ b/quantum/keymap_extras/sendstring_french_mac_iso.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_french_mac_iso.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_german.h
+++ b/quantum/keymap_extras/sendstring_german.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_german.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_german_mac_iso.h
+++ b/quantum/keymap_extras/sendstring_german_mac_iso.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_german_mac_iso.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_hungarian.h
+++ b/quantum/keymap_extras/sendstring_hungarian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_hungarian.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_icelandic.h
+++ b/quantum/keymap_extras/sendstring_icelandic.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_icelandic.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_italian.h
+++ b/quantum/keymap_extras/sendstring_italian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_italian.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_italian_mac_ansi.h
+++ b/quantum/keymap_extras/sendstring_italian_mac_ansi.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_italian_mac_ansi.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_italian_mac_iso.h
+++ b/quantum/keymap_extras/sendstring_italian_mac_iso.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_italian_mac_iso.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_japanese.h
+++ b/quantum/keymap_extras/sendstring_japanese.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_japanese.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_latvian.h
+++ b/quantum/keymap_extras/sendstring_latvian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_latvian.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_lithuanian_azerty.h
+++ b/quantum/keymap_extras/sendstring_lithuanian_azerty.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_lithuanian_azerty.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_lithuanian_qwerty.h
+++ b/quantum/keymap_extras/sendstring_lithuanian_qwerty.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_lithuanian_qwerty.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_norman.h
+++ b/quantum/keymap_extras/sendstring_norman.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_norman.h"
 
 // clang-format off

--- a/quantum/keymap_extras/sendstring_norwegian.h
+++ b/quantum/keymap_extras/sendstring_norwegian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_norwegian.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_portuguese.h
+++ b/quantum/keymap_extras/sendstring_portuguese.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_portuguese.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_portuguese_mac_iso.h
+++ b/quantum/keymap_extras/sendstring_portuguese_mac_iso.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_portuguese_mac_iso.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_romanian.h
+++ b/quantum/keymap_extras/sendstring_romanian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_romanian.h"
-#include "quantum"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_serbian_latin.h
+++ b/quantum/keymap_extras/sendstring_serbian_latin.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_serbian_latin.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_slovak.h
+++ b/quantum/keymap_extras/sendstring_slovak.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_slovak.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_slovenian.h
+++ b/quantum/keymap_extras/sendstring_slovenian.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_slovenian.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_spanish.h
+++ b/quantum/keymap_extras/sendstring_spanish.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_spanish.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_spanish_dvorak.h
+++ b/quantum/keymap_extras/sendstring_spanish_dvorak.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_spanish_dvorak.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_swedish.h
+++ b/quantum/keymap_extras/sendstring_swedish.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_swedish.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_swiss_de.h
+++ b/quantum/keymap_extras/sendstring_swiss_de.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_swiss_de.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_swiss_fr.h
+++ b/quantum/keymap_extras/sendstring_swiss_fr.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_swiss_fr.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_turkish_f.h
+++ b/quantum/keymap_extras/sendstring_turkish_f.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_turkish_f.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_turkish_q.h
+++ b/quantum/keymap_extras/sendstring_turkish_q.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_turkish_q.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_uk.h
+++ b/quantum/keymap_extras/sendstring_uk.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_uk.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_us_international.h
+++ b/quantum/keymap_extras/sendstring_us_international.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_us_international.h"
-#include "quantum.h"
 
 // clang-format off
 

--- a/quantum/keymap_extras/sendstring_workman.h
+++ b/quantum/keymap_extras/sendstring_workman.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_workman.h"
 
 // clang-format off

--- a/quantum/keymap_extras/sendstring_workman_zxcvm.h
+++ b/quantum/keymap_extras/sendstring_workman_zxcvm.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "send_string.h"
 #include "keymap_workman_zxcvm.h"
 
 // clang-format off


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
