### PR TITLE
[Core] Add OS detection callbacks

### DIFF
--- a/docs/feature_os_detection.md
+++ b/docs/feature_os_detection.md
@@ -37,11 +37,11 @@ This time is quite short, probably hundreds of milliseconds, but this data may b
 If you want to perform custom actions when the OS is detected, then you can use the `process_detected_host_os_kb` function on the keyboard level source file, or `process_detected_host_os_user` function in the user `keymap.c`.
 
 ```c
-bool process_detected_host_os_kb(os_variant_t os) {
-    if (!process_detected_host_os_user(os)) {
+bool process_detected_host_os_kb(os_variant_t detected_os) {
+    if (!process_detected_host_os_user(detected_os)) {
         return false;
     }
-    switch (os) {
+    switch (detected_os) {
         case OS_MACOS:
         case OS_IOS:
             rgb_matrix_set_color_all(RGB_WHITE);

--- a/docs/feature_os_detection.md
+++ b/docs/feature_os_detection.md
@@ -79,8 +79,6 @@ If your keyboard does not redetect the OS in this situation, you can force the k
   * defined the debounce time for OS detection, in milliseconds
 * `#define OS_DETECTION_KEYBOARD_RESET`
   * enables the keyboard reset upon a USB device reinitilization, such as switching devices on some KVMs
-* `#define OS_DETECTION_KEYBOARD_RESET_BOOTLOADER`
-  * changes the keyboard reset strategy from a soft reset to a full reset, requires `OS_DETECTION_KEYBOARD_RESET` to be defined as well
 
 ## Debug
 

--- a/docs/feature_os_detection.md
+++ b/docs/feature_os_detection.md
@@ -61,6 +61,27 @@ bool process_detected_host_os_kb(os_variant_t os) {
 }
 ```
 
+## OS detection stability
+
+The OS detection is currently handled while the USB device descriptor is being assembled. 
+The process is done in steps, generating a number of intermediate results until it stabilizes.
+We therefore resort to debouncing the result until it has been stable for a given amount of milliseconds.
+This amount can be configured, in case your board is not stable within the default debouncing time of 200ms.
+
+## KVM and USB switches
+
+Some KVM and USB switches may not trigger the USB controller on the keyboard to fully reset upon switching machines.
+If your keyboard does not redetect the OS in this situation, you can force the keyboard to reset when the USB initialization event is detected, forcing the USB controller to be reconfigured.
+
+## Configuration Options
+
+* `#define OS_DETECTION_DEBOUNCE 200`
+  * defined the debounce time for OS detection, in milliseconds
+* `#define OS_DETECTION_KEYBOARD_RESET`
+  * enables the keyboard reset upon a USB device reinitilization, such as switching devices on some KVMs
+* `#define OS_DETECTION_KEYBOARD_RESET_BOOTLOADER`
+  * changes the keyboard reset strategy from a soft reset to a full reset, requires `OS_DETECTION_KEYBOARD_RESET` to be defined as well
+
 ## Debug
 
 If OS is guessed incorrectly, you may want to collect data about USB setup packets to refine the detection logic.

