### PR TITLE
backlight: split AVR PWM and timer drivers

### DIFF
--- a/docs/feature_backlight.md
+++ b/docs/feature_backlight.md
@@ -1,12 +1,12 @@
 # Backlighting :id=backlighting
 
-Many keyboards support backlit keys by way of individual LEDs placed through or underneath the keyswitches. This feature is distinct from both the [RGB underglow](feature_rgblight.md) and [RGB matrix](feature_rgb_matrix.md) features as it usually allows for only a single colour per switch, though you can obviously install multiple different single coloured LEDs on a keyboard.
+Many keyboards support backlit keys by way of individual LEDs placed through or underneath the keyswitches. This feature is distinct from both the [RGB Underglow](feature_rgblight.md) and [RGB Matrix](feature_rgb_matrix.md) features as it usually allows for only a single colour per switch, though you can obviously install multiple different single coloured LEDs on a keyboard.
 
 QMK is able to control the brightness of these LEDs by switching them on and off rapidly in a certain ratio, a technique known as *Pulse Width Modulation*, or PWM. By altering the duty cycle of the PWM signal, it creates the illusion of dimming.
 
-The MCU can only supply so much current to its GPIO pins. Instead of powering the backlight directly from the MCU, the backlight pin is connected to a transistor or MOSFET that switches the power to the LEDs.
+## Usage :id=usage
 
-Most keyboards have backlighting enabled by default if they support it, but if it is not working for you, check that your `rules.mk` includes the following:
+Most keyboards have backlighting enabled by default if they support it, but if it is not working for you (or you have added support), check that your `rules.mk` includes the following:
 
 ```make
 BACKLIGHT_ENABLE = yes
@@ -14,57 +14,23 @@ BACKLIGHT_ENABLE = yes
 
 ## Keycodes :id=keycodes
 
-Once enabled, the following keycodes below can be used to change the backlight level.
+|Key                            |Aliases  |Description                        |
+|-------------------------------|---------|-----------------------------------|
+|`QK_BACKLIGHT_TOGGLE`          |`BL_TOGG`|Turn the backlight on or off       |
+|`QK_BACKLIGHT_STEP`            |`BL_STEP`|Cycle through backlight levels     |
+|`QK_BACKLIGHT_ON`              |`BL_ON`  |Set the backlight to max brightness|
+|`QK_BACKLIGHT_OFF`             |`BL_OFF` |Turn the backlight off             |
+|`QK_BACKLIGHT_UP`              |`BL_UP`  |Increase the backlight level       |
+|`QK_BACKLIGHT_DOWN`            |`BL_DOWN`|Decrease the backlight level       |
+|`QK_BACKLIGHT_TOGGLE_BREATHING`|`BL_BRTG`|Toggle backlight breathing         |
 
-| Key                             | Aliases   | Description                         |
-|---------------------------------|-----------|-------------------------------------|
-| `QK_BACKLIGHT_TOGGLE`           | `BL_TOGG` | Turn the backlight on or off        |
-| `QK_BACKLIGHT_STEP`             | `BL_STEP` | Cycle through backlight levels      |
-| `QK_BACKLIGHT_ON`               | `BL_ON`   | Set the backlight to max brightness |
-| `QK_BACKLIGHT_OFF`              | `BL_OFF`  | Turn the backlight off              |
-| `QK_BACKLIGHT_UP`               | `BL_UP`   | Increase the backlight level        |
-| `QK_BACKLIGHT_DOWN`             | `BL_DOWN` | Decrease the backlight level        |
-| `QK_BACKLIGHT_TOGGLE_BREATHING` | `BL_BRTG` | Toggle backlight breathing          |
+## Basic Configuration :id=basic-configuration
 
-## Functions :id=functions
-
-These functions can be used to change the backlighting in custom code:
-
-|Function                |Description                                 |
-|------------------------|--------------------------------------------|
-|`backlight_toggle()`    |Turn the backlight on or off                |
-|`backlight_enable()`    |Turn the backlight on                       |
-|`backlight_disable()`   |Turn the backlight off                      |
-|`backlight_step()`      |Cycle through backlight levels              |
-|`backlight_increase()`  |Increase the backlight level                |
-|`backlight_decrease()`  |Decrease the backlight level                |
-|`backlight_level(x)`    |Sets the backlight level to specified level |
-|`get_backlight_level()` |Return the current backlight level          |
-|`is_backlight_enabled()`|Return whether the backlight is currently on|
-
-If backlight breathing is enabled (see below), the following functions are also available:
-
-|Function             |Description                           |
-|---------------------|--------------------------------------|
-|`breathing_toggle()` |Turn the backlight breathing on or off|
-|`breathing_enable()` |Turns on backlight breathing          |
-|`breathing_disable()`|Turns off backlight breathing         |
-
-## Configuration :id=configuration
-
-To select which driver to use, configure your `rules.mk` with the following:
-
-```make
-BACKLIGHT_DRIVER = software
-```
-
-Valid driver values are `pwm`, `software`, `custom` or `no`. See below for help on individual drivers.
-
-To configure the backlighting, `#define` these in your `config.h`:
+Add the following to your `config.h`:
 
 |Define                       |Default           |Description                                                                                                      |
 |-----------------------------|------------------|-----------------------------------------------------------------------------------------------------------------|
-|`BACKLIGHT_PIN`              |*Not defined*     |The pin that controls the LED(s)                                                                                 |
+|`BACKLIGHT_PIN`              |*Not defined*     |The pin that controls the LEDs                                                                                   |
 |`BACKLIGHT_LEVELS`           |`3`               |The number of brightness levels (maximum 31 excluding off)                                                       |
 |`BACKLIGHT_CAPS_LOCK`        |*Not defined*     |Enable Caps Lock indicator using backlight (for keyboards without dedicated LED)                                 |
 |`BACKLIGHT_BREATHING`        |*Not defined*     |Enable backlight breathing, if supported                                                                         |
@@ -76,123 +42,65 @@ To configure the backlighting, `#define` these in your `config.h`:
 
 Unless you are designing your own keyboard, you generally should not need to change the `BACKLIGHT_PIN` or `BACKLIGHT_ON_STATE`.
 
