### PR TITLE
Optimize the additive DAC code, fixing performance-related hangs

### DIFF
--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -138,10 +138,10 @@ __attribute__((weak)) uint16_t dac_value_generate(void) {
 
         while (new_dac_if >= AUDIO_DAC_BUFFER_SIZE)
             new_dac_if -= AUDIO_DAC_BUFFER_SIZE;
+        dac_if[i] = new_dac_if;
 
         // Wavetable generation/lookup
         size_t dac_i = (size_t)new_dac_if;
-        dac_if[i] = new_dac_if;
 
 #if defined(AUDIO_DAC_SAMPLE_WAVEFORM_SINE)
         value += dac_buffer_sine[dac_i] / active_tones_snapshot_length;

--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -121,24 +121,27 @@ __attribute__((weak)) uint16_t dac_value_generate(void) {
     /* doing additive wave synthesis over all currently playing tones = adding up
      * sine-wave-samples for each frequency, scaled by the number of active tones
      */
-    uint16_t value     = 0;
-    float    frequency = 0.0f;
+    uint_fast16_t value     = 0;
+    float         frequency = 0.0f;
 
-    for (uint8_t i = 0; i < active_tones_snapshot_length; i++) {
+    for (size_t i = 0; i < active_tones_snapshot_length; i++) {
         /* Note: a user implementation does not have to rely on the active_tones_snapshot, but
          * could directly query the active frequencies through audio_get_processed_frequency */
         frequency = active_tones_snapshot[i];
 
-        dac_if[i] = dac_if[i] + ((frequency * AUDIO_DAC_BUFFER_SIZE) / AUDIO_DAC_SAMPLE_RATE) * 2 / 3;
+        float new_dac_if = dac_if[i];
+        new_dac_if += frequency * ((float)AUDIO_DAC_BUFFER_SIZE / AUDIO_DAC_SAMPLE_RATE * 2.0f / 3.0f);
         /*Note: the 2/3 are necessary to get the correct frequencies on the
          *      DAC output (as measured with an oscilloscope), since the gpt
          *      timer runs with 3*AUDIO_DAC_SAMPLE_RATE; and the DAC callback
          *      is called twice per conversion.*/
 
-        dac_if[i] = fmodf(dac_if[i], AUDIO_DAC_BUFFER_SIZE);
+        while (new_dac_if >= AUDIO_DAC_BUFFER_SIZE)
+            new_dac_if -= AUDIO_DAC_BUFFER_SIZE;
 
         // Wavetable generation/lookup
-        uint16_t dac_i = (uint16_t)dac_if[i];
+        size_t dac_i = (size_t)new_dac_if;
+        dac_if[i] = new_dac_if;
 
 #if defined(AUDIO_DAC_SAMPLE_WAVEFORM_SINE)
         value += dac_buffer_sine[dac_i] / active_tones_snapshot_length;


### PR DESCRIPTION
## Description

In current code, the interrupt that fires when the DAC needs more samples could take so long to process that another interrupt is already waiting, as does another once that one is done, and so on. As a result, processing DAC interrupts may be the only thing the CPU can do. This prevents any code from working which would be able to request a note to be stopped:

* the matrix scan code, which would allow a note from the audio feature or Audio Clicky to be stopped if the user had released the key that started the note, had the CPU had the opportunity to get to the next matrix scan;
* the code for MIDI over USB, which would allow a NOTEOFF event to stop a note, had the CPU had the opportunity to get to the next USB interrupt, which has a lower priority than the DAC interrupt in the ChibiOS platform support code (thanks to sigprof on Discord <https://discord.com/channels/440868230475677696/1134720693460815975/1135140965233991801> for this tip!).

Here are the changes in decreasing order of importance:

* changing `fmodf` out for a `while` loop that puts the offsets back within the chosen waveform, which is expected to run only once in most cases (saves hundreds of instructions per active tone per sample);
* multiplying the frequency by a single compile-time constant rather than using two multiplications and two divisions (saves 4 instructions per active tone per sample);
* changing types to avoid zero-extension on assignment before the implicit conversion to the return type of `dac_value_generate` (saves 3 instructions per active tone per sample).

Even if the CPU is not hanging due to being busy all the time on a user's board, these optimizations still lower CPU utilization, so the input latency goes down, and/or the user can increase the maximum number of concurrent notes or the sample rate. `fmodf` being gone also saves 416 bytes of firmware size on STM32F303. So this is still a win.

However, more stress testing is needed to make sure there aren't more causes for audio-related hangs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix (arguably)
- [ ] New feature
- [x] Enhancement/optimization (definitely)
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #8503

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
   *I have also tested that the changes improve things.*