### PR TITLE
helix/rev3_4rows, helix/rev3_5rows: Fix build with converters

### DIFF
--- a/keyboards/helix/rev3_4rows/config.h
+++ b/keyboards/helix/rev3_4rows/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <stdio.h>
-
 /* key matrix size */
 #define MATRIX_ROWS 8
 #define MATRIX_COLS 7

--- a/keyboards/helix/rev3_4rows/keymaps/default/oled_display.c
+++ b/keyboards/helix/rev3_4rows/keymaps/default/oled_display.c
@@ -16,6 +16,8 @@
 
 #include QMK_KEYBOARD_H
 
+#include <stdio.h>
+
 // Defines names for use in layer keycodes and the keymap
 enum layer_names {
   _QWERTY = 0,

--- a/keyboards/helix/rev3_4rows/keymaps/via/oled_display.c
+++ b/keyboards/helix/rev3_4rows/keymaps/via/oled_display.c
@@ -16,6 +16,8 @@
 
 #include QMK_KEYBOARD_H
 
+#include <stdio.h>
+
 // Defines names for use in layer keycodes and the keymap
 enum layer_names {
   _QWERTY = 0,

--- a/keyboards/helix/rev3_5rows/config.h
+++ b/keyboards/helix/rev3_5rows/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <stdio.h>
-
 /* key matrix size */
 #define MATRIX_ROWS 10
 #define MATRIX_COLS 7

--- a/keyboards/helix/rev3_5rows/keymaps/default/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/default/oled_display.c
@@ -16,6 +16,8 @@
 
 #include QMK_KEYBOARD_H
 
+#include <stdio.h>
+
 // Defines names for use in layer keycodes and the keymap
 enum layer_names {
   _QWERTY = 0,

--- a/keyboards/helix/rev3_5rows/keymaps/via/oled_display.c
+++ b/keyboards/helix/rev3_5rows/keymaps/via/oled_display.c
@@ -16,6 +16,8 @@
 
 #include QMK_KEYBOARD_H
 
+#include <stdio.h>
+
 // Defines names for use in layer keycodes and the keymap
 enum layer_names {
   _QWERTY = 0,


### PR DESCRIPTION
## Description

The code for Helix rev3 boards could not be built with, e.g., `CONVERT_TO=rp2040_ce` due to invalid `#include <stdio.h>` in the keyboard level `config.h` (apparently the AVR version of that file contains guards against usage in assembly code, which was hiding the bug).  Move `#include <stdio.h>` to the C sources which need it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* These commands were failing:
```sh
qmk compile -kb helix/rev3_4rows -km default -e CONVERT_TO=rp2040_ce
qmk compile -kb helix/rev3_4rows -km via -e CONVERT_TO=rp2040_ce
qmk compile -kb helix/rev3_5rows -km default -e CONVERT_TO=rp2040_ce
qmk compile -kb helix/rev3_5rows -km via -e CONVERT_TO=rp2040_ce
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
