### PR TITLE
aleblazer/zodiark:via: Disable two RGB effects

### DIFF
--- a/keyboards/aleblazer/zodiark/keymaps/via/config.h
+++ b/keyboards/aleblazer/zodiark/keymaps/via/config.h
@@ -20,3 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   #define OLED_DISPLAY_128X64
   #define OLED_TIMEOUT 400000
 #endif
+
+#ifdef RGBLIGHT_ENABLE
+  #undef RGBLIGHT_EFFECT_RGB_TEST
+  #undef RGBLIGHT_EFFECT_ALTERNATING
+#endif


### PR DESCRIPTION
## Description

Remove two effects to bring firmware size under the limit

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
