### PR TITLE
`qmk format-json`: Add an in-place mode to format json command

### DIFF
--- a/lib/python/qmk/cli/format/json.py
+++ b/lib/python/qmk/cli/format/json.py
@@ -66,7 +66,7 @@ def format_json(cli):
     output = json.dumps(json_file, cls=json_encoder, sort_keys=True)
 
     if cli.args.inplace:
-        with open(cli.args.json_file, 'w+') as outfile:
+        with open(cli.args.json_file, 'w+', encoding='utf-8') as outfile:
             outfile.write(output)
 
     # Display the results if print was set

--- a/lib/python/qmk/cli/format/json.py
+++ b/lib/python/qmk/cli/format/json.py
@@ -16,6 +16,7 @@ from qmk.path import normpath
 @cli.argument('json_file', arg_only=True, type=normpath, help='JSON file to format')
 @cli.argument('-f', '--format', choices=['auto', 'keyboard', 'keymap'], default='auto', arg_only=True, help='JSON formatter to use (Default: autodetect)')
 @cli.argument('-i', '--inplace', action='store_true', arg_only=True, help='If set, will operate in-place on the input file')
+@cli.argument('-p', '--print', action='store_true', arg_only=True, help='If set, will print the formatted json to stdout ')
 @cli.subcommand('Generate an info.json file for a keyboard.', hidden=False if cli.config.user.developer else True)
 def format_json(cli):
     """Format a json file.
@@ -68,5 +69,8 @@ def format_json(cli):
         with open(cli.args.json_file, 'w+') as outfile:
             outfile.write(output)
 
-    # Display the results
-    print(output)
+    # Display the results if print was set
+    # We don't operate in-place by default, so also display to stdout
+    # if in-place is not set.
+    if cli.args.print or not cli.args.inplace:
+        print(output)

--- a/lib/python/qmk/cli/format/json.py
+++ b/lib/python/qmk/cli/format/json.py
@@ -15,6 +15,7 @@ from qmk.path import normpath
 
 @cli.argument('json_file', arg_only=True, type=normpath, help='JSON file to format')
 @cli.argument('-f', '--format', choices=['auto', 'keyboard', 'keymap'], default='auto', arg_only=True, help='JSON formatter to use (Default: autodetect)')
+@cli.argument('-i', '--inplace', action='store_true', arg_only=True, help='If set, will operate in-place on the input file')
 @cli.subcommand('Generate an info.json file for a keyboard.', hidden=False if cli.config.user.developer else True)
 def format_json(cli):
     """Format a json file.
@@ -61,5 +62,11 @@ def format_json(cli):
 
                 json_file['layers'][layer_num] = current_layer
 
+    output = json.dumps(json_file, cls=json_encoder, sort_keys=True)
+
+    if cli.args.inplace:
+        with open(cli.args.json_file, 'w+') as outfile:
+            outfile.write(output)
+
     # Display the results
-    print(json.dumps(json_file, cls=json_encoder, sort_keys=True))
+    print(output)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This adds an in-place mode to the format-json command.
It's off by default and requires the '-i' or '--inplace' flag to be set to run in-place

This will make it easier to format info.jsons without having to do an extra move operation

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
