### PR TITLE
Unify MIDI note calculation with the audio feature (from #21496)

### DIFF
--- a/quantum/midi/qmk_midi.c
+++ b/quantum/midi/qmk_midi.c
@@ -108,10 +108,10 @@ static void fallthrough_callback(MidiDevice* device, uint16_t cnt, uint8_t byte0
     if (cnt == 3) {
         switch (byte0 & 0xF0) {
             case MIDI_NOTEON:
-                play_note(((double)261.6) * pow(2.0, -4.0) * pow(2.0, (byte1 & 0x7F) / 12.0), (byte2 & 0x7F) / 8);
+                play_note(440.0f * powf(2.0f, ((byte1 & 0x7F) - 57) / 12.0f), (byte2 & 0x7F) / 8);
                 break;
             case MIDI_NOTEOFF:
-                stop_note(((double)261.6) * pow(2.0, -4.0) * pow(2.0, (byte1 & 0x7F) / 12.0));
+                stop_note(440.0f * powf(2.0f, ((byte1 & 0x7F) - 57) / 12.0f));
                 break;
         }
     }


### PR DESCRIPTION
## Description

In #21496, I proposed a change to the note frequency calculation of the audio feature, and in a comment on that pull request, @sigprof pointed out that the MIDI code used a different calculation that was inaudibly imprecise, and distinct from the implementation used in the audio feature.

This pull request:
* unifies the calculation of the note frequency in the MIDI code to the existing code of the audio feature, calculating note pitches based on standard A at exactly 440 Hz;
* changes the calculation so that it's done on `float` rather than `double`, and using `powf` rather than `pow`, like #21496. Like that pull request, this one saves around 4.5 KB of firmware size on ARM with a float-precision FPU (like the STM32F303).

Tested on my Moonlander by playing a MIDI file with the current code and the proposed code, recording that and using a spectrum analyzer, as well as by printing out the frequencies to the console. The difference is there, but is indeed inaudible.

I did not implement this by calling `float compute_freq_for_midi_note(uint8_t)` from the audio feature due to separation of concerns; due to #21496 not having been merged in yet; and because, as noted in #21496, the calculation is different by one octave, and calling `compute_freq_for_midi_note(note + 12)` would cause overflow in argument type conversion for notes 244 to 255 inclusive.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
