### PR TITLE
Audio: Don't play the first note of zero-note melodies

### DIFF
--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -311,6 +311,10 @@ void audio_play_melody(float (*np)[][2], uint16_t n_count, bool n_repeat) {
         return;
     }
 
+    if (n_count == 0) {
+        return;
+    }
+
     if (!audio_initialized) {
         audio_init();
     }


### PR DESCRIPTION
## Description

`audio_play_melody`/`PLAY_SONG` may be called with a zero-note array if the user has enabled audio but disabled a particular melody with `SONG(NO_SOUND)`. Current code still calls `audio_play_note` in that case, which causes an out-of-bounds array access.

At least for the start-up melody, this access happens to work for most users, because during the DAC initialization, the RAM is close to full of `<00>` bytes, which means that `audio_play_note` is likely to be called with a frequency and a delay of 0, interpreted as silence.

However, this breaks down when either the address of the song array is at the very end of RAM or any of the bytes of what would be the first note, which are really the contents of the nearby variables, make up:
* NaN or infinity;
* a valid but bugged note frequency (too low or too high for the hardware to handle).

This manifests as random notes playing when a user toggles a feature that plays a melody when turned on or off, possibly forever (if the lower 16 bits of the duration happen to be `0xFFFF`), or weird hangs that are difficult to pin down to audio, such as the board not going into bootloader mode when using `QK_BOOT`, layouts failing to switch on boards that have layout switch melodies, etc.

This PR properly nullifies zero-note melodies.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Possibly #1149, if the boards not working and getting corrupted audio on start-up only on some OSes means that the memory around a disabled start-up melody depends on the state of USB enumeration.
* Unknown. Many issues could be related to this one without anyone knowing, and some are experienced by users who have melodies with notes that don't play, rather than by users who have zero-note melodies that cause crashes.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
