### PR TITLE
included keyboard.h. To use is_keyboard_master with a split with an i…

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "spi_master.h"
 #elif defined(OLED_TRANSPORT_I2C)
 #    include "i2c_master.h"
+#    include "keyboard.h"
 #endif
 #include "oled_driver.h"
 #include OLED_FONT_H

--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -19,7 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "spi_master.h"
 #elif defined(OLED_TRANSPORT_I2C)
 #    include "i2c_master.h"
-#    include "keyboard.h"
+#    if defined(USE_I2C) && defined(SPLIT_KEYBOARD)
+#        include "keyboard.h"
+#    endif
 #endif
 #include "oled_driver.h"
 #include OLED_FONT_H


### PR DESCRIPTION
…2c protocol

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

It seems like the issue #21570 was caused by implicit declaration of function "is_keyboard_master()" when you combine i2c + split + oled using the i2c. 

To fix this issue I've added 
`#    include "keyboard.h"`
under the elif in the defined part of the oled_driver.c to be able to use "is_keyboard_master()"




## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
