### PR TITLE
Add RGB Matrix get colour helper

### DIFF
--- a/docs/feature_rgb_matrix.md
+++ b/docs/feature_rgb_matrix.md
@@ -902,6 +902,7 @@ The EEPROM for it is currently shared with the LED Matrix system (it's generally
 |--------------------------------------------|-------------|
 |`rgb_matrix_set_color_all(r, g, b)`         |Set all of the LEDs to the given RGB value, where `r`/`g`/`b` are between 0 and 255 (not written to EEPROM) |
 |`rgb_matrix_set_color(index, r, g, b)`      |Set a single LED to the given RGB value, where `r`/`g`/`b` are between 0 and 255, and `index` is between 0 and `RGB_MATRIX_LED_COUNT` (not written to EEPROM) |
+|`rgb_matrix_get_color(index)`               |Get the RGB data for a single LED stored in the matrix buffer, a result struct is returned with a `color` field and a `success` field, if success is `false`, then the RGB data could not be successfully acquired |
 
 ### Disable/Enable Effects :id=disable-enable-effects
 |Function                                    |Description  |

--- a/drivers/led/aw20216.c
+++ b/drivers/led/aw20216.c
@@ -154,6 +154,22 @@ void AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     g_pwm_buffer_update_required[led.driver] = true;
 }
 
