### PR TITLE
Fix variable misspelling

### DIFF
--- a/layouts/community/ortho_4x12/drashna/rules.mk
+++ b/layouts/community/ortho_4x12/drashna/rules.mk
@@ -8,7 +8,7 @@ CONSOLE_ENABLE     = no
 COMMAND_ENABLE     = no
 BACKLIGHT_ENABLE   = no
 
-ifeq ($(strip $(LAYOUT_HAS_RGB)), yes)
+ifeq ($(strip $(LAYOUTS_HAS_RGB)), yes)
     RGBLIGHT_ENABLE            = yes
 endif
 


### PR DESCRIPTION
## Description

This is a very simple pull request that fixes a possible variable name misspelling in `layouts/community/ortho_4x12/drashna/rules.mk`: `LAYOUTS_HAS_RGB` is spelled without an `S` at `LAYOUTS`.

As most of the other `rules.mk` spell it with an `S`, I suppose this is a mistake. I am new to QMK and not sure how to properly test this keyboard layout.

## Types of Changes

- [X] Bugfix

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