-### Backlight On State :id=backlight-on-state
+### "On" State :id=on-state
 
 Most backlight circuits are driven by an N-channel MOSFET or NPN transistor. This means that to turn the transistor *on* and light the LEDs, you must drive the backlight pin, connected to the gate or base, *high*.
 Sometimes, however, a P-channel MOSFET, or a PNP transistor is used. In this case, when the transistor is on, the pin is driven *low* instead.
 
-This functionality is configured at the keyboard level with the `BACKLIGHT_ON_STATE` define.
+To configure the "on" state of the backlight circuit, add the following to your `config.h`:
 
-### AVR Driver :id=avr-driver
-
-The `pwm` driver is configured by default, however the equivalent setting within `rules.mk` would be:
-
-```make
-BACKLIGHT_DRIVER = pwm
+```c
+#define BACKLIGHT_ON_STATE 0
 ```
 
-#### Caveats :id=avr-caveats
-
-On AVR boards, QMK automatically decides which driver to use according to the following table:
-
-|Backlight Pin|AT90USB64/128|AT90USB162|ATmega16/32U4|ATmega16/32U2|ATmega32A|ATmega328/P|
-|-------------|-------------|----------|-------------|-------------|---------|-----------|
-|`B1`         |             |          |             |             |         |Timer 1    |
-|`B2`         |             |          |             |             |         |Timer 1    |
-|`B5`         |Timer 1      |          |Timer 1      |             |         |           |
-|`B6`         |Timer 1      |          |Timer 1      |             |         |           |
-|`B7`         |Timer 1      |Timer 1   |Timer 1      |Timer 1      |         |           |
-|`C4`         |Timer 3      |          |             |             |         |           |
-|`C5`         |Timer 3      |Timer 1   |             |Timer 1      |         |           |
-|`C6`         |Timer 3      |Timer 1   |Timer 3      |Timer 1      |         |           |
-|`D4`         |             |          |             |             |Timer 1  |           |
-|`D5`         |             |          |             |             |Timer 1  |           |
-
-All other pins will use timer-assisted software PWM:
-
-|Audio Pin|Audio Timer|Software PWM Timer|
-|---------|-----------|------------------|
-|`C4`     |Timer 3    |Timer 1           |
-|`C5`     |Timer 3    |Timer 1           |
-|`C6`     |Timer 3    |Timer 1           |
-|`B5`     |Timer 1    |Timer 3           |
-|`B6`     |Timer 1    |Timer 3           |
-|`B7`     |Timer 1    |Timer 3           |
-
-When both timers are in use for Audio, the backlight PWM cannot use a hardware timer, and will instead be triggered during the matrix scan. In this case, breathing is not supported, and the backlight might flicker, because the PWM computation may not be called with enough timing precision.
-
-#### Hardware PWM Implementation :id=hardware-pwm-implementation
-
-When using the supported pins for backlighting, QMK will use a hardware timer configured to output a PWM signal. This timer will count up to `ICRx` (by default `0xFFFF`) before resetting to 0.
-The desired brightness is calculated and stored in the `OCRxx` register. When the counter reaches this value, the backlight pin will go low, and is pulled high again when the counter resets.
-In this way `OCRxx` essentially controls the duty cycle of the LEDs, and thus the brightness, where `0x0000` is completely off and `0xFFFF` is completely on.
-
-The breathing effect is achieved by registering an interrupt handler for `TIMER1_OVF_vect` that is called whenever the counter resets, roughly 244 times per second.
-In this handler, the value of an incrementing counter is mapped onto a precomputed brightness curve. To turn off breathing, the interrupt handler is simply disabled, and the brightness reset to the level stored in EEPROM.
-
-#### Timer Assisted PWM Implementation :id=timer-assisted-implementation
-
-When `BACKLIGHT_PIN` is not set to a hardware backlight pin, QMK will use a hardware timer configured to trigger software interrupts. This time will count up to `ICRx` (by default `0xFFFF`) before resetting to 0.
-When resetting to 0, the CPU will fire an OVF (overflow) interrupt that will turn the LEDs on, starting the duty cycle.
-The desired brightness is calculated and stored in the `OCRxx` register. When the counter reaches this value, the CPU will fire a Compare Output match interrupt, which will turn the LEDs off.
-In this way `OCRxx` essentially controls the duty cycle of the LEDs, and thus the brightness, where `0x0000` is completely off and `0xFFFF` is completely on.
-
-The breathing effect is the same as in the hardware PWM implementation.
-
-### ARM Driver :id=arm-configuration
-
-While still in its early stages, ARM backlight support aims to eventually have feature parity with AVR. The `pwm` driver is configured by default, however the equivalent setting within `rules.mk` would be:
-
-```make
-BACKLIGHT_DRIVER = pwm
-```
-
-#### ChibiOS Configuration :id=arm-configuration
-
-The following `#define`s apply only to ARM-based keyboards:
-
-|Define                 |Default|Description                        |
-|-----------------------|-------|-----------------------------------|
-|`BACKLIGHT_PWM_DRIVER` |`PWMD4`|The PWM driver to use              |
-|`BACKLIGHT_PWM_CHANNEL`|`3`    |The PWM channel to use             |
-|`BACKLIGHT_PAL_MODE`   |`2`    |The pin alternative function to use|
-
-See the ST datasheet for your particular MCU to determine these values. Unless you are designing your own keyboard, you generally should not need to change them.
-
-#### Caveats :id=arm-caveats
-
-Currently only hardware PWM is supported, not timer assisted, and does not provide automatic configuration.
-
-### Software PWM Driver :id=software-pwm-driver
-
-In this mode, PWM is "emulated" while running other keyboard tasks. It offers maximum hardware compatibility without extra platform configuration. The tradeoff is the backlight might jitter when the keyboard is busy. To enable, add this to your `rules.mk`:
-
-```make
-BACKLIGHT_DRIVER = software
-```
-
-#### Multiple Backlight Pins :id=multiple-backlight-pins
+### Multiple Backlight Pins :id=multiple-backlight-pins
 
 Most keyboards have only one backlight pin which controls all backlight LEDs (especially if the backlight is connected to a hardware PWM pin).