+color_result_t AW20216_get_color(int index) {
+    aw_led led;
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        memcpy_P(&led, (&g_aw_leds[index]), sizeof(led));
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.g],
+                .b = g_pwm_buffer[led.driver][led.b]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void AW20216_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (uint8_t i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         AW20216_set_color(i, red, green, blue);

--- a/drivers/led/aw20216.c
+++ b/drivers/led/aw20216.c
@@ -158,6 +158,7 @@ color_result_t AW20216_get_color(int index) {
     aw_led led;
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_aw_leds[index]), sizeof(led));
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -166,8 +167,9 @@ color_result_t AW20216_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void AW20216_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/aw20216.h
+++ b/drivers/led/aw20216.h
@@ -30,11 +30,11 @@ typedef struct aw_led {
 
 extern const aw_led PROGMEM g_aw_leds[RGB_MATRIX_LED_COUNT];
 
-void AW20216_init(pin_t cs_pin, pin_t en_pin);
-void AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           AW20216_init(pin_t cs_pin, pin_t en_pin);
+void           AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t AW20216_get_color(int index);
-void AW20216_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
-void AW20216_update_pwm_buffers(pin_t cs_pin, uint8_t index);
+void           AW20216_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           AW20216_update_pwm_buffers(pin_t cs_pin, uint8_t index);
 
 #define CS1_SW1 0x00
 #define CS2_SW1 0x01

--- a/drivers/led/aw20216.h
+++ b/drivers/led/aw20216.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 #include "progmem.h"
 #include "gpio.h"
-
+#include "color.h"
 typedef struct aw_led {
     uint8_t driver : 2;
     uint8_t r;
@@ -32,6 +32,7 @@ extern const aw_led PROGMEM g_aw_leds[RGB_MATRIX_LED_COUNT];
 
 void AW20216_init(pin_t cs_pin, pin_t en_pin);
 void AW20216_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t AW20216_get_color(int index);
 void AW20216_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 void AW20216_update_pwm_buffers(pin_t cs_pin, uint8_t index);
 

--- a/drivers/led/ckled2001.c
+++ b/drivers/led/ckled2001.c
@@ -164,6 +164,7 @@ color_result_t CKLED2001_get_color(int index) {
     ckled2001_led led;
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_ckled2001_leds[index]), sizeof(led));
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -172,8 +173,9 @@ color_result_t CKLED2001_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void CKLED2001_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/ckled2001.c
+++ b/drivers/led/ckled2001.c
@@ -160,6 +160,22 @@ void CKLED2001_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t CKLED2001_get_color(int index) {
+    ckled2001_led led;
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        memcpy_P(&led, (&g_ckled2001_leds[index]), sizeof(led));
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.g],
+                .b = g_pwm_buffer[led.driver][led.b]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void CKLED2001_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         CKLED2001_set_color(i, red, green, blue);

--- a/drivers/led/ckled2001.h
+++ b/drivers/led/ckled2001.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "progmem.h"
+#include "color.h"
 
 typedef struct ckled2001_led {
     uint8_t driver : 2;
@@ -34,6 +35,7 @@ bool CKLED2001_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 bool CKLED2001_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void CKLED2001_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t CKLED2001_get_color(int index);
 void CKLED2001_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void CKLED2001_set_led_control_register(uint8_t index, bool red, bool green, bool blue);

--- a/drivers/led/ckled2001.h
+++ b/drivers/led/ckled2001.h
@@ -34,9 +34,9 @@ void CKLED2001_init(uint8_t addr);
 bool CKLED2001_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 bool CKLED2001_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
-void CKLED2001_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           CKLED2001_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t CKLED2001_get_color(int index);
-void CKLED2001_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           CKLED2001_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void CKLED2001_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
 

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -194,6 +194,23 @@ void IS31FL3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t IS31FL3731_get_color(int index) {
+    is31_led led;
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
+
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r - 0x24],
+                .g = g_pwm_buffer[led.driver][led.g - 0x24],
+                .b = g_pwm_buffer[led.driver][led.b - 0x24]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void IS31FL3731_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         IS31FL3731_set_color(i, red, green, blue);

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -198,7 +198,7 @@ color_result_t IS31FL3731_get_color(int index) {
     is31_led led;
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
-
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r - 0x24],
@@ -207,8 +207,9 @@ color_result_t IS31FL3731_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void IS31FL3731_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/issi/is31fl3731.h
+++ b/drivers/led/issi/is31fl3731.h
@@ -36,9 +36,9 @@ void IS31FL3731_init(uint8_t addr);
 void IS31FL3731_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void IS31FL3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
-void IS31FL3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t IS31FL3731_get_color(int index);
-void IS31FL3731_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3731_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3731_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
 

--- a/drivers/led/issi/is31fl3731.h
+++ b/drivers/led/issi/is31fl3731.h
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "progmem.h"
+#include "color.h"
 
 typedef struct is31_led {
     uint8_t driver : 2;
@@ -36,6 +37,7 @@ void IS31FL3731_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void IS31FL3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t IS31FL3731_get_color(int index);
 void IS31FL3731_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3731_set_led_control_register(uint8_t index, bool red, bool green, bool blue);

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -199,6 +199,23 @@ void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t IS31FL3733_get_color(int index) {
+    is31_led led;
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
+
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.g],
+                .b = g_pwm_buffer[led.driver][led.b]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         IS31FL3733_set_color(i, red, green, blue);

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -203,7 +203,7 @@ color_result_t IS31FL3733_get_color(int index) {
     is31_led led;
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
-
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -212,8 +212,9 @@ color_result_t IS31FL3733_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -37,9 +37,9 @@ void IS31FL3733_init(uint8_t addr, uint8_t sync);
 bool IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 bool IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
-void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t IS31FL3733_get_color(int index);
-void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3733_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
 

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "progmem.h"
+#include "color.h"
 
 typedef struct is31_led {
     uint8_t driver : 2;
@@ -37,6 +38,7 @@ bool IS31FL3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 bool IS31FL3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t IS31FL3733_get_color(int index);
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3733_set_led_control_register(uint8_t index, bool red, bool green, bool blue);

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -183,7 +183,7 @@ color_result_t IS31FL3736_get_color(int index) {
     is31_led led;
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
-
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -192,8 +192,9 @@ color_result_t IS31FL3736_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void IS31FL3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -179,6 +179,23 @@ void IS31FL3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t IS31FL3736_get_color(int index) {
+    is31_led led;
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
+
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.g],
+                .b = g_pwm_buffer[led.driver][led.b]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void IS31FL3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         IS31FL3736_set_color(i, red, green, blue);

--- a/drivers/led/issi/is31fl3736.h
+++ b/drivers/led/issi/is31fl3736.h
@@ -47,9 +47,9 @@ void IS31FL3736_init(uint8_t addr);
 void IS31FL3736_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void IS31FL3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
-void IS31FL3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t IS31FL3736_get_color(int index);
-void IS31FL3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3736_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
 

--- a/drivers/led/issi/is31fl3736.h
+++ b/drivers/led/issi/is31fl3736.h
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "progmem.h"
+#include "color.h"
 
 // Simple interface option.
 // If these aren't defined, just define them to make it compile
@@ -47,6 +48,7 @@ void IS31FL3736_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void IS31FL3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t IS31FL3736_get_color(int index);
 void IS31FL3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3736_set_led_control_register(uint8_t index, bool red, bool green, bool blue);

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -190,6 +190,7 @@ color_result_t IS31FL3737_get_color(int index) {
     is31_led led;
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -198,8 +199,9 @@ color_result_t IS31FL3737_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void IS31FL3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -186,6 +186,22 @@ void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t IS31FL3737_get_color(int index) {
+    is31_led led;
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.r],
+                .b = g_pwm_buffer[led.driver][led.r]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void IS31FL3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         IS31FL3737_set_color(i, red, green, blue);

--- a/drivers/led/issi/is31fl3737.h
+++ b/drivers/led/issi/is31fl3737.h
@@ -38,9 +38,9 @@ void IS31FL3737_init(uint8_t addr);
 void IS31FL3737_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void IS31FL3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
-void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t IS31FL3737_get_color(int index);
-void IS31FL3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3737_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
 

--- a/drivers/led/issi/is31fl3737.h
+++ b/drivers/led/issi/is31fl3737.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "progmem.h"
+#include "color.h"
 
 typedef struct is31_led {
     uint8_t driver : 2;
@@ -38,6 +39,7 @@ void IS31FL3737_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void IS31FL3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t IS31FL3737_get_color(int index);
 void IS31FL3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3737_set_led_control_register(uint8_t index, bool red, bool green, bool blue);

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -194,7 +194,7 @@ color_result_t IS31FL3741_get_color(int index) {
     is31_led led;
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
-
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -203,8 +203,9 @@ color_result_t IS31FL3741_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void IS31FL3741_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -190,6 +190,23 @@ void IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t IS31FL3741_get_color(int index) {
+    is31_led led;
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
+
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.g],
+                .b = g_pwm_buffer[led.driver][led.b]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void IS31FL3741_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         IS31FL3741_set_color(i, red, green, blue);

--- a/drivers/led/issi/is31fl3741.h
+++ b/drivers/led/issi/is31fl3741.h
@@ -37,9 +37,9 @@ void IS31FL3741_init(uint8_t addr);
 void IS31FL3741_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 bool IS31FL3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
-void IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t IS31FL3741_get_color(int index);
-void IS31FL3741_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3741_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3741_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
 

--- a/drivers/led/issi/is31fl3741.h
+++ b/drivers/led/issi/is31fl3741.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "progmem.h"
+#include "color.h"
 
 typedef struct is31_led {
     uint32_t driver : 2;
@@ -37,6 +38,7 @@ void IS31FL3741_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 bool IS31FL3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t IS31FL3741_get_color(int index);
 void IS31FL3741_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3741_set_led_control_register(uint8_t index, bool red, bool green, bool blue);

--- a/drivers/led/issi/is31flcommon.c
+++ b/drivers/led/issi/is31flcommon.c
@@ -191,6 +191,7 @@ void IS31FL_RGB_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
 color_result_t IS31FL_RGB_get_color(int index) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         is31_led led = g_is31_leds[index];
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -199,8 +200,9 @@ color_result_t IS31FL_RGB_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void IS31FL_RGB_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/issi/is31flcommon.c
+++ b/drivers/led/issi/is31flcommon.c
@@ -188,6 +188,21 @@ void IS31FL_RGB_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t IS31FL_RGB_get_color(int index) {
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        is31_led led = g_is31_leds[index];
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.g],
+                .b = g_pwm_buffer[led.driver][led.b]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void IS31FL_RGB_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         IS31FL_RGB_set_color(i, red, green, blue);

--- a/drivers/led/issi/is31flcommon.h
+++ b/drivers/led/issi/is31flcommon.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "progmem.h"
+#include "rgb_matrix/rgb_matrix.h"
 
 // Which variant header file to use
 #ifdef IS31FL3742A
@@ -70,6 +71,7 @@ void IS31FL_common_update_scaling_register(uint8_t addr, uint8_t index);
 #ifdef RGB_MATRIX_ENABLE
 // RGB Matrix Specific scripts
 void IS31FL_RGB_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+RGB IS31FL_RGB_get_color(int index);
 void IS31FL_RGB_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 void IS31FL_RGB_set_scaling_buffer(uint8_t index, bool red, bool green, bool blue);
 #elif defined(LED_MATRIX_ENABLE)

--- a/drivers/led/issi/is31flcommon.h
+++ b/drivers/led/issi/is31flcommon.h
@@ -70,10 +70,10 @@ void IS31FL_common_update_scaling_register(uint8_t addr, uint8_t index);
 
 #ifdef RGB_MATRIX_ENABLE
 // RGB Matrix Specific scripts
-void IS31FL_RGB_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
-RGB IS31FL_RGB_get_color(int index);
-void IS31FL_RGB_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
-void IS31FL_RGB_set_scaling_buffer(uint8_t index, bool red, bool green, bool blue);
+void           IS31FL_RGB_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t IS31FL_RGB_get_color(int index);
+void           IS31FL_RGB_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL_RGB_set_scaling_buffer(uint8_t index, bool red, bool green, bool blue);
 #elif defined(LED_MATRIX_ENABLE)
 // LED Matrix Specific scripts
 void IS31FL_simple_set_scaling_buffer(uint8_t index, bool value);

--- a/keyboards/input_club/k_type/is31fl3733-dual.c
+++ b/keyboards/input_club/k_type/is31fl3733-dual.c
@@ -170,6 +170,22 @@ void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     }
 }
 
+color_result_t IS31FL3733_get_color(int index) {
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        is31_led led = g_is31_leds[index];
+
+        return (color_result_t) {
+            .color = {
+                .r = g_pwm_buffer[led.driver][led.r],
+                .g = g_pwm_buffer[led.driver][led.g],
+                .b = g_pwm_buffer[led.driver][led.b]
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
         IS31FL3733_set_color(i, red, green, blue);

--- a/keyboards/input_club/k_type/is31fl3733-dual.c
+++ b/keyboards/input_club/k_type/is31fl3733-dual.c
@@ -18,9 +18,9 @@
 
 #ifdef RGB_MATRIX_ENABLE
 
-#include "is31fl3733-dual.h"
-#include "i2c_master.h"
-#include "wait.h"
+#    include "is31fl3733-dual.h"
+#    include "i2c_master.h"
+#    include "wait.h"
 
 // This is a 7-bit address, that gets left-shifted and bit 0
 // set to 0 for write, 1 for read (as per I2C protocol)
@@ -32,31 +32,31 @@
 // ADDR1 represents A1:A0 of the 7-bit address.
 // ADDR2 represents A3:A2 of the 7-bit address.
 // The result is: 0b101(ADDR2)(ADDR1)
-#define ISSI_ADDR_DEFAULT 0x50
+#    define ISSI_ADDR_DEFAULT 0x50
 
-#define ISSI_COMMANDREGISTER 0xFD
-#define ISSI_COMMANDREGISTER_WRITELOCK 0xFE
-#define ISSI_INTERRUPTMASKREGISTER 0xF0
-#define ISSI_INTERRUPTSTATUSREGISTER 0xF1
+#    define ISSI_COMMANDREGISTER 0xFD
+#    define ISSI_COMMANDREGISTER_WRITELOCK 0xFE
+#    define ISSI_INTERRUPTMASKREGISTER 0xF0
+#    define ISSI_INTERRUPTSTATUSREGISTER 0xF1
 
-#define ISSI_PAGE_LEDCONTROL 0x00  // PG0
-#define ISSI_PAGE_PWM 0x01         // PG1
-#define ISSI_PAGE_AUTOBREATH 0x02  // PG2
-#define ISSI_PAGE_FUNCTION 0x03    // PG3
+#    define ISSI_PAGE_LEDCONTROL 0x00 // PG0
+#    define ISSI_PAGE_PWM 0x01        // PG1
+#    define ISSI_PAGE_AUTOBREATH 0x02 // PG2
+#    define ISSI_PAGE_FUNCTION 0x03   // PG3
 
-#define ISSI_REG_CONFIGURATION 0x00  // PG3
-#define ISSI_REG_GLOBALCURRENT 0x01  // PG3
-#define ISSI_REG_RESET 0x11          // PG3
-#define ISSI_REG_SWPULLUP 0x0F       // PG3
-#define ISSI_REG_CSPULLUP 0x10       // PG3
+#    define ISSI_REG_CONFIGURATION 0x00 // PG3
+#    define ISSI_REG_GLOBALCURRENT 0x01 // PG3
+#    define ISSI_REG_RESET 0x11         // PG3
+#    define ISSI_REG_SWPULLUP 0x0F      // PG3
+#    define ISSI_REG_CSPULLUP 0x10      // PG3
 
-#ifndef ISSI_TIMEOUT
-#    define ISSI_TIMEOUT 5000
-#endif
+#    ifndef ISSI_TIMEOUT
+#        define ISSI_TIMEOUT 5000
+#    endif
 
-#ifndef ISSI_PERSISTENCE
-#    define ISSI_PERSISTENCE 0
-#endif
+#    ifndef ISSI_PERSISTENCE
+#        define ISSI_PERSISTENCE 0
+#    endif
 
 // Transfer buffer for TWITransmitData()
 uint8_t g_twi_transfer_buffer[20];
@@ -78,17 +78,17 @@ bool IS31FL3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t
     g_twi_transfer_buffer[0] = reg;
     g_twi_transfer_buffer[1] = data;
 
-#if ISSI_PERSISTENCE > 0
+#    if ISSI_PERSISTENCE > 0
     for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
         if (i2c_transmit(index, addr << 1, g_twi_transfer_buffer, 2, TIME_US2I(ISSI_TIMEOUT)) != 0) {
             return false;
         }
     }
-#else
+#    else
     if (i2c_transmit(index, addr << 1, g_twi_transfer_buffer, 2, TIME_US2I(ISSI_TIMEOUT)) != 0) {
         return false;
     }
-#endif
+#    endif
     return true;
 }
 
@@ -108,17 +108,17 @@ bool IS31FL3733_write_pwm_buffer(uint8_t index, uint8_t addr, uint8_t *pwm_buffe
             g_twi_transfer_buffer[1 + j] = pwm_buffer[i + j];
         }
 
-#if ISSI_PERSISTENCE > 0
+#    if ISSI_PERSISTENCE > 0
         for (uint8_t i = 0; i < ISSI_PERSISTENCE; i++) {
             if (i2c_transmit(index, addr << 1, g_twi_transfer_buffer, 17, TIME_US2I(ISSI_TIMEOUT)) != 0) {
                 return false;
             }
         }
-#else
+#    else
         if (i2c_transmit(index, addr << 1, g_twi_transfer_buffer, 17, TIME_US2I(ISSI_TIMEOUT)) != 0) {
             return false;
         }
-#endif
+#    endif
     }
     return true;
 }
@@ -173,7 +173,7 @@ void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
 color_result_t IS31FL3733_get_color(int index) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
         is31_led led = g_is31_leds[index];
-
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = g_pwm_buffer[led.driver][led.r],
@@ -182,8 +182,9 @@ color_result_t IS31FL3733_get_color(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
@@ -247,6 +248,5 @@ void IS31FL3733_update_led_control_registers(uint8_t addr, uint8_t index) {
     }
     g_led_control_registers_update_required[index] = false;
 }
-
 
 #endif

--- a/keyboards/input_club/k_type/is31fl3733-dual.h
+++ b/keyboards/input_club/k_type/is31fl3733-dual.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "progmem.h"
+#include "color.h"
 
 typedef struct is31_led {
     uint8_t driver : 2;
@@ -36,6 +37,7 @@ bool IS31FL3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t
 bool IS31FL3733_write_pwm_buffer(uint8_t index, uint8_t addr, uint8_t *pwm_buffer);
 
 void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+color_result_t IS31FL3733_get_color(int index);
 void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3733_set_led_control_register(uint8_t index, bool red, bool green, bool blue);

--- a/keyboards/input_club/k_type/is31fl3733-dual.h
+++ b/keyboards/input_club/k_type/is31fl3733-dual.h
@@ -36,9 +36,9 @@ void IS31FL3733_init(uint8_t bus, uint8_t addr, uint8_t sync);
 bool IS31FL3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data);
 bool IS31FL3733_write_pwm_buffer(uint8_t index, uint8_t addr, uint8_t *pwm_buffer);
 
-void IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 color_result_t IS31FL3733_get_color(int index);
-void IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void           IS31FL3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void IS31FL3733_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
 

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -140,7 +140,7 @@ typedef struct PACKED {
 } HSV;
 
 typedef struct {
-    RGB color;
+    RGB  color;
     bool success;
 } color_result_t;
 

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -139,6 +139,11 @@ typedef struct PACKED {
     uint8_t v;
 } HSV;
 
+typedef struct {
+    RGB color;
+    bool success;
+} color_result_t;
+
 #if defined(_MSC_VER)
 #    pragma pack(pop)
 #endif

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -239,6 +239,13 @@ typedef struct {
     void (*init)(void);
     /* Set the colour of a single LED in the buffer. */
     void (*set_color)(int index, uint8_t r, uint8_t g, uint8_t b);
+
+    /* Get the colour of a single LED in the buffer.
+     *
+     * If the color cannot be fetched for any reason
+     * the returned result will be unsuccessful
+     */
+    color_result_t (*get_color)(int index);
     /* Set the colour of all LEDS on the keyboard in the buffer. */
     void (*set_color_all)(uint8_t r, uint8_t g, uint8_t b);
     /* Flush any buffered changes to the hardware. */

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -351,8 +351,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = IS31FL3741_set_color,
-    .get_color = IS31FL3741_get_color
-    .set_color_all = IS31FL3741_set_color_all,
+    .get_color = IS31FL3741_get_color.set_color_all = IS31FL3741_set_color_all,
 };
 
 #    elif defined(IS31FLCOMMON)
@@ -478,6 +477,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
 
 static color_result_t get_led(int index) {
     if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        // clang-format off
         return (color_result_t) {
             .color = {
                 .r = rgb_matrix_ws2812_array[index].r,
@@ -486,8 +486,9 @@ static color_result_t get_led(int index) {
             },
             .success = true
         };
+        // clang-format on
     }
-    return (color_result_t) {};
+    return (color_result_t){};
 }
 
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -351,7 +351,8 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = IS31FL3741_set_color,
-    .get_color = IS31FL3741_get_color.set_color_all = IS31FL3741_set_color_all,
+    .get_color = IS31FL3741_get_color,
+    .set_color_all = IS31FL3741_set_color_all,
 };
 
 #    elif defined(IS31FLCOMMON)

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -263,6 +263,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init          = init,
     .flush         = flush,
     .set_color     = IS31FL3731_set_color,
+    .get_color     = IS31FL3731_get_color,
     .set_color_all = IS31FL3731_set_color_all,
 };
 
@@ -284,6 +285,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = IS31FL3733_set_color,
+    .get_color = IS31FL3733_get_color,
     .set_color_all = IS31FL3733_set_color_all,
 };
 
@@ -305,6 +307,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = IS31FL3736_set_color,
+    .get_color = IS31FL3736_get_color,
     .set_color_all = IS31FL3736_set_color_all,
 };
 
@@ -326,6 +329,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = IS31FL3737_set_color,
+    .get_color = IS31FL3737_get_color,
     .set_color_all = IS31FL3737_set_color_all,
 };
 
@@ -347,6 +351,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = IS31FL3741_set_color,
+    .get_color = IS31FL3741_get_color
     .set_color_all = IS31FL3741_set_color_all,
 };
 
@@ -368,6 +373,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = IS31FL_RGB_set_color,
+    .get_color = IS31FL_RGB_get_color,
     .set_color_all = IS31FL_RGB_set_color_all,
 };
 
