### PR TITLE
Add 3geek14's keymap for Planck

### DIFF
--- a/keyboards/planck/keymaps/3geek14/.gitignore
+++ b/keyboards/planck/keymaps/3geek14/.gitignore
@@ -1,0 +1,1 @@
+/user-includes.h

--- a/keyboards/planck/keymaps/3geek14/.gitignore
+++ b/keyboards/planck/keymaps/3geek14/.gitignore
@@ -1,1 +1,1 @@
-/user-includes.h
+/user_includes.h

--- a/keyboards/planck/keymaps/3geek14/config.h
+++ b/keyboards/planck/keymaps/3geek14/config.h
@@ -1,0 +1,41 @@
+/* Copyright 2023 Pi Fisher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef AUDIO_ENABLE
+#    define STARTUP_SONG SONG(PLANCK_SOUND)
+#endif
+
+#define MIDI_BASIC
+#define HOLD_ON_OTHER_KEY_PRESS_PER_KEY
+#define DOUBLE_TAP_SHIFT_TURNS_ON_CAPS_WORD
+#define TAP_CODE_DELAY 10
+#define TAPPING_TERM 175
+
+// Unicode support for WinCompose with Right Alt as compose key
+#define UNICODE_SELECTED_MODES UNICODE_MODE_WINCOMPOSE
+#define UNICODE_KEY_WINC KC_RALT
+
+// Reduces firmware size and limits to 8 layers
+#define LAYER_STATE_8BIT
+
+#if __has_include("user-includes.h")
+#    include "user-includes.h"
+#else
+#    define EMAIL_STRING ""
+#    define SIGNATURE_STRING ""
+#endif

--- a/keyboards/planck/keymaps/3geek14/config.h
+++ b/keyboards/planck/keymaps/3geek14/config.h
@@ -18,6 +18,9 @@
 
 #ifdef AUDIO_ENABLE
 #    define STARTUP_SONG SONG(PLANCK_SOUND)
+#    define DEFAULT_LAYER_SONGS { SONG(QWERTY_SOUND), \
+                                  SONG(COLEMAK_SOUND) \
+                                }
 #endif
 
 #define MIDI_BASIC

--- a/keyboards/planck/keymaps/3geek14/config.h
+++ b/keyboards/planck/keymaps/3geek14/config.h
@@ -28,7 +28,6 @@
 
 // Unicode support for WinCompose with Right Alt as compose key
 #define UNICODE_SELECTED_MODES UNICODE_MODE_WINCOMPOSE
-#define UNICODE_KEY_WINC KC_RALT
 
 // Reduces firmware size and limits to 8 layers
 #define LAYER_STATE_8BIT

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -179,17 +179,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case QWERTY:
             if (record->event.pressed) {
                 set_single_persistent_default_layer(_QWERTY);
-                #ifdef AUDIO_ENABLE
-                    PLAY_SONG(qwerty_song);
-                #endif
             }
             return false;
         case COLEMAK:
             if (record->event.pressed) {
                 set_single_persistent_default_layer(_COLEMAK_DH);
-                #ifdef AUDIO_ENABLE
-                    PLAY_SONG(colemak_song);
-                #endif
             }
             return false;
         case MU_ON:

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -15,87 +15,57 @@
  */
 
 #include QMK_KEYBOARD_H
-
-#define SCREEN_LEFT LCTL(LGUI(KC_LEFT))
-#define SCREEN_RIGHT LCTL(LGUI(KC_RIGHT))
-#define SCREENSHOT LGUI(LSFT(KC_S))
+#include "keymap.h"
+#include "tap_dance.h"
 
 #ifdef AUDIO_ENABLE
 #    include "muse.h"
+#    include "muse_mode.h"
 #endif
-
-enum planck_layers {
-    _QWERTY,
-    _COLEMAK, // one day…I might learn this
-    _RAISE,
-    _LOWER,
-    _ADJUST,
-    _UTILS,
-};
-
-enum planck_keycodes {
-    QWERTY = SAFE_RANGE,
-    COLEMAK,
-    SHRUG,
-    SIGNATURE,
-    EMAIL,
-    THUMB_U,
-    WAVE,
-    EYES,
-    INTERRO,
-};
-
-enum tap_dance_declarations {
-    TD_DOT_DOTS,
-    TD_DASHES,
-};
-
-#define LOWER MO(_LOWER)
-#define RAISE MO(_RAISE)
 
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* Qwerty
     * ,-----------------------------------------------------------------------------------.
-    * | Esc  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+    * |  Esc |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | Tab  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  '   |
+    * |  Tab |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |   '  |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+    * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  | Enter|
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+    * | UTILS| Ctrl |  Alt |  GUI | Lower|    Space    | Raise| Left | Down |  Up  | Right|
     * `-----------------------------------------------------------------------------------'
     */
     [_QWERTY] = LAYOUT_planck_grid(
-        KC_ESCAPE,      KC_Q,         KC_W,    KC_E,    KC_R,       KC_T,   KC_Y,    KC_U,       KC_I,     KC_O,            KC_P,             KC_BACKSPACE,
-        LALT_T(KC_TAB), KC_A,         KC_S,    KC_D,    KC_F,       KC_G,   KC_H,    KC_J,       KC_K,     KC_L,            KC_SEMICOLON,     LGUI_T(KC_QUOTE),
-        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_N,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
-        MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
+        KC_ESCAPE,      KC_Q,         KC_W,    KC_E,    KC_R,       KC_T,   KC_Y,    KC_U,       KC_I,     KC_O,     KC_P,             KC_BACKSPACE,
+        LALT_T(KC_TAB), KC_A,         KC_S,    KC_D,    KC_F,       KC_G,   KC_H,    KC_J,       KC_K,     KC_L,     KC_SEMICOLON,     LGUI_T(KC_QUOTE),
+        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_N,    KC_M,       KC_COMMA, DOT_DOTS, RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
+        MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,  KC_UP,            KC_RIGHT
     ),
 
     /* Colemak
     * ,-----------------------------------------------------------------------------------.
-    * | Esc  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+    * |  Esc |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | Tab  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  '   |
+    * |  Tab |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |   '  |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+    * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  | Enter|
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+    * | UTILS| Ctrl |  Alt |  GUI | Lower|    Space    | Raise| Left | Down |  Up  | Right|
     * `-----------------------------------------------------------------------------------'
     */
     [_COLEMAK] = LAYOUT_planck_grid(
-        KC_ESCAPE,      KC_Q,         KC_W,    KC_F,    KC_P,       KC_G,   KC_J,    KC_L,       KC_U,     KC_Y,            KC_SEMICOLON,     KC_BACKSPACE,
-        LALT_T(KC_TAB), KC_A,         KC_R,    KC_S,    KC_T,       KC_D,   KC_H,    KC_N,       KC_E,     KC_I,            KC_O,             LGUI_T(KC_QUOTE),
-        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_K,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
-        MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
+        KC_ESCAPE,      KC_Q,         KC_W,    KC_F,    KC_P,       KC_G,   KC_J,    KC_L,       KC_U,     KC_Y,     KC_SEMICOLON,     KC_BACKSPACE,
+        LALT_T(KC_TAB), KC_A,         KC_R,    KC_S,    KC_T,       KC_D,   KC_H,    KC_N,       KC_E,     KC_I,     KC_O,             LGUI_T(KC_QUOTE),
+        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_K,    KC_M,       KC_COMMA, DOT_DOTS, RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
+        MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,  KC_UP,            KC_RIGHT
     ),
 
     /* Raise
     * ,-----------------------------------------------------------------------------------.
     * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |      |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+    * |  Del |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |   \  |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
     * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
@@ -103,17 +73,17 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     * `-----------------------------------------------------------------------------------'
     */
     [_RAISE] = LAYOUT_planck_grid(
-        KC_GRAVE,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,          KC_8,     KC_9,            KC_0,             _______,
-        KC_DELETE, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   TD(TD_DASHES), KC_EQUAL, KC_LEFT_BRACKET, KC_RIGHT_BRACKET, KC_BACKSLASH,
-        _______,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,       _______,  _______,         _______,          _______,
-        _______,   _______, _______, _______, _______, _______, XXXXXXX, _______,       _______,  _______,         _______,          _______
+        KC_GRAVE,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,     KC_8,     KC_9,            KC_0,             _______,
+        KC_DELETE, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINUS, KC_EQUAL, KC_LEFT_BRACKET, KC_RIGHT_BRACKET, KC_BACKSLASH,
+        _______,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,  _______,  _______,         _______,          _______,
+        _______,   _______, _______, _______, _______, _______, XXXXXXX, _______,  _______,  _______,         _______,          _______
     ),
 
     /* Lower
     * ,-----------------------------------------------------------------------------------.
     * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  |      |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
+    * |  Del |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |   |  |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
     * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
@@ -127,6 +97,24 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______,   _______,    _______, _______, _______,    _______,    XXXXXXX,       _______,       KC_HOME,     KC_PAGE_DOWN,        KC_PAGE_UP,           KC_END
     ),
 
+    /* Music (Only active during music mode, and suppresses everything but turning off music mode)
+    * ,-----------------------------------------------------------------------------------.
+    * | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX | XXXX |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | XXXX | XXXX | XXXX | XXXX | XXXX |   EndMuse   | XXXX | XXXX | XXXX | XXXX | XXXX |
+    * `-----------------------------------------------------------------------------------'
+    */
+    [_MUSIC] = LAYOUT_planck_grid(
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+        XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, END_MUS, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX
+    ),
+
     /* Adjust (Lower + Raise)
     *                      v------------------------RGB CONTROL--------------------v
     * ,-----------------------------------------------------------------------------------.
@@ -134,7 +122,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     * |------+------+------+------+------+------+------+------+------+------+------+------|
     * |      |Colemk|Music+| AudOn|AudOff|      |      |      |      |      |      | Boot |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * |      |Voice-|Voice+| MusOn|MusOff|MidiOn|MidiOf|      |      |      |      |      |
+    * |      |Voice-|Voice+| MusOn|      |MidiOn|MidiOf|      |      |      |      |      |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
     * |      |      |      |      |      |             |      | Vol0 | Vol- | Vol+ |RgbTog|
     * `-----------------------------------------------------------------------------------'
@@ -142,23 +130,23 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_ADJUST] = LAYOUT_planck_grid(
         _______, QWERTY,  _______, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______,
         _______, COLEMAK, MU_NEXT, AU_ON,   AU_OFF,  _______, _______, _______, _______, _______, _______, QK_BOOTLOADER,
-        _______, AU_PREV, AU_NEXT, MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______,
+        _______, AU_PREV, AU_NEXT, MU_ON,   _______, MI_ON,   MI_OFF,  _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, XXXXXXX, _______, KC_MUTE, KC_VOLD, KC_VOLU, RGB_TOG
     ),
 
     /* Utils
     * ,-----------------------------------------------------------------------------------.
-    * |      |      |      |      |   👀  |      |      |   👍🏻  |   7  |   8  |   9  |      |
+    * |      |      |      |      |  O.O |      | (+1) |   7  |   8  |   9  |      |dashes|
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * |      |      |PrtScn|      |      |      |      |   👋🏻  |   4  |   5  |   6  |      |
+    * |      |      |PrtScn|      |      |      |  hi  |   4  |   5  |   6  |      |      |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * |      | Undo |      |      |      |      |      |   0  |   1  |   2  |   3  |   ‽  |
+    * |      | Undo |      |      |      |      |   0  |   1  |   2  |   3  |   ‽  |      |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
     * |      |C+PgUp|C+PgDn|Scn <-|Scn ->|             |      | email|  sig |shrug?|      |
     * `-----------------------------------------------------------------------------------'
     */
     [_UTILS] = LAYOUT_planck_grid(
-        _______, _______,          _______,            EYES,        _______,      _______, THUMB_U, KC_7,    KC_8,  KC_9,      _______, _______,
+        _______, _______,          _______,            EYES,        _______,      _______, THUMB_U, KC_7,    KC_8,  KC_9,      _______, DASHES,
         _______, _______,          SCREENSHOT,         _______,     _______,      _______, WAVE,    KC_4,    KC_5,  KC_6,      _______, _______,
         _______, LCTL(KC_Z),       _______,            _______,     _______,      _______, KC_0,    KC_1,    KC_2,  KC_3,      INTERRO, _______,
         _______, LCTL(KC_PAGE_UP), LCTL(KC_PAGE_DOWN), SCREEN_LEFT, SCREEN_RIGHT, _______, XXXXXXX, _______, EMAIL, SIGNATURE, SHRUG,   _______
@@ -191,6 +179,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case COLEMAK:
             if (record->event.pressed) {
                 set_single_persistent_default_layer(_COLEMAK);
+            }
+            return false;
+        case MU_ON:
+            if (record->event.pressed) {
+                layer_on(_MUSIC);
+            }
+            return true; // then process keycode
+        case END_MUS:
+            if (record->event.pressed) {
+                layer_off(_MUSIC);
+                music_off();
             }
             return false;
         case SHRUG:
@@ -232,125 +231,3 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             return true;
     }
 }
-
-// Music
-bool muse_mode = false;
-uint8_t last_muse_note = 0;
-uint16_t muse_counter = 0;
-uint8_t muse_offset = 70;
-uint16_t muse_tempo = 50;
-
-void matrix_scan_user(void) {
-#ifdef AUDIO_ENABLE
-    if (muse_mode) {
-        if (muse_counter == 0) {
-            uint8_t muse_note = muse_offset + SCALE[muse_clock_pulse()];
-            if (muse_note != last_muse_note) {
-                stop_note(compute_freq_for_midi_note(last_muse_note));
-                play_note(compute_freq_for_midi_note(muse_note), 0xF);
-                last_muse_note = muse_note;
-            }
-        }
-        muse_counter = (muse_counter + 1) % muse_tempo;
-    } else {
-        if (muse_counter) {
-            stop_all_notes();
-            muse_counter = 0;
-        }
-    }
-#endif
-}
-
-bool music_mask_user(uint16_t keycode) {
-    switch (keycode) {
-        case RAISE:
-        case LOWER:
-            return false;
-        default:
-            return true;
-    }
-}
-
-// Tap Dance ./…
-static bool dot_held;
-
-void dot_dots_each(tap_dance_state_t *state, void *user_data) {
-    if (state->count > 1) {
-        unregister_code(KC_DOT);
-    }
-    register_code(KC_DOT);
-}
-
-void dot_dots_finished(tap_dance_state_t *state, void *user_data) {
-    if (state->count == 3) {
-        unregister_code(KC_DOT);
-        tap_code(KC_BACKSPACE);
-        tap_code(KC_BACKSPACE);
-        tap_code(KC_BACKSPACE);
-        send_unicode_string("…"); // ellipsis
-    } else {
-        if (state->pressed) {
-            dot_held = true;
-        } else {
-            unregister_code(KC_DOT);
-            dot_held = false;
-        }
-    }
-};
-
-void dot_dots_reset(tap_dance_state_t *state, void *user_data) {
-    if(dot_held) {
-        unregister_code(KC_DOT);
-        dot_held = false;
-    }
-};
-
-// Tap Dance -/–/—
-static bool minus_held;
-
-void dashes_each(tap_dance_state_t *state, void *user_data) {
-    if (state->count > 1) {
-        unregister_code(KC_MINUS);
-    }
-    register_code(KC_MINUS);
-}
-
-void dashes_finished(tap_dance_state_t *state, void *user_data) {
-    switch (state->count) {
-        case 2:
-            unregister_code(KC_MINUS);
-            tap_code(KC_BACKSPACE);
-            tap_code(KC_BACKSPACE);
-            send_unicode_string("–"); // en dash
-            break;
-        case 3:
-            unregister_code(KC_MINUS);
-            tap_code(KC_BACKSPACE);
-            tap_code(KC_BACKSPACE);
-            tap_code(KC_BACKSPACE);
-            send_unicode_string("—"); // em dash
-            break;
-        default:
-            if (state->pressed) {
-                minus_held = true;
-            } else {
-                unregister_code(KC_MINUS);
-                minus_held = false;
-            }
-            break;
-    }
-};
-
-void dashes_reset(tap_dance_state_t *state, void *user_data) {
-    if(minus_held) {
-        unregister_code(KC_MINUS);
-        minus_held = false;
-    }
-};
-
-tap_dance_action_t tap_dance_actions[] = {
-    // Tap once for period, thrice for ellipsis
-    [TD_DOT_DOTS] = ACTION_TAP_DANCE_FN_ADVANCED(dot_dots_each, dot_dots_finished, dot_dots_reset),
-    // Tap once for hyphen, twice for en dash, thrice for em dash
-    [TD_DASHES] = ACTION_TAP_DANCE_FN_ADVANCED(dashes_each, dashes_finished, dashes_reset),
-};

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -189,7 +189,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case END_MUS:
             if (record->event.pressed) {
                 layer_off(_MUSIC);
-                music_off();
+                #ifdef AUDIO_ENABLE
+                    music_off();
+                #endif
             }
             return false;
         case SHRUG:

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -154,6 +154,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
+float colemak_song[][2] = SONG(COLEMAK_SOUND);
+float qwerty_song[][2] = SONG(QWERTY_SOUND);
+
 layer_state_t layer_state_set_user(layer_state_t state) {
     return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
@@ -174,11 +177,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case QWERTY:
             if (record->event.pressed) {
                 set_single_persistent_default_layer(_QWERTY);
+                #ifdef AUDIO_ENABLE
+                    PLAY_SONG(qwerty_song);
+                #endif
             }
             return false;
         case COLEMAK:
             if (record->event.pressed) {
                 set_single_persistent_default_layer(_COLEMAK_DH);
+                #ifdef AUDIO_ENABLE
+                    PLAY_SONG(colemak_song);
+                #endif
             }
             return false;
         case MU_ON:

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -43,21 +43,21 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,  KC_UP,            KC_RIGHT
     ),
 
