### PR TITLE
[Bug] Fix mouse-key spamming empty reports

### DIFF
--- a/tmk_core/protocol/report.c
+++ b/tmk_core/protocol/report.c
@@ -281,13 +281,21 @@ void clear_keys_from_report(report_keyboard_t* keyboard_report) {
 
 #ifdef MOUSE_ENABLE
 /**
- * @brief Compares 2 mouse reports for difference and returns result
+ * @brief Compares 2 mouse reports for difference and returns result. Empty
+ * reports always evaluate as unchanged.
  *
  * @param[in] new_report report_mouse_t
  * @param[in] old_report report_mouse_t
  * @return bool result
  */
 __attribute__((weak)) bool has_mouse_report_changed(report_mouse_t* new_report, report_mouse_t* old_report) {
-    return memcmp(new_report, old_report, sizeof(report_mouse_t));
+    // memcmp doesn't work here because of the `report_id` field when using
+    // shared mouse endpoint
+    bool changed = ((new_report->buttons != old_report->buttons) ||
+#    ifdef MOUSE_EXTENDED_REPORT
+                    (new_report->boot_x != 0 && new_report->boot_x != old_report->boot_x) || (new_report->boot_y != 0 && new_report->boot_y != old_report->boot_y) ||
+#    endif
+                    (new_report->x != 0 && new_report->x != old_report->x) || (new_report->y != 0 && new_report->y != old_report->y) || (new_report->h != 0 && new_report->h != old_report->h) || (new_report->v != 0 && new_report->v != old_report->v));
+    return changed;
 }
 #endif


### PR DESCRIPTION
## Description

Problem:

`mousekey_task` spams empty hid reports with when a mouse key is pressed, causing resource exhaustion in the USB mouse endpoint.

Cause:

The check whether or not to send a new mouse report would always evaluate to true if a mouse key is pressed:

1. `mouse_report` has non-zero fields and `tmpmr` is a copy of this fields.
2. `mouse_report` is set to zero, `tmpmr` has now non-zero fields.
3. `has_mouse_report_changed` compares the two and evaluates to `true`.
4. an empty mouse report is sent.

Fix:

The check condition of `has_mouse_report_changed` will evaluate any empty record as unchanged, as mouse report data is relative and doesn't need to return to zero. An empty report will still be send by `register_mouse` on release of all mouse buttons.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Choppy mouse keys with #21656 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
