### PR TITLE
[keyboard] add sweeq, a ferris/sweep variant with diodes

### DIFF
--- a/keyboards/idank/sweeq/config.h
+++ b/keyboards/idank/sweeq/config.h
@@ -1,0 +1,6 @@
+// Copyright 2023 Idan Kamara (@idank)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define MASTER_RIGHT

--- a/keyboards/idank/sweeq/info.json
+++ b/keyboards/idank/sweeq/info.json
@@ -1,0 +1,80 @@
+{
+    "url": "https://github.com/idank/keyboards/tree/main/sweeq",
+    "maintainer": "idank",
+    "keyboard_name": "Sweeq",
+    "manufacturer": "idank",
+    "development_board": "promicro",
+    "usb": {
+        "vid": "0xC3AB",
+        "pid": "0x3139",
+        "device_version": "0.0.1"
+    },
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true
+    },
+    "matrix_pins": {
+        "cols": [ "F4", "F5", "F6", "F7", "B1" ],
+        "rows": [ "D4", "C6", "D7", "E6" ]
+    },
+    "diode_direction": "COL2ROW",
+    "split": {
+        "enabled": true,
+        "soft_serial_pin": "D2"
+    },
+    "community_layouts": ["split_3x5_2"],
+    "layout_aliases": {
+        "LAYOUT": "LAYOUT_split_3x5_2"
+    },
+    "layouts": {
+        "LAYOUT_split_3x5_2": {
+            "layout": [
+                {"x": 0, "y": 0.93, "matrix": [0, 0]},
+                {"x": 1, "y": 0.31, "matrix": [0, 1]},
+                {"x": 2, "y": 0, "matrix": [0, 2]},
+                {"x": 3, "y": 0.28, "matrix": [0, 3]},
+                {"x": 4, "y": 0.42, "matrix": [0, 4]},
+
+                {"x": 7, "y": 0.42, "matrix": [4, 4]},
+                {"x": 8, "y": 0.28, "matrix": [4, 3]},
+                {"x": 9, "y": 0, "matrix": [4, 2]},
+                {"x": 10, "y": 0.31, "matrix": [4, 1]},
+                {"x": 11, "y": 0.93, "matrix": [4, 0]},
+
+                {"x": 0, "y": 1.93, "matrix": [1, 0]},
+                {"x": 1, "y": 1.31, "matrix": [1, 1]},
+                {"x": 2, "y": 1, "matrix": [1, 2]},
+                {"x": 3, "y": 1.28, "matrix": [1, 3]},
+                {"x": 4, "y": 1.42, "matrix": [1, 4]},
+
+                {"x": 7, "y": 1.42, "matrix": [5, 4]},
+                {"x": 8, "y": 1.28, "matrix": [5, 3]},
+                {"x": 9, "y": 1, "matrix": [5, 2]},
+                {"x": 10, "y": 1.31, "matrix": [5, 1]},
+                {"x": 11, "y": 1.93, "matrix": [5, 0]},
+
+                {"x": 0, "y": 2.93, "matrix": [2, 0]},
+                {"x": 1, "y": 2.31, "matrix": [2, 1]},
+                {"x": 2, "y": 2, "matrix": [2, 2]},
+                {"x": 3, "y": 2.28, "matrix": [2, 3]},
+                {"x": 4, "y": 2.42, "matrix": [2, 4]},
+
+                {"x": 7, "y": 2.42, "matrix": [6, 4]},
+                {"x": 8, "y": 2.28, "matrix": [6, 3]},
+                {"x": 9, "y": 2, "matrix": [6, 2]},
+                {"x": 10, "y": 2.31, "matrix": [6, 1]},
+                {"x": 11, "y": 2.93, "matrix": [6, 0]},
+
+                {"x": 3.5, "y": 3.75, "matrix": [3, 3]},
+                {"x": 4.5, "y": 4, "matrix": [3, 4]},
+
+                {"x": 6.5, "y": 4, "matrix": [7, 4]},
+                {"x": 7.5, "y": 3.75, "matrix": [7, 3]}
+            ]
+        }
+    }
+}

--- a/keyboards/idank/sweeq/keymaps/default/config.h
+++ b/keyboards/idank/sweeq/keymaps/default/config.h
@@ -1,0 +1,21 @@
+// Copyright 2023 Idan Kamara (@idank)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+// Set the mouse settings to a comfortable speed/accuracy trade-off,
+// assuming a screen refresh rate of 60 Htz or higher
+// The default is 50. This makes the mouse ~3 times faster and more accurate
+#define MOUSEKEY_INTERVAL 16
+// The default is 20. Since we made the mouse about 3 times faster with the previous setting,
+// give it more time to accelerate to max speed to retain precise control over short distances.
+#define MOUSEKEY_TIME_TO_MAX 40
+// The default is 300. Let's try and make this as low as possible while keeping the cursor responsive
+#define MOUSEKEY_DELAY 100
+// It makes sense to use the same delay for the mouseweel
+#define MOUSEKEY_WHEEL_DELAY 100
+// The default is 100
+#define MOUSEKEY_WHEEL_INTERVAL 50
+// The default is 40
+#define MOUSEKEY_WHEEL_TIME_TO_MAX 100
+
+#define QUICK_TAP_TERM 0

