### PR TITLE
`qmk find`, `qmk mass-compile` search speed improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ quantum/version.h
 /keyboards/**/kb.h
 /keyboards/**/kb.c
 
+# Python profiling
+callgrind.out.*
+
 # Eclipse/PyCharm/Other IDE Settings
 *.iml
 .browse.VC.db*

--- a/data/mappings/keyboard_aliases.hjson
+++ b/data/mappings/keyboard_aliases.hjson
@@ -401,7 +401,7 @@
         "target": "mechlovin/adelais/rgb_led/rev1"
     },
     "mechlovin/adelais/standard_led": {
-        "target": "mechlovin/adelais/standard_led/rev2"
+        "target": "mechlovin/adelais/standard_led/arm/rev2"
     },
     "mechlovin/delphine": {
         "target": "mechlovin/delphine/mono_led"

--- a/lib/python/qmk/cli/find.py
+++ b/lib/python/qmk/cli/find.py
@@ -15,6 +15,7 @@ from qmk.search import search_keymap_targets
 )
 @cli.argument('-p', '--print', arg_only=True, action='append', default=[], help="For each matched target, print the value of the supplied info.json key. May be passed multiple times.")
 @cli.argument('-km', '--keymap', type=str, default='default', help="The keymap name to build. Default is 'default'.")
+@cli.argument('-n', '--no-parallel', arg_only=True, action='store_true', default=True, help="Don't execute in parallel.")
 @cli.subcommand('Find builds which match supplied search criteria.')
 def find(cli):
     """Search through all keyboards and keymaps for a given search criteria.
@@ -23,7 +24,7 @@ def find(cli):
     if len(cli.args.filter) == 0 and len(cli.args.print) > 0:
         cli.log.warning('No filters supplied -- keymaps not parsed, unable to print requested values.')
 
-    targets = search_keymap_targets(cli.args.keymap, cli.args.filter, cli.args.print)
+    targets = search_keymap_targets(cli.args.keymap, cli.args.filter, cli.args.print, False if cli.args.no_parallel else True)
     for keyboard, keymap, print_vals in targets:
         print(f'{keyboard}:{keymap}')
 

--- a/lib/python/qmk/json_schema.py
+++ b/lib/python/qmk/json_schema.py
@@ -42,7 +42,15 @@ def json_load(json_file, strict=True):
         exit(1)
 
 
-@lru_cache(maxsize=0)
+@lru_cache(maxsize=20)
+def json_load_cached(json_file):
+    """Load a json file from disk, using a cache to avoid parsing the same file multiple times.
+
+    Note: file must be a Path object.
+    """
+    return json_load(json_file)
+
+
 def load_jsonschema(schema_name):
     """Read a jsonschema file from disk.
     """
@@ -57,7 +65,7 @@ def load_jsonschema(schema_name):
     return json_load(schema_path)
 
 
-@lru_cache(maxsize=0)
+@lru_cache(maxsize=None)
 def compile_schema_store():
     """Compile all our schemas into a schema store.
     """
@@ -73,7 +81,7 @@ def compile_schema_store():
     return schema_store
 
 
-@lru_cache(maxsize=0)
+@lru_cache(maxsize=20)
 def create_validator(schema):
     """Creates a validator for the given schema id.
     """

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -5,10 +5,11 @@ from math import ceil
 from pathlib import Path
 import os
 from glob import glob
+from functools import lru_cache
 
 import qmk.path
 from qmk.c_parse import parse_config_h_file
-from qmk.json_schema import json_load
+from qmk.json_schema import json_load_cached
 from qmk.makefile import parse_rules_mk_file
 
 BOX_DRAWING_CHARACTERS = {
@@ -69,7 +70,7 @@ def keyboard_folder(keyboard):
 
     This checks aliases and DEFAULT_FOLDER to resolve the actual path for a keyboard.
     """
-    aliases = json_load(Path('data/mappings/keyboard_aliases.hjson'))
+    aliases = json_load_cached(Path('data/mappings/keyboard_aliases.hjson'))
 
     if keyboard in aliases:
         keyboard = aliases[keyboard].get('target', keyboard)
@@ -112,6 +113,7 @@ def list_keyboards(resolve_defaults=True):
     return sorted(set(found))
 
 
+@lru_cache(maxsize=50)
 def resolve_keyboard(keyboard):
     cur_dir = Path('keyboards')
     rules = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')


### PR DESCRIPTION
## Description

`qmk find` and `qmk mass-compile` have been quite slow, mainly due to misuse of `lru_cache` as well as logically doing things more often than necessary.

This PR introduces the following changes:
* fixing up usage of `@lru_cache` so that it actually functions as intended
* a new `@profile_code` decorator, allowing executions call tracing to be output (requires `yappi` to be installed by `pip`)
* deferring validation of the resulting json when necessary
* a fix to `data/mappings/keyboard_aliases.hjson`
* optional de-parallelisation of `qmk.search.search_keymap_targets`, which is necessary for code profiling to make sense (profiling does not like parallel execution)

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).