-In software PWM, it is possible to define multiple backlight pins, which will be turned on and off at the same time during the PWM duty cycle.
+The `timer` and `software` drivers allow you to define multiple backlight pins, which will be turned on and off at the same time during the PWM duty cycle.
 
 This feature allows to set, for instance, the Caps Lock LED's (or any other controllable LED) brightness at the same level as the other LEDs of the backlight. This is useful if you have mapped Control in place of Caps Lock and you need the Caps Lock LED to be part of the backlight instead of being activated when Caps Lock is on, as it is usually wired to a separate pin from the backlight.
 
-To activate multiple backlight pins, add something like this to your `config.h`, instead of `BACKLIGHT_PIN`:
+To configure multiple backlight pins, add something like this to your `config.h`, instead of `BACKLIGHT_PIN`:
 
 ```c
 #define BACKLIGHT_PINS { F5, B2 }
 ```
 
+## Driver Configuration :id=driver-configuration
+
+Backlight driver selection is configured in `rules.mk`. Valid drivers are `pwm` (default), `timer`, `software`, or `custom`. See below for information on individual drivers.
+
+### PWM Driver :id=pwm-driver
+
+This is the default backlight driver, which leverages the hardware PWM output capability of the microcontroller.
+
+```make
+BACKLIGHT_DRIVER = pwm
+```
+
+### Timer Driver :id=timer-driver
+
+This driver is similar to the PWM driver, but instead of directly configuring the pin to output a PWM signal, an interrupt handler is attached to the timer to turn the pin on and off as appropriate.
+
+```make
+BACKLIGHT_DRIVER = timer
+```
+
+### Software Driver :id=software-driver
+
+In this mode, PWM is "emulated" while running other keyboard tasks. It offers maximum hardware compatibility without extra platform configuration. However, breathing is not supported, and the backlight can flicker when the keyboard is busy.
+
+```make
+BACKLIGHT_DRIVER = software
+```
+
 ### Custom Driver :id=custom-driver
 
-If none of the above drivers apply to your board (for example, you are using a separate IC to control the backlight), you can implement a custom backlight driver using this simple API provided by QMK. To enable, add this to your `rules.mk`:
+If none of the above drivers apply to your board (for example, you are using a separate IC to control the backlight), you can implement a custom backlight driver using a simple API.
 
 ```make
 BACKLIGHT_DRIVER = custom
 ```
-
-Then implement any of these hooks:
 
 ```c
 void backlight_init_ports(void) {
@@ -211,10 +119,188 @@ void backlight_task(void) {
 }
 ```
 
+## AVR Configuration :id=avr-configuration
+
+### PWM Driver :id=avr-pwm-driver
+
+The following table describes the supported pins for the PWM driver. Only cells marked with a timer number are capable of hardware PWM output; any others must use the `timer` driver.
+
+|Backlight Pin|AT90USB64/128|AT90USB162|ATmega16/32U4|ATmega16/32U2|ATmega32A|ATmega328/P|
+|-------------|-------------|----------|-------------|-------------|---------|-----------|
+|`B1`         |             |          |             |             |         |Timer 1    |
+|`B2`         |             |          |             |             |         |Timer 1    |
+|`B5`         |Timer 1      |          |Timer 1      |             |         |           |
+|`B6`         |Timer 1      |          |Timer 1      |             |         |           |
+|`B7`         |Timer 1      |Timer 1   |Timer 1      |Timer 1      |         |           |
+|`C4`         |Timer 3      |          |             |             |         |           |
+|`C5`         |Timer 3      |Timer 1   |             |Timer 1      |         |           |
+|`C6`         |Timer 3      |Timer 1   |Timer 3      |Timer 1      |         |           |
+|`D4`         |             |          |             |             |Timer 1  |           |
+|`D5`         |             |          |             |             |Timer 1  |           |
+
+### Timer Driver :id=avr-timer-driver
+
+Any GPIO pin can be used with this driver. The following table describes the supported timers:
+
+|AT90USB64/128|AT90USB162|ATmega16/32U4|ATmega16/32U2|ATmega32A|ATmega328/P|
+|-------------|----------|-------------|-------------|---------|-----------|
+|Timers 1 & 3 |Timer 1   |Timers 1 & 3 |Timer 1      |Timer 1  |Timer 1    |
+
+The following `#define`s apply only to the `timer` driver:
+
+|Define                 |Default|Description     |
+|-----------------------|-------|----------------|
+|`BACKLIGHT_PWM_TIMER`  |`1`    |The timer to use|
+
+Note that the choice of timer may conflict with the [Audio](feature_audio.md) feature.
+
+## ChibiOS/ARM Configuration :id=arm-configuration
+
+### PWM Driver :id=arm-pwm-driver
+
+Depending on the ChibiOS board configuration, you may need to enable PWM at the keyboard level. For STM32, this would look like:
+
+`halconf.h`:
+```c
+#define HAL_USE_PWM TRUE
+```
+`mcuconf.h`:
+```c
+#undef STM32_PWM_USE_TIM4
+#define STM32_PWM_USE_TIM4 TRUE
+```
+
+The following `#define`s apply only to the `pwm` driver:
+
+|Define                 |Default |Description                        |
+|-----------------------|--------|-----------------------------------|
+|`BACKLIGHT_PWM_DRIVER` |`PWMD4` |The PWM driver to use              |
+|`BACKLIGHT_PWM_CHANNEL`|`3`     |The PWM channel to use             |
+|`BACKLIGHT_PAL_MODE`   |`2`     |The pin alternative function to use|
+
+Refer to the ST datasheet for your particular MCU to determine these values. For example, these defaults are set up for pin `B8` on a Proton-C (STM32F303) using `TIM4_CH3` on AF2. Unless you are designing your own keyboard, you generally should not need to change them.
+
+### Timer Driver :id=arm-timer-driver
+
+Depending on the ChibiOS board configuration, you may need to enable general-purpose timers at the keyboard level. For STM32, this would look like:
+
+`halconf.h`:
+```c
+#define HAL_USE_GPT TRUE
+```
+`mcuconf.h`:
+```c
+#undef STM32_GPT_USE_TIM15
+#define STM32_GPT_USE_TIM15 TRUE
+```
+
+The following `#define`s apply only to the `timer` driver:
+
+|Define                |Default |Description     |
+|----------------------|--------|----------------|
+|`BACKLIGHT_GPT_DRIVER`|`GPTD15`|The timer to use|
+
 ## Example Schematic
