### PR TITLE
[Bug] Fix compilation error for APA on ChibiOS

### DIFF
--- a/drivers/led/apa102.c
+++ b/drivers/led/apa102.c
@@ -22,8 +22,8 @@
 #    if defined(__AVR__)
 #        define APA102_NOPS 0 // AVR at 16 MHz already spends 62.5 ns per clock, so no extra delay is needed
 #    elif defined(PROTOCOL_CHIBIOS)
-
 #        include "hal.h"
+#        include "chibios_config.h"
 #        if defined(STM32F0XX) || defined(STM32F1XX) || defined(STM32F3XX) || defined(STM32F4XX) || defined(STM32L0XX) || defined(GD32VF103)
 #            define APA102_NOPS (100 / (1000000000L / (CPU_CLOCK / 4))) // This calculates how many loops of 4 nops to run to delay 100 ns
 #        else


### PR DESCRIPTION

## Description

Removing quantum.h from apa102.c removed chibios_config.h include, which breaks compilation as it depends on the CPU_CLOCK define. 

Can verify that it works on STM32F405 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Testing locally with Sparkfun input and display micromod carrier board

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