--- a/keyboards/idank/sweeq/keymaps/default/keymap.json
+++ b/keyboards/idank/sweeq/keymaps/default/keymap.json
@@ -1,0 +1,107 @@
+{
+    "version": 1,
+    "notes": "sweeq default keymap",
+    "documentation": "\"This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK's source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`\"\n",
+    "keyboard": "idank/sweeq",
+    "keymap": "default",
+    "layout": "LAYOUT_split_3x5_2",
+    "layers": [
+        ["KC_Q"        , "KC_W"        , "KC_E"           , "KC_R"          , "KC_T",
+         "KC_Y"        , "KC_U"        , "KC_I"           , "KC_O"          , "KC_P",
+
+         "LSFT_T(KC_A)", "LT(5,KC_S)"  , "LT(1,KC_D)"     , "LT(3,KC_F)"    , "KC_G",
+         "KC_H"        , "LT(4,KC_J)"  , "LT(2,KC_K)"     , "LT(6,KC_L)"    , "LSFT_T(KC_SCLN)",
+
+         "KC_Z"        , "LCTL_T(KC_X)", "LALT_T(KC_C)"   , "KC_V"          , "KC_B",
+         "KC_N"        , "KC_M"        , "LALT_T(KC_COMM)", "LCTL_T(KC_DOT)", "KC_SLSH",
+
+         "KC_P0"       , "KC_BSPC",
+         "LT(7,KC_SPC)", "KC_P1"
+        ],
+        ["KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_BTN1"     , "KC_WH_U"        , "KC_BTN2"       , "KC_TRNS",
+
+         "KC_TRNS"     , "KC_BTN2"     , "KC_NO"          , "KC_BTN1"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_MS_L"     , "KC_MS_D"        , "KC_MS_U"       , "KC_MS_R",
+
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_WH_L"     , "KC_WH_D"        , "KC_WH_R"       , "KC_TRNS",
+
+         "KC_TRNS"     , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"
+        ],
+        ["KC_TRNS"     , "KC_TRNS"     , "KC_PGUP"        , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+
+         "KC_LEFT"     , "KC_UP"       , "KC_DOWN"        , "KC_RGHT"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_LGUI"     , "KC_NO"          , "LCTL(KC_LALT)" , "LCA(KC_LSFT)",
+
+         "KC_TRNS"     , "KC_HOME"     , "KC_PGDN"        , "KC_END"        , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+
+         "KC_TRNS"     , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"
+        ],
+        ["KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_UNDS"     , "KC_PIPE"        , "KC_QUOT"       , "KC_TRNS",
+
+         "KC_CIRC"     , "KC_ASTR"     , "KC_AMPR"        , "KC_NO"         , "KC_TRNS",
+         "KC_HASH"     , "KC_TILD"     , "KC_SLSH"        , "KC_DQUO"       , "KC_DLR",
+
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_MINS"     , "KC_BSLS"        , "KC_GRV"        , "KC_TRNS",
+
+         "RGB_RMOD"    , "KC_TRNS",
+         "KC_TRNS"     , "RGB_MOD"
+        ],
+        ["KC_TRNS"     , "KC_COLN"     , "KC_LT"          , "KC_GT"         , "KC_SCLN",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+
+         "KC_LCBR"     , "KC_RCBR"     , "KC_LPRN"        , "KC_RPRN"       , "KC_AT",
+         "KC_TRNS"     , "KC_NO"       , "KC_EQL"         , "KC_PLUS"       , "KC_PERC",
+
+         "KC_TRNS"     , "KC_EXLM"     , "KC_LBRC"        , "KC_RBRC"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+
+         "KC_VOLD"     , "KC_TRNS",
+         "KC_TRNS"     , "KC_VOLU"
+        ],
+        ["KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_F7"       , "KC_F8"          , "KC_F9"         , "KC_F10",
+
+         "KC_TRNS"     , "KC_NO"       , "LCTL(KC_LALT)"  , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_F4"       , "KC_F5"          , "KC_F6"         , "KC_F11",
+
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+         "KC_TRNS"     , "KC_F1"       , "KC_F2"          , "KC_F3"         , "KC_F12",
+
+         "KC_TRNS"     , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"
+        ],
+        ["KC_PSLS"     , "KC_7"        , "KC_8"           , "KC_9"          , "KC_PPLS",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+
+         "KC_0"        , "KC_1"        , "KC_2"           , "KC_3"          , "KC_PMNS",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_NO"         , "KC_TRNS",
+
+         "KC_PAST"     , "KC_4"        , "KC_5"           , "KC_6"          , "KC_PEQL",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+
+         "KC_TRNS"     , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"
+        ],
+        ["KC_TRNS"     , "KC_TRNS"     , "KC_COLN"        , "KC_ESC"        , "KC_TRNS",
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_TRNS"       , "KC_DEL",
+
+         "KC_TRNS"     , "KC_PERC"     , "KC_SLSH"        , "KC_ENT"        , "KC_TRNS",
+         "DF(1)"       , "KC_LGUI"     , "KC_TRNS"        , "KC_TRNS"       , "KC_TRNS",
+
+         "KC_TRNS"     , "KC_TRNS"     , "KC_TRNS"        , "KC_EXLM"       , "KC_TRNS",
+         "DF(0)"       , "KC_TRNS"     , "RALT_T(KC_COMM)", "RCTL_T(KC_DOT)", "QK_BOOT",
+
+         "KC_TRNS"     , "KC_TAB",
+         "KC_NO"       , "KC_TRNS"
+        ]
+    ],
+    "author": "idank"
+}

