### PR TITLE
Fix paragon keyboard encoder step

### DIFF
--- a/keyboards/artemis/paragon/info.json
+++ b/keyboards/artemis/paragon/info.json
@@ -20,7 +20,7 @@
     "url": "",
     "encoder": {
         "rotary": [
-            { "pin_a": "D3", "pin_b": "D5" }
+            { "pin_a": "D3", "pin_b": "D5", "resolution": 2 }
         ]
     },
     "usb": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes the paragon keyboard encoder step. Before this change, turning the encoder of two steps results in only one key press. After this change, one step = one key press.
<!--- Describe your changes in detail here. -->

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentatio
