### PR TITLE
Fix Dynamic Macro Compilation for avr-gcc 5.4.0 + Linux

### DIFF
--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -196,7 +196,7 @@ static keyrecord_t *macro_end = macro_buffer;
 static keyrecord_t *const r_macro_buffer = macro_buffer + DYNAMIC_MACRO_SIZE - 1;
 
 /* Like macro_end but for the second macro. */
-static keyrecord_t *r_macro_end = r_macro_buffer;
+static keyrecord_t *r_macro_end = macro_buffer + DYNAMIC_MACRO_SIZE - 1;
 
 /* A persistent pointer to the current macro position (iterator)
  * used during the recording. */


### PR DESCRIPTION
## Description

This PR fixes an issue introduced in #21108 that prevents compilation in `avr-gcc` 5.4.0 on Linux when the Dynamic Macro feature is enabled.

### `qmk doctor` output:

```
$ qmk doctor
Ψ QMK Doctor is checking your environment.
Ψ CLI version: 1.1.1
Ψ QMK home: /home/noroadsleft/Documents/GitHub/qmk_firmware
Ψ Detected Linux (Linux Mint 21.1).
Ψ Git branch: develop
Ψ Repo version: 0.21.6
Ψ - Latest develop: 2023-07-30 04:23:13 +0000 (fa4d51dab7) -- Merge remote-tracking branch 'origin/master' into develop
Ψ - Latest upstream/master: 2023-07-30 00:22:39 -0400 (14e14e9ab8) -- Correct "less than" to "up to" in squeezing_avr?id=layers (#21639)
Ψ - Latest upstream/develop: 2023-07-30 04:23:13 +0000 (fa4d51dab7) -- Merge remote-tracking branch 'origin/master' into develop
Ψ - Common ancestor with upstream/master: 2023-07-30 00:22:39 -0400 (14e14e9ab8) -- Correct "less than" to "up to" in squeezing_avr?id=layers (#21639)
Ψ - Common ancestor with upstream/develop: 2023-07-30 04:23:13 +0000 (fa4d51dab7) -- Merge remote-tracking branch 'origin/master' into develop
Ψ All dependencies are installed.
Ψ Found arm-none-eabi-gcc version 10.3.1
Ψ Found avr-gcc version 5.4.0
Ψ Found avrdude version 6.3-20171130
Ψ Found dfu-programmer version 0.6.1
Ψ Found dfu-util version 0.9
Ψ Submodules are up to date.
Ψ Submodule status:
Ψ - lib/chibios: 2023-04-15 13:48:04 +0000 --  (11edb16109)
Ψ - lib/chibios-contrib: 2023-07-17 11:39:05 +0200 --  (da78eb37)
Ψ - lib/googletest: 2021-06-11 06:37:43 -0700 --  (e2239ee6)
Ψ - lib/lufa: 2022-08-26 12:09:55 +1000 --  (549b97320)
Ψ - lib/vusb: 2022-06-13 09:18:17 +1000 --  (819dbc1)
Ψ - lib/printf: 2022-06-29 23:59:58 +0300 --  (c2e3b4e)
Ψ - lib/pico-sdk: 2023-02-12 20:19:37 +0100 --  (a3398d8)
Ψ - lib/lvgl: 2022-04-11 04:44:53 -0600 --  (e19410f)
Ψ QMK is ready to go
```

### Sample Compilation output:

```sh
$ make -j1 kc60:noroadsleft
QMK Firmware 0.21.6
Making kc60 with keymap noroadsleft

Generating: .build/obj_kc60_noroadsleft/src/info_deps.d                                             [OK]
avr-gcc (GCC) 5.4.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Generating: .build/obj_kc60_noroadsleft/src/info_config.h                                           [OK]
Generating: .build/obj_kc60_noroadsleft/src/default_keyboard.c                                      [OK]
Generating: .build/obj_kc60_noroadsleft/src/default_keyboard.h                                      [OK]
Compiling: users/noroadsleft/noroadsleft.c                                                          [OK]
...snip...
Compiling: quantum/process_keycode/process_magic.c                                                  [OK]
Compiling: quantum/send_string/send_string.c                                                        [OK]
Compiling: quantum/command.c                                                                        [OK]
Compiling: quantum/process_keycode/process_dynamic_macro.c                                         quantum/process_keycode/process_dynamic_macro.c:199:35: error: initializer element is not constant
 static keyrecord_t *r_macro_end = r_macro_buffer;
                                   ^
 [ERRORS]
 | 
 | 
 | 
make[1]: *** [builddefs/common_rules.mk:361: .build/obj_kc60_noroadsleft/quantum/process_keycode/process_dynamic_macro.o] Error 1
Make finished with errors
make: *** [Makefile:392: kc60:noroadsleft] Error 1
```

**Full disclosure**: this patch was provided to me by @zvecr when I first reported this issue, and I have **no idea** why it works. It's especially puzzling to me because I read the changes for the PR that introduced this issue, and nothing there jumps out at me as being wrong. :man_shrugging: 

cc @ariane-emory (author of #21108)


## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
