### PR TITLE
add x123 keymap for crkbd/rev1

### DIFF
--- a/keyboards/crkbd/keymaps/x123/config.h
+++ b/keyboards/crkbd/keymaps/x123/config.h
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 x123 <@x123>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#define ONESHOT_TAP_TOGGLE 3
+#define ONESHOT_TIMEOUT 5000
+#define TAPPING_TOGGLE 1
+#define TAPPING_TERM 280
+
+#define UNICODE_SELECTED_MODES UNICODE_MODE_WINCOMPOSE, UNICODE_MODE_MACOS, UNICODE_MODE_LINUX
+
+#define TRI_LAYER_LOWER_LAYER 4
+#define TRI_LAYER_UPPER_LAYER 5
+#define TRI_LAYER_ADJUST_LAYER 6

--- a/keyboards/crkbd/keymaps/x123/keymap.c
+++ b/keyboards/crkbd/keymaps/x123/keymap.c
@@ -1,0 +1,165 @@
+/*
+Copyright 2022 x123 <@x123>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+enum layer_names {
+    _QWERTY,
+    _QWERTY_NOHOMEROW,
+    _COLEMAK,
+    _COLEMAK_NOHOMEROW,
+    _LOWER,
+    _UPPER,
+    _ADJUST,
+};
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  QWERTY_NOHOMEROW,
+  COLEMAK,
+  COLEMAK_NOHOMEROW,
+};
+
+#define LSFT_KA LSFT_T(KC_A)
+#define LCTL_KS LCTL_T(KC_S)
+#define LGUI_KD LGUI_T(KC_D)
+#define LALT_KF LALT_T(KC_F)
+#define LALT_KJ LALT_T(KC_J)
+#define RGUI_KK RGUI_T(KC_K)
+#define RCTL_KL RCTL_T(KC_L)
+#define RS_SCLN RSFT_T(KC_SCLN)
+
+#define LCTL_KR LCTL_T(KC_R)
+#define LGUI_KS LGUI_T(KC_S)
+#define LALT_KT LALT_T(KC_T)
+#define LALT_KN LALT_T(KC_N)
+#define RGUI_KE RGUI_T(KC_E)
+#define RCTL_KI RCTL_T(KC_I)
+#define RSFT_KO RSFT_T(KC_O)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_QWERTY] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                         KC_Y,    KC_U,    KC_I,    KC_O,   KC_P,  KC_BSPC,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_BSPC, LSFT_KA, LCTL_KS, LGUI_KD, LALT_KF,    KC_G,                         KC_H, LALT_KJ, RGUI_KK, RCTL_KL, RS_SCLN, KC_QUOT,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,                         KC_N,    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          KC_LALT, TL_LOWR,  KC_SPC,     KC_ENT, TL_UPPR, KC_RALT
+                                      //`--------------------------'  `--------------------------'
+
+  ),
+
+  [_QWERTY_NOHOMEROW] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                         KC_Y,    KC_U,    KC_I,    KC_O,   KC_P,  KC_BSPC,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_BSPC,    KC_A,    KC_S,    KC_D,    KC_F,    KC_G,                         KC_H,    KC_J,    KC_K,    KC_L, KC_SCLN, KC_QUOT,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,                         KC_N,    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          KC_LALT, TL_LOWR,  KC_SPC,     KC_ENT, TL_UPPR, KC_RALT
+                                      //`--------------------------'  `--------------------------'
+
+  ),
+
+  [_COLEMAK] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_TAB,    KC_Q,    KC_W,    KC_F,    KC_P,    KC_B,                         KC_J,    KC_L,    KC_U,    KC_Y, KC_SCLN, KC_BSLS,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_BSPC, LSFT_KA, LCTL_KR, LGUI_KS, LALT_KT,    KC_G,                         KC_M, LALT_KN, RGUI_KE, RCTL_KI, RSFT_KO, KC_QUOT,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_D,    KC_V,                         KC_K,    KC_H, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          KC_LALT, TL_LOWR,  KC_SPC,     KC_ENT, TL_UPPR, KC_RALT
+                                      //`--------------------------'  `--------------------------'
+  ),
+
+  [_COLEMAK_NOHOMEROW] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_TAB,    KC_Q,    KC_W,    KC_F,    KC_P,    KC_B,                         KC_J,    KC_L,    KC_U,    KC_Y, KC_SCLN, KC_BSLS,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_BSPC,    KC_A,    KC_R,    KC_S,    KC_T,    KC_G,                         KC_M,    KC_N,    KC_E,    KC_I,    KC_O, KC_QUOT,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_D,    KC_V,                         KC_K,    KC_H, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          KC_LALT, TL_LOWR,  KC_SPC,     KC_ENT, TL_UPPR, KC_RALT
+                                      //`--------------------------'  `--------------------------'
+  ),
+
+  [_LOWER] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_GRV,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,                         KC_1,    KC_2,    KC_3,    KC_4,    KC_5, _______,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      _______,    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,                         KC_6,    KC_7,    KC_8,    KC_9,    KC_0, KC_MINS,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      _______, _______, _______, _______, KC_LBRC, KC_LCBR,                      KC_RCBR, KC_RBRC,  KC_EQL, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          _______, _______, _______,    _______, _______, _______
+                                      //`--------------------------'  `--------------------------'
+  ),
+
+  [_UPPER] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+      _______, KC_ESC, KC_WH_U, KC_WBAK, KC_WFWD, KC_MS_U,                       KC_PGUP, KC_HOME,   KC_UP,  KC_END,  KC_DEL, _______,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      _______, KC_RALT, KC_WH_D, KC_LSFT, KC_LCTL, KC_MS_D,                      KC_PGDN, KC_LEFT, KC_DOWN, KC_RGHT, KC_BSPC, _______,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      _______, C(KC_Z), C(KC_X), C(KC_C), KC_BTN1, C(KC_V),                      KC_BTN2, KC_BTN3, KC_MS_L, KC_MS_R, _______, _______,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          _______, _______, _______,    _______, _______, _______
+                                      //`--------------------------'  `--------------------------'
+  ),
+
+  [_ADJUST] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_F12,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                        KC_F6,   KC_F7,   KC_F8,   KC_F9,  KC_F10,  KC_F11,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      _______, _______, _______, _______, _______, _______,                      _______, _______, _______, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      _______, COLEMAK,  QWERTY, _______, _______, _______,                      QK_BOOT, _______, _______, QWERTY_NOHOMEROW, COLEMAK_NOHOMEROW, _______,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          _______, _______, _______,    _______, _______, _______
+                                      //`--------------------------'  `--------------------------'
+  )
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_QWERTY);
+      }
+      return false;
+    case QWERTY_NOHOMEROW:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_QWERTY_NOHOMEROW);
+      }
+      return false;
+    case COLEMAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_COLEMAK);
+      }
+      return false;
+    case COLEMAK_NOHOMEROW:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_COLEMAK_NOHOMEROW);
+      }
+      return false;
+  }
+  return true;
+}

--- a/keyboards/crkbd/keymaps/x123/readme.md
+++ b/keyboards/crkbd/keymaps/x123/readme.md
@@ -1,0 +1,57 @@
+# x123 Keymap for the Corne
+
+This keymap is based on many concepts from Dreymar's big bag theory (see https://dreymar.colemak.org/index.html), tweaked a bit for my own preferences and adopted to the Corne.
+
+## Features
+
+- Supports both QWERTY and COLEMAK layouts
+- Layouts switchable on the fly
+- Homerow mods can be toggled (useful for gaming)
+- Uses Tri Layers (see https://docs.qmk.fm/#/feature_tri_layer)
+- Normal capslock key location has been replaced with backspace for ergonomics. Note that backspace is also placed in it's normal location for the QWERTY layouts (useful for letting others test the keyboard/layout)
+- Uses Dreymar's EXTEND for the UPPER layer
+- Keeps numbers and symbols on the LOWER layer, with all numbers accessible either along the home row (for two-handed operation), as well as invidually all numbers accessible for each individual side (for one-handed operation)
+- Function keys and quick configuration settings on the ADJUST layer
+- Designed to use RALT as a compose key
+
+### QWERTY
+
+Basic QWERTY with homerow mods enabled.
+
+![QWERTY](https://i.imgur.com/Mjz4g3g.png)
+
+### QWERTY_NOHOMEROW
+
+Basic QWERTY with homerow mods disabled.
+
+![QWERTY_NOHOMEROW](https://i.imgur.com/yjt7Plz.png)
+
+### COLEMAK
+
+COLEMAK with homerow mods enabled.
+
+![COLEMAK](https://i.imgur.com/3Zk9QZG.png)
+
+### COLEMAK_NOHOMEROW
+
+COLEMAK with homerow mods disabled.
+
+![COLEMAK_NOHOMEROW](https://i.imgur.com/7fmvHXf.png)
+
+### LOWER
+
+LOWER is where numbers and symbols live.
+
+![LOWER](https://i.imgur.com/ZbWn7hN.png)
+
+### UPPER
+
+UPPER is basically a direct rip of Dreymar's EXTEND for small keyboards (see the very bottom image on https://dreymar.colemak.org/layers-extend.html). This is where you'll find the arrow keys, navigation keys, mouse controls, and others.
+
+![UPPER](https://i.imgur.com/ByFTbL1.png)
+
+### ADJUST
+
+ADJUST houses the function keys, it also allows quick access to swap between default layers described above as well as issue a QK_BOOT to the keyboard for use when flashing.
+
+![ONESHOT](https://i.imgur.com/0OIvGPu.png)

--- a/keyboards/crkbd/keymaps/x123/rules.mk
+++ b/keyboards/crkbd/keymaps/x123/rules.mk
@@ -1,0 +1,23 @@
+# Copyright 2022 x123 <@x123>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+RGB_MATRIX_ENABLE = no
+RGBLIGHT_ENABLE = no
+MOUSEKEY_ENABLE = yes
+OLED_ENABLE     = no
+LTO_ENABLE      = yes
+UNICODE_ENABLE  = yes
+TRI_LAYER_ENABLE = yes

--- a/keyboards/crkbd/keymaps/x123/rules.mk
+++ b/keyboards/crkbd/keymaps/x123/rules.mk
@@ -1,19 +1,3 @@
-# Copyright 2022 x123 <@x123>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-
 RGB_MATRIX_ENABLE = no
 RGBLIGHT_ENABLE = no
 MOUSEKEY_ENABLE = yes


### PR DESCRIPTION
add x123 keymap for crkbd/rev1

This keymap is based on many concepts from Dreymar's big bag theory (see https://dreymar.colemak.org/index.html), tweaked a bit for my own preferences and adopted to the Corne. The readme provides further details and images of the layout.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