+
+Since the MCU can only supply so much current to its GPIO pins, instead of powering the backlight directly from the MCU, the backlight pin is connected to a transistor or MOSFET that switches the power to the LEDs.
 
 In this typical example, the backlight LEDs are all connected in parallel towards an N-channel MOSFET. Its gate pin is wired to one of the microcontroller's GPIO pins through a 470Ω resistor to avoid ringing.
 A pulldown resistor is also placed between the gate pin and ground to keep it at a defined state when it is not otherwise being driven by the MCU.
 The values of these resistors are not critical - see [this Electronics StackExchange question](https://electronics.stackexchange.com/q/68748) for more information.
 
 ![Backlight example circuit](https://i.imgur.com/BmAvoUC.png)
+
+## API :id=api
+
+### `void backlight_toggle(void)` :id=api-backlight-toggle
+
+Toggle the backlight on or off.
+
+---
+
+### `void backlight_enable(void)` :id=api-backlight-enable
+
+Turn the backlight on.
+
+---
+
+### `void backlight_disable(void)` :id=api-backlight-disable
+
+Turn the backlight off.
+
+---
+
+### `void backlight_step(void)` :id=api-backlight-step
+
+Cycle through backlight levels.
+
+---
+
+### `void backlight_increase(void)` :id=api-backlight-increase
+
+Increase the backlight level.
+
+---
+
+### `void backlight_decrease(void)` :id=api-backlight-decrease
+
+Decrease the backlight level.
+
+---
+
+### `void backlight_level(uint8_t level)` :id=api-backlight-level
+
+Set the backlight level.
+
+#### Arguments :id=api-backlight-level-arguments
+
+ - `uint8_t level`  
+   The level to set, from 0 to `BACKLIGHT_LEVELS`.
+
+---
+
+### `uint8_t get_backlight_level(void)` :id=api-get-backlight-level
+
+Get the current backlight level.
+
+#### Return Value :id=api-get-backlight-level-return
+
+The current backlight level, from 0 to `BACKLIGHT_LEVELS`.
+
+---
+
+### `bool is_backlight_enabled(void)` :id=api-is-backlight-enabled
+
+Get the current backlight state.
+
+#### Return Value :id=api-is-backlight-enabled-return
+
+`true` if the backlight is enabled.
+
+---
+
+### `void backlight_toggle_breathing(void)` :id=api-backlight-toggle-breathing
+
+Toggle backlight breathing on or off.
+
+---
+
+### `void backlight_enable_breathing(void)` :id=api-backlight-enable-breathing
+
+Turn backlight breathing on.
+
+---
+
+### `void backlight_disable_breathing(void)` :id=api-backlight-disable-breathing
+
+Turn backlight breathing off.
+
+---
+
+### `bool is_backlight_breathing(void)` :id=api-is-backlight-breathing
+
+Get the current backlight breathing state.
+
+#### Return Value :id=api-is-backlight-breathing-return
+
+`true` if backlight breathing is enabled.

--- a/keyboards/40percentclub/4pack/info.json
+++ b/keyboards/40percentclub/4pack/info.json
@@ -9,6 +9,7 @@
         "device_version": "0.0.1"
     },
     "backlight": {
+        "driver": "timer",
         "pins": ["F6", "F7"]
     },
     "processor": "atmega32u4",

--- a/keyboards/40percentclub/sixpack/info.json
+++ b/keyboards/40percentclub/sixpack/info.json
@@ -9,6 +9,7 @@
       "device_version": "10.0.1"
     },
     "backlight": {
+      "driver": "timer",
       "pins": ["F4", "F5"],
       "levels": 6,
       "breathing": true

--- a/keyboards/8pack/info.json
+++ b/keyboards/8pack/info.json
@@ -8,6 +8,7 @@
     "pid": "0x2171"
   },
   "backlight": {
+    "driver": "timer",
     "pins": ["D1", "D0", "D4", "C6", "D7", "E6", "B4", "B5"],
     "levels": 8
   },

--- a/keyboards/ai03/equinox/rev0/info.json
+++ b/keyboards/ai03/equinox/rev0/info.json
@@ -5,6 +5,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D1",
         "levels": 5,
         "breathing": true

--- a/keyboards/amjkeyboard/amj66/info.json
+++ b/keyboards/amjkeyboard/amj66/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D4",
         "breathing": true
     },

--- a/keyboards/anavi/macropad8/info.json
+++ b/keyboards/anavi/macropad8/info.json
@@ -9,6 +9,7 @@
       "device_version": "0.0.1"
   },
   "backlight": {
+    "driver": "timer",
     "pin": "D7",
     "breathing": true
   },

--- a/keyboards/bear_face/info.json
+++ b/keyboards/bear_face/info.json
@@ -15,6 +15,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F7"
     },
     "processor": "atmega32u4",

--- a/keyboards/cablecardesigns/cypher/rev6/info.json
+++ b/keyboards/cablecardesigns/cypher/rev6/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+      "driver": "timer",
       "pin": "D0",
       "levels": 5,
       "breathing": true

