### PR TITLE
Correct "less than" to "up to" in squeezing_avr?id=layers

### DIFF
--- a/docs/squeezing_avr.md
+++ b/docs/squeezing_avr.md
@@ -75,7 +75,7 @@ MUSIC_ENABLE = no
 
 There are also some options for layers, that can reduce the firmware size. All of these settings are for your `config.h`.
 
-You can limit the number of layers that the firmware uses -- if you're using less than 8 layers in total:
+You can limit the number of layers that the firmware uses -- if you're using up to 8 layers in total:
 ```c
 #define LAYER_STATE_8BIT
 ```


### PR DESCRIPTION
The documentation for LAYER_STATE_8BIT and LAYER_STATE_16BIT claim that 8BIT excludes 8 layers and 16BIT includes 16 layers. I'm told both are inclusive, so this corrects the documentation for 8BIT.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* I didn't file an Issue for this, as it seemed to me like the change stands on its own. If you prefer I file Issues in the future, please let me know!

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

(I don't know whether "I'm changing the documentation" counts for "My change requires a change to the documentation". If you have a preference, let me know, and I'll try to act accordingly in the future.)

I tested with `qmk docs`.