-    /* Colemak
+    /* Colemak DH
     * ,-----------------------------------------------------------------------------------.
-    * |  Esc |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+    * |  Esc |   Q  |   W  |   F  |   P  |   B  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * |  Tab |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |   '  |
+    * |  Tab |   A  |   R  |   S  |   T  |   G  |   M  |   N  |   E  |   I  |   O  |   '  |
     * |------+------+------+------+------+------+------+------+------+------+------+------|
-    * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  | Enter|
+    * | Shift|   Z  |   X  |   C  |   D  |   V  |   K  |   H  |   ,  |   .  |   /  | Enter|
     * |------+------+------+------+------+------+------+------+------+------+------+------|
     * | UTILS| Ctrl |  Alt |  GUI | Lower|    Space    | Raise| Left | Down |  Up  | Right|
     * `-----------------------------------------------------------------------------------'
     */
-    [_COLEMAK] = LAYOUT_planck_grid(
-        KC_ESCAPE,      KC_Q,         KC_W,    KC_F,    KC_P,       KC_G,   KC_J,    KC_L,       KC_U,     KC_Y,     KC_SEMICOLON,     KC_BACKSPACE,
-        LALT_T(KC_TAB), KC_A,         KC_R,    KC_S,    KC_T,       KC_D,   KC_H,    KC_N,       KC_E,     KC_I,     KC_O,             LGUI_T(KC_QUOTE),
-        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_K,    KC_M,       KC_COMMA, DOT_DOTS, RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
+    [_COLEMAK_DH] = LAYOUT_planck_grid(
+        KC_ESCAPE,      KC_Q,         KC_W,    KC_F,    KC_P,       KC_B,   KC_J,    KC_L,       KC_U,     KC_Y,     KC_SEMICOLON,     KC_BACKSPACE,
+        LALT_T(KC_TAB), KC_A,         KC_R,    KC_S,    KC_T,       KC_G,   KC_M,    KC_N,       KC_E,     KC_I,     KC_O,             LGUI_T(KC_QUOTE),
+        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_D,       KC_V,   KC_K,    KC_H,       KC_COMMA, DOT_DOTS, RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
         MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,  KC_UP,            KC_RIGHT
     ),
 
@@ -178,7 +178,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             return false;
         case COLEMAK:
             if (record->event.pressed) {
-                set_single_persistent_default_layer(_COLEMAK);
+                set_single_persistent_default_layer(_COLEMAK_DH);
             }
             return false;
         case MU_ON:

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -154,8 +154,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
-float colemak_song[][2] = SONG(COLEMAK_SOUND);
-float qwerty_song[][2] = SONG(QWERTY_SOUND);
+#ifdef AUDIO_ENABLE
+    float colemak_song[][2] = SONG(COLEMAK_SOUND);
+    float qwerty_song[][2] = SONG(QWERTY_SOUND);
+#endif
 
 layer_state_t layer_state_set_user(layer_state_t state) {
     return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -45,9 +45,6 @@ enum planck_keycodes {
     INTERRO,
 };
 
-// needs to be defined, but I don't use it
-const uint32_t unicode_map[] PROGMEM = {};
-
 enum tap_dance_declarations {
     TD_DOT_DOTS,
     TD_DASHES,

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -25,152 +25,152 @@
 #endif
 
 enum planck_layers {
-  _QWERTY,
-  _COLEMAK, // one day…I might learn this
-  _RAISE,
-  _LOWER,
-  _ADJUST,
-  _UTILS,
+    _QWERTY,
+    _COLEMAK, // one day…I might learn this
+    _RAISE,
+    _LOWER,
+    _ADJUST,
+    _UTILS,
 };
 
 enum planck_keycodes {
-  QWERTY = SAFE_RANGE,
-  COLEMAK,
-  SHRUG,
-  SIGNATURE,
-  EMAIL,
-  THUMB_U,
-  WAVE,
-  EYES,
-  INTERRO,
+    QWERTY = SAFE_RANGE,
+    COLEMAK,
+    SHRUG,
+    SIGNATURE,
+    EMAIL,
+    THUMB_U,
+    WAVE,
+    EYES,
+    INTERRO,
 };
 
 // needs to be defined, but I don't use it
 const uint32_t unicode_map[] PROGMEM = {};
 
 enum tap_dance_declarations {
-  TD_DOT_DOTS,
-  TD_DASHES,
+    TD_DOT_DOTS,
+    TD_DASHES,
 };
 
 #define LOWER MO(_LOWER)
 #define RAISE MO(_RAISE)
 
+// clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Qwerty
+    * ,-----------------------------------------------------------------------------------.
+    * | Esc  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | Tab  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  '   |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+    * `-----------------------------------------------------------------------------------'
+    */
+    [_QWERTY] = LAYOUT_planck_grid(
+        KC_ESCAPE,      KC_Q,         KC_W,    KC_E,    KC_R,       KC_T,   KC_Y,    KC_U,       KC_I,     KC_O,            KC_P,             KC_BACKSPACE,
+        LALT_T(KC_TAB), KC_A,         KC_S,    KC_D,    KC_F,       KC_G,   KC_H,    KC_J,       KC_K,     KC_L,            KC_SEMICOLON,     LGUI_T(KC_QUOTE),
+        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_N,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
+        MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
+    ),
 
-/* Qwerty
- * ,-----------------------------------------------------------------------------------.
- * | Esc  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Tab  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  '   |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
- * `-----------------------------------------------------------------------------------'
- */
-[_QWERTY] = LAYOUT_planck_grid(
-    KC_ESCAPE,      KC_Q,         KC_W,    KC_E,    KC_R,       KC_T,   KC_Y,    KC_U,       KC_I,     KC_O,            KC_P,             KC_BACKSPACE,
-    LALT_T(KC_TAB), KC_A,         KC_S,    KC_D,    KC_F,       KC_G,   KC_H,    KC_J,       KC_K,     KC_L,            KC_SEMICOLON,     LGUI_T(KC_QUOTE),
-    KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_N,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
-    MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
-),
+    /* Colemak
+    * ,-----------------------------------------------------------------------------------.
+    * | Esc  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | Tab  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  '   |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+    * `-----------------------------------------------------------------------------------'
+    */
+    [_COLEMAK] = LAYOUT_planck_grid(
+        KC_ESCAPE,      KC_Q,         KC_W,    KC_F,    KC_P,       KC_G,   KC_J,    KC_L,       KC_U,     KC_Y,            KC_SEMICOLON,     KC_BACKSPACE,
+        LALT_T(KC_TAB), KC_A,         KC_R,    KC_S,    KC_T,       KC_D,   KC_H,    KC_N,       KC_E,     KC_I,            KC_O,             LGUI_T(KC_QUOTE),
+        KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_K,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
+        MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
+    ),
 
-/* Colemak
- * ,-----------------------------------------------------------------------------------.
- * | Esc  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Tab  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  '   |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
- * `-----------------------------------------------------------------------------------'
- */
-[_COLEMAK] = LAYOUT_planck_grid(
-    KC_ESCAPE,      KC_Q,         KC_W,    KC_F,    KC_P,       KC_G,   KC_J,    KC_L,       KC_U,     KC_Y,            KC_SEMICOLON,     KC_BACKSPACE,
-    LALT_T(KC_TAB), KC_A,         KC_R,    KC_S,    KC_T,       KC_D,   KC_H,    KC_N,       KC_E,     KC_I,            KC_O,             LGUI_T(KC_QUOTE),
-    KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_K,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
-    MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
-),
+    /* Raise
+    * ,-----------------------------------------------------------------------------------.
+    * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |      |      |      |      |             |      |      |      |      |      |
+    * `-----------------------------------------------------------------------------------'
+    */
+    [_RAISE] = LAYOUT_planck_grid(
+        KC_GRAVE,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,          KC_8,     KC_9,            KC_0,             _______,
+        KC_DELETE, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   TD(TD_DASHES), KC_EQUAL, KC_LEFT_BRACKET, KC_RIGHT_BRACKET, KC_BACKSLASH,
+        _______,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,       _______,  _______,         _______,          _______,
+        _______,   _______, _______, _______, _______, _______, XXXXXXX, _______,       _______,  _______,         _______,          _______
+    ),
 
-/* Raise
- * ,-----------------------------------------------------------------------------------.
- * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |      |      |      |             |      |      |      |      |      |
- * `-----------------------------------------------------------------------------------'
- */
-[_RAISE] = LAYOUT_planck_grid(
-    KC_GRAVE,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,          KC_8,     KC_9,            KC_0,             _______,
-    KC_DELETE, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   TD(TD_DASHES), KC_EQUAL, KC_LEFT_BRACKET, KC_RIGHT_BRACKET, KC_BACKSLASH,
-    _______,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,       _______,  _______,         _______,          _______,
-    _______,   _______, _______, _______, _______, _______, XXXXXXX, _______,       _______,  _______,         _______,          _______
-),
+    /* Lower
+    * ,-----------------------------------------------------------------------------------.
+    * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  |      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |      |      |      |      |             |      | Home | PgDn | PgUp | End  |
+    * `-----------------------------------------------------------------------------------'
+    */
+    [_LOWER] = LAYOUT_planck_grid(
+        KC_TILDE,  KC_EXCLAIM, KC_AT,   KC_HASH, KC_DOLLAR,  KC_PERCENT, KC_CIRCUMFLEX, KC_AMPERSAND,  KC_ASTERISK, KC_LEFT_PAREN,       KC_RIGHT_PAREN,       _______,
+        KC_DELETE, KC_F1,      KC_F2,   KC_F3,   KC_F4,      KC_F5,      KC_F6,         KC_UNDERSCORE, KC_PLUS,     KC_LEFT_CURLY_BRACE, KC_RIGHT_CURLY_BRACE, KC_PIPE,
+        _______,   KC_F7,      KC_F8,   KC_F9,   KC_F10,     KC_F11,     KC_F12,        _______,       _______,     _______,             _______,              _______,
+        _______,   _______,    _______, _______, _______,    _______,    XXXXXXX,       _______,       KC_HOME,     KC_PAGE_DOWN,        KC_PAGE_UP,           KC_END
+    ),
 
-/* Lower
- * ,-----------------------------------------------------------------------------------.
- * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |      |      |      |             |      | Home | PgDn | PgUp | End  |
- * `-----------------------------------------------------------------------------------'
- */
-[_LOWER] = LAYOUT_planck_grid(
-    KC_TILDE,  KC_EXCLAIM, KC_AT,   KC_HASH, KC_DOLLAR,  KC_PERCENT, KC_CIRCUMFLEX, KC_AMPERSAND,  KC_ASTERISK, KC_LEFT_PAREN,       KC_RIGHT_PAREN,       _______,
-    KC_DELETE, KC_F1,      KC_F2,   KC_F3,   KC_F4,      KC_F5,      KC_F6,         KC_UNDERSCORE, KC_PLUS,     KC_LEFT_CURLY_BRACE, KC_RIGHT_CURLY_BRACE, KC_PIPE,
-    _______,   KC_F7,      KC_F8,   KC_F9,   KC_F10,     KC_F11,     KC_F12,        _______,       _______,     _______,             _______,              _______,
-    _______,   _______,    _______, _______, _______,    _______,    XXXXXXX,       _______,       KC_HOME,     KC_PAGE_DOWN,        KC_PAGE_UP,           KC_END
-),
+    /* Adjust (Lower + Raise)
+    *                      v------------------------RGB CONTROL--------------------v
+    * ,-----------------------------------------------------------------------------------.
+    * |      |Qwerty|      |RgbTog|RgbMod| HUE+ | HUE- | SAT+ | SAT- |BRGTH+|BRGTH-|      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |Colemk|Music+| AudOn|AudOff|      |      |      |      |      |      | Boot |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |Voice-|Voice+| MusOn|MusOff|MidiOn|MidiOf|      |      |      |      |      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |      |      |      |      |             |      | Vol0 | Vol- | Vol+ |RgbTog|
+    * `-----------------------------------------------------------------------------------'
+    */
+    [_ADJUST] = LAYOUT_planck_grid(
+        _______, QWERTY,  _______, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______,
+        _______, COLEMAK, MU_NEXT, AU_ON,   AU_OFF,  _______, _______, _______, _______, _______, _______, QK_BOOTLOADER,
+        _______, AU_PREV, AU_NEXT, MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, XXXXXXX, _______, KC_MUTE, KC_VOLD, KC_VOLU, RGB_TOG
+    ),
 
-/* Adjust (Lower + Raise)
- *                      v------------------------RGB CONTROL--------------------v
- * ,-----------------------------------------------------------------------------------.
- * |      |Qwerty|      |RgbTog|RgbMod| HUE+ | HUE- | SAT+ | SAT- |BRGTH+|BRGTH-|      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |Colemk|Music+| AudOn|AudOff|      |      |      |      |      |      | Boot |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |Voice-|Voice+| MusOn|MusOff|MidiOn|MidiOf|      |      |      |      |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |      |      |      |             |      | Vol0 | Vol- | Vol+ |RgbTog|
- * `-----------------------------------------------------------------------------------'
- */
-[_ADJUST] = LAYOUT_planck_grid(
-    _______, QWERTY,  _______, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______,
-    _______, COLEMAK, MU_NEXT, AU_ON,   AU_OFF,  _______, _______, _______, _______, _______, _______, QK_BOOTLOADER,
-    _______, AU_PREV, AU_NEXT, MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______,
-    _______, _______, _______, _______, _______, _______, XXXXXXX, _______, KC_MUTE, KC_VOLD, KC_VOLU, RGB_TOG
-),
-
-/* Utils
- * ,-----------------------------------------------------------------------------------.
- * |      |      |      |      |   👀  |      |      |   👍🏻  |   7  |   8  |   9  |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |      |PrtScn|      |      |      |      |   👋🏻  |   4  |   5  |   6  |      |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      | Undo |      |      |      |      |      |   0  |   1  |   2  |   3  |   ‽  |
- * |------+------+------+------+------+------+------+------+------+------+------+------|
- * |      |C+PgUp|C+PgDn|Scn <-|Scn ->|             |      | email|  sig |shrug?|      |
- * `-----------------------------------------------------------------------------------'
- */
-[_UTILS] = LAYOUT_planck_grid(
-    _______, _______,          _______,            EYES,        _______,      _______, THUMB_U, KC_7,    KC_8,  KC_9,      _______, _______,
-    _______, _______,          SCREENSHOT,         _______,     _______,      _______, WAVE,    KC_4,    KC_5,  KC_6,      _______, _______,
-    _______, LCTL(KC_Z),       _______,            _______,     _______,      _______, KC_0,    KC_1,    KC_2,  KC_3,      INTERRO, _______,
-    _______, LCTL(KC_PAGE_UP), LCTL(KC_PAGE_DOWN), SCREEN_LEFT, SCREEN_RIGHT, _______, XXXXXXX, _______, EMAIL, SIGNATURE, SHRUG,   _______
-)
-
+    /* Utils
+    * ,-----------------------------------------------------------------------------------.
+    * |      |      |      |      |   👀  |      |      |   👍🏻  |   7  |   8  |   9  |      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |      |PrtScn|      |      |      |      |   👋🏻  |   4  |   5  |   6  |      |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      | Undo |      |      |      |      |      |   0  |   1  |   2  |   3  |   ‽  |
+    * |------+------+------+------+------+------+------+------+------+------+------+------|
+    * |      |C+PgUp|C+PgDn|Scn <-|Scn ->|             |      | email|  sig |shrug?|      |
+    * `-----------------------------------------------------------------------------------'
+    */
+    [_UTILS] = LAYOUT_planck_grid(
+        _______, _______,          _______,            EYES,        _______,      _______, THUMB_U, KC_7,    KC_8,  KC_9,      _______, _______,
+        _______, _______,          SCREENSHOT,         _______,     _______,      _______, WAVE,    KC_4,    KC_5,  KC_6,      _______, _______,
+        _______, LCTL(KC_Z),       _______,            _______,     _______,      _______, KC_0,    KC_1,    KC_2,  KC_3,      INTERRO, _______,
+        _______, LCTL(KC_PAGE_UP), LCTL(KC_PAGE_DOWN), SCREEN_LEFT, SCREEN_RIGHT, _______, XXXXXXX, _______, EMAIL, SIGNATURE, SHRUG,   _______
+    )
 };
+// clang-format on
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+    return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
 bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
@@ -185,55 +185,55 @@ bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  switch (keycode) {
-    case QWERTY:
-      if (record->event.pressed) {
-        set_single_persistent_default_layer(_QWERTY);
-      }
-      return false;
-    case COLEMAK:
-      if (record->event.pressed) {
-        set_single_persistent_default_layer(_COLEMAK);
-      }
-      return false;
-    case SHRUG:
-      if (record->event.pressed) {
-        send_unicode_string("¯\\_(ツ)_/¯"); // Shruggie
-        return true;
-      }
-    case SIGNATURE:
-      if (record->event.pressed) {
-        send_unicode_string(SIGNATURE_STRING); // 4∑(-1)^n÷(2n+1) Person Rowing Boat, Fishing Pole
-        return true;
-      }
-    case EMAIL:
-      if (record->event.pressed) {
-        send_unicode_string(EMAIL_STRING); // Person: Light Skin Tone, Beard @ Person Rowing Boat, Fishing Pole
-        return true;
-      }
-    case THUMB_U:
-      if (record->event.pressed) {
-        send_unicode_string("👍🏻"); // Thumbs Up: Light Skin Tone
-        return true;
-      }
-    case WAVE:
-      if (record->event.pressed) {
-        send_unicode_string("👋🏻"); // Waving Hand: Light Skin Tone
-        return true;
-      }
-    case EYES:
-      if (record->event.pressed) {
-        send_unicode_string("👀"); // Eyes
-        return true;
-      }
-    case INTERRO:
-      if (record->event.pressed) {
-        send_unicode_string("‽"); // interrobang
-        return true;
-      }
-    default:
-      return true;
-  }
+    switch (keycode) {
+        case QWERTY:
+            if (record->event.pressed) {
+                set_single_persistent_default_layer(_QWERTY);
+            }
+            return false;
+        case COLEMAK:
+            if (record->event.pressed) {
+                set_single_persistent_default_layer(_COLEMAK);
+            }
+            return false;
+        case SHRUG:
+            if (record->event.pressed) {
+                send_unicode_string("¯\\_(ツ)_/¯"); // Shruggie
+            }
+            return false;
+        case SIGNATURE:
+            if (record->event.pressed) {
+                send_unicode_string(SIGNATURE_STRING); // 4∑(-1)^n÷(2n+1) Person Rowing Boat, Fishing Pole
+            }
+            return false;
+        case EMAIL:
+            if (record->event.pressed) {
+                send_unicode_string(EMAIL_STRING); // Person: Light Skin Tone, Beard @ Person Rowing Boat, Fishing Pole
+            }
+            return false;
+        case THUMB_U:
+            if (record->event.pressed) {
+                send_unicode_string("👍🏻"); // Thumbs Up: Light Skin Tone
+            }
+            return false;
+        case WAVE:
+            if (record->event.pressed) {
+                send_unicode_string("👋🏻"); // Waving Hand: Light Skin Tone
+            }
+            return false;
+        case EYES:
+            if (record->event.pressed) {
+                send_unicode_string("👀"); // Eyes
+            }
+            return false;
+        case INTERRO:
+            if (record->event.pressed) {
+                send_unicode_string("‽"); // interrobang
+            }
+            return false;
+        default:
+            return true;
+    }
 }
 
 // Music
@@ -265,90 +265,90 @@ void matrix_scan_user(void) {
 }
 
 bool music_mask_user(uint16_t keycode) {
-  switch (keycode) {
-    case RAISE:
-    case LOWER:
-      return false;
-    default:
-      return true;
-  }
+    switch (keycode) {
+        case RAISE:
+        case LOWER:
+            return false;
+        default:
+            return true;
+    }
 }
 
 // Tap Dance ./…
 static bool dot_held;
 
 void dot_dots_each(tap_dance_state_t *state, void *user_data) {
-  if (state->count > 1) {
-    unregister_code(KC_DOT);
-  }
-  register_code(KC_DOT);
+    if (state->count > 1) {
+        unregister_code(KC_DOT);
+    }
+    register_code(KC_DOT);
 }
 
 void dot_dots_finished(tap_dance_state_t *state, void *user_data) {
-  if (state->count == 3) {
-    unregister_code(KC_DOT);
-    tap_code(KC_BACKSPACE);
-    tap_code(KC_BACKSPACE);
-    tap_code(KC_BACKSPACE);
-    send_unicode_string("…"); // ellipsis
-  } else {
-    if (state->pressed) {
-      dot_held = true;
+    if (state->count == 3) {
+        unregister_code(KC_DOT);
+        tap_code(KC_BACKSPACE);
+        tap_code(KC_BACKSPACE);
+        tap_code(KC_BACKSPACE);
+        send_unicode_string("…"); // ellipsis
     } else {
-      unregister_code(KC_DOT);
-      dot_held = false;
+        if (state->pressed) {
+            dot_held = true;
+        } else {
+            unregister_code(KC_DOT);
+            dot_held = false;
+        }
     }
-  }
 };
 
 void dot_dots_reset(tap_dance_state_t *state, void *user_data) {
-  if(dot_held) {
-    unregister_code(KC_DOT);
-    dot_held = false;
-  }
+    if(dot_held) {
+        unregister_code(KC_DOT);
+        dot_held = false;
+    }
 };
 
 // Tap Dance -/–/—
 static bool minus_held;
 
 void dashes_each(tap_dance_state_t *state, void *user_data) {
-  if (state->count > 1) {
-    unregister_code(KC_MINUS);
-  }
-  register_code(KC_MINUS);
+    if (state->count > 1) {
+        unregister_code(KC_MINUS);
+    }
+    register_code(KC_MINUS);
 }
 
 void dashes_finished(tap_dance_state_t *state, void *user_data) {
-  switch (state->count) {
-    case 2:
-      unregister_code(KC_MINUS);
-      tap_code(KC_BACKSPACE);
-      tap_code(KC_BACKSPACE);
-      send_unicode_string("–"); // en dash
-      break;
-    case 3:
-      unregister_code(KC_MINUS);
-      tap_code(KC_BACKSPACE);
-      tap_code(KC_BACKSPACE);
-      tap_code(KC_BACKSPACE);
-      send_unicode_string("—"); // em dash
-      break;
-    default:
-      if (state->pressed) {
-        minus_held = true;
-      } else {
-        unregister_code(KC_MINUS);
-        minus_held = false;
-      }
-      break;
-  }
+    switch (state->count) {
+        case 2:
+            unregister_code(KC_MINUS);
+            tap_code(KC_BACKSPACE);
+            tap_code(KC_BACKSPACE);
+            send_unicode_string("–"); // en dash
+            break;
+        case 3:
+            unregister_code(KC_MINUS);
+            tap_code(KC_BACKSPACE);
+            tap_code(KC_BACKSPACE);
+            tap_code(KC_BACKSPACE);
+            send_unicode_string("—"); // em dash
+            break;
+        default:
+            if (state->pressed) {
+                minus_held = true;
+            } else {
+                unregister_code(KC_MINUS);
+                minus_held = false;
+            }
+            break;
+    }
 };
 
 void dashes_reset(tap_dance_state_t *state, void *user_data) {
-  if(minus_held) {
-    unregister_code(KC_MINUS);
-    minus_held = false;
-  }
+    if(minus_held) {
+        unregister_code(KC_MINUS);
+        minus_held = false;
+    }
 };
 
 tap_dance_action_t tap_dance_actions[] = {

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -1,0 +1,359 @@
+/* Copyright 2023 Pi Fisher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+#define SCREEN_LEFT LCTL(LGUI(KC_LEFT))
+#define SCREEN_RIGHT LCTL(LGUI(KC_RIGHT))
+#define SCREENSHOT LGUI(LSFT(KC_S))
+
+#ifdef AUDIO_ENABLE
+#    include "muse.h"
+#endif
+
+enum planck_layers {
+  _QWERTY,
+  _COLEMAK, // one day…I might learn this
+  _RAISE,
+  _LOWER,
+  _ADJUST,
+  _UTILS,
+};
+
+enum planck_keycodes {
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  SHRUG,
+  SIGNATURE,
+  EMAIL,
+  THUMB_U,
+  WAVE,
+  EYES,
+  INTERRO,
+};
+
+// needs to be defined, but I don't use it
+const uint32_t unicode_map[] PROGMEM = {};
+
+enum tap_dance_declarations {
+  TD_DOT_DOTS,
+  TD_DASHES,
+};
+
+#define LOWER MO(_LOWER)
+#define RAISE MO(_RAISE)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* Qwerty
+ * ,-----------------------------------------------------------------------------------.
+ * | Esc  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Tab  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  '   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_QWERTY] = LAYOUT_planck_grid(
+    KC_ESCAPE,      KC_Q,         KC_W,    KC_E,    KC_R,       KC_T,   KC_Y,    KC_U,       KC_I,     KC_O,            KC_P,             KC_BACKSPACE,
+    LALT_T(KC_TAB), KC_A,         KC_S,    KC_D,    KC_F,       KC_G,   KC_H,    KC_J,       KC_K,     KC_L,            KC_SEMICOLON,     LGUI_T(KC_QUOTE),
+    KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_N,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
+    MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
+),
+
+/* Colemak
+ * ,-----------------------------------------------------------------------------------.
+ * | Esc  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Tab  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  '   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | UTILS| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_COLEMAK] = LAYOUT_planck_grid(
+    KC_ESCAPE,      KC_Q,         KC_W,    KC_F,    KC_P,       KC_G,   KC_J,    KC_L,       KC_U,     KC_Y,            KC_SEMICOLON,     KC_BACKSPACE,
+    LALT_T(KC_TAB), KC_A,         KC_R,    KC_S,    KC_T,       KC_D,   KC_H,    KC_N,       KC_E,     KC_I,            KC_O,             LGUI_T(KC_QUOTE),
+    KC_LSFT,        LCTL_T(KC_Z), KC_X,    KC_C,    KC_V,       KC_B,   KC_K,    KC_M,       KC_COMMA, TD(TD_DOT_DOTS), RCTL_T(KC_SLASH), RSFT_T(KC_ENT),
+    MO(_UTILS),     KC_LCTL,      KC_LALT, KC_LGUI, MO(_LOWER), KC_SPC, XXXXXXX, MO(_RAISE), KC_LEFT,  KC_DOWN,         KC_UP,            KC_RIGHT
+),
+
+/* Raise
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      |      |      |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_RAISE] = LAYOUT_planck_grid(
+    KC_GRAVE,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,          KC_8,     KC_9,            KC_0,             _______,
+    KC_DELETE, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   TD(TD_DASHES), KC_EQUAL, KC_LEFT_BRACKET, KC_RIGHT_BRACKET, KC_BACKSLASH,
+    _______,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______,       _______,  _______,         _______,          _______,
+    _______,   _______, _______, _______, _______, _______, XXXXXXX, _______,       _______,  _______,         _______,          _______
+),
+
+/* Lower
+ * ,-----------------------------------------------------------------------------------.
+ * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Home | PgDn | PgUp | End  |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_LOWER] = LAYOUT_planck_grid(
+    KC_TILDE,  KC_EXCLAIM, KC_AT,   KC_HASH, KC_DOLLAR,  KC_PERCENT, KC_CIRCUMFLEX, KC_AMPERSAND,  KC_ASTERISK, KC_LEFT_PAREN,       KC_RIGHT_PAREN,       _______,
+    KC_DELETE, KC_F1,      KC_F2,   KC_F3,   KC_F4,      KC_F5,      KC_F6,         KC_UNDERSCORE, KC_PLUS,     KC_LEFT_CURLY_BRACE, KC_RIGHT_CURLY_BRACE, KC_PIPE,
+    _______,   KC_F7,      KC_F8,   KC_F9,   KC_F10,     KC_F11,     KC_F12,        _______,       _______,     _______,             _______,              _______,
+    _______,   _______,    _______, _______, _______,    _______,    XXXXXXX,       _______,       KC_HOME,     KC_PAGE_DOWN,        KC_PAGE_UP,           KC_END
+),
+
+/* Adjust (Lower + Raise)
+ *                      v------------------------RGB CONTROL--------------------v
+ * ,-----------------------------------------------------------------------------------.
+ * |      |Qwerty|      |RgbTog|RgbMod| HUE+ | HUE- | SAT+ | SAT- |BRGTH+|BRGTH-|      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |Colemk|Music+| AudOn|AudOff|      |      |      |      |      |      | Boot |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |Voice-|Voice+| MusOn|MusOff|MidiOn|MidiOf|      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Vol0 | Vol- | Vol+ |RgbTog|
+ * `-----------------------------------------------------------------------------------'
+ */
+[_ADJUST] = LAYOUT_planck_grid(
+    _______, QWERTY,  _______, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, _______,
+    _______, COLEMAK, MU_NEXT, AU_ON,   AU_OFF,  _______, _______, _______, _______, _______, _______, QK_BOOTLOADER,
+    _______, AU_PREV, AU_NEXT, MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, XXXXXXX, _______, KC_MUTE, KC_VOLD, KC_VOLU, RGB_TOG
+),
+
+/* Utils
+ * ,-----------------------------------------------------------------------------------.
+ * |      |      |      |      |   👀  |      |      |   👍🏻  |   7  |   8  |   9  |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |PrtScn|      |      |      |      |   👋🏻  |   4  |   5  |   6  |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      | Undo |      |      |      |      |      |   0  |   1  |   2  |   3  |   ‽  |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |C+PgUp|C+PgDn|Scn <-|Scn ->|             |      | email|  sig |shrug?|      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_UTILS] = LAYOUT_planck_grid(
+    _______, _______,          _______,            EYES,        _______,      _______, THUMB_U, KC_7,    KC_8,  KC_9,      _______, _______,
+    _______, _______,          SCREENSHOT,         _______,     _______,      _______, WAVE,    KC_4,    KC_5,  KC_6,      _______, _______,
+    _______, LCTL(KC_Z),       _______,            _______,     _______,      _______, KC_0,    KC_1,    KC_2,  KC_3,      INTERRO, _______,
+    _______, LCTL(KC_PAGE_UP), LCTL(KC_PAGE_DOWN), SCREEN_LEFT, SCREEN_RIGHT, _______, XXXXXXX, _______, EMAIL, SIGNATURE, SHRUG,   _______
+)
+
+};
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+}
+
+bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case MT(MOD_RSFT, KC_ENTER):
+            // Immediately select the hold action when another key is pressed.
+            return true;
+        default:
+            // Do not select the hold action when another key is pressed.
+            return false;
+    }
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_QWERTY);
+      }
+      return false;
+    case COLEMAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_COLEMAK);
+      }
+      return false;
+    case SHRUG:
+      if (record->event.pressed) {
+        send_unicode_string("¯\\_(ツ)_/¯"); // Shruggie
+        return true;
+      }
+    case SIGNATURE:
+      if (record->event.pressed) {
+        send_unicode_string(SIGNATURE_STRING); // 4∑(-1)^n÷(2n+1) Person Rowing Boat, Fishing Pole
+        return true;
+      }
+    case EMAIL:
+      if (record->event.pressed) {
+        send_unicode_string(EMAIL_STRING); // Person: Light Skin Tone, Beard @ Person Rowing Boat, Fishing Pole
+        return true;
+      }
+    case THUMB_U:
+      if (record->event.pressed) {
+        send_unicode_string("👍🏻"); // Thumbs Up: Light Skin Tone
+        return true;
+      }
+    case WAVE:
+      if (record->event.pressed) {
+        send_unicode_string("👋🏻"); // Waving Hand: Light Skin Tone
+        return true;
+      }
+    case EYES:
+      if (record->event.pressed) {
+        send_unicode_string("👀"); // Eyes
+        return true;
+      }
+    case INTERRO:
+      if (record->event.pressed) {
+        send_unicode_string("‽"); // interrobang
+        return true;
+      }
+    default:
+      return true;
+  }
+}
+
+// Music
+bool muse_mode = false;
+uint8_t last_muse_note = 0;
+uint16_t muse_counter = 0;
+uint8_t muse_offset = 70;
+uint16_t muse_tempo = 50;
+
+void matrix_scan_user(void) {
+#ifdef AUDIO_ENABLE
+    if (muse_mode) {
+        if (muse_counter == 0) {
+            uint8_t muse_note = muse_offset + SCALE[muse_clock_pulse()];
+            if (muse_note != last_muse_note) {
+                stop_note(compute_freq_for_midi_note(last_muse_note));
+                play_note(compute_freq_for_midi_note(muse_note), 0xF);
+                last_muse_note = muse_note;
+            }
+        }
+        muse_counter = (muse_counter + 1) % muse_tempo;
+    } else {
+        if (muse_counter) {
+            stop_all_notes();
+            muse_counter = 0;
+        }
+    }
+#endif
+}
+
+bool music_mask_user(uint16_t keycode) {
+  switch (keycode) {
+    case RAISE:
+    case LOWER:
+      return false;
+    default:
+      return true;
+  }
+}
+
+// Tap Dance ./…
+static bool dot_held;
+
+void dot_dots_each(tap_dance_state_t *state, void *user_data) {
+  if (state->count > 1) {
+    unregister_code(KC_DOT);
+  }
+  register_code(KC_DOT);
+}
+
+void dot_dots_finished(tap_dance_state_t *state, void *user_data) {
+  if (state->count == 3) {
+    unregister_code(KC_DOT);
+    tap_code(KC_BACKSPACE);
+    tap_code(KC_BACKSPACE);
+    tap_code(KC_BACKSPACE);
+    send_unicode_string("…"); // ellipsis
+  } else {
+    if (state->pressed) {
+      dot_held = true;
+    } else {
+      unregister_code(KC_DOT);
+      dot_held = false;
+    }
+  }
+};
+
+void dot_dots_reset(tap_dance_state_t *state, void *user_data) {
+  if(dot_held) {
+    unregister_code(KC_DOT);
+    dot_held = false;
+  }
+};
+
+// Tap Dance -/–/—
+static bool minus_held;
+
+void dashes_each(tap_dance_state_t *state, void *user_data) {
+  if (state->count > 1) {
+    unregister_code(KC_MINUS);
+  }
+  register_code(KC_MINUS);
+}
+
+void dashes_finished(tap_dance_state_t *state, void *user_data) {
+  switch (state->count) {
+    case 2:
+      unregister_code(KC_MINUS);
+      tap_code(KC_BACKSPACE);
+      tap_code(KC_BACKSPACE);
+      send_unicode_string("–"); // en dash
+      break;
+    case 3:
+      unregister_code(KC_MINUS);
+      tap_code(KC_BACKSPACE);
+      tap_code(KC_BACKSPACE);
+      tap_code(KC_BACKSPACE);
+      send_unicode_string("—"); // em dash
+      break;
+    default:
+      if (state->pressed) {
+        minus_held = true;
+      } else {
+        unregister_code(KC_MINUS);
+        minus_held = false;
+      }
+      break;
+  }
+};
+
+void dashes_reset(tap_dance_state_t *state, void *user_data) {
+  if(minus_held) {
+    unregister_code(KC_MINUS);
+    minus_held = false;
+  }
+};
+
+tap_dance_action_t tap_dance_actions[] = {
+    // Tap once for period, thrice for ellipsis
+    [TD_DOT_DOTS] = ACTION_TAP_DANCE_FN_ADVANCED(dot_dots_each, dot_dots_finished, dot_dots_reset),
+    // Tap once for hyphen, twice for en dash, thrice for em dash
+    [TD_DASHES] = ACTION_TAP_DANCE_FN_ADVANCED(dashes_each, dashes_finished, dashes_reset),
+};

--- a/keyboards/planck/keymaps/3geek14/keymap.c
+++ b/keyboards/planck/keymaps/3geek14/keymap.c
@@ -154,11 +154,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
-#ifdef AUDIO_ENABLE
-    float colemak_song[][2] = SONG(COLEMAK_SOUND);
-    float qwerty_song[][2] = SONG(QWERTY_SOUND);
-#endif
-
 layer_state_t layer_state_set_user(layer_state_t state) {
     return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }

--- a/keyboards/planck/keymaps/3geek14/keymap.h
+++ b/keyboards/planck/keymaps/3geek14/keymap.h
@@ -15,27 +15,33 @@
  */
 
 #pragma once
+#include "quantum.h"
 
-#ifdef AUDIO_ENABLE
-#    define STARTUP_SONG SONG(PLANCK_SOUND)
-#endif
+enum planck_layers {
+    _QWERTY,
+    _COLEMAK, // one day…I might learn this
+    _RAISE,
+    _LOWER,
+    _MUSIC,
+    _ADJUST,
+    _UTILS,
+};
 
-#define MIDI_BASIC
-#define HOLD_ON_OTHER_KEY_PRESS_PER_KEY
-#define DOUBLE_TAP_SHIFT_TURNS_ON_CAPS_WORD
-#define TAP_CODE_DELAY 10
-#define TAPPING_TERM 175
+enum planck_keycodes {
+    QWERTY = SAFE_RANGE,
+    COLEMAK,
+    END_MUS,
+    SHRUG,
+    SIGNATURE,
+    EMAIL,
+    THUMB_U,
+    WAVE,
+    EYES,
+    INTERRO,
+};
 
-// Unicode support for WinCompose with Right Alt as compose key
-#define UNICODE_SELECTED_MODES UNICODE_MODE_WINCOMPOSE
-#define UNICODE_KEY_WINC KC_RALT
-
-// Reduces firmware size and limits to 8 layers
-#define LAYER_STATE_8BIT
-
-#if __has_include("user_includes.h")
-#    include "user_includes.h"
-#else
-#    define EMAIL_STRING ""
-#    define SIGNATURE_STRING ""
-#endif
+#define LOWER MO(_LOWER)
+#define RAISE MO(_RAISE)
+#define SCREEN_LEFT LCTL(LGUI(KC_LEFT))
+#define SCREEN_RIGHT LCTL(LGUI(KC_RIGHT))
+#define SCREENSHOT LGUI(LSFT(KC_S))

--- a/keyboards/planck/keymaps/3geek14/keymap.h
+++ b/keyboards/planck/keymaps/3geek14/keymap.h
@@ -19,7 +19,7 @@
 
 enum planck_layers {
     _QWERTY,
-    _COLEMAK, // one day…I might learn this
+    _COLEMAK_DH, // one day…I might learn this
     _RAISE,
     _LOWER,
     _MUSIC,

--- a/keyboards/planck/keymaps/3geek14/muse_mode.c
+++ b/keyboards/planck/keymaps/3geek14/muse_mode.c
@@ -1,0 +1,53 @@
+/* Copyright 2023 Pi Fisher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "muse_mode.h"
+
+bool muse_mode = false;
+uint8_t last_muse_note = 0;
+uint16_t muse_counter = 0;
+uint8_t muse_offset = 70;
+uint16_t muse_tempo = 50;
+
+void matrix_scan_user(void) {
+    if (muse_mode) {
+        if (muse_counter == 0) {
+            uint8_t muse_note = muse_offset + SCALE[muse_clock_pulse()];
+            if (muse_note != last_muse_note) {
+                stop_note(compute_freq_for_midi_note(last_muse_note));
+                play_note(compute_freq_for_midi_note(muse_note), 0xF);
+                last_muse_note = muse_note;
+            }
+        }
+        muse_counter = (muse_counter + 1) % muse_tempo;
+    } else {
+        if (muse_counter) {
+            stop_all_notes();
+            muse_counter = 0;
+        }
+    }
+}
+
+bool music_mask_user(uint16_t keycode) {
+    switch (keycode) {
+        case RAISE:
+        case LOWER:
+        case END_MUS:
+            return false;
+        default:
+            return true;
+    }
+}

--- a/keyboards/planck/keymaps/3geek14/muse_mode.h
+++ b/keyboards/planck/keymaps/3geek14/muse_mode.h
@@ -15,27 +15,9 @@
  */
 
 #pragma once
+#include "quantum.h"
+#include "muse.h"
+#include "keymap.h"
 
-#ifdef AUDIO_ENABLE
-#    define STARTUP_SONG SONG(PLANCK_SOUND)
-#endif
-
-#define MIDI_BASIC
-#define HOLD_ON_OTHER_KEY_PRESS_PER_KEY
-#define DOUBLE_TAP_SHIFT_TURNS_ON_CAPS_WORD
-#define TAP_CODE_DELAY 10
-#define TAPPING_TERM 175
-
-// Unicode support for WinCompose with Right Alt as compose key
-#define UNICODE_SELECTED_MODES UNICODE_MODE_WINCOMPOSE
-#define UNICODE_KEY_WINC KC_RALT
-
-// Reduces firmware size and limits to 8 layers
-#define LAYER_STATE_8BIT
-
-#if __has_include("user_includes.h")
-#    include "user_includes.h"
-#else
-#    define EMAIL_STRING ""
-#    define SIGNATURE_STRING ""
-#endif
+void matrix_scan_user(void);
+bool music_mask_user(uint16_t keycode);

--- a/keyboards/planck/keymaps/3geek14/readme.md
+++ b/keyboards/planck/keymaps/3geek14/readme.md
@@ -1,0 +1,13 @@
+# 3geek14's Planck layout
+
+A QWERTY layout based on my Ergodox/Moonlander layouts. I got a Planck in part
+because I broke my left thumb, and I wanted a board where my left thumb wasn't
+as necessary (no thumb cluster). My thumb was somewhat better by the time I got
+the board, so I was able to use the left layer key from the default layout.
+
+Notable carry-overs from my other layouts:
+* tap/hold to use CTRL from the [Z] and [/] keys
+* tap/hold to use GUI from the ['] key
+* tap dance to type ellipsis from the [.] key and en and em dashes from the [-]
+  key
+* a layer with various emoji macros and a numpad

--- a/keyboards/planck/keymaps/3geek14/readme.md
+++ b/keyboards/planck/keymaps/3geek14/readme.md
@@ -11,3 +11,10 @@ Notable carry-overs from my other layouts:
 * tap dance to type ellipsis from the [.] key and en and em dashes from the [-]
   key
 * a layer with various emoji macros and a numpad
+
+By defining strings in a custom user-includes.h file, you can get your own email
+and signature to be put into the keyboard's firmware. Doing this as a way to
+store a password is a significant security risk, so please don't do that.
+Because I wanted to store an email address and signature that include emojis, I
+use `send_unicode_string` to print the two. If you don't add your own file, the
+kaymap will still compile, and those two keys simply won't do anything.

--- a/keyboards/planck/keymaps/3geek14/readme.md
+++ b/keyboards/planck/keymaps/3geek14/readme.md
@@ -8,8 +8,7 @@ the board, so I was able to use the left layer key from the default layout.
 Notable carry-overs from my other layouts:
 * tap/hold to use CTRL from the [Z] and [/] keys
 * tap/hold to use GUI from the ['] key
-* tap dance to type ellipsis from the [.] key and en and em dashes from the [-]
-  key
+* tap dance to type ellipsis from the [.] key
 * a layer with various emoji macros and a numpad
 
 By defining strings in a custom user-includes.h file, you can get your own email

--- a/keyboards/planck/keymaps/3geek14/rules.mk
+++ b/keyboards/planck/keymaps/3geek14/rules.mk
@@ -1,0 +1,16 @@
+ifeq ($(strip $(AUDIO_ENABLE)), yes)
+    SRC += muse.c
+endif
+
+CAPS_WORD_ENABLE = yes
+TAP_DANCE_ENABLE = yes
+UNICODEMAP_ENABLE = yes # I maybe need this for send_unicode_string
+
+# Firmware size optimizations:
+LTO_ENABLE = yes
+CONSOLE_ENABLE = no
+COMMAND_ENABLE = no
+MOUSEKEY_ENABLE = no
+SPACE_CADET_ENABLE = no
+GRAVE_ESC_ENABLE = no
+MAGIC_ENABLE = no

--- a/keyboards/planck/keymaps/3geek14/rules.mk
+++ b/keyboards/planck/keymaps/3geek14/rules.mk
@@ -4,7 +4,7 @@ endif
 
 CAPS_WORD_ENABLE = yes
 TAP_DANCE_ENABLE = yes
-UNICODEMAP_ENABLE = yes # I maybe need this for send_unicode_string
+UNICODE_COMMON = yes
 
 # Firmware size optimizations:
 LTO_ENABLE = yes

--- a/keyboards/planck/keymaps/3geek14/rules.mk
+++ b/keyboards/planck/keymaps/3geek14/rules.mk
@@ -1,6 +1,8 @@
 ifeq ($(strip $(AUDIO_ENABLE)), yes)
     SRC += muse.c
+    SRC += muse_mode.c
 endif
+SRC += tap_dance.c
 
 CAPS_WORD_ENABLE = yes
 TAP_DANCE_ENABLE = yes

--- a/keyboards/planck/keymaps/3geek14/tap_dance.c
+++ b/keyboards/planck/keymaps/3geek14/tap_dance.c
@@ -1,0 +1,91 @@
+/* Copyright 2023 Pi Fisher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "tap_dance.h"
+
+/* Dot Dots
+ *
+ * Tapping the period key three times quickly results in an ellipsis. Any
+ * other number of taps is that many periods. Holding the key acts normally,
+ * as the KC_DOT code stays registered.
+ *
+ * In order to have periods show up immediately for an easier flow when
+ * typing, the *_each function (unregisters and) registers KC_DOT each time,
+ * so the *_finished function needs to send KC_BACKSPACE to delete the
+ * periods before it sends the ellipsis character. Unfortunately, this
+ * interacts poorly with tools like Google Docs which already have an
+ * ellipsis replacement. With Google Docs, typing three periods results in
+ * an ellipsis, the first backspace undoes the replacement (leaving three
+ * periods), and the end result is a period followed by an ellipsis.
+ */
+static bool dot_held;
+
+void dot_dots_each(tap_dance_state_t *state, void *user_data) {
+    if (state->count > 1) {
+        unregister_code(KC_DOT);
+    }
+    register_code(KC_DOT);
+}
+
+void dot_dots_finished(tap_dance_state_t *state, void *user_data) {
+    uint8_t mods = get_mods() | get_oneshot_mods() | get_weak_mods();
+    if (!mods && state->count == 3) {
+        unregister_code(KC_DOT);
+        tap_code(KC_BACKSPACE);
+        tap_code(KC_BACKSPACE);
+        tap_code(KC_BACKSPACE);
+        send_unicode_string("…"); // ellipsis
+    } else {
+        if (state->pressed) {
+            dot_held = true;
+        } else {
+            unregister_code(KC_DOT);
+            dot_held = false;
+        }
+    }
+}
+
+void dot_dots_reset(tap_dance_state_t *state, void *user_data) {
+    if(dot_held) {
+        unregister_code(KC_DOT);
+        dot_held = false;
+    }
+}
+
+/* Dashes
+ *
+ * Tap twice for en dash or thrice for em dash. No other behaviours
+ * result in any visible behaviour.
+ */
+void dashes_finished(tap_dance_state_t *state, void *user_data) {
+    switch (state->count) {
+        case 2:
+            send_unicode_string("–"); // en dash
+            break;
+        case 3:
+            send_unicode_string("—"); // em dash
+            break;
+        default:
+            break;
+    }
+}
+
+tap_dance_action_t tap_dance_actions[] = {
+    // Tap once for period, thrice for ellipsis
+    [TD_DOT_DOTS] = ACTION_TAP_DANCE_FN_ADVANCED(dot_dots_each, dot_dots_finished, dot_dots_reset),
+    // Tap once for hyphen, twice for en dash, thrice for em dash
+    [TD_DASHES] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dashes_finished, NULL),
+};

--- a/keyboards/planck/keymaps/3geek14/tap_dance.h
+++ b/keyboards/planck/keymaps/3geek14/tap_dance.h
@@ -15,27 +15,12 @@
  */
 
 #pragma once
+#include "quantum.h"
 
-#ifdef AUDIO_ENABLE
-#    define STARTUP_SONG SONG(PLANCK_SOUND)
-#endif
+#define DOT_DOTS TD(TD_DOT_DOTS)
+#define DASHES TD(TD_DASHES)
 
-#define MIDI_BASIC
-#define HOLD_ON_OTHER_KEY_PRESS_PER_KEY
-#define DOUBLE_TAP_SHIFT_TURNS_ON_CAPS_WORD
-#define TAP_CODE_DELAY 10
-#define TAPPING_TERM 175
-
-// Unicode support for WinCompose with Right Alt as compose key
-#define UNICODE_SELECTED_MODES UNICODE_MODE_WINCOMPOSE
-#define UNICODE_KEY_WINC KC_RALT
-
-// Reduces firmware size and limits to 8 layers
-#define LAYER_STATE_8BIT
-
-#if __has_include("user_includes.h")
-#    include "user_includes.h"
-#else
-#    define EMAIL_STRING ""
-#    define SIGNATURE_STRING ""
-#endif
+enum tap_dance_declarations {
+    TD_DOT_DOTS,
+    TD_DASHES,
+};


### PR DESCRIPTION
Adding my custom keymap for Planck. I welcome any feedback about antipatterns in my code!

This is a work in progress because I just realised that my tap dance for en dashes makes it harder to use double-hyphen command line flags. 😅

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I tested compilation both with and without my user-includes.h file (which is not included in the PR).