--- a/keyboards/cest73/tkm/info.json
+++ b/keyboards/cest73/tkm/info.json
@@ -15,6 +15,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "E6"
     },
     "indicators": {

--- a/keyboards/checkerboards/nop60/info.json
+++ b/keyboards/checkerboards/nop60/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D1",
         "levels": 6,
         "breathing": true

--- a/keyboards/checkerboards/quark_plus/info.json
+++ b/keyboards/checkerboards/quark_plus/info.json
@@ -31,6 +31,7 @@
       ]
     },
     "backlight": {
+      "driver": "timer",
       "pin": "C4",
       "levels": 6,
       "breathing": true

--- a/keyboards/checkerboards/snop60/info.json
+++ b/keyboards/checkerboards/snop60/info.json
@@ -19,6 +19,7 @@
         ]
     },
     "backlight": {
+        "driver": "timer",
         "pin": "D1",
         "levels": 6,
         "breathing": true

--- a/keyboards/efreet/info.json
+++ b/keyboards/efreet/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D0",
         "breathing": true
     },

--- a/keyboards/gray_studio/cod67/info.json
+++ b/keyboards/gray_studio/cod67/info.json
@@ -23,6 +23,7 @@
   },
   "diode_direction": "COL2ROW",
   "backlight": {
+    "driver": "timer",
     "pin": "D4",
     "on_state": 0
   },

--- a/keyboards/handwired/bdn9_ble/info.json
+++ b/keyboards/handwired/bdn9_ble/info.json
@@ -9,6 +9,7 @@
     "device_version": "1.0.0"
   },
   "backlight": {
+    "driver": "timer",
     "pin": "F6",
     "levels": 5
   },

--- a/keyboards/kc60se/info.json
+++ b/keyboards/kc60se/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F5",
         "levels": 6
     },

--- a/keyboards/keebio/iris/rev1/info.json
+++ b/keyboards/keebio/iris/rev1/info.json
@@ -10,6 +10,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D2",
         "levels": 5
     },

--- a/keyboards/kopibeng/xt65/info.json
+++ b/keyboards/kopibeng/xt65/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "B1",
         "levels": 5
     },

--- a/keyboards/kprepublic/cospad/info.json
+++ b/keyboards/kprepublic/cospad/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F7",
         "on_state": 0
     },

--- a/keyboards/ktec/daisy/info.json
+++ b/keyboards/ktec/daisy/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D0",
         "levels": 6
     },

--- a/keyboards/ktec/staryu/info.json
+++ b/keyboards/ktec/staryu/info.json
@@ -9,6 +9,7 @@
         "device_version": "2.0.5"
     },
     "backlight": {
+        "driver": "timer",
         "pins": ["C2", "C7", "D5", "D6", "B0"],
         "levels": 10
     },

--- a/keyboards/maple_computing/christmas_tree/info.json
+++ b/keyboards/maple_computing/christmas_tree/info.json
@@ -13,6 +13,7 @@
   },
   "diode_direction": "COL2ROW",
   "backlight": {
+    "driver": "timer",
     "pin": "D2"
   },
   "processor": "atmega32u4",

--- a/keyboards/maple_computing/ivy/rev1/info.json
+++ b/keyboards/maple_computing/ivy/rev1/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D2"
     },
     "processor": "atmega32u4",

--- a/keyboards/maple_computing/jnao/info.json
+++ b/keyboards/maple_computing/jnao/info.json
@@ -14,6 +14,7 @@
   },
   "diode_direction": "COL2ROW",
   "backlight": {
+    "driver": "timer",
     "pin": "D0"
   },
   "processor": "atmega32u4",

--- a/keyboards/melgeek/mj6xy/rev3/info.json
+++ b/keyboards/melgeek/mj6xy/rev3/info.json
@@ -5,7 +5,6 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
-        "driver": "software",
         "pin": "B7",
         "levels": 10
     },

--- a/keyboards/mntre/config.h
+++ b/keyboards/mntre/config.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#define BACKLIGHT_CUSTOM_RESOLUTION 0x400
+#define BACKLIGHT_RESOLUTION 0x400
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/mt/mt40/info.json
+++ b/keyboards/mt/mt40/info.json
@@ -14,6 +14,7 @@
   },
   "diode_direction": "COL2ROW",
   "backlight": {
+    "driver": "timer",
     "pin": "D2"
   },
   "rgblight": {

--- a/keyboards/nopunin10did/jabberwocky/v2/info.json
+++ b/keyboards/nopunin10did/jabberwocky/v2/info.json
@@ -14,8 +14,8 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
-        "driver": "software",
-        "pins": ["D6"],
+        "driver": "timer",
+        "pin": "D6",
         "levels": 6
     },
     "indicators": {

--- a/keyboards/org60/info.json
+++ b/keyboards/org60/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F5",
         "levels": 6
     },

--- a/keyboards/playkbtw/ca66/info.json
+++ b/keyboards/playkbtw/ca66/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F0"
     },
     "rgblight": {

--- a/keyboards/sandwich/keeb68/info.json
+++ b/keyboards/sandwich/keeb68/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "C7",
         "levels": 5,
         "breathing": true

--- a/keyboards/tkc/osav2/info.json
+++ b/keyboards/tkc/osav2/info.json
@@ -21,6 +21,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D6",
         "breathing": true
     },

--- a/keyboards/v60_type_r/info.json
+++ b/keyboards/v60_type_r/info.json
@@ -14,6 +14,7 @@
   },
   "diode_direction": "COL2ROW",
   "backlight": {
+    "driver": "timer",
     "pin": "F7",
     "on_state": 0
   },

--- a/keyboards/viktus/osav2/info.json
+++ b/keyboards/viktus/osav2/info.json
@@ -44,6 +44,7 @@
         "pin": "D4"
     },
     "backlight": {
+        "driver": "timer",
         "levels": 6,
         "max_brightness": 191,
         "pin": "D6"

--- a/keyboards/westfoxtrot/cypher/rev5/info.json
+++ b/keyboards/westfoxtrot/cypher/rev5/info.json
@@ -12,6 +12,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "D0",
         "levels": 5,
         "breathing": true

--- a/keyboards/xiudi/xd60/rev2/info.json
+++ b/keyboards/xiudi/xd60/rev2/info.json
@@ -9,6 +9,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F5",
         "levels": 6,
         "on_state": 0

--- a/keyboards/xiudi/xd60/rev3/info.json
+++ b/keyboards/xiudi/xd60/rev3/info.json
@@ -9,6 +9,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F5",
         "levels": 6,
         "on_state": 0

--- a/keyboards/xiudi/xd68/info.json
+++ b/keyboards/xiudi/xd68/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F5",
         "levels": 6,
         "breathing": true,

--- a/keyboards/xiudi/xd84pro/info.json
+++ b/keyboards/xiudi/xd84pro/info.json
@@ -14,6 +14,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F5",
         "levels": 10,
         "on_state": 0

--- a/keyboards/xiudi/xd87/info.json
+++ b/keyboards/xiudi/xd87/info.json
@@ -14,6 +14,7 @@
   },
   "diode_direction": "COL2ROW",
   "backlight": {
+    "driver": "timer",
     "pin": "D0",
     "on_state": 0
   },

