### PR TITLE
[Keyboard] Add ANAVI Macro Pad 12

### DIFF
--- a/keyboards/anavi/macropad12/config.h
+++ b/keyboards/anavi/macropad12/config.h
@@ -1,0 +1,25 @@
+// Copyright 2023 Leon Anavi <leon@anavi.org>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define RGBLIGHT_DEFAULT_MODE RGBLIGHT_MODE_RAINBOW_MOOD
+
+/* Double tap reset button to enter bootloader */
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP17
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500U
+
+#ifdef BACKLIGHT_ENABLE
+#   define BACKLIGHT_PWM_DRIVER PWMD5
+#   define BACKLIGHT_PWM_CHANNEL RP2040_PWM_CHANNEL_A
+#endif
+
+#define I2C1_SDA_PIN GP6
+#define I2C1_SCL_PIN GP7
+
+#ifdef OLED_ENABLE
+#   define OLED_DISPLAY_128X64
+#   define OLED_TIMEOUT 60000
+#   define OLED_BRIGHTNESS 128
+#endif

--- a/keyboards/anavi/macropad12/halconf.h
+++ b/keyboards/anavi/macropad12/halconf.h
@@ -1,0 +1,9 @@
+// Copyright 2023 Leon Anavi <leon@anavi.org>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define HAL_USE_I2C TRUE
+#define HAL_USE_PWM TRUE
+
+#include_next <halconf.h>

--- a/keyboards/anavi/macropad12/info.json
+++ b/keyboards/anavi/macropad12/info.json
@@ -1,0 +1,69 @@
+{
+    "keyboard_name": "Macro Pad 12",
+    "manufacturer": "ANAVI",
+    "url": "https://github.com/AnaviTechnology/anavi-macro-pad-12",
+    "maintainer": "leon-anavi",
+    "processor": "RP2040",
+    "bootloader": "rp2040",
+    "diode_direction": "COL2ROW",
+    "matrix_pins": {
+        "cols": ["GP0", "GP2", "GP4"],
+        "rows": ["GP27", "GP28", "GP29", "GP1"]
+    },
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true,
+        "rgblight": true,
+        "backlight": true,
+        "oled": true
+    },
+    "rgblight": {
+        "led_count": 6,
+        "animations": {
+            "alternating": true,
+            "breathing": true,
+            "christmas": true,
+            "knight": true,
+            "rainbow_mood": true,
+            "rainbow_swirl": true,
+            "rgb_test": true,
+            "snake": true,
+            "static_gradient": true,
+            "twinkle": true
+        }
+    },
+    "ws2812": {
+        "pin": "GP3",
+        "driver": "vendor"
+    },
+    "backlight": {
+        "pin": "GP26"
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0},
+                {"matrix": [0, 1], "x": 1, "y": 0},
+                {"matrix": [0, 2], "x": 2, "y": 0},
+                {"matrix": [1, 0], "x": 0, "y": 1},
+                {"matrix": [1, 1], "x": 1, "y": 1},
+                {"matrix": [1, 2], "x": 2, "y": 1},
+                {"matrix": [2, 0], "x": 0, "y": 2},
+                {"matrix": [2, 1], "x": 1, "y": 2},
+                {"matrix": [2, 2], "x": 2, "y": 2},
+                {"matrix": [3, 0], "x": 0, "y": 3},
+                {"matrix": [3, 1], "x": 1, "y": 3},
+                {"matrix": [3, 2], "x": 2, "y": 3}
+            ]
+        }
+    },
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x9A25",
+        "vid": "0xFEED"
+    }
+}

--- a/keyboards/anavi/macropad12/keymaps/default/keymap.c
+++ b/keyboards/anavi/macropad12/keymaps/default/keymap.c
@@ -1,0 +1,17 @@
+// Copyright 2023 Leon Anavi <leon@anavi.org>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+enum layer_names {
+    _BASE
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_BASE] = LAYOUT(
+        KC_1, KC_2, KC_3,
+        KC_4, KC_5, KC_6,
+        KC_7, KC_8, KC_9,
+        BL_STEP, RGB_MOD, RGB_TOG
+    )
+};

