### PR TITLE
[Keyboard] Add STM32f3 Discovery onekey

### DIFF
--- a/keyboards/handwired/onekey/stm32f3_disco/config.h
+++ b/keyboards/handwired/onekey/stm32f3_disco/config.h
@@ -1,0 +1,6 @@
+// Copyright 2023 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define ADC_PIN A0

--- a/keyboards/handwired/onekey/stm32f3_disco/halconf.h
+++ b/keyboards/handwired/onekey/stm32f3_disco/halconf.h
@@ -1,0 +1,8 @@
+// Copyright 2023 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define HAL_USE_ADC TRUE
+
+#include_next <halconf.h>

--- a/keyboards/handwired/onekey/stm32f3_disco/info.json
+++ b/keyboards/handwired/onekey/stm32f3_disco/info.json
@@ -1,0 +1,19 @@
+{
+    "keyboard_name": "Onekey STM32F3 Discovery",
+    "processor": "STM32F303",
+    "bootloader": "stm32-dfu",
+    "matrix_pins": {
+        "cols": ["B4"],
+        "rows": ["B5"]
+    },
+    "backlight": {
+        "pin": "E8"
+    },
+    "ws2812": {
+        "pin": "A0"
+    },
+    "apa102": {
+        "data_pin": "A0",
+        "clock_pin": "B13"
+    }
+}

--- a/keyboards/handwired/onekey/stm32f3_disco/mcuconf.h
+++ b/keyboards/handwired/onekey/stm32f3_disco/mcuconf.h
@@ -1,0 +1,9 @@
+// Copyright 2023 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include_next <mcuconf.h>
+
+#undef STM32_ADC_USE_ADC1
+#define STM32_ADC_USE_ADC1 TRUE

--- a/keyboards/handwired/onekey/stm32f3_disco/readme.md
+++ b/keyboards/handwired/onekey/stm32f3_disco/readme.md
@@ -1,0 +1,5 @@
+# STM32F303 Discovery kit onekey
+
+* Supported Hardware: [STM32F303 Discovery](https://www.st.com/en/evaluation-tools/stm32f3discovery.html)
+
+To trigger keypress, short together pins *B4* and *B5*.


### PR DESCRIPTION
## Description

This adds support for the [STM32F303 Discovery](https://www.st.com/en/evaluation-tools/stm32f3discovery.html) kit.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
