### PR TITLE
[Core] Bump mouse endpoint packet size to 16 bytes

### DIFF
--- a/tmk_core/protocol/arm_atsam/usb/udi_device_epsize.h
+++ b/tmk_core/protocol/arm_atsam/usb/udi_device_epsize.h
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define _UDI_DEVICE_EPSIZE_H_
 
 #define KEYBOARD_EPSIZE 8
-#define MOUSE_EPSIZE 8
+#define MOUSE_EPSIZE 16
 #define EXTRAKEY_EPSIZE 8
 #define RAW_EPSIZE 32
 #define CONSOLE_EPSIZE 32

--- a/tmk_core/protocol/usb_descriptor.h
+++ b/tmk_core/protocol/usb_descriptor.h
@@ -299,7 +299,7 @@ enum usb_endpoints {
 
 #define KEYBOARD_EPSIZE 8
 #define SHARED_EPSIZE 32
-#define MOUSE_EPSIZE 8
+#define MOUSE_EPSIZE 16
 #define RAW_EPSIZE 32
 #define CONSOLE_EPSIZE 32
 #define MIDI_STREAM_EPSIZE 64


### PR DESCRIPTION
## Description

...to accommodate mouse reports with a size of 9 bytes, which happens
when the extended 16 bit movement range is activated by defining
`MOUSE_EXTENDED_REPORT` and `MOUSE_SHARED_EP` is NOT set.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Miss match in mouse endpoint packetsize when `mouse_report_t` has `MOUSE_EXTENDED_REPORT` set

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
