### PR TITLE
Revert "[Bug] Fix compilation error when Split Watchdog enabled"

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -31,10 +31,6 @@
 #    include "rgblight.h"
 #endif
 
-#if defined(SPLIT_WATCHDOG_ENABLE)
-#    include "bootloader.h"
-#endif
-
 #ifndef SPLIT_USB_TIMEOUT
 #    define SPLIT_USB_TIMEOUT 2000
 #endif


### PR DESCRIPTION
Reverts qmk/qmk_firmware#21543

Already done in #21551