### PR TITLE
[Bug] Fix compilation error when Split Watchdog enabled

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -74,6 +74,7 @@ static inline bool usbIsActive(void) {
 #endif
 
 #if defined(SPLIT_WATCHDOG_ENABLE)
+#    include "bootloader.h"
 #    if !defined(SPLIT_WATCHDOG_TIMEOUT)
 #        if defined(SPLIT_USB_TIMEOUT)
 #            define SPLIT_WATCHDOG_TIMEOUT (SPLIT_USB_TIMEOUT + 100)

--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -30,6 +30,10 @@
 #    include "rgblight.h"
 #endif
 
+#if defined(SPLIT_WATCHDOG_ENABLE)
+#    include "bootloader.h"
+#endif
+
 #ifndef SPLIT_USB_TIMEOUT
 #    define SPLIT_USB_TIMEOUT 2000
 #endif
@@ -74,7 +78,6 @@ static inline bool usbIsActive(void) {
 #endif
 
 #if defined(SPLIT_WATCHDOG_ENABLE)
-#    include "bootloader.h"
 #    if !defined(SPLIT_WATCHDOG_TIMEOUT)
 #        if defined(SPLIT_USB_TIMEOUT)
 #            define SPLIT_WATCHDOG_TIMEOUT (SPLIT_USB_TIMEOUT + 100)


### PR DESCRIPTION
## Description

#21507 removed quantum.h from split_util.c, but split watchdog needs bootloader.h for `mcu_reset(void)`.  Adds the bootloader.h only when split watchdog is enabled. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* local testing

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
