### PR TITLE
[Keyboard] Add Binepad Pixie

### DIFF
--- a/keyboards/binepad/pixie/config.h
+++ b/keyboards/binepad/pixie/config.h
@@ -1,0 +1,32 @@
+// Copyright 2023 binepad (@binepad)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define ENCODER_DEFAULT_POS 0x3  // enable 1:1 resolution
+
+/*
+ * Wear-leveling RP2040 Driver Configuration
+ */
+
+// #define WEAR_LEVELING_RP2040_FLASH_SIZE (32 * 1024 * 1024)  // Number of bytes of flash on the board.
+// #define WEAR_LEVELING_RP2040_FLASH_BASE (flash_size-sector_size)  // The byte-wise location that the backing storage should be located.
+#define WEAR_LEVELING_LOGICAL_SIZE (2 * 1024)  // Number of bytes “exposed” to the rest of QMK and denotes the size of the usable EEPROM.
+#define WEAR_LEVELING_BACKING_SIZE (WEAR_LEVELING_LOGICAL_SIZE * 2)  // Number of bytes used by the wear-leveling algorithm for its underlying storage, and needs to be a multiple of the logical size as well as the sector size.
+// #define BACKING_STORE_WRITE_SIZE 2  // The write width used whenever a write is performed on the external flash peripheral.
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT

--- a/keyboards/binepad/pixie/config.h
+++ b/keyboards/binepad/pixie/config.h
@@ -4,29 +4,3 @@
 #pragma once
 
 #define ENCODER_DEFAULT_POS 0x3  // enable 1:1 resolution
-
-/*
- * Wear-leveling RP2040 Driver Configuration
- */
-
-// #define WEAR_LEVELING_RP2040_FLASH_SIZE (32 * 1024 * 1024)  // Number of bytes of flash on the board.
-// #define WEAR_LEVELING_RP2040_FLASH_BASE (flash_size-sector_size)  // The byte-wise location that the backing storage should be located.
-#define WEAR_LEVELING_LOGICAL_SIZE (2 * 1024)  // Number of bytes “exposed” to the rest of QMK and denotes the size of the usable EEPROM.
-#define WEAR_LEVELING_BACKING_SIZE (WEAR_LEVELING_LOGICAL_SIZE * 2)  // Number of bytes used by the wear-leveling algorithm for its underlying storage, and needs to be a multiple of the logical size as well as the sector size.
-// #define BACKING_STORE_WRITE_SIZE 2  // The write width used whenever a write is performed on the external flash peripheral.
-
-/*
- * Feature disable options
- *  These options are also useful to firmware size reduction.
- */
-
-/* disable debug print */
-//#define NO_DEBUG
-
-/* disable print */
-//#define NO_PRINT
-
-/* disable action features */
-//#define NO_ACTION_LAYER
-//#define NO_ACTION_TAPPING
-//#define NO_ACTION_ONESHOT

--- a/keyboards/binepad/pixie/info.json
+++ b/keyboards/binepad/pixie/info.json
@@ -25,7 +25,6 @@
         "rows": ["GP28", "GP5"]
     },
     "encoder": {
-        "enabled": true,
         "rotary": [
             {
                 "pin_a": "GP18",

--- a/keyboards/binepad/pixie/info.json
+++ b/keyboards/binepad/pixie/info.json
@@ -1,0 +1,50 @@
+{
+    "manufacturer": "binepad",
+    "keyboard_name": "PIXIE",
+    "url": "http://binepad.com",
+    "maintainer": "binepad",
+    "processor": "RP2040",
+    "bootloader": "rp2040",
+    "diode_direction": "COL2ROW",
+    "usb": {
+        "vid": "0x4249",
+        "pid": "0x5078",
+        "device_version": "1.0.0"
+    },
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": false,
+        "encoder": true
+    },
+    "matrix_pins": {
+        "cols": ["GP19", "GP4"],
+        "rows": ["GP28", "GP5"]
+    },
+    "encoder": {
+        "enabled": true,
+        "rotary": [
+            {
+                "pin_a": "GP18",
+                "pin_b": "GP17"
+            },
+            {
+                "pin_a": "GP20",
+                "pin_b": "GP21"
+            }
+        ]
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                { "matrix": [0, 0], "x": 0, "y": 0 },
+                { "matrix": [0, 1], "x": 1.25, "y": 0 },
+                { "matrix": [1, 0], "x": 0, "y": 1.25 },
+                { "matrix": [1, 1], "x": 1.25, "y": 1.25 }
+            ]
+        }
+    }
+}

