### PR TITLE
[Keyboard][Update] Fix RS60 Indicators on_state

### DIFF
--- a/keyboards/xelus/rs60/rev1/info.json
+++ b/keyboards/xelus/rs60/rev1/info.json
@@ -9,7 +9,8 @@
     },
     "diode_direction": "COL2ROW",
     "indicators": {
-        "caps_lock": "B0"
+        "caps_lock": "B0",
+        "on_state": 0
     },
     "processor": "atmega32u4",
     "bootloader": "atmel-dfu",

--- a/keyboards/xelus/rs60/rev2_1/info.json
+++ b/keyboards/xelus/rs60/rev2_1/info.json
@@ -9,7 +9,8 @@
     },
     "diode_direction": "COL2ROW",
     "indicators": {
-        "caps_lock": "A1"
+        "caps_lock": "A1",
+        "on_state": 0
     },
     "processor": "STM32L412",
     "bootloader": "stm32-dfu",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Fix RS60 indicators on_state to be 0 instead of default 1.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix rs60 inverted led

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
