### PR TITLE
Added breathing pulse for ChibiOS pwm

### DIFF
--- a/platforms/chibios/drivers/backlight_pwm.c
+++ b/platforms/chibios/drivers/backlight_pwm.c
@@ -55,6 +55,9 @@ static PWMConfig pwmCFG = {
 
 #ifdef BACKLIGHT_BREATHING
 static virtual_timer_t breathing_vt;
+static virtual_timer_t pulse_vt;
+static uint16_t        breathing_counter    = 0;
+static bool            breathing_pulse_flag = false;
 #endif
 
 // See http://jared.geek.nz/2013/feb/linear-led-pwm
@@ -93,6 +96,7 @@ void backlight_init_ports(void) {
 
 #ifdef BACKLIGHT_BREATHING
     chVTObjectInit(&breathing_vt);
+    chVTObjectInit(&pulse_vt);
     if (is_backlight_breathing()) {
         breathing_enable();
     }
@@ -132,11 +136,15 @@ bool is_breathing(void) {
 }
 
 void breathing_enable(void) {
+    breathing_pulse_flag = false;
+    chVTReset(&pulse_vt);
     /* Update frequency is 256Hz -> 3906us intervals */
     chVTSetContinuous(&breathing_vt, TIME_US2I(3906), breathing_callback, NULL);
 }
 
 void breathing_disable(void) {
+    breathing_pulse_flag = false;
+    chVTReset(&pulse_vt);
     chVTReset(&breathing_vt);
 
     // Restore backlight level
@@ -153,10 +161,18 @@ static void breathing_callback(virtual_timer_t *vtp, void *p) {
     uint16_t interval         = (uint16_t)breathing_period * 256 / BREATHING_STEPS;
 
     // resetting after one period to prevent ugly reset at overflow.
-    static uint16_t breathing_counter = 0;
-    breathing_counter                 = (breathing_counter + 1) % (breathing_period * 256);
-    uint8_t  index                    = breathing_counter / interval % BREATHING_STEPS;
-    uint32_t duty                     = cie_lightness(rescale_limit_val(scale_backlight(breathing_table[index] * 256)));
+    breathing_counter = (breathing_counter + 1) % (breathing_period * 256);
+    uint8_t  index    = breathing_counter / interval % BREATHING_STEPS;
+    uint32_t duty     = cie_lightness(rescale_limit_val(scale_backlight(breathing_table[index] * 256)));
+    if (breathing_pulse_flag) {
+        chSysLockFromISR();
+        if (index == BREATHING_STEPS - 1) {
+            breathing_pulse_flag = false;
+        } else {
+            chVTSetI(&pulse_vt, TIME_US2I(3906), breathing_callback, NULL);
+        }
+        chSysUnlockFromISR();
+    }
 
     chSysLockFromISR();
     pwmEnableChannelI(&BACKLIGHT_PWM_DRIVER, BACKLIGHT_PWM_CHANNEL - 1, PWM_FRACTION_TO_WIDTH(&BACKLIGHT_PWM_DRIVER, 0xFFFF, duty));
@@ -165,9 +181,13 @@ static void breathing_callback(virtual_timer_t *vtp, void *p) {
 
 // TODO: integrate generic pulse solution
 void breathing_pulse(void) {
-    backlight_set(is_backlight_enabled() ? 0 : BACKLIGHT_LEVELS);
-    wait_ms(10);
-    backlight_set(is_backlight_enabled() ? get_backlight_level() : 0);
+    if (get_backlight_level() == 0) {
+        breathing_counter = 0;
+    } else {
+        breathing_counter = get_breathing_period() * 256 / 2;
+    }
+    breathing_pulse_flag = true;
+    chVTSet(&pulse_vt, TIME_US2I(3906), breathing_callback, NULL);
 }
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Added an implementation of the breathing pulse method that will light up the backlight to the current backlight level and then gradually fade out the LED. 
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Replaced simple on/off pulse function with one that makes use of a virtual timer and the existing breathing_callback. If the pulse flag is set, the callback will continuously set the virtual timer to keep calling the breathing_callback function until the breathing cycle is complete. 

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* resolves qmk/qmk_firmware#21790

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I have tested that the other backlight states (solid, off, breathing) are still functional with this change. This is my first time programming for the QMK platform, so any suggestions are welcome.  