### PR TITLE
Generalize AVR -Werror=array-bounds workaround

### DIFF
--- a/platforms/avr/platform.mk
+++ b/platforms/avr/platform.mk
@@ -12,8 +12,7 @@ HEX = $(OBJCOPY) -O $(FORMAT) -R .eeprom -R .fuse -R .lock -R .signature
 EEP = $(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" --change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT)
 BIN =
 
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-ifneq ($(findstring 12.,$(shell avr-gcc --version 2>/dev/null)),)
+ifeq ("$(shell echo "int main(){}" | $(CC) --param=min-pagesize=0 -x c - -o /dev/null 2>&1)", "")
 COMPILEFLAGS += --param=min-pagesize=0
 endif
 


### PR DESCRIPTION
GCC 13 needs the same workaround as GCC 12.
To avoid having to maintain an ever-growing list of broken versions apply the workaround wherever it can be used.

If at some point a fixed version of GCC is released the workaround can be disabled for those fixed versions.

See #17064

<!--- Provide a general summary of your changes in the title above. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
