### PR TITLE
state should be F0_BREAK, otherwise the state will stay in invalid state for ever

### DIFF
--- a/keyboards/converter/ibm_terminal/matrix.c
+++ b/keyboards/converter/ibm_terminal/matrix.c
@@ -131,7 +131,7 @@ uint8_t matrix_scan(void)
                 case 0x00:
                     break;
                 case 0xF0:
-                    state = F0;
+                    state = F0_BREAK;
                     debug(" ");
                     break;
                 default:    // normal key make


### PR DESCRIPTION
## Description
F0 is not a valid state. Set the state to F0 will cause the state staying in invalid state for ever. When a key pressed the key will repeat for ever.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
