### PR TITLE
Remove needless precision in additive DAC sample generation

### DIFF
--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -134,7 +134,7 @@ __attribute__((weak)) uint16_t dac_value_generate(void) {
          *      timer runs with 3*AUDIO_DAC_SAMPLE_RATE; and the DAC callback
          *      is called twice per conversion.*/
 
-        dac_if[i] = fmod(dac_if[i], AUDIO_DAC_BUFFER_SIZE);
+        dac_if[i] = fmodf(dac_if[i], AUDIO_DAC_BUFFER_SIZE);
 
         // Wavetable generation/lookup
         uint16_t dac_i = (uint16_t)dac_if[i];


### PR DESCRIPTION
## Description

In the additive DAC driver, calls to `fmod`, a `double`-precision function, got as inputs each element of `float dac_if[]` and their results were immediately assigned back to those `float` elements in the default implementation of `dac_value_generate`, and this was used to clamp the location within the bounds of the lookup table for the user-selected waveform. The added precision was thus immediately lost. Using `fmodf` instead saves cycles, especially important in the tight loop that repeatedly calls `dac_value_generate` in `dac_end`, and program space.

As an example, on my Moonlander (STM32F303, ARM with a single-precision FPU), switching `fmod` out for `fmodf` saves 436 bytes.

Boards whose MCUs have low clocks may crackle less from buffer underflows after this change, provided they use the default implementation of `dac_value_generate`. If the reduction in needed cycles to compute the audio happens to make the computation fit into a half-buffer-time, it will stop the crackling altogether.

A more invasive version of this PR could rework `dac_if` so that the integer location within the lookup table is separated from the fractional part. That would allow the use of the integer `%` operator only on the integer part to clamp the location within the lookup table *really* quickly.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
