### PR TITLE
Added rgb_matrix_activity() to provide a way for encoders (and others) to reset the RGB matrix timer when using RGB_MATRIX_TIMEOUT

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -654,7 +654,7 @@ void keyboard_task(void) {
 #endif
 
 #if RGB_MATRIX_TIMEOUT > 0
-    // Wake the RGB matrix or reset the RGB matrix timeout timer if there was activity 
+    // Wake the RGB matrix or reset the RGB matrix timeout timer if there was activity
     // on the encoders or pointing device.
     if (activity_has_occurred) rgb_matrix_activity();
 #endif

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -653,6 +653,12 @@ void keyboard_task(void) {
     }
 #endif
 
+#if RGB_MATRIX_TIMEOUT > 0
+    // Wake the RGB matrix or reset the RGB matrix timeout timer if there was activity 
+    // on the encoders or pointing device.
+    if (activity_has_occurred) rgb_matrix_activity();
+#endif
+
 #ifdef OLED_ENABLE
     oled_task();
 #    if OLED_TIMEOUT > 0

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -257,6 +257,12 @@ void process_rgb_matrix(uint8_t row, uint8_t col, bool pressed) {
 #endif // defined(RGB_MATRIX_FRAMEBUFFER_EFFECTS) && defined(ENABLE_RGB_MATRIX_TYPING_HEATMAP)
 }
 
+#if RGB_MATRIX_TIMEOUT > 0
+void rgb_matrix_activity(void) {
+    rgb_anykey_timer = 0;
+}
+#endif
+
 void rgb_matrix_test(void) {
     // Mask out bits 4 and 5
     // Increase the factor to make the test animation slower (and reduce to make it faster)

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -189,6 +189,10 @@ led_flags_t rgb_matrix_get_flags(void);
 void        rgb_matrix_set_flags(led_flags_t flags);
 void        rgb_matrix_set_flags_noeeprom(led_flags_t flags);
 
+#if RGB_MATRIX_TIMEOUT > 0
+void rgb_matrix_activity(void);
+#endif
+
 #ifndef RGBLIGHT_ENABLE
 #    define eeconfig_update_rgblight_current eeconfig_update_rgb_matrix
 #    define rgblight_reload_from_eeprom rgb_matrix_reload_from_eeprom


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
After setting RGB_MATRIX_TIMEOUT to a value on my macro pad (winry315), the timeout worked as expected, but I was frustrated that turning my encoder knobs would not turn the LEDs back on and would not prevent them from turning off. This solution works similar to how encoder activity will turn an oled display back on, but it just resets the timer value in rgb_matrix, similar to what a keypress does.

This was tested extensively on the one QMK device I have with rotory encoders: winry315. It does add 38 bytes to the size of the firmware. 
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

I think the encoder activity not waking the rgb matrix was technically a bug with the RGB_MATRIX_TIMEOUT feature, but I was unable to find an issue on it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
