### PR TITLE
Allow the user to select a single tone for the additive DAC

### DIFF
--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -89,7 +89,7 @@ static dacsample_t dac_buffer_empty[AUDIO_DAC_BUFFER_SIZE] = {AUDIO_DAC_OFF_VALU
 /* keep track of the sample position for for each frequency */
 static float dac_if[AUDIO_MAX_SIMULTANEOUS_TONES] = {0.0};
 
-static float   active_tones_snapshot[AUDIO_MAX_SIMULTANEOUS_TONES] = {0, 0};
+static float   active_tones_snapshot[AUDIO_MAX_SIMULTANEOUS_TONES] = {0};
 static uint8_t active_tones_snapshot_length                        = 0;
 
 typedef enum {


### PR DESCRIPTION
## Description

Previously, if the user tried to build a firmware with audio enabled and `#define AUDIO_MAX_SIMULTANEOUS_TONES 1` to conserve CPU time, their firmware would fail to build with this error:

```
platforms/chibios/drivers/audio_dac_additive.c:91:73: error: excess elements in array initializer [-Werror]
   91 | static float   active_tones_snapshot[AUDIO_MAX_SIMULTANEOUS_TONES] = {0, 0};
      |                                                                          ^
```

This also affected the preset `#define AUDIO_DAC_QUALITY_VERY_HIGH`, which called up only one simultaneous tone at 88200 Hz.

This pull request changes the array initialization to allow for only one element if chosen.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
