### PR TITLE
Load rules.mk when building with JSON keymap

### DIFF
--- a/builddefs/build_json.mk
+++ b/builddefs/build_json.mk
@@ -1,17 +1,22 @@
 # Look for a json keymap file
 ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_5)/keymap.json)","")
+    -include $(MAIN_KEYMAP_PATH_5)/rules.mk
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_5)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_5)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_4)/keymap.json)","")
+    -include $(MAIN_KEYMAP_PATH_4)/rules.mk
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_4)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_4)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_3)/keymap.json)","")
+    -include $(MAIN_KEYMAP_PATH_3)/rules.mk
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_3)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_3)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_2)/keymap.json)","")
+    -include $(MAIN_KEYMAP_PATH_2)/rules.mk
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_2)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_2)
 else ifneq ("$(wildcard $(MAIN_KEYMAP_PATH_1)/keymap.json)","")
+    -include $(MAIN_KEYMAP_PATH_1)/rules.mk
     KEYMAP_JSON := $(MAIN_KEYMAP_PATH_1)/keymap.json
     KEYMAP_PATH := $(MAIN_KEYMAP_PATH_1)
 endif


### PR DESCRIPTION
## Description

Load rules.mk when building with a JSON keymap. This enables keyboard build customization in combination with a JSON keymap. I'm using this for my ErgoDash.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* I see a few comments about C vs JSON keymap build inconsistency in #19939 , and this addresses that inconsistency, but is not otherwise related.
* #19855 also notes that custom rules.mk are not included when using a JSON keymap, but was resolved differently.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I've tested that this works for my keyboard, but I'm not sure how to test it for all keyboards. Is this something that the CI system will do?

I'm not sure if there is existing documentation of this limitation; if there is, I'm happy to update it.