### PR TITLE
Improve directional transition of overlapping mouse keys

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -389,7 +389,19 @@ void mousekey_on(uint8_t code) {
     if (mouse_timer == 0) {
         mouse_timer = timer_read();
     }
-#    endif /* #ifdef MK_KINETIC_SPEED */
+#    endif
+
+#    ifndef MOUSEKEY_INERTIA
+    // Restart acceleration for overlapping mouse key presses
+    if (mouse_report.x || mouse_report.y || mouse_report.h || mouse_report.v) {
+#        ifdef MK_KINETIC_SPEED
+        mouse_timer = timer_read() - (MOUSEKEY_INTERVAL << 2);
+#        else
+        mousekey_repeat       = MOUSEKEY_MOVE_DELTA;
+        mousekey_wheel_repeat = MOUSEKEY_WHEEL_DELTA;
+#        endif
+    }
+#    endif // ifndef MOUSEKEY_INERTIA
 
 #    ifdef MOUSEKEY_INERTIA
 

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -392,7 +392,8 @@ void mousekey_on(uint8_t code) {
 #    endif
 
 #    ifndef MOUSEKEY_INERTIA
-    // Restart acceleration for overlapping mouse key presses
+    // If mouse report is not zero, the current mousekey press is overlapping
+    // with another. Restart acceleration for smoother directional transition.
     if (mouse_report.x || mouse_report.y || mouse_report.h || mouse_report.v) {
 #        ifdef MK_KINETIC_SPEED
         mouse_timer = timer_read() - (MOUSEKEY_INTERVAL << 2);


### PR DESCRIPTION
## Description

Mouse movement will continue its acceleration in the new direction of an overlapping mouse key press. This behaviour can be especially jarring when the new overlapping key is for the opposite direction.

This change will restart the acceleration before processing the new overlapping direction for a smoother transition.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
