### PR TITLE
[Refactor] Unified `qmk format-XXX` behaviour

### DIFF
--- a/lib/python/qmk/cli/format/__init__.py
+++ b/lib/python/qmk/cli/format/__init__.py
@@ -1,0 +1,1 @@
+from ._common import *

--- a/lib/python/qmk/cli/format/_common.py
+++ b/lib/python/qmk/cli/format/_common.py
@@ -1,0 +1,170 @@
+"""
+Shared functionality across all formatters.
+"""
+
+import functools
+from pathlib import Path
+from subprocess import DEVNULL
+
+from argcomplete.completers import FilesCompleter
+from milc import cli
+
+from qmk.path import normpath
+
+ALL_FILES = "__all__"  # identifier to format every file in the repo
+
+CORE_DIRS = {
+    'c': ('drivers', 'quantum', 'tests', 'tmk_core', 'platforms'),
+    'python': ('lib/python', 'util/ci'),
+    'text': ALL_FILES,
+}
+IGNORED_DIRS = {
+    'c': ('tmk_core/protocol/usb_hid', 'platforms/chibios/boards'),
+}
+
+FILE_SUFFIXES = {
+    'c': ('c', 'h', 'cpp', 'hpp'),
+    'python': ('py', ),
+    'text': ('', ),  # '' matches with everything
+    'json': ('json', ),
+}
+
+def source_files(dir_names, suffixes):
+    """Returns a list of all source files for a given list of directories, given their suffixes
+
+    Args:
+
+        dir_names
+            List of directories relative to `qmk_firmware`.
+
+        suffixes
+            List of file suffixes to find.
+    """
+    files = []
+    for dir in dir_names:
+        # suffix contains dot, remove it
+        files.extend(file for file in Path(dir).glob('**/*') if file.suffix[1:] in suffixes)
+    return files
+
+
+def is_relative_to(file, other):
+    """Provide similar behavior to PurePath.is_relative_to in Python > 3.9
+    """
+    return str(normpath(file).resolve()).startswith(str(normpath(other).resolve()))
+
+
+def qmk_formatter(func):
+    """
+    This decorator defines flags and behaviour common to all formatters.
+    """
+    def _filter_files(_files, core_only=False):
+        """
+        Helper to yield only files to be formatted and skip the rest
+        """
+
+        _files = list(map(normpath, filter(None, _files)))
+
+        for file in _files:
+            # The following statement checks each file to see if the file path is
+            # - in the core directories
+            # - not in the ignored directories
+            # ... when core_only is flagged
+            if (
+                core_only
+                and (
+                    not any(is_relative_to(file, i) for i in core_dirs)
+                    or any(is_relative_to(file, i) for i in ignored_dirs)
+                )
+            ):
+                    cli.log.debug("Skipping non-core file %s, as '--core-only' is used.", file)
+                    continue
+
+            if file.suffix[1:] in suffixes:
+                yield file
+            else:
+                cli.log.debug('Skipping file %s', file)
+
+    def _get_files(_cli):
+        """
+        Helper to get the list of files to be format, according to CLI args
+        """
+
+        files = []
+        # List of files was supplied
+        if _cli.args.files:
+            files = list(_filter_files(_cli.args.files, _cli.args.core_only))
+
+            if _cli.args.all_files:
+                _cli.log.warning('Filename passed along -a, ignoring -a')
+
+        # All core files
+        elif _cli.args.all_files:
+            # all files in repo vs all core files
+            if core_dirs == ALL_FILES:
+                git_ls_cmd = ['git', 'ls-files']
+                git_ls = cli.run(git_ls_cmd, stdin=DEVNULL)
+                files = list(filter(None, git_ls.stdout.split('\n')))
+            else:
+                files = source_files(core_dirs, suffixes)
+
+        # Git diff
+        else:
+            git_diff_cmd = ['git', 'diff', '--name-only', _cli.args.base_branch, *core_dirs]
+            git_diff = _cli.run(git_diff_cmd, stdin=DEVNULL)
+
+            if git_diff.returncode != 0:
+                _cli.log.error('Error running %s', git_diff_cmd)
+                print(git_diff.stderr)
+                exit(git_diff.returncode)
+
+            files = git_diff.stdout.strip().split('\n')
+            files = list(_filter_files(files, True))
+
+        # remove empty values and then sort them
+        return sorted(files)
+
+    # funcs are named format_<file_extension>
+    func_name: str = func.__name__
+    lang_name = func_name[func_name.index("_") + 1:]
+
+    suffixes = FILE_SUFFIXES.get(lang_name)
+    if suffixes is None:
+        cli.log.error(f"Unknown file extensions for language: '{lang_name}'")
+
+    # default: no folders to be formatted nor ignored
+    core_dirs = CORE_DIRS.get(lang_name, [])
+
+
+    ignored_dirs = IGNORED_DIRS.get(lang_name, [])
+
+
+    @cli.argument('-i', '--inplace', arg_only=True, action='store_true', help='Edit the file instead of showing changes.')
+    @cli.argument('-b', '--base-branch', default='origin/master', help='Branch to compare to, to get diffs.')
+    @cli.argument('-a', '--all-files', arg_only=True, action='store_true', help='Format all core files.')
+    @cli.argument('--core-only', arg_only=True, action='store_true', help='Format core files only.')
+    @cli.argument('files', nargs='*', arg_only=True, type=normpath, completer=FilesCompleter(suffixes), help='Filename(s) to format.')
+    @cli.subcommand(f"Format {lang_name} code according to QMK's style.", hidden=not cli.config.user.developer)
+    @functools.wraps(func)
+    def wrapper(cli):
+        """
+        Actual logic to format code according to QMK's style.
+        """
+
+        files = _get_files(cli)
+        if not files:
+            cli.log.error('No files to be formatted found')
+            exit(0)
+
+
+        # Done one file at a time because JSON (and potentially others in the future) only supports it
+        for file in files:
+            output = func(cli, file)
+            if not output:  # halt on errors
+                return output
+
+    return wrapper
+
+__all__ = [
+    "qmk_formatter",
+    "CORE_DIRS",
+]

--- a/lib/python/qmk/cli/format/c.py
+++ b/lib/python/qmk/cli/format/c.py
@@ -3,21 +3,8 @@
 from shutil import which
 from subprocess import CalledProcessError, DEVNULL, Popen, PIPE
 
-from argcomplete.completers import FilesCompleter
 from milc import cli
-
-from qmk.path import normpath
-from qmk.c_parse import c_source_files
-
-c_file_suffixes = ('c', 'h', 'cpp', 'hpp')
-core_dirs = ('drivers', 'quantum', 'tests', 'tmk_core', 'platforms')
-ignored = ('tmk_core/protocol/usb_hid', 'platforms/chibios/boards')
-
-
-def is_relative_to(file, other):
-    """Provide similar behavior to PurePath.is_relative_to in Python > 3.9
-    """
-    return str(normpath(file).resolve()).startswith(str(normpath(other).resolve()))
+from . import qmk_formatter
 
 
 def find_clang_format():
@@ -32,36 +19,40 @@ def find_clang_format():
     return 'clang-format'
 
 
-def find_diffs(files):
+def find_diff(file, verbose=True):
     """Run clang-format and diff it against a file.
     """
     found_diffs = False
 
-    for file in files:
-        cli.log.debug('Checking for changes in %s', file)
-        clang_format = Popen([find_clang_format(), file], stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        diff = cli.run(['diff', '-u', f'--label=a/{file}', f'--label=b/{file}', str(file), '-'], stdin=clang_format.stdout, capture_output=True)
+    cli.log.debug('Checking for changes in %s', file)
+    clang_format = Popen([find_clang_format(), file], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    diff = cli.run(['diff', '-u', f'--label=a/{file}', f'--label=b/{file}', str(file), '-'], stdin=clang_format.stdout, capture_output=True)
 
-        if diff.returncode != 0:
+    if diff.returncode != 0:
+        if verbose:
             print(diff.stdout)
-            found_diffs = True
+        found_diffs = True
 
     return found_diffs
 
 
-def cformat_run(files):
+def cformat_run(file):
     """Spawn clang-format subprocess with proper arguments
     """
     # Determine which version of clang-format to use
     clang_format = [find_clang_format(), '-i']
 
+    # early stop if no change to be made
+    if not find_diff(file, verbose=False):
+        return True
+
     try:
-        cli.run([*clang_format, *map(str, files)], check=True, capture_output=False, stdin=DEVNULL)
-        cli.log.info('Successfully formatted the C code.')
+        cli.run([*clang_format, file], check=True, capture_output=False, stdin=DEVNULL)
+        cli.log.info(f'Successfully formatted the C code. ({file})')
         return True
 
     except CalledProcessError as e:
-        cli.log.error('Error formatting C code!')
+        cli.log.error(f'Error formatting C code! ({file})')
         cli.log.debug('%s exited with returncode %s', e.cmd, e.returncode)
         cli.log.debug('STDOUT:')
         cli.log.debug(e.stdout)
@@ -70,69 +61,14 @@ def cformat_run(files):
         return False
 
 
-def filter_files(files, core_only=False):
-    """Yield only files to be formatted and skip the rest
+@qmk_formatter
+def format_c(cli, file):
     """
-    files = list(map(normpath, filter(None, files)))
-
-    for file in files:
-        if core_only:
-            # The following statement checks each file to see if the file path is
-            # - in the core directories
-            # - not in the ignored directories
-            if not any(is_relative_to(file, i) for i in core_dirs) or any(is_relative_to(file, i) for i in ignored):
-                cli.log.debug("Skipping non-core file %s, as '--core-only' is used.", file)
-                continue
-
-        if file.suffix[1:] in c_file_suffixes:
-            yield file
-        else:
-            cli.log.debug('Skipping file %s', file)
-
-
-@cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Flag only, don't automatically format.")
-@cli.argument('-b', '--base-branch', default='origin/master', help='Branch to compare to diffs to.')
-@cli.argument('-a', '--all-files', arg_only=True, action='store_true', help='Format all core files.')
-@cli.argument('--core-only', arg_only=True, action='store_true', help='Format core files only.')
-@cli.argument('files', nargs='*', arg_only=True, type=normpath, completer=FilesCompleter('.c'), help='Filename(s) to format.')
-@cli.subcommand("Format C code according to QMK's style.", hidden=False if cli.config.user.developer else True)
-def format_c(cli):
-    """Format C code according to QMK's style.
+    Format a single C file according to QMK's style.
+    Itrating over target files is handled in decorator.
     """
-    # Find the list of files to format
-    if cli.args.files:
-        files = list(filter_files(cli.args.files, cli.args.core_only))
 
-        if not files:
-            cli.log.error('No C files in filelist: %s', ', '.join(map(str, cli.args.files)))
-            exit(0)
+    if cli.args.inplace:
+        return cformat_run(file)
 
-        if cli.args.all_files:
-            cli.log.warning('Filenames passed with -a, only formatting: %s', ','.join(map(str, files)))
-
-    elif cli.args.all_files:
-        all_files = c_source_files(core_dirs)
-        files = list(filter_files(all_files, True))
-
-    else:
-        git_diff_cmd = ['git', 'diff', '--name-only', cli.args.base_branch, *core_dirs]
-        git_diff = cli.run(git_diff_cmd, stdin=DEVNULL)
-
-        if git_diff.returncode != 0:
-            cli.log.error("Error running %s", git_diff_cmd)
-            print(git_diff.stderr)
-            return git_diff.returncode
-
-        changed_files = git_diff.stdout.strip().split('\n')
-        files = list(filter_files(changed_files, True))
-
-    # Sanity check
-    if not files:
-        cli.log.error('No changed files detected. Use "qmk format-c -a" to format all core files')
-        return False
-
-    # Run clang-format on the files we've found
-    if cli.args.dry_run:
-        return not find_diffs(files)
-    else:
-        return cformat_run(files)
+    return not find_diff(file)

--- a/lib/python/qmk/cli/format/python.py
+++ b/lib/python/qmk/cli/format/python.py
@@ -3,68 +3,28 @@
 from subprocess import CalledProcessError, DEVNULL
 
 from milc import cli
+from . import qmk_formatter, CORE_DIRS
 
-from qmk.path import normpath
-
-py_file_suffixes = ('py',)
-py_dirs = ['lib/python', 'util/ci']
+py_dirs = CORE_DIRS.get('python')
 
 
-def yapf_run(files):
-    edit = '--diff' if cli.args.dry_run else '--in-place'
-    yapf_cmd = ['yapf', '-vv', '--recursive', edit, *files]
+def yapf_run(file, inplace):
+    edit = '--in-place' if inplace else '--diff'
+    yapf_cmd = ['yapf', '-vv', edit, file]
     try:
         cli.run(yapf_cmd, check=True, capture_output=False, stdin=DEVNULL)
-        cli.log.info('Successfully formatted the python code.')
+        cli.log.info(f'Successfully formatted the python code. ({file})')
 
     except CalledProcessError:
-        cli.log.error(f'Python code in {",".join(py_dirs)} incorrectly formatted!')
+        cli.log.error(f'Python code incorrectly formatted! ({file})')
         return False
 
 
-def filter_files(files):
-    """Yield only files to be formatted and skip the rest
+@qmk_formatter
+def format_python(cli, file):
     """
-    files = list(map(normpath, filter(None, files)))
-    for file in files:
-        if file.suffix[1:] in py_file_suffixes:
-            yield file
-        else:
-            cli.log.debug('Skipping file %s', file)
-
-
-@cli.argument('-n', '--dry-run', arg_only=True, action='store_true', help="Don't actually format.")
-@cli.argument('-b', '--base-branch', default='origin/master', help='Branch to compare to diffs to.')
-@cli.argument('-a', '--all-files', arg_only=True, action='store_true', help='Format all files.')
-@cli.argument('files', nargs='*', arg_only=True, type=normpath, help='Filename(s) to format.')
-@cli.subcommand("Format python code according to QMK's style.", hidden=False if cli.config.user.developer else True)
-def format_python(cli):
-    """Format python code according to QMK's style.
+    Format a single Python file according to QMK's style.
+    Itrating over target files is handled in decorator.
     """
-    # Find the list of files to format
-    if cli.args.files:
-        files = list(filter_files(cli.args.files))
 
-        if not files:
-            cli.log.error('No Python files in filelist: %s', ', '.join(map(str, cli.args.files)))
-            exit(0)
-
-        if cli.args.all_files:
-            cli.log.warning('Filenames passed with -a, only formatting: %s', ','.join(map(str, files)))
-
-    elif cli.args.all_files:
-        git_ls_cmd = ['git', 'ls-files', *py_dirs]
-        git_ls = cli.run(git_ls_cmd, stdin=DEVNULL)
-        files = list(filter_files(git_ls.stdout.split('\n')))
-
-    else:
-        git_diff_cmd = ['git', 'diff', '--name-only', cli.args.base_branch, *py_dirs]
-        git_diff = cli.run(git_diff_cmd, stdin=DEVNULL)
-        files = list(filter_files(git_diff.stdout.split('\n')))
-
-    # Sanity check
-    if not files:
-        cli.log.error('No changed files detected. Use "qmk format-python -a" to format all files')
-        return False
-
-    return yapf_run(files)
+    return yapf_run(file, cli.args.inplace)

--- a/lib/python/qmk/cli/format/text.py
+++ b/lib/python/qmk/cli/format/text.py
@@ -1,11 +1,10 @@
 """Ensure text files have the proper line endings.
 """
 from itertools import islice
-from subprocess import DEVNULL
 
 from milc import cli
 
-from qmk.path import normpath
+from . import qmk_formatter
 
 
 def _get_chunks(it, size):
@@ -15,43 +14,21 @@ def _get_chunks(it, size):
     return iter(lambda: tuple(islice(it, size)), ())
 
 
-def dos2unix_run(files):
+def dos2unix_run(file):
     """Spawn multiple dos2unix subprocess avoiding too long commands on formatting everything
     """
-    for chunk in _get_chunks(files, 10):
-        dos2unix = cli.run(['dos2unix', *chunk])
+    # for chunk in _get_chunks(files, 10):
+    dos2unix = cli.run(['dos2unix', file])
 
-        if dos2unix.returncode:
-            return False
-
-
-@cli.argument('-b', '--base-branch', default='origin/master', help='Branch to compare to diffs to.')
-@cli.argument('-a', '--all-files', arg_only=True, action='store_true', help='Format all files.')
-@cli.argument('files', nargs='*', arg_only=True, type=normpath, help='Filename(s) to format.')
-@cli.subcommand("Ensure text files have the proper line endings.", hidden=True)
-def format_text(cli):
-    """Ensure text files have the proper line endings.
-    """
-    # Find the list of files to format
-    if cli.args.files:
-        files = list(cli.args.files)
-
-        if cli.args.all_files:
-            cli.log.warning('Filenames passed with -a, only formatting: %s', ','.join(map(str, files)))
-
-    elif cli.args.all_files:
-        git_ls_cmd = ['git', 'ls-files']
-        git_ls = cli.run(git_ls_cmd, stdin=DEVNULL)
-        files = list(filter(None, git_ls.stdout.split('\n')))
-
-    else:
-        git_diff_cmd = ['git', 'diff', '--name-only', cli.args.base_branch]
-        git_diff = cli.run(git_diff_cmd, stdin=DEVNULL)
-        files = list(filter(None, git_diff.stdout.split('\n')))
-
-    # Sanity check
-    if not files:
-        cli.log.error('No changed files detected. Use "qmk format-text -a" to format all files')
+    if dos2unix.returncode:
         return False
 
-    return dos2unix_run(files)
+
+@qmk_formatter
+def format_text(cli, file):
+    """
+    Ensure a single text file has the proper line endings.
+    Itrating over target files is handled in decorator.
+    """
+
+    return dos2unix_run(file)


### PR DESCRIPTION
## Description

There is some inconsistency between the different formatters.
In order to solve this, i've made a wrapper which each formatter has to "inherit" from, which contains most of the logic:
1. Creates a subcommand with the appropriate name and arguments
    - If a specific formatter needs extra arguments (eg: JSON), they can still be added on top 
2. Finds the files to be formatted based on `-a` and whatnot
3. Iterate over them. This is for sure slower than before, as we were calling whichever formatting-command on many files at once before, but given that:
    a) Files will usually be formatted in rather smaller batches
    b) We can now add which file has error'ed/been formated, to the log messages
   \> I dont think it is such a bad thing. Perhaps CI/CD will become -even- slower due to it, but i guess it only formats files affected by each PR anyway (not many)
4. Each of the formatters, after being decorated with `@qmk_formatter` only has to provide the specific logic to handle a single file.

Final notes:
* `_common.py` just because i didn't feel like having a chunky `__init__.py`, could move it there if that's preferred
* This makes code harder to read, but prevents some duplication and should be easier to maintain.
* Implementation is messy (and not throughfully tested), please review carefully in sake of improving it :D
* `dos2unix` doesn't seem to have a "dry" mode, so it just ignores the `--inplace` argument
* C formatter is now doing the work twice (checking if anything has to be changed, then changing it) when `-i` is used, in order to not spam `C file formatted (<file>)` with files that weren't actually formatted. Could re-use the output from `find_diff` instead of re-doing the same thing, but im not sure how.

## Types of Changes

- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #21634

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
