### PR TITLE
keychron/c2_pro/ansi/white: Fix column 19 in the custom matrix

### DIFF
--- a/keyboards/keychron/c2_pro/config.h
+++ b/keyboards/keychron/c2_pro/config.h
@@ -41,4 +41,4 @@
 #define HC595_SHCP A1
 #define HC595_DS C15
 #define SHIFT_COL_START 11
-#define SHIFT_COL_END 19
+#define SHIFT_COL_END 18

--- a/keyboards/keychron/c2_pro/matrix.c
+++ b/keyboards/keychron/c2_pro/matrix.c
@@ -24,10 +24,10 @@
 #endif
 
 #if defined(SHIFT_COL_START) && defined(SHIFT_COL_END)
-#    if ((SHIFT_COL_END - SHIFT_COL_START) > 16)
+#    if ((SHIFT_COL_END - SHIFT_COL_START + 1) > 16)
 #        define SIZE_T uint32_t
 #        define UNSELECT_ALL_COL 0xFFFFFFFF
-#    elif ((SHIFT_COL_END - SHIFT_COL_START) > 8)
+#    elif ((SHIFT_COL_END - SHIFT_COL_START + 1) > 8)
 #        define SIZE_T uint16_t
 #        define UNSELECT_ALL_COL 0xFFFF
 #    else


### PR DESCRIPTION
## Description

Although `keychron/c2_pro/ansi/rgb` and `keychron/c2_pro/ansi/white` use the same custom matrix code, the matrix layouts are slightly different; in particular, only the `keychron/c2_pro/ansi/white` board actually uses column 19.  However, the handling of column 19 in the custom matrix code was broken, therefore that column did not work.

Looks like the custom matrix code assumes that `SHIFT_COL_END` refers to the last column connected to the shift register, and not to the column past that; so the value of `SHIFT_COL_END` needs to be changed from 19 to 18 (columns 11...18 are connected to the shift register, and column 19 is connected to the C14 pin).

Also the code which was determining `SIZE_T` and `UNSELECT_ALL_COL` had an off-by-one bug when counting the required number of bits (again due to the confusion on the `SHIFT_COL_END` meaning); this had been fixed too (the actual behavior of that part of the code did not change, because both the old and the new version select the 8 bit variant).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Some keys (`KC_PDOT`, `KC_P3`, `KC_P6`, `KC_P9`, `KC_PAST`, `KC_PENT` in the default keymap — the whole column 19) on `keychron/c2_pro/ansi/white` did not work: https://discord.com/channels/440868230475677696/473506116718952450/1143395180242812958 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

@lalalademaxiya1 Could you test this change on both `keychron/c2_pro/ansi/rgb` and `keychron/c2_pro/ansi/white`?