--- a/keyboards/binepad/pixie/keymaps/default/keymap.c
+++ b/keyboards/binepad/pixie/keymaps/default/keymap.c
@@ -12,7 +12,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 #if defined(ENCODER_MAP_ENABLE)
 
-const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
     [0] = {
         ENCODER_CCW_CW(KC_VOLD, KC_VOLU),
         ENCODER_CCW_CW(KC_WH_U, KC_WH_D)

--- a/keyboards/binepad/pixie/keymaps/default/keymap.c
+++ b/keyboards/binepad/pixie/keymaps/default/keymap.c
@@ -1,0 +1,22 @@
+// Copyright 2023 Binepad (@binpad)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_MUTE, KC_MPLY,
+        KC_MPRV, KC_MNXT
+    )
+};
+
+#if defined(ENCODER_MAP_ENABLE)
+
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
+    [0] = {
+        ENCODER_CCW_CW(KC_VOLD, KC_VOLU),
+        ENCODER_CCW_CW(KC_WH_U, KC_WH_D)
+    }
+};
+
+#endif

--- a/keyboards/binepad/pixie/keymaps/default/rules.mk
+++ b/keyboards/binepad/pixie/keymaps/default/rules.mk
@@ -1,0 +1,4 @@
+# Copyright 2023 Binepad (@binpad)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+ENCODER_MAP_ENABLE = yes

--- a/keyboards/binepad/pixie/keymaps/default/rules.mk
+++ b/keyboards/binepad/pixie/keymaps/default/rules.mk
@@ -1,4 +1,2 @@
-# Copyright 2023 Binepad (@binpad)
-# SPDX-License-Identifier: GPL-2.0-or-later
 
 ENCODER_MAP_ENABLE = yes

--- a/keyboards/binepad/pixie/keymaps/via/config.h
+++ b/keyboards/binepad/pixie/keymaps/via/config.h
@@ -1,6 +1,0 @@
-// Copyright 2023 Binepad (@binpad)
-// SPDX-License-Identifier: GPL-2.0-or-later
-
-#pragma once
-
-#define DYNAMIC_KEYMAP_LAYER_COUNT 3

--- a/keyboards/binepad/pixie/keymaps/via/config.h
+++ b/keyboards/binepad/pixie/keymaps/via/config.h
@@ -3,9 +3,4 @@
 
 #pragma once
 
-// #define TAPPING_TERM 175
-
-#ifdef DYNAMIC_KEYMAP_LAYER_COUNT
-    #undef DYNAMIC_KEYMAP_LAYER_COUNT
-#endif
 #define DYNAMIC_KEYMAP_LAYER_COUNT 3

--- a/keyboards/binepad/pixie/keymaps/via/config.h
+++ b/keyboards/binepad/pixie/keymaps/via/config.h
@@ -1,0 +1,11 @@
+// Copyright 2023 Binepad (@binpad)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// #define TAPPING_TERM 175
+
+#ifdef DYNAMIC_KEYMAP_LAYER_COUNT
+    #undef DYNAMIC_KEYMAP_LAYER_COUNT
+#endif
+#define DYNAMIC_KEYMAP_LAYER_COUNT 3

--- a/keyboards/binepad/pixie/keymaps/via/keymap.c
+++ b/keyboards/binepad/pixie/keymaps/via/keymap.c
@@ -7,16 +7,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
         KC_MUTE, KC_MPLY,
         KC_MPRV, KC_MNXT
-    ),
-
-    [1] = LAYOUT(
-        _______, _______,
-        _______, _______
-    ),
-
-    [2] = LAYOUT(
-        _______, _______,
-        _______, _______
     )
 };
 
@@ -26,16 +16,6 @@ const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
     [0] = {
         ENCODER_CCW_CW(KC_VOLD, KC_VOLU),
         ENCODER_CCW_CW(KC_WH_U, KC_WH_D)
-    },
-
-    [1] = {
-        ENCODER_CCW_CW(_______, _______),
-        ENCODER_CCW_CW(_______, _______)
-    },
-
-    [2] = {
-        ENCODER_CCW_CW(_______, _______),
-        ENCODER_CCW_CW(_______, _______)
     }
 };
 

--- a/keyboards/binepad/pixie/keymaps/via/keymap.c
+++ b/keyboards/binepad/pixie/keymaps/via/keymap.c
@@ -12,7 +12,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 #if defined(ENCODER_MAP_ENABLE)
 
-const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
     [0] = {
         ENCODER_CCW_CW(KC_VOLD, KC_VOLU),
         ENCODER_CCW_CW(KC_WH_U, KC_WH_D)

--- a/keyboards/binepad/pixie/keymaps/via/keymap.c
+++ b/keyboards/binepad/pixie/keymaps/via/keymap.c
@@ -1,0 +1,42 @@
+// Copyright 2023 Binepad (@binpad)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_MUTE, KC_MPLY,
+        KC_MPRV, KC_MNXT
+    ),
+
+    [1] = LAYOUT(
+        _______, _______,
+        _______, _______
+    ),
+
+    [2] = LAYOUT(
+        _______, _______,
+        _______, _______
+    )
+};
+
+#if defined(ENCODER_MAP_ENABLE)
+
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
+    [0] = {
+        ENCODER_CCW_CW(KC_VOLD, KC_VOLU),
+        ENCODER_CCW_CW(KC_WH_U, KC_WH_D)
+    },
+
+    [1] = {
+        ENCODER_CCW_CW(_______, _______),
+        ENCODER_CCW_CW(_______, _______)
+    },
+
+    [2] = {
+        ENCODER_CCW_CW(_______, _______),
+        ENCODER_CCW_CW(_______, _______)
+    }
+};
+
+#endif

--- a/keyboards/binepad/pixie/keymaps/via/rules.mk
+++ b/keyboards/binepad/pixie/keymaps/via/rules.mk
@@ -1,0 +1,5 @@
+# Copyright 2023 Binepad (@binpad)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+VIA_ENABLE = yes
+ENCODER_MAP_ENABLE = yes

--- a/keyboards/binepad/pixie/keymaps/via/rules.mk
+++ b/keyboards/binepad/pixie/keymaps/via/rules.mk
@@ -1,5 +1,3 @@
-# Copyright 2023 Binepad (@binpad)
-# SPDX-License-Identifier: GPL-2.0-or-later
 
 VIA_ENABLE = yes
 ENCODER_MAP_ENABLE = yes

--- a/keyboards/binepad/pixie/readme.md
+++ b/keyboards/binepad/pixie/readme.md
@@ -1,0 +1,27 @@
+# BINEPAD PIXIE
+
+![BINEPAD PIXIE](https://i.imgur.com/OnQnkdUh.jpeg)
+
+*A 2x2 macropad with 2x rotary encoders*
+
+* Keyboard Maintainer: [binepad](https://github.com/binepad)
+* Hardware Supported: BINPAD PIXIE
+* Hardware Availability: [binepad.com](https://www.binepad.com/pixie)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make binepad/pixie:default
+
+Flashing example for this keyboard:
+
+    make binepad/pixie:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (010) in the matrix (the bottom left key) and plug in the keyboard
+* **Physical reset button**: Briefly press the PCB button located on the back of the PCB
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` or `RESET` if it is available

--- a/keyboards/binepad/pixie/rules.mk
+++ b/keyboards/binepad/pixie/rules.mk
@@ -1,5 +1,1 @@
-# Copyright 2023 Binepad (@binpad)
-# SPDX-License-Identifier: GPL-2.0-or-later
-
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = rp2040_flash
+# This file intentionally left blank

--- a/keyboards/binepad/pixie/rules.mk
+++ b/keyboards/binepad/pixie/rules.mk
@@ -1,0 +1,5 @@
+# Copyright 2023 Binepad (@binpad)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+EEPROM_DRIVER = wear_leveling
+WEAR_LEVELING_DRIVER = rp2040_flash


### PR DESCRIPTION

## Description

Adding Binepad PIXIE keyboard, an RP2040 based 2x2 macro keypad featuring 2 rotary encoders and 2 macro buttons.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* (n/a)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
