### PR TITLE
Fix drop/shift/v2 compilation

### DIFF
--- a/keyboards/drop/shift/v2/v2.c
+++ b/keyboards/drop/shift/v2/v2.c
@@ -1,6 +1,7 @@
 // Copyright 2023 Massdrop, Inc.
 // SPDX-License-Identifier: GPL-2.0-or-later
 #ifdef RGB_MATRIX_ENABLE
+#    include "host.h"
 #    include "rgb_matrix.h"
 
 const is31_led PROGMEM g_is31_leds[RGB_MATRIX_LED_COUNT] = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Headers have changed on develop, which produces:
```
make clean drop/shift/v2:default
QMK Firmware 0.21.6
Deleting .build/ ... done.
Making drop/shift/v2 with keymap default

Generating: .build/obj_drop_shift_v2_default/src/info_deps.d                                        [OK]
arm-none-eabi-gcc (Arch Repository) 13.1.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Generating: .build/obj_drop_shift_v2_default/src/info_config.h                                     Generating: .build/obj_drop_shift_v2_default/src/default_keyboard.c                                Generating: .build/obj_drop_shift_v2_default/src/default_keyboard.h                                 [OK]
 [OK]
 [OK]
Compiling: platforms/chibios/drivers/analog.c                                                      Compiling: keyboards/drop/lib/common.c                                                             Compiling: keyboards/drop/lib/mux.c                                                                Compiling: keyboards/drop/shift/v2/v2.c                                                            Compiling: quantum/keymap_introspection.c                                                          Compiling: .build/obj_drop_shift_v2_default/src/default_keyboard.c                                 keyboards/drop/shift/v2/v2.c: In function 'rgb_matrix_indicators_kb':
keyboards/drop/shift/v2/v2.c:179:25: error: implicit declaration of function 'host_keyboard_led_state' [-Werror=implicit-function-declaration]
  179 |     uint8_t num_state = host_keyboard_led_state().num_lock ? 0xFF : 0;
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
keyboards/drop/shift/v2/v2.c:179:50: error: request for member 'num_lock' in something not a structure or union
  179 |     uint8_t num_state = host_keyboard_led_state().num_lock ? 0xFF : 0;
      |                                                  ^
keyboards/drop/shift/v2/v2.c:180:51: error: request for member 'caps_lock' in something not a structure or union
  180 |     uint8_t caps_state = host_keyboard_led_state().caps_lock ? 0xFF : 0;
      |                                                   ^
keyboards/drop/shift/v2/v2.c:181:53: error: request for member 'scroll_lock' in something not a structure or union
  181 |     uint8_t scroll_state = host_keyboard_led_state().scroll_lock ? 0xFF : 0;
      |                                                     ^
cc1: all warnings being treated as errors
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