--- a/docs/feature_os_detection.md
+++ b/docs/feature_os_detection.md
@@ -14,7 +14,7 @@ In your `rules.mk` add:
 OS_DETECTION_ENABLE = yes
 ```
 
-Include `"os_detection.h"` in your `keymap.c`.
+It will automatically include the required headers file.
 It declares `os_variant_t detected_host_os(void);` which you can call to get detected OS.
 
 It returns one of the following values:
@@ -31,6 +31,35 @@ enum {
 
 ?> Note that it takes some time after firmware is booted to detect the OS.
 This time is quite short, probably hundreds of milliseconds, but this data may be not ready in keyboard and layout setup functions which run very early during firmware startup.
+
+## Callbacks :id=callbacks
+
+If you want to perform custom actions when the OS is detected, then you can use the `process_detected_host_os_kb` function on the keyboard level source file, or `process_detected_host_os_user` function in the user `keymap.c`.
+
+```c
+bool process_detected_host_os_kb(os_variant_t os) {
+    if (!process_detected_host_os_user(os)) {
+        return false;
+    }
+    switch (os) {
+        case OS_MACOS:
+        case OS_IOS:
+            rgb_matrix_set_color_all(RGB_WHITE);
+            break;
+        case OS_WINDOWS:
+            rgb_matrix_set_color_all(RGB_BLUE);
+            break;
+        case OS_LINUX:
+            rgb_matrix_set_color_all(RGB_ORANGE);
+            break;
+        case OS_UNSURE:
+            rgb_matrix_set_color_all(RGB_RED);
+            break;
+    }
+    
+    return true;
+}
+```
 
 ## Debug
 

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -137,6 +137,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef WPM_ENABLE
 #    include "wpm.h"
 #endif
+#ifdef OS_DETECTION_ENABLE
+#    include "os_detection.h"
+#endif
 
 static uint32_t last_input_modification_time = 0;
 uint32_t        last_input_activity_time(void) {
@@ -738,4 +741,8 @@ void keyboard_task(void) {
 #endif
 
     led_task();
+
+#ifdef OS_DETECTION_ENABLE
+    os_detection_task();
+#endif
 }

--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -20,7 +20,9 @@
 
 #    include <string.h>
 #    include "timer.h"
-#    include "quantum.h"
+#    ifdef OS_DETECTION_KEYBOARD_RESET
+#        include "quantum.h"
+#    endif
 
 #    ifdef OS_DETECTION_DEBUG_ENABLE
 #        include "eeconfig.h"
@@ -91,11 +93,7 @@ void os_detection_task(void) {
     // resetting the keyboard on the USB device state change callback results in instability, so delegate that to this task
     // only take action if it's been stable at least once, to avoid issues with some KVMs
     else if (current_usb_device_state == USB_DEVICE_STATE_INIT && reported_usb_device_state == USB_DEVICE_STATE_CONFIGURED) {
-#        ifdef OS_DETECTION_KEYBOARD_RESET_BOOTLOADER
-        reset_keyboard();
-#        else
         soft_reset_keyboard();
-#        endif
     }
 #    endif
 }

--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -16,20 +16,22 @@
 
 #include "os_detection.h"
 
-#include <string.h>
-
-#ifdef OS_DETECTION_DEBUG_ENABLE
-#    include "eeconfig.h"
-#    include "eeprom.h"
-#    include "print.h"
-
-#    define STORED_USB_SETUPS 50
-#    define EEPROM_USER_OFFSET (uint8_t*)EECONFIG_SIZE
-
-uint16_t usb_setups[STORED_USB_SETUPS];
-#endif
-
 #ifdef OS_DETECTION_ENABLE
+
+#    include <string.h>
+#    include "timer.h"
+
+#    ifdef OS_DETECTION_DEBUG_ENABLE
+#        include "eeconfig.h"
+#        include "eeprom.h"
+#        include "print.h"
+
+#        define STORED_USB_SETUPS 50
+#        define EEPROM_USER_OFFSET (uint8_t*)EECONFIG_SIZE
+
+static uint16_t usb_setups[STORED_USB_SETUPS];
+#    endif
+
 struct setups_data_t {
     uint8_t  count;
     uint8_t  cnt_02;
@@ -45,41 +47,81 @@ struct setups_data_t setups_data = {
     .cnt_ff = 0,
 };
 
-os_variant_t detected_os = OS_UNSURE;
+#    ifndef OS_DETECTION_DEBOUNCE
+#        define OS_DETECTION_DEBOUNCE 100
+#    endif
+
+// 5s should always be more than enough
+#    if OS_DETECTION_DEBOUNCE > 5000
+#        undef OS_DETECTION_DEBOUNCE
+#        define OS_DETECTION_DEBOUNCE 5000
+#    endif
+
+#    define OS_DETECTION_DEBOUNCE_ELAPSED 0
+
+typedef uint16_t debounce_counter_t;
+
+static volatile os_variant_t detected_os = OS_UNSURE;
+static os_variant_t          reported_os = OS_UNSURE;
+
+// we need to be able to report OS_UNSURE if that is the stable result of the guesses
+static bool first_report = true;
+
+// the OS detection might be unstable for a while, "debounce" it
+static volatile debounce_counter_t debounce_counter = OS_DETECTION_DEBOUNCE_ELAPSED;
+static volatile fast_timer_t       last_time;
+
+void os_detection_task(void) {
+    if (debounce_counter != OS_DETECTION_DEBOUNCE_ELAPSED) {
+        if (debounce_counter <= timer_elapsed_fast(last_time)) {
+            debounce_counter = OS_DETECTION_DEBOUNCE_ELAPSED;
+            if (detected_os != reported_os || first_report) {
+                process_detected_host_os(detected_os);
+            }
+        }
+    }
+}
+
+void process_detected_host_os(os_variant_t os) {
+    first_report = false;
+    reported_os  = os;
+    process_detected_host_os_kb(os);
+}
+
+__attribute__((weak)) bool process_detected_host_os_kb(os_variant_t os) {
+    return process_detected_host_os_user(os);
+}
+
+__attribute__((weak)) bool process_detected_host_os_user(os_variant_t os) {
+    return true;
+}
 
 // Some collected sequences of wLength can be found in tests.
 void make_guess(void) {
-    if (setups_data.count < 3) {
-        return;
+    os_variant_t guessed = OS_UNSURE;
+    if (setups_data.count >= 3) {
+        if (setups_data.cnt_ff >= 2 && setups_data.cnt_04 >= 1) {
+            guessed = OS_WINDOWS;
+        } else if (setups_data.count == setups_data.cnt_ff) {
+            // Linux has 3 packets with 0xFF.
+            guessed = OS_LINUX;
+        } else if (setups_data.count == 5 && setups_data.last_wlength == 0xFF && setups_data.cnt_ff == 1 && setups_data.cnt_02 == 2) {
+            guessed = OS_MACOS;
+        } else if (setups_data.count == 4 && setups_data.cnt_ff == 0 && setups_data.cnt_02 == 2) {
+            // iOS and iPadOS don't have the last 0xFF packet.
+            guessed = OS_IOS;
+        } else if (setups_data.cnt_ff == 0 && setups_data.cnt_02 == 3 && setups_data.cnt_04 == 1) {
+            // This is actually PS5.
+            guessed = OS_LINUX;
+        } else if (setups_data.cnt_ff >= 1 && setups_data.cnt_02 == 0 && setups_data.cnt_04 == 0) {
+            // This is actually Quest 2 or Nintendo Switch.
+            guessed = OS_LINUX;
+        }
     }
-    if (setups_data.cnt_ff >= 2 && setups_data.cnt_04 >= 1) {
-        detected_os = OS_WINDOWS;
-        return;
-    }
-    if (setups_data.count == setups_data.cnt_ff) {
-        // Linux has 3 packets with 0xFF.
-        detected_os = OS_LINUX;
-        return;
-    }
-    if (setups_data.count == 5 && setups_data.last_wlength == 0xFF && setups_data.cnt_ff == 1 && setups_data.cnt_02 == 2) {
-        detected_os = OS_MACOS;
-        return;
-    }
-    if (setups_data.count == 4 && setups_data.cnt_ff == 0 && setups_data.cnt_02 == 2) {
-        // iOS and iPadOS don't have the last 0xFF packet.
-        detected_os = OS_IOS;
-        return;
-    }
-    if (setups_data.cnt_ff == 0 && setups_data.cnt_02 == 3 && setups_data.cnt_04 == 1) {
-        // This is actually PS5.
-        detected_os = OS_LINUX;
-        return;
-    }
-    if (setups_data.cnt_ff >= 1 && setups_data.cnt_02 == 0 && setups_data.cnt_04 == 0) {
-        // This is actually Quest 2 or Nintendo Switch.
-        detected_os = OS_LINUX;
-        return;
-    }
+    // whatever the result, debounce
+    debounce_counter = OS_DETECTION_DEBOUNCE;
+    detected_os      = guessed;
+    last_time        = timer_read_fast();
 }
 
 void process_wlength(const uint16_t w_length) {
@@ -104,25 +146,27 @@ os_variant_t detected_host_os(void) {
 
 void erase_wlength_data(void) {
     memset(&setups_data, 0, sizeof(setups_data));
-    detected_os = OS_UNSURE;
+    detected_os      = OS_UNSURE;
+    reported_os      = OS_UNSURE;
+    debounce_counter = OS_DETECTION_DEBOUNCE_ELAPSED;
+    first_report     = true;
 }
 
 #    if defined(SPLIT_KEYBOARD) && defined(SPLIT_DETECTED_OS_ENABLE)
 void slave_update_detected_host_os(os_variant_t os) {
     detected_os = os;
 }
-#    endif // defined(SPLIT_KEYBOARD) && defined(SPLIT_DETECTED_OS_ENABLE)
-#endif     // OS_DETECTION_ENABLE
+#    endif
 
-#ifdef OS_DETECTION_DEBUG_ENABLE
+#    ifdef OS_DETECTION_DEBUG_ENABLE
 void print_stored_setups(void) {
-#    ifdef CONSOLE_ENABLE
+#        ifdef CONSOLE_ENABLE
     uint8_t cnt = eeprom_read_byte(EEPROM_USER_OFFSET);
     for (uint16_t i = 0; i < cnt; ++i) {
         uint16_t* addr = (uint16_t*)EEPROM_USER_OFFSET + i * sizeof(uint16_t) + sizeof(uint8_t);
         xprintf("i: %d, wLength: 0x%02X\n", i, eeprom_read_word(addr));
     }
-#    endif
+#        endif
 }
 
 void store_setups_in_eeprom(void) {
@@ -133,4 +177,6 @@ void store_setups_in_eeprom(void) {
     }
 }
 
-#endif // OS_DETECTION_DEBUG_ENABLE
+#    endif // OS_DETECTION_DEBUG_ENABLE
+
+#endif

--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -58,14 +58,6 @@ struct setups_data_t setups_data = {
 #        define OS_DETECTION_DEBOUNCE 2000
 #    endif
 
-#    ifndef OS_DETECTION_KEYBOARD_RESET
-#        define OS_DETECTION_KEYBOARD_RESET true
-#    endif
-
-#    ifndef OS_DETECTION_KEYBOARD_RESET_BOOTLOADER
-#        define OS_DETECTION_KEYBOARD_RESET_BOOTLOADER false
-#    endif
-
 typedef uint16_t debouncing_t;
 
 static volatile os_variant_t detected_os = OS_UNSURE;
@@ -95,11 +87,11 @@ void os_detection_task(void) {
             }
         }
     }
-#    if OS_DETECTION_KEYBOARD_RESET
-    // resetting the keyboard on the USB device state change callback results in instability
-    // only take action if it's been stable at least once
+#    ifdef OS_DETECTION_KEYBOARD_RESET
+    // resetting the keyboard on the USB device state change callback results in instability, so delegate that to this task
+    // only take action if it's been stable at least once, to avoid issues with some KVMs
     else if (current_usb_device_state == USB_DEVICE_STATE_INIT && reported_usb_device_state == USB_DEVICE_STATE_CONFIGURED) {
-#        if OS_DETECTION_KEYBOARD_RESET_BOOTLOADER
+#        ifdef OS_DETECTION_KEYBOARD_RESET_BOOTLOADER
         reset_keyboard();
 #        else
         soft_reset_keyboard();

--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -54,7 +54,7 @@ struct setups_data_t setups_data = {
 #        define OS_DETECTION_DEBOUNCE 200
 #    endif
 
-// 2s should always be more than enough
+// 2s should always be more than enough (otherwise, you may have other issues)
 #    if OS_DETECTION_DEBOUNCE > 2000
 #        undef OS_DETECTION_DEBOUNCE
 #        define OS_DETECTION_DEBOUNCE 2000
@@ -98,11 +98,11 @@ void os_detection_task(void) {
 #    endif
 }
 
-__attribute__((weak)) bool process_detected_host_os_kb(os_variant_t os) {
-    return process_detected_host_os_user(os);
+__attribute__((weak)) bool process_detected_host_os_kb(os_variant_t detected_os) {
+    return process_detected_host_os_user(detected_os);
 }
 
-__attribute__((weak)) bool process_detected_host_os_user(os_variant_t os) {
+__attribute__((weak)) bool process_detected_host_os_user(os_variant_t detected_os) {
     return true;
 }
 

--- a/quantum/os_detection.h
+++ b/quantum/os_detection.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #ifdef OS_DETECTION_ENABLE
+
+#    include <stdint.h>
+#    include <stdbool.h>
+
 typedef enum {
     OS_UNSURE,
     OS_LINUX,
@@ -31,12 +33,19 @@ void         process_wlength(const uint16_t w_length);
 os_variant_t detected_host_os(void);
 void         erase_wlength_data(void);
 
+void os_detection_task(void);
+
+void process_detected_host_os(os_variant_t os);
+bool process_detected_host_os_kb(os_variant_t os);
+bool process_detected_host_os_user(os_variant_t os);
+
 #    if defined(SPLIT_KEYBOARD) && defined(SPLIT_DETECTED_OS_ENABLE)
 void slave_update_detected_host_os(os_variant_t os);
-#    endif // defined(SPLIT_KEYBOARD) && defined(SPLIT_DETECTED_OS_ENABLE)
-#endif
+#    endif
 
-#ifdef OS_DETECTION_DEBUG_ENABLE
+#    ifdef OS_DETECTION_DEBUG_ENABLE
 void print_stored_setups(void);
 void store_setups_in_eeprom(void);
-#endif
+#    endif
+
+#endif // OS_DETECTION_ENABLE

--- a/quantum/os_detection.h
+++ b/quantum/os_detection.h
@@ -20,6 +20,7 @@
 
 #    include <stdint.h>
 #    include <stdbool.h>
+#    include "usb_device_state.h"
 
 typedef enum {
     OS_UNSURE,
@@ -32,10 +33,10 @@ typedef enum {
 void         process_wlength(const uint16_t w_length);
 os_variant_t detected_host_os(void);
 void         erase_wlength_data(void);
+void         os_detection_notify_usb_device_state_change(enum usb_device_state usb_device_state);
 
 void os_detection_task(void);
 
-void process_detected_host_os(os_variant_t os);
 bool process_detected_host_os_kb(os_variant_t os);
 bool process_detected_host_os_user(os_variant_t os);
 

--- a/quantum/os_detection/tests/os_detection.cpp
+++ b/quantum/os_detection/tests/os_detection.cpp
@@ -233,8 +233,20 @@ TEST_F(OsDetectionTest, TestVusbQuest2) {
     assert_not_reported();
 }
 
+TEST_F(OsDetectionTest, TestDoNotReportIfUsbUnstable) {
+    EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF, 0xFE}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
+
+    advance_time(OS_DETECTION_DEBOUNCE);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+}
+
 TEST_F(OsDetectionTest, TestReportAfterDebounce) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF, 0xFE}), OS_LINUX);
+    os_detection_notify_usb_device_state_change(USB_DEVICE_STATE_CONFIGURED);
     os_detection_task();
     assert_not_reported();
 
@@ -270,6 +282,7 @@ TEST_F(OsDetectionTest, TestReportAfterDebounce) {
 
 TEST_F(OsDetectionTest, TestReportAfterDebounceLongWait) {
     EXPECT_EQ(check_sequence({0x12, 0xFF, 0xFF, 0x4, 0x10, 0xFF, 0xFF, 0xFF, 0x4, 0x10, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A}), OS_WINDOWS);
+    os_detection_notify_usb_device_state_change(USB_DEVICE_STATE_CONFIGURED);
     os_detection_task();
     assert_not_reported();
 
@@ -296,6 +309,7 @@ TEST_F(OsDetectionTest, TestReportAfterDebounceLongWait) {
 
 TEST_F(OsDetectionTest, TestReportUnsure) {
     EXPECT_EQ(check_sequence({0x12, 0xFF}), OS_UNSURE);
+    os_detection_notify_usb_device_state_change(USB_DEVICE_STATE_CONFIGURED);
     os_detection_task();
     assert_not_reported();
 
@@ -322,6 +336,7 @@ TEST_F(OsDetectionTest, TestReportUnsure) {
 
 TEST_F(OsDetectionTest, TestDoNotReportIntermediateResults) {
     EXPECT_EQ(check_sequence({0x12, 0xFF}), OS_UNSURE);
+    os_detection_notify_usb_device_state_change(USB_DEVICE_STATE_CONFIGURED);
     os_detection_task();
     assert_not_reported();
 
@@ -332,6 +347,7 @@ TEST_F(OsDetectionTest, TestDoNotReportIntermediateResults) {
 
     // at this stage, the final result has not been reached yet
     EXPECT_EQ(check_sequence({0xFF}), OS_LINUX);
+    os_detection_notify_usb_device_state_change(USB_DEVICE_STATE_CONFIGURED);
     advance_time(OS_DETECTION_DEBOUNCE - 1);
     os_detection_task();
     assert_not_reported();
@@ -340,6 +356,7 @@ TEST_F(OsDetectionTest, TestDoNotReportIntermediateResults) {
 
     // the remainder is processed
     EXPECT_EQ(check_sequence({0x4, 0x10, 0xFF, 0xFF, 0xFF, 0x4, 0x10, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A}), OS_WINDOWS);
+    os_detection_notify_usb_device_state_change(USB_DEVICE_STATE_CONFIGURED);
     advance_time(OS_DETECTION_DEBOUNCE - 1);
     os_detection_task();
     assert_not_reported();

--- a/quantum/os_detection/tests/os_detection.cpp
+++ b/quantum/os_detection/tests/os_detection.cpp
@@ -18,12 +18,20 @@
 
 extern "C" {
 #include "os_detection.h"
+#include "timer.h"
+
+void advance_time(uint32_t ms);
 }
+
+static uint32_t     reported_count;
+static os_variant_t reported_os;
 
 class OsDetectionTest : public ::testing::Test {
    protected:
     void SetUp() override {
         erase_wlength_data();
+        reported_count = 0;
+        reported_os    = OS_UNSURE;
     }
 };
 
@@ -32,6 +40,24 @@ os_variant_t check_sequence(const std::vector<uint16_t> &w_lengths) {
         process_wlength(w_length);
     }
     return detected_host_os();
+}
+
+bool process_detected_host_os_kb(os_variant_t os) {
+    reported_count = reported_count + 1;
+    reported_os    = os;
+}
+
+void assert_not_reported(void) {
+    // check that it does not report the result, nor any intermediate results
+    EXPECT_EQ(reported_count, 0);
+    EXPECT_EQ(reported_os, OS_UNSURE);
+}
+
+void assert_reported(os_variant_t os) {
+    // check that it reports exclusively the result, not any intermediate results
+    EXPECT_EQ(reported_count, 1);
+    EXPECT_EQ(reported_os, os);
+    EXPECT_EQ(reported_os, detected_host_os());
 }
 
 /* Some collected data.
@@ -77,88 +103,260 @@ Quest 2: [FF, FF, FF, FE, ...]
 */
 TEST_F(OsDetectionTest, TestLinux) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestChibiosMacos) {
     EXPECT_EQ(check_sequence({0x2, 0x24, 0x2, 0x28, 0xFF}), OS_MACOS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestLufaMacos) {
     EXPECT_EQ(check_sequence({0x2, 0x10, 0x2, 0xE, 0xFF}), OS_MACOS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestVusbMacos) {
     EXPECT_EQ(check_sequence({0x2, 0xE, 0x2, 0xE, 0xFF}), OS_MACOS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestChibiosIos) {
     EXPECT_EQ(check_sequence({0x2, 0x24, 0x2, 0x28}), OS_IOS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestLufaIos) {
     EXPECT_EQ(check_sequence({0x2, 0x10, 0x2, 0xE}), OS_IOS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestVusbIos) {
     EXPECT_EQ(check_sequence({0x2, 0xE, 0x2, 0xE}), OS_IOS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestChibiosWindows10) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0x4, 0x24, 0x4, 0x24, 0x4, 0xFF, 0x24, 0xFF, 0x4, 0xFF, 0x24, 0x4, 0x24, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestChibiosWindows10_2) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0x4, 0x24, 0x4, 0x24, 0x4, 0x24, 0x4, 0x24, 0x4, 0x24}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestLufaWindows10) {
     EXPECT_EQ(check_sequence({0x12, 0xFF, 0xFF, 0x4, 0x10, 0xFF, 0xFF, 0xFF, 0x4, 0x10, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestLufaWindows10_2) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0x4, 0x10, 0xFF, 0x4, 0xFF, 0x10, 0xFF, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestLufaWindows10_3) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0x4, 0x10, 0x4, 0x10}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestVusbWindows10) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0x4, 0xE, 0xFF}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestVusbWindows10_2) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0x4, 0xE, 0x4}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestChibiosPs5) {
     EXPECT_EQ(check_sequence({0x2, 0x4, 0x2, 0x28, 0x2, 0x24}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestLufaPs5) {
     EXPECT_EQ(check_sequence({0x2, 0x4, 0x2, 0xE, 0x2, 0x10}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestVusbPs5) {
     EXPECT_EQ(check_sequence({0x2, 0x4, 0x2, 0xE, 0x2}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestChibiosNintendoSwitch) {
     EXPECT_EQ(check_sequence({0x82, 0xFF, 0x40, 0x40, 0xFF, 0x40, 0x40, 0xFF, 0x40, 0x40, 0xFF, 0x40, 0x40, 0xFF, 0x40, 0x40}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestLufaNintendoSwitch) {
     EXPECT_EQ(check_sequence({0x82, 0xFF, 0x40, 0x40, 0xFF, 0x40, 0x40}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestVusbNintendoSwitch) {
     EXPECT_EQ(check_sequence({0x82, 0xFF, 0x40, 0x40}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestChibiosQuest2) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }
 
 TEST_F(OsDetectionTest, TestVusbQuest2) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF, 0xFE}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
+}
+
+TEST_F(OsDetectionTest, TestReportAfterDebounce) {
+    EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF, 0xFE}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
+
+    advance_time(1);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+
+    advance_time(OS_DETECTION_DEBOUNCE - 3);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+
+    advance_time(1);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+
+    // advancing the timer alone must not cause a report
+    advance_time(1);
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+    // the task will cause a report
+    os_detection_task();
+    assert_reported(OS_LINUX);
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+
+    // check that it remains the same after a long time
+    advance_time(OS_DETECTION_DEBOUNCE * 15);
+    assert_reported(OS_LINUX);
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+}
+
+TEST_F(OsDetectionTest, TestReportAfterDebounceLongWait) {
+    EXPECT_EQ(check_sequence({0x12, 0xFF, 0xFF, 0x4, 0x10, 0xFF, 0xFF, 0xFF, 0x4, 0x10, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A}), OS_WINDOWS);
+    os_detection_task();
+    assert_not_reported();
+
+    advance_time(1);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+
+    // advancing the timer alone must not cause a report
+    advance_time(OS_DETECTION_DEBOUNCE * 15);
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+    // the task will cause a report
+    os_detection_task();
+    assert_reported(OS_WINDOWS);
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+
+    // check that it remains the same after a long time
+    advance_time(OS_DETECTION_DEBOUNCE * 10);
+    os_detection_task();
+    assert_reported(OS_WINDOWS);
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+}
+
+TEST_F(OsDetectionTest, TestReportUnsure) {
+    EXPECT_EQ(check_sequence({0x12, 0xFF}), OS_UNSURE);
+    os_detection_task();
+    assert_not_reported();
+
+    advance_time(1);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_UNSURE);
+
+    // advancing the timer alone must not cause a report
+    advance_time(OS_DETECTION_DEBOUNCE - 1);
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_UNSURE);
+    // the task will cause a report
+    os_detection_task();
+    assert_reported(OS_UNSURE);
+    EXPECT_EQ(detected_host_os(), OS_UNSURE);
+
+    // check that it remains the same after a long time
+    advance_time(OS_DETECTION_DEBOUNCE * 10);
+    os_detection_task();
+    assert_reported(OS_UNSURE);
+    EXPECT_EQ(detected_host_os(), OS_UNSURE);
+}
+
+TEST_F(OsDetectionTest, TestDoNotReportIntermediateResults) {
+    EXPECT_EQ(check_sequence({0x12, 0xFF}), OS_UNSURE);
+    os_detection_task();
+    assert_not_reported();
+
+    advance_time(OS_DETECTION_DEBOUNCE - 1);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_UNSURE);
+
+    // at this stage, the final result has not been reached yet
+    EXPECT_EQ(check_sequence({0xFF}), OS_LINUX);
+    advance_time(OS_DETECTION_DEBOUNCE - 1);
+    os_detection_task();
+    assert_not_reported();
+    // the intermedite but yet unstable result is exposed through detected_host_os()
+    EXPECT_EQ(detected_host_os(), OS_LINUX);
+
+    // the remainder is processed
+    EXPECT_EQ(check_sequence({0x4, 0x10, 0xFF, 0xFF, 0xFF, 0x4, 0x10, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A, 0x20A}), OS_WINDOWS);
+    advance_time(OS_DETECTION_DEBOUNCE - 1);
+    os_detection_task();
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+
+    // advancing the timer alone must not cause a report
+    advance_time(1);
+    assert_not_reported();
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+    // the task will cause a report
+    os_detection_task();
+    assert_reported(OS_WINDOWS);
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+
+    // check that it remains the same after a long time
+    advance_time(OS_DETECTION_DEBOUNCE * 10);
+    os_detection_task();
+    assert_reported(OS_WINDOWS);
+    EXPECT_EQ(detected_host_os(), OS_WINDOWS);
 }

--- a/quantum/os_detection/tests/os_detection.cpp
+++ b/quantum/os_detection/tests/os_detection.cpp
@@ -233,6 +233,13 @@ TEST_F(OsDetectionTest, TestVusbQuest2) {
     assert_not_reported();
 }
 
+// Regression reported in https://github.com/qmk/qmk_firmware/pull/21777#issuecomment-1922815841
+TEST_F(OsDetectionTest, TestDetectMacM1AsIOS) {
+    EXPECT_EQ(check_sequence({0x02, 0x32, 0x02, 0x24, 0x101, 0xFF}), OS_IOS);
+    os_detection_task();
+    assert_not_reported();
+}
+
 TEST_F(OsDetectionTest, TestDoNotReportIfUsbUnstable) {
     EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF, 0xFE}), OS_LINUX);
     os_detection_task();
@@ -376,4 +383,11 @@ TEST_F(OsDetectionTest, TestDoNotReportIntermediateResults) {
     os_detection_task();
     assert_reported(OS_WINDOWS);
     EXPECT_EQ(detected_host_os(), OS_WINDOWS);
+}
+
+TEST_F(OsDetectionTest, TestDoNotGoBackToUnsure) {
+    // 0x02 would cause it to go back to Unsure, so check that it does not
+    EXPECT_EQ(check_sequence({0xFF, 0xFF, 0xFF, 0xFE, 0x02}), OS_LINUX);
+    os_detection_task();
+    assert_not_reported();
 }

--- a/quantum/os_detection/tests/rules.mk
+++ b/quantum/os_detection/tests/rules.mk
@@ -1,5 +1,7 @@
 os_detection_DEFS := -DOS_DETECTION_ENABLE
+os_detection_DEFS += -DOS_DETECTION_DEBOUNCE=50
 
 os_detection_SRC := \
     $(QUANTUM_PATH)/os_detection/tests/os_detection.cpp \
-    $(QUANTUM_PATH)/os_detection.c
+    $(QUANTUM_PATH)/os_detection.c \
+    $(PLATFORM_PATH)/$(PLATFORM_KEY)/timer.c

--- a/quantum/os_detection/tests/rules.mk
+++ b/quantum/os_detection/tests/rules.mk
@@ -1,6 +1,5 @@
 os_detection_DEFS := -DOS_DETECTION_ENABLE
 os_detection_DEFS += -DOS_DETECTION_DEBOUNCE=50
-os_detection_DEFS += -DOS_DETECTION_KEYBOARD_RESET=false
 
 os_detection_SRC := \
     $(QUANTUM_PATH)/os_detection/tests/os_detection.cpp \

--- a/quantum/os_detection/tests/rules.mk
+++ b/quantum/os_detection/tests/rules.mk
@@ -1,5 +1,6 @@
 os_detection_DEFS := -DOS_DETECTION_ENABLE
 os_detection_DEFS += -DOS_DETECTION_DEBOUNCE=50
+os_detection_DEFS += -DOS_DETECTION_KEYBOARD_RESET=false
 
 os_detection_SRC := \
     $(QUANTUM_PATH)/os_detection/tests/os_detection.cpp \

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -236,6 +236,10 @@ extern layer_state_t layer_state;
 #    include "process_repeat_key.h"
 #endif
 
+#ifdef OS_DETECTION_ENABLE
+#    include "os_detection.h"
+#endif
+
 void set_single_persistent_default_layer(uint8_t default_layer);
 
 #define IS_LAYER_ON(layer) layer_state_is(layer)

--- a/tmk_core/protocol/usb_device_state.c
+++ b/tmk_core/protocol/usb_device_state.c
@@ -20,6 +20,10 @@
 #    include "haptic.h"
 #endif
 
+#ifdef OS_DETECTION_ENABLE
+#    include "os_detection.h"
+#endif
+
 enum usb_device_state usb_device_state = USB_DEVICE_STATE_NO_INIT;
 
 __attribute__((weak)) void notify_usb_device_state_change_kb(enum usb_device_state usb_device_state) {
@@ -32,7 +36,12 @@ static void notify_usb_device_state_change(enum usb_device_state usb_device_stat
 #if defined(HAPTIC_ENABLE) && HAPTIC_OFF_IN_LOW_POWER
     haptic_notify_usb_device_state_change();
 #endif
+
     notify_usb_device_state_change_kb(usb_device_state);
+
+#ifdef OS_DETECTION_ENABLE
+    os_detection_notify_usb_device_state_change(usb_device_state);
+#endif
 }
 
 void usb_device_state_set_configuration(bool isConfigured, uint8_t configurationNumber) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This adds callbacks for OS detection, similar to other mechanisms we already have to allow the KB/user to run custom code on an event.

The main use is withholding taking action until the OS detection has run, so the user does not have to craft some sort of periodic checks for the current OS, etc. As an example (and my usage), to set the current default layer depending on whether the detected OS is Windows, macOS, etc. 

This also eliminates any questions on whether OS_UNSURE means the detection ran *and* it resulted in that, or if it just happened to be the default value.

Since the detection runs when the USB device descriptor is being assembled, I added the option to also automatically reboot the keyboard when the USB link goes back to a non-configured state, due to e.g. KVM switching when the KVM does not cut power to the USB devices. This will trigger the initialization again and thus allows the detection to run again for the new host device. This is disabled by default and can be enabled by defining `OS_DETECTION_KEYBOARD_RESET`.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