--- a/platforms/avr/drivers/backlight_pwm.c
+++ b/platforms/avr/drivers/backlight_pwm.c
@@ -127,21 +127,20 @@
 #define BREATHING_SCALE_FACTOR F_CPU / BACKLIGHT_RESOLUTION / 120
 
 static inline void enable_pwm(void) {
-#    if BACKLIGHT_ON_STATE == 1
+#if BACKLIGHT_ON_STATE == 1
     TCCRxA |= _BV(COMxx1);
-#    else
+#else
     TCCRxA |= _BV(COMxx1) | _BV(COMxx0);
-#    endif
+#endif
 }
 
 static inline void disable_pwm(void) {
-#    if BACKLIGHT_ON_STATE == 1
+#if BACKLIGHT_ON_STATE == 1
     TCCRxA &= ~(_BV(COMxx1));
-#    else
+#else
     TCCRxA &= ~(_BV(COMxx1) | _BV(COMxx0));
-#    endif
+#endif
 }
-
 
 // See http://jared.geek.nz/2013/feb/linear-led-pwm
 static uint16_t cie_lightness(uint16_t v) {
@@ -198,7 +197,7 @@ static uint16_t breathing_counter = 0;
 
 static uint8_t breath_scale_counter = 1;
 /* Run the breathing loop at ~120Hz*/
-const uint8_t   breathing_ISR_frequency = 120;
+const uint8_t breathing_ISR_frequency = 120;
 
 bool is_breathing(void) {
     return !!(TIMSKx & _BV(TOIEx));
@@ -265,9 +264,7 @@ static inline uint16_t scale_backlight(uint16_t v) {
  *
  * The following ISR runs at F_CPU/ISRx. With a 16MHz clock and default pwm resolution, that means 244Hz
  */
-ISR(TIMERx_OVF_vect)
-{
-
+ISR(TIMERx_OVF_vect) {
     // Only run this ISR at ~120 Hz
     if (breath_scale_counter++ == BREATHING_SCALE_FACTOR) {
         breath_scale_counter = 1;
@@ -318,7 +315,7 @@ void backlight_init_ports(void) {
     */
     TCCRxA = _BV(COMxx1) | _BV(WGM11);            // = 0b00001010;
     TCCRxB = _BV(WGM13) | _BV(WGM12) | _BV(CS10); // = 0b00011001;
-    ICRx = BACKLIGHT_RESOLUTION;
+    ICRx   = BACKLIGHT_RESOLUTION;
 
     backlight_init();
 

--- a/platforms/avr/drivers/backlight_timer.c
+++ b/platforms/avr/drivers/backlight_timer.c
@@ -1,5 +1,5 @@
 #include "backlight.h"
-#include "gpio.h"
+#include "backlight_driver_common.h"
 #include "progmem.h"
 #include <avr/io.h>
 #include <avr/interrupt.h>
@@ -9,111 +9,38 @@
 #    define BACKLIGHT_LIMIT_VAL 255
 #endif
 
-#if (defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)) && (BACKLIGHT_PIN == B5 || BACKLIGHT_PIN == B6 || BACKLIGHT_PIN == B7)
+#ifndef BACKLIGHT_PWM_TIMER
+#    define BACKLIGHT_PWM_TIMER 1
+#endif
+
+#if BACKLIGHT_PWM_TIMER == 1
 #    define ICRx ICR1
 #    define TCCRxA TCCR1A
 #    define TCCRxB TCCR1B
+#    define TIMERx_COMPA_vect TIMER1_COMPA_vect
 #    define TIMERx_OVF_vect TIMER1_OVF_vect
-#    define TIMSKx TIMSK1
+#    if defined(__AVR_ATmega32A__) // This MCU has only one TIMSK register
+#        define TIMSKx TIMSK
+#    else
+#        define TIMSKx TIMSK1
+#    endif
 #    define TOIEx TOIE1
 
-#    if BACKLIGHT_PIN == B5
-#        define COMxx0 COM1A0
-#        define COMxx1 COM1A1
-#        define OCRxx OCR1A
-#    elif BACKLIGHT_PIN == B6
-#        define COMxx0 COM1B0
-#        define COMxx1 COM1B1
-#        define OCRxx OCR1B
-#    elif BACKLIGHT_PIN == B7
-#        define COMxx0 COM1C0
-#        define COMxx1 COM1C1
-#        define OCRxx OCR1C
-#    endif
-#elif (defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1287__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__)) && (BACKLIGHT_PIN == C4 || BACKLIGHT_PIN == C5 || BACKLIGHT_PIN == C6)
-#    define ICRx ICR3
+#    define OCIExA OCIE1A
+#    define OCRxx OCR1A
+#elif BACKLIGHT_PWM_TIMER == 3
+#    define ICRx ICR1
 #    define TCCRxA TCCR3A
 #    define TCCRxB TCCR3B
+#    define TIMERx_COMPA_vect TIMER3_COMPA_vect
 #    define TIMERx_OVF_vect TIMER3_OVF_vect
 #    define TIMSKx TIMSK3
 #    define TOIEx TOIE3
 
-#    if BACKLIGHT_PIN == C4
-#        if (defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__))
-#            error This MCU has no C4 pin!
-#        else
-#            define COMxx0 COM3C0
-#            define COMxx1 COM3C1
-#            define OCRxx OCR3C
-#        endif
-#    elif BACKLIGHT_PIN == C5
-#        if (defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U4__))
-#            error This MCU has no C5 pin!
-#        else
-#            define COMxx0 COM3B0
-#            define COMxx1 COM3B1
-#            define OCRxx OCR3B
-#        endif
-#    elif BACKLIGHT_PIN == C6
-#        define COMxx0 COM3A0
-#        define COMxx1 COM3A1
-#        define OCRxx OCR3A
-#    endif
-#elif (defined(__AVR_AT90USB162__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega32U2__)) && (BACKLIGHT_PIN == B7 || BACKLIGHT_PIN == C5 || BACKLIGHT_PIN == C6)
-#    define ICRx ICR1
-#    define TCCRxA TCCR1A
-#    define TCCRxB TCCR1B
-#    define TIMERx_OVF_vect TIMER1_OVF_vect
-#    define TIMSKx TIMSK1
-#    define TOIEx TOIE1
-
-#    if BACKLIGHT_PIN == B7
-#        define COMxx0 COM1C0
-#        define COMxx1 COM1C1
-#        define OCRxx OCR1C
-#    elif BACKLIGHT_PIN == C5
-#        define COMxx0 COM1B0
-#        define COMxx1 COM1B1
-#        define OCRxx OCR1B
-#    elif BACKLIGHT_PIN == C6
-#        define COMxx0 COM1A0
-#        define COMxx1 COM1A1
-#        define OCRxx OCR1A
-#    endif
-#elif defined(__AVR_ATmega32A__) && (BACKLIGHT_PIN == D4 || BACKLIGHT_PIN == D5)
-#    define ICRx ICR1
-#    define TCCRxA TCCR1A
-#    define TCCRxB TCCR1B
-#    define TIMERx_OVF_vect TIMER1_OVF_vect
-#    define TIMSKx TIMSK
-#    define TOIEx TOIE1
-
-#    if BACKLIGHT_PIN == D4
-#        define COMxx0 COM1B0
-#        define COMxx1 COM1B1
-#        define OCRxx OCR1B
-#    elif BACKLIGHT_PIN == D5
-#        define COMxx0 COM1A0
-#        define COMxx1 COM1A1
-#        define OCRxx OCR1A
-#    endif
-#elif (defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328__)) && (BACKLIGHT_PIN == B1 || BACKLIGHT_PIN == B2)
-#    define ICRx ICR1
-#    define TCCRxA TCCR1A
-#    define TCCRxB TCCR1B
-#    define TIMERx_OVF_vect TIMER1_OVF_vect
-#    define TIMSKx TIMSK1
-#    define TOIEx TOIE1
-
-#    if BACKLIGHT_PIN == B1
-#        define COMxx0 COM1A0
-#        define COMxx1 COM1A1
-#        define OCRxx OCR1A
-#    elif BACKLIGHT_PIN == B2
-#        define COMxx0 COM1B0
-#        define COMxx1 COM1B1
-#        define OCRxx OCR1B
-#    endif
+#    define OCIExA OCIE3A
+#    define OCRxx OCR3A
+#else
+#    error Invalid backlight PWM timer!
 #endif
 
 #ifndef BACKLIGHT_RESOLUTION
@@ -126,22 +53,45 @@
 
 #define BREATHING_SCALE_FACTOR F_CPU / BACKLIGHT_RESOLUTION / 120
 
-static inline void enable_pwm(void) {
-#    if BACKLIGHT_ON_STATE == 1
-    TCCRxA |= _BV(COMxx1);
-#    else
-    TCCRxA |= _BV(COMxx1) | _BV(COMxx0);
-#    endif
+// The idea of software PWM assisted by hardware timers is the following
+// we use the hardware timer in fast PWM mode like for hardware PWM, but
+// instead of letting the Output Match Comparator control the led pin
+// (which is not possible since the backlight is not wired to PWM pins on the
+// CPU), we do the LED on/off by oursleves.
+// The timer is setup to count up to 0xFFFF, and we set the Output Compare
+// register to the current 16bits backlight level (after CIE correction).
+// This means the CPU will trigger a compare match interrupt when the counter
+// reaches the backlight level, where we turn off the LEDs,
+// but also an overflow interrupt when the counter rolls back to 0,
+// in which we're going to turn on the LEDs.
+// The LED will then be on for OCRxx/0xFFFF time, adjusted every 244Hz,
+// or F_CPU/BACKLIGHT_RESOLUTION if used.
+
+// Triggered when the counter reaches the OCRx value
+ISR(TIMERx_COMPA_vect) {
+    backlight_pins_off();
 }
 
-static inline void disable_pwm(void) {
-#    if BACKLIGHT_ON_STATE == 1
-    TCCRxA &= ~(_BV(COMxx1));
-#    else
-    TCCRxA &= ~(_BV(COMxx1) | _BV(COMxx0));
+// Triggered when the counter reaches the TOP value
+// this one triggers at F_CPU/ICRx = 16MHz/65536 =~ 244 Hz
+ISR(TIMERx_OVF_vect) {
+#    ifdef BACKLIGHT_BREATHING
+    if (is_breathing()) {
+        breathing_task();
+    }
 #    endif
+    // for very small values of OCRxx (or backlight level)
+    // we can't guarantee this whole code won't execute
+    // at the same time as the compare match interrupt
+    // which means that we might turn on the leds while
+    // trying to turn them off, leading to flickering
+    // artifacts (especially while breathing, because breathing_task
+    // takes many computation cycles).
+    // so better not turn them on while the counter TOP is very low.
+    if (OCRxx > ICRx / 250 + 5) {
+        backlight_pins_on();
+    }
 }
-
 
 // See http://jared.geek.nz/2013/feb/linear-led-pwm
 static uint16_t cie_lightness(uint16_t v) {
@@ -175,11 +125,16 @@ void backlight_set(uint8_t level) {
     if (level > BACKLIGHT_LEVELS) level = BACKLIGHT_LEVELS;
 
     if (level == 0) {
-        // Turn off PWM control on backlight pin
-        disable_pwm();
+        if (OCRxx) {
+            TIMSKx &= ~(_BV(OCIExA));
+            TIMSKx &= ~(_BV(TOIEx));
+        }
+        backlight_pins_off();
     } else {
-        // Turn on PWM control of backlight pin
-        enable_pwm();
+        if (!OCRxx) {
+            TIMSKx |= _BV(OCIExA);
+            TIMSKx |= _BV(TOIEx);
+        }
     }
     // Set the brightness
     set_pwm(cie_lightness(rescale_limit_val(ICRx * (uint32_t)level / BACKLIGHT_LEVELS)));
@@ -200,17 +155,19 @@ static uint8_t breath_scale_counter = 1;
 /* Run the breathing loop at ~120Hz*/
 const uint8_t   breathing_ISR_frequency = 120;
 
+static bool breathing = false;
+
 bool is_breathing(void) {
-    return !!(TIMSKx & _BV(TOIEx));
+    return breathing;
 }
 
 #    define breathing_interrupt_enable() \
         do {                             \
-            TIMSKx |= _BV(TOIEx);        \
+            breathing = true;            \
         } while (0)
 #    define breathing_interrupt_disable() \
         do {                              \
-            TIMSKx &= ~_BV(TOIEx);        \
+            breathing = false;            \
         } while (0)
 
 #    define breathing_min()        \
@@ -260,14 +217,7 @@ static inline uint16_t scale_backlight(uint16_t v) {
     return v / BACKLIGHT_LEVELS * get_backlight_level();
 }
 
-/* Assuming a 16MHz CPU clock and a timer that resets at 64k (ICR1), the following interrupt handler will run
- * about 244 times per second.
- *
- * The following ISR runs at F_CPU/ISRx. With a 16MHz clock and default pwm resolution, that means 244Hz
- */
-ISR(TIMERx_OVF_vect)
-{
-
+void breathing_task(void) {
     // Only run this ISR at ~120 Hz
     if (breath_scale_counter++ == BREATHING_SCALE_FACTOR) {
         breath_scale_counter = 1;
@@ -294,29 +244,16 @@ ISR(TIMERx_OVF_vect)
 #endif // BACKLIGHT_BREATHING
 
 void backlight_init_ports(void) {
-    setPinOutput(BACKLIGHT_PIN);
-#if BACKLIGHT_ON_STATE == 1
-    writePinLow(BACKLIGHT_PIN);
-#else
-    writePinHigh(BACKLIGHT_PIN);
-#endif
+    // Setup backlight pin as output and output to on state.
+    backlight_pins_init();
 
     // I could write a wall of text here to explain... but TL;DW
     // Go read the ATmega32u4 datasheet.
     // And this: http://blog.saikoled.com/post/43165849837/secret-konami-cheat-code-to-high-resolution-pwm-on
 
-    // Pin PB7 = OCR1C (Timer 1, Channel C)
-    // Compare Output Mode = Clear on compare match, Channel C = COM1C1=1 COM1C0=0
-    // (i.e. start high, go low when counter matches.)
-    // WGM Mode 14 (Fast PWM) = WGM13=1 WGM12=1 WGM11=1 WGM10=0
-    // Clock Select = clk/1 (no prescaling) = CS12=0 CS11=0 CS10=1
-
-    /*
-    14.8.3:
-    "In fast PWM mode, the compare units allow generation of PWM waveforms on the OCnx pins. Setting the COMnx1:0 bits to two will produce a non-inverted PWM [..]."
-    "In fast PWM mode the counter is incremented until the counter value matches either one of the fixed values 0x00FF, 0x01FF, or 0x03FF (WGMn3:0 = 5, 6, or 7), the value in ICRn (WGMn3:0 = 14), or the value in OCRnA (WGMn3:0 = 15)."
-    */
-    TCCRxA = _BV(COMxx1) | _BV(WGM11);            // = 0b00001010;
+    // TimerX setup, Fast PWM mode count to TOP set in ICRx
+    TCCRxA = _BV(WGM11); // = 0b00000010;
+    // clock select clk/1
     TCCRxB = _BV(WGM13) | _BV(WGM12) | _BV(CS10); // = 0b00011001;
     ICRx = BACKLIGHT_RESOLUTION;
 

--- a/platforms/avr/drivers/backlight_timer.c
+++ b/platforms/avr/drivers/backlight_timer.c
@@ -75,11 +75,11 @@ ISR(TIMERx_COMPA_vect) {
 // Triggered when the counter reaches the TOP value
 // this one triggers at F_CPU/ICRx = 16MHz/65536 =~ 244 Hz
 ISR(TIMERx_OVF_vect) {
-#    ifdef BACKLIGHT_BREATHING
+#ifdef BACKLIGHT_BREATHING
     if (is_breathing()) {
         breathing_task();
     }
-#    endif
+#endif
     // for very small values of OCRxx (or backlight level)
     // we can't guarantee this whole code won't execute
     // at the same time as the compare match interrupt
@@ -153,7 +153,7 @@ static uint16_t breathing_counter = 0;
 
 static uint8_t breath_scale_counter = 1;
 /* Run the breathing loop at ~120Hz*/
-const uint8_t   breathing_ISR_frequency = 120;
+const uint8_t breathing_ISR_frequency = 120;
 
 static bool breathing = false;
 
@@ -255,7 +255,7 @@ void backlight_init_ports(void) {
     TCCRxA = _BV(WGM11); // = 0b00000010;
     // clock select clk/1
     TCCRxB = _BV(WGM13) | _BV(WGM12) | _BV(CS10); // = 0b00011001;
-    ICRx = BACKLIGHT_RESOLUTION;
+    ICRx   = BACKLIGHT_RESOLUTION;
 
     backlight_init();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Split up AVR backlight driver into full hardware PWM and timer-assisted drivers for parity with ChibiOS
- Updated existing boards which fell back to timer driver
  - None were using timer 3
  - Less `#pragma message`s in build output! Yay!
- Refurbished docs; added API reference

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