--- a/keyboards/idank/sweeq/keymaps/default/readme.md
+++ b/keyboards/idank/sweeq/keymaps/default/readme.md
@@ -1,0 +1,1 @@
+See the readme of the Ferris [default keymap](https://github.com/qmk/qmk_firmware/tree/master/keyboards/ferris/keymaps/default).

--- a/keyboards/idank/sweeq/keymaps/via/config.h
+++ b/keyboards/idank/sweeq/keymaps/via/config.h
@@ -1,0 +1,7 @@
+// Copyright 2023 Idan Kamara (@idank)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// Good defaults for home row modifiers
+#define TAPPING_TERM 230

--- a/keyboards/idank/sweeq/keymaps/via/keymap.c
+++ b/keyboards/idank/sweeq/keymaps/via/keymap.c
@@ -1,0 +1,36 @@
+// Copyright 2023 Idan Kamara (@idank)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+#define KC_CTSC RCTL_T(KC_SCLN)
+#define KC_CTLA LCTL_T(KC_A)
+#define KC_LSHZ LSFT_T(KC_Z)
+#define KC_RLSH RSFT_T(KC_SLSH)
+#define KC_SPM2 LT(2, KC_SPC)
+#define KC_BSM1 LT(1, KC_BSPC)
+#define KC_GUTA GUI_T(KC_TAB)
+#define KC_CLGV CTL_T(KC_GRV)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT(
+    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,            KC_Y,    KC_U,  KC_I,    KC_O,   KC_P,
+    KC_CTLA, KC_S,    KC_D,    KC_F,    KC_G,            KC_H,    KC_J,  KC_K,    KC_L,   KC_SCLN,
+    KC_LSHZ, KC_X,    KC_C,    KC_V,    KC_B,            KC_N,    KC_M,  KC_COMM, KC_DOT, KC_RLSH,
+                                    KC_CLGV, KC_BSM1, KC_SPM2, KC_GUTA
+  ),
+
+  [1] = LAYOUT(
+    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,            KC_6,    KC_7,    KC_8,    KC_9,    KC_0,
+    QK_GESC, KC_HOME, KC_PGDN, KC_PGUP, KC_END,          KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_QUOT,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_BTN1, KC_BTN2,         KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R, KC_ENT,
+                                    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+  ),
+
+  [2] = LAYOUT(
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,           KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,
+    KC_TAB,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_PIPE,
+    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,         KC_UNDS, KC_PLUS, KC_TRNS, KC_TRNS, QK_BOOT,
+                                    KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS
+  )
+};

--- a/keyboards/idank/sweeq/keymaps/via/rules.mk
+++ b/keyboards/idank/sweeq/keymaps/via/rules.mk
@@ -1,0 +1,2 @@
+VIA_ENABLE = yes
+LTO_ENABLE = yes

--- a/keyboards/idank/sweeq/readme.md
+++ b/keyboards/idank/sweeq/readme.md
@@ -1,0 +1,31 @@
+# Sweeq
+
+![sweeq](https://i.imgur.com/TGSyHHxh.png)
+
+*Sweeq is a Ferris Sweep clone that uses diodes, instead of the latter's direct pin matrix.*
+
+The primary goal is to free up the SDA/SCL pins so they can be used by auxiliary devices such as a trackball, trackpoint or an OLED screen.
+
+Other than the diode changes and the ability to use hotswap sockets, this keyboard is identical to the original Sweep.
+
+* Keyboard Maintainer: [@idank](https://github.com/idank)
+* Hardware Supported: [sweeq](https://github.com/idank/keyboards/tree/main/sweeq)
+* Hardware Availability: *[holykeebs](https://holykeebs.com)*
+
+Make example for this keyboard (after setting up your build environment):
+
+    make idank/sweeq:default
+
+Flashing example for this keyboard:
+
+    make idank/sweeq:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/idank/sweeq/rules.mk
+++ b/keyboards/idank/sweeq/rules.mk
@@ -1,0 +1,1 @@
+# This file intentionally left blank


### PR DESCRIPTION
This version of the Ferris sweep uses diodes rather than directly soldering the switches to the MCU pins. The primary
goal is to free up the SDA/SCL pins so they can be used by auxiliary devices such as a trackball, trackpoint or an OLED
screen.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
