### PR TITLE
Fix stuck note with square wave in additive DAC

### DIFF
--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -66,7 +66,7 @@ static const dacsample_t dac_buffer_triangle[AUDIO_DAC_BUFFER_SIZE] = {
 #endif // AUDIO_DAC_SAMPLE_WAVEFORM_TRIANGLE
 #ifdef AUDIO_DAC_SAMPLE_WAVEFORM_SQUARE
 static const dacsample_t dac_buffer_square[AUDIO_DAC_BUFFER_SIZE] = {
-    [0 ... AUDIO_DAC_BUFFER_SIZE / 2 - 1]                     = 0,                    // first and
+    [0 ... AUDIO_DAC_BUFFER_SIZE / 2 - 1]                     = AUDIO_DAC_OFF_VALUE,  // first and
     [AUDIO_DAC_BUFFER_SIZE / 2 ... AUDIO_DAC_BUFFER_SIZE - 1] = AUDIO_DAC_SAMPLE_MAX, // second half
 };
 #endif // AUDIO_DAC_SAMPLE_WAVEFORM_SQUARE


### PR DESCRIPTION
## Description

If `AUDIO_DAC_SAMPLE_WAVEFORM_SQUARE` is selected by the user, on the `dac_additive` driver, on a device where `AUDIO_DAC_OFF_VALUE` is not 0 or close to 0, `stop_note` did not work on the last concurrently active note, and the last note got stuck until a new one started, at which point that note got stuck instead.

One of the comments in `platforms/chibios/drivers/audio_dac_additive.c` explains why this happened:

```c
        /* zero crossing (or approach, whereas zero == DAC_OFF_VALUE, which can be configured to anything from 0 to DAC_SAMPLE_MAX)
         * ============================*=*========================== AUDIO_DAC_SAMPLE_MAX
         *                          *       *
         *                        *           *
         * ---------------------------------------------------------
         *                     *                 *                  } AUDIO_DAC_SAMPLE_MAX/100
         * --------------------------------------------------------- AUDIO_DAC_OFF_VALUE
         *                  *                       *               } AUDIO_DAC_SAMPLE_MAX/100
         * ---------------------------------------------------------
         *               *
         * *           *
         *   *       *
         * =====*=*================================================= 0x0
         */
        if (((sample_p[s] + (AUDIO_DAC_SAMPLE_MAX / 100)) > AUDIO_DAC_OFF_VALUE) && // value approaches from below
            (sample_p[s] < (AUDIO_DAC_OFF_VALUE + (AUDIO_DAC_SAMPLE_MAX / 100)))    // or above
        ) {
```

Essentially, the code in that file tries to find the next appropriate moment to stop the DAC to avoid popping, by waiting for the next "close to zero crossing" at `AUDIO_DAC_OFF_VALUE`. Unfortunately, with the square wave as it was written, there was never such a moment: the sample value was always far (> 1/100) above or below `AUDIO_DAC_OFF_VALUE`, never near it, so the DAC never stopped and kept calling `dac_value_generate` to fill up the buffer, long after `stop_note` got called.

This commit fixes the stuck note by having half the samples in the precomputed table be exactly equal to `AUDIO_DAC_OFF_VALUE` so that the check to stop the DAC can succeed. On devices having `AUDIO_DAC_OFF_VALUE` at half of `AUDIO_DAC_SAMPLE_MAX`, this halves the volume of the square wave; however, square waves are plenty loud on their own.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* May partially fix or explain: #12080
* May partially fix or explain: #8503

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