--- a/keyboards/anavi/macropad12/macropad12.c
+++ b/keyboards/anavi/macropad12/macropad12.c
@@ -1,0 +1,38 @@
+// Copyright 2023 Leon Anavi <leon@anavi.org>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+
+#ifdef OLED_ENABLE
+
+bool oled_task_kb(void) {
+
+    if (!oled_task_user()) {
+        return false;
+    }
+
+    // Host Keyboard Layer Status
+    oled_write_ln_P(PSTR("ANAVI Macro Pad 12"), false);
+    oled_write_ln_P(PSTR("Keymap: Default"), false);
+
+    // Host Keyboard LED Status
+    led_t led_state = host_keyboard_led_state();
+    oled_write_P(PSTR("Num Lock: "), false);
+    oled_write_ln_P(led_state.num_lock ? PSTR("On") : PSTR("Off"), false);
+    oled_write_P(PSTR("Caps Lock: "), false);
+    oled_write_ln_P(led_state.caps_lock ? PSTR("On") : PSTR("Off"), false);
+    oled_write_P(PSTR("Scroll Lock: "), false);
+    oled_write_ln_P(led_state.scroll_lock ? PSTR("On") : PSTR("Off"), false);
+#   ifdef RGBLIGHT_ENABLE
+        oled_write_P(PSTR("RGB Mode: "), false);
+        oled_write_ln(get_u8_str(rgblight_get_mode(), ' '), false);
+        oled_write_P(PSTR("h: "), false);
+        oled_write(get_u8_str(rgblight_get_hue(), ' '), false);
+        oled_write_P(PSTR("s: "), false);
+        oled_write(get_u8_str(rgblight_get_sat(), ' '), false);
+        oled_write_P(PSTR("v: "), false);
+        oled_write_ln(get_u8_str(rgblight_get_val(), ' '), false);
+#   endif
+    return false;
+}
+#endif

--- a/keyboards/anavi/macropad12/mcuconf.h
+++ b/keyboards/anavi/macropad12/mcuconf.h
@@ -1,0 +1,15 @@
+// Copyright 2023 Leon Anavi (@leon-anavi)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include_next <mcuconf.h>
+
+#undef RP_I2C_USE_I2C0
+#define RP_I2C_USE_I2C0 FALSE
+
+#undef RP_I2C_USE_I2C1
+#define RP_I2C_USE_I2C1 TRUE
+
+#undef RP_PWM_USE_PWM5
+#define RP_PWM_USE_PWM5 TRUE

--- a/keyboards/anavi/macropad12/readme.md
+++ b/keyboards/anavi/macropad12/readme.md
@@ -1,0 +1,21 @@
+# ANAVI Macro Pad 12
+
+ANAVI Macro Pad 12 is a compact mechanical keyboard with hot-swappable Cherry MX compatible mechanical switches, translucent keycaps, USB-C, RP2040 microcontroller, backlighting and under lighting.
+
+* Keyboard Maintainer: [Leon Anavi](https://github.com/leon-anavi)
+* Hardware Supported: ANAVI Macro Pad 12
+* Hardware Availability: [Crowd Supply](https://www.crowdsupply.com/anavi-technology/anavi-macro-pad-12-and-arrows), [GitHub repository](https://github.com/AnaviTechnology/anavi-macro-pad-12)
+
+Make example for this keyboard (after setting up your build environment):
+
+    qmk compile -kb anavi/macropad12 -km default
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the top left key on the left half, or top right key on the right half, and then plug in the USB cable on that keyboard half.
+* **Physical reset button**: Double tap the reset button on the XIAO RP2040.
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available.

--- a/keyboards/anavi/macropad12/rules.mk
+++ b/keyboards/anavi/macropad12/rules.mk
@@ -1,0 +1,1 @@
+# This file intentionally left blank


### PR DESCRIPTION
ANAVI Macro Pad 12 is a compact hot-swappable mechanical keyboard with 12 Cherry MX compatible switches, translucent key caps, USB-C, RP2040 microcontroller, backlighting and under lighting.

This commits adds initial QMK support for ANAVI Macro Pad 12 with:

- Default keymap
- Mini OLED I2C Display
- WS2812B RGB underlighting
- Backlighting (with PWMD5 and channel A as defined for GPIO 26 in the Raspberry Pi RP2040 datasheet)

The Neopixel on XIAO RP2040 is not supported as of the moment.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Add support for ANAVI Macro Pad 12 with Raspberry Pi RP2040 MCU and the following QMK features:

- Default keymap
- Mini OLED I2C Display
- WS2812B RGB underlighting
- Backlighting (with PWMD5 and channel A as defined for GPIO 26 in the [Raspberry Pi RP2040 datasheet page 14](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf))

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
