### PR TITLE
fix: restore rgb matrix indicators to jellybean_raindrops animation

### DIFF
--- a/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
@@ -10,17 +10,16 @@ static void jellybean_raindrops_set_color(int i, effect_params_t* params) {
 }
 
 bool JELLYBEAN_RAINDROPS(effect_params_t* params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
     if (!params->init) {
         // Change one LED every tick, make sure speed is not 0
         if (scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 16)) % 5 == 0) {
             jellybean_raindrops_set_color(random8_max(RGB_MATRIX_LED_COUNT), params);
         }
-        return false;
-    }
-
-    RGB_MATRIX_USE_LIMITS(led_min, led_max);
-    for (int i = led_min; i < led_max; i++) {
-        jellybean_raindrops_set_color(i, params);
+    } else {
+        for (int i = led_min; i < led_max; i++) {
+            jellybean_raindrops_set_color(i, params);
+        }
     }
     return rgb_matrix_check_finished_leds(led_max);
 }


### PR DESCRIPTION
## Description

After #21169, `rgb_matrix_indicators()` was limited to running on the final render iteration. Since the `jellybean_raindrops` animation immediately returns false after updating a single LED, `rgb_effect_params.iter` is never incremented enough for `rgb_matrix_indicators()` to run.

This change also brings `jellybean_raindrops` more in line with `raindrops`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
