### PR TITLE
enable: dynamic tapping term for keychron/q10

### DIFF
--- a/keyboards/keychron/q10/ansi_encoder/config.h
+++ b/keyboards/keychron/q10/ansi_encoder/config.h
@@ -26,3 +26,6 @@
 
 /* Enable caps-lock LED */
 #define CAPS_LOCK_LED_INDEX 48
+
+/* Set Default Tapping Term */
+#define TAPPING_TERM 210

--- a/keyboards/keychron/q10/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q10/ansi_encoder/rules.mk
@@ -15,6 +15,7 @@ DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 EEPROM_DRIVER = wear_leveling
 WEAR_LEVELING_DRIVER = embedded_flash
+DYNAMIC_TAPPING_TERM_ENABLE  = yes	# Enable Dynamic Tapping Term
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/keychron/q10/iso_encoder/config.h
+++ b/keyboards/keychron/q10/iso_encoder/config.h
@@ -26,3 +26,6 @@
 
 /* Enable caps-lock LED */
 #define CAPS_LOCK_LED_INDEX 47
+
+/* Set Default Tapping Term */
+#define TAPPING_TERM 210

--- a/keyboards/keychron/q10/iso_encoder/rules.mk
+++ b/keyboards/keychron/q10/iso_encoder/rules.mk
@@ -15,6 +15,7 @@ DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 EEPROM_DRIVER = wear_leveling
 WEAR_LEVELING_DRIVER = embedded_flash
+DYNAMIC_TAPPING_TERM_ENABLE  = yes	# Enable Dynamic Tapping Term
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE


### PR DESCRIPTION
## Description

this is to enable the dynamic tapping term feature for keychron q10 keyboard

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard  **update**
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