@@ -389,6 +395,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init = init,
     .flush = flush,
     .set_color = CKLED2001_set_color,
+    .get_color = CKLED2001_get_color,
     .set_color_all = CKLED2001_set_color_all,
 };
 #    endif
@@ -416,6 +423,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init          = init,
     .flush         = flush,
     .set_color     = AW20216_set_color,
+    .get_color     = AW20216_get_color,
     .set_color_all = AW20216_set_color_all,
 };
 
@@ -468,6 +476,20 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
 #    endif
 }
 
+static color_result_t get_led(int index) {
+    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+        return (color_result_t) {
+            .color = {
+                .r = rgb_matrix_ws2812_array[index].r,
+                .g = rgb_matrix_ws2812_array[index].g,
+                .b = rgb_matrix_ws2812_array[index].b
+            },
+            .success = true
+        };
+    }
+    return (color_result_t) {};
+}
+
 static void setled_all(uint8_t r, uint8_t g, uint8_t b) {
     for (int i = 0; i < ARRAY_SIZE(rgb_matrix_ws2812_array); i++) {
         setled(i, r, g, b);
@@ -478,6 +500,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .init          = init,
     .flush         = flush,
     .set_color     = setled,
+    .get_color     = get_led,
     .set_color_all = setled_all,
 };
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently if a user wants to check the rgb matrix buffers current colour, they have to keep track of the data themselves, since this is already stored in memory we can expose the data to them instead through the rgb_matrix_driver API.

### Questions

Before adding unit tests I have a query, is the standard approach for adding unit tests for this sort of change creating a folder for each currently supported RGB matrix driver for example:
- `test/rgb_matrix/drivers/WS6812/test_rgb_matrix_ws2812.cpp`
- `test/rgb_matrix/drivers/WS6812/test.mk`
- `test/rgb_matrix/drivers/WS6812/config.h`

where for each driver I would test LEDs outside and inside of the allowed range and assert on the result?

### Future

Going forward I would like to utilise this feature to modify the rgb_matrix implementation further by creating a standardised rgb_matrix indicator system allowing users to declaritively define indicator keys being triggered by the host devices current led status.

As currently it is a common pattern to implement a manual check in the RGB indicator callback instead of just setting a config property, leading to duplicated code across keyboard implementations and a requirement on code where keyboard JSON configuration could be used.

This of course would come in a later PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
