### PR TITLE
[Feature] SPI support for STMH7xx

### DIFF
--- a/platforms/chibios/drivers/spi_master.c
+++ b/platforms/chibios/drivers/spi_master.c
@@ -1,4 +1,5 @@
 /* Copyright 2020 Nick Brassel (tzarc)
+ * Copyright 2023 Pablo Martinez (elpekenin)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,17 +15,15 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+// Info about DCache hacks for STM32H7 found at: <https://community.st.com/t5/stm32-mcus/dma-is-not-working-on-stm32h7-devices/ta-p/49498>
+
 #include "spi_master.h"
 
 #include "timer.h"
 
 static pin_t currentSlavePin = NO_PIN;
 
-#if defined(K20x) || defined(KL2x) || defined(RP2040)
-static SPIConfig spiConfig = {NULL, 0, 0, 0};
-#else
-static SPIConfig spiConfig = {false, NULL, 0, 0, 0, 0};
-#endif
+static SPIConfig spiConfig = {0};
 
 __attribute__((weak)) void spi_init(void) {
     static bool is_initialised = false;
@@ -199,6 +198,55 @@ bool spi_start(pin_t slavePin, bool lsbFirst, uint8_t mode, uint16_t divisor) {
             spiConfig.SSPCR0 |= SPI_SSPCR0_SPH; // Clock phase: sample on second edge transition
             break;
     }
+#elif defined(QMK_MCU_SERIES_STM32H7XX)
+    spiConfig.cfg1 = 0;
+    spiConfig.cfg2 = 0;
+
+    if (lsbFirst) {
+        spiConfig.cfg2 |= SPI_CFG2_LSBFRST;
+    }
+
+    switch (mode) {
+        case 0:
+            break;
+        case 1:
+            spiConfig.cfg2 |= SPI_CFG2_CPHA;
+            break;
+        case 2:
+            spiConfig.cfg2 |= SPI_CFG2_CPOL;
+            break;
+        case 3:
+            spiConfig.cfg2 |= SPI_CFG2_CPHA | SPI_CFG2_CPOL;
+            break;
+    }
+
+    switch (roundedDivisor) {
+        case 2:
+            break;
+        case 4:
+            spiConfig.cfg1 |= SPI_CFG1_MBR_0;
+            break;
+        case 8:
+            spiConfig.cfg1 |= SPI_CFG1_MBR_1;
+            break;
+        case 16:
+            spiConfig.cfg1 |= SPI_CFG1_MBR_1 | SPI_CFG1_MBR_0;
+            break;
+        case 32:
+            spiConfig.cfg1 |= SPI_CFG1_MBR_2;
+            break;
+        case 64:
+            spiConfig.cfg1 |= SPI_CFG1_MBR_2 | SPI_CFG1_MBR_0;
+            break;
+        case 128:
+            spiConfig.cfg1 |= SPI_CFG1_MBR_2 | SPI_CFG1_MBR_1;
+            break;
+        case 256:
+            spiConfig.cfg1 |= SPI_CFG1_MBR_2 | SPI_CFG1_MBR_1 | SPI_CFG1_MBR_0;
+            break;
+    }
+
+    spiConfig.cfg1 |= SPI_CFG1_DSIZE_2 | SPI_CFG1_DSIZE_1 | SPI_CFG1_DSIZE_0; // 8bit data frame
 #else
     spiConfig.cr1 = 0;
 
@@ -259,6 +307,10 @@ bool spi_start(pin_t slavePin, bool lsbFirst, uint8_t mode, uint16_t divisor) {
 }
 
 spi_status_t spi_write(uint8_t data) {
+#if defined(QMK_MCU_SERIES_STM32H7XX)
+    SCB_CleanDCache_by_Addr((uint32_t*)(((uint32_t)&data) & ~(uint32_t)0x1F), 1+32);
+#endif
+
     uint8_t rxData;
     spiExchange(&SPI_DRIVER, 1, &data, &rxData);
 
@@ -267,17 +319,30 @@ spi_status_t spi_write(uint8_t data) {
 
 spi_status_t spi_read(void) {
     uint8_t data = 0;
+
+#if defined(QMK_MCU_SERIES_STM32H7XX)
+    SCB_InvalidateDCache_by_Addr((uint32_t*)(((uint32_t)&data) & ~(uint32_t)0x1F), 1+32);
+#endif
+
     spiReceive(&SPI_DRIVER, 1, &data);
 
     return data;
 }
 
 spi_status_t spi_transmit(const uint8_t *data, uint16_t length) {
+#if defined(QMK_MCU_SERIES_STM32H7XX)
+    SCB_CleanDCache_by_Addr((uint32_t*)(((uint32_t)data) & ~(uint32_t)0x1F), length+32);
+#endif
+
     spiSend(&SPI_DRIVER, length, data);
     return SPI_STATUS_SUCCESS;
 }
 
 spi_status_t spi_receive(uint8_t *data, uint16_t length) {
+#if defined(QMK_MCU_SERIES_STM32H7XX)
+    SCB_InvalidateDCache_by_Addr((uint32_t*)(((uint32_t)data) & ~(uint32_t)0x1F), length+32);
+#endif
+
     spiReceive(&SPI_DRIVER, length, data);
     return SPI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Description

Tested on H750VBT6 drawing on a ST7735.

Needed a customized `ld` so that stack is not `ram5` but `ram0` (some data being transmited is not statically allocated). Otherwise the code halted with a [DMA failure](https://discord.com/channels/440868230475677696/1144541762489176094/1144632083839451197) because that part of RAM is not accessible fromthe DMA controller.
Said link script(2-chars changed from default ChibiOS one) will be part of the H750 PR when (if) i make it.

Friendly ping to @tzarc to get this tested on other H7 chip(s), beware the potentially required `ld` changes.

Thank you very much @sigprof for the help over Discord :)

PS: Also changed the initialization of `spiConfig` since all fields are 0 anyway, and avoids the `#if` for different amount of fields across MCUs.

## Types of Changes

- [X] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
