### PR TITLE
Reduce needless precision in audio note frequency calculation

### DIFF
--- a/quantum/process_keycode/process_audio.c
+++ b/quantum/process_keycode/process_audio.c
@@ -12,7 +12,7 @@ float voice_change_song[][2] = VOICE_CHANGE_SONG;
 
 float compute_freq_for_midi_note(uint8_t note) {
     // https://en.wikipedia.org/wiki/MIDI_tuning_standard
-    return pow(2.0, (note - 69) / 12.0) * PITCH_STANDARD_A;
+    return powf(2.0f, (note - 69) / 12.0f) * PITCH_STANDARD_A;
 }
 
 bool process_audio(uint16_t keycode, keyrecord_t *record) {


### PR DESCRIPTION
## Description

The computations done in `float compute_freq_for_midi_note(uint8_t)`, to support the music mode feature, were invoking the `pow` function on double-precision inputs and immediately discarding any precision in excess of `float` from the `double`-precision output to make the return value. This is wasteful in both size and cycles, so I have made an edit to use `powf` and literals suffixed with `f` in that function.

As an example, on ARM MCUs having a single-precision FPU and the audio keycodes enabled, this saves around 4.5 KiB in firmware size.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
