### PR TITLE
Clean up Unicode API usage in user keymaps

### DIFF
--- a/keyboards/input_club/ergodox_infinity/keymaps/not-quite-neo/keymap.c
+++ b/keyboards/input_club/ergodox_infinity/keymaps/not-quite-neo/keymap.c
@@ -21,11 +21,6 @@ A layout based on neo2
 #endif
 #define LEADER_TIMEOUT 300
 
-#define TAP_ONCE(code)  \
-  register_code (code); \
-  unregister_code (code)
-
-
 // Automatic number generation of important keywords
 enum my_keycodes{
     // Layer numbers follow the neo2 terminology, i.e. base layer = layer 1
@@ -257,22 +252,11 @@ L06 -> <TBD>: UNSPECIFIED
 
 void leader_end_user(void) {
   if (leader_sequence_one_key(KC_1)) {
-    // ¯\_(ツ)_/¯
-    unicode_input_start(); register_hex(0xaf); unicode_input_finish();
-    register_code (KC_RALT); TAP_ONCE (KC_MINS); unregister_code (KC_RALT);
-    register_code (KC_RSFT); TAP_ONCE (KC_8); unregister_code (KC_RSFT);
-    unicode_input_start (); register_hex(0x30c4); unicode_input_finish();
-    register_code (KC_RSFT); TAP_ONCE (KC_9); TAP_ONCE(KC_7); unregister_code (KC_RSFT);
-    unicode_input_start (); register_hex(0xaf); unicode_input_finish();
+    send_unicode_string("¯\\_(ツ)_/¯");
   }
 
   if (leader_sequence_one_key(KC_2)) {
-    // 凸(ツ)凸
-    unicode_input_start(); register_hex(0x51F8); unicode_input_finish();
-    register_code (KC_RSFT); TAP_ONCE (KC_8); unregister_code (KC_RSFT);
-    unicode_input_start (); register_hex(0x30c4); unicode_input_finish();
-    register_code (KC_RSFT); TAP_ONCE (KC_9); unregister_code (KC_RSFT);
-    unicode_input_start (); register_hex(0x51F8); unicode_input_finish();
+    send_unicode_string("凸(ツ)凸");
   }
 }
 

--- a/keyboards/planck/keymaps/rootiest/keymap.c
+++ b/keyboards/planck/keymaps/rootiest/keymap.c
@@ -1328,33 +1328,25 @@ void send_degree_symbol(tap_dance_state_t* state, void* user_data) {
     switch (state->count) {
         case 4:
             // ℃
-            unicode_input_start();
-            register_hex(0x2103);
-            unicode_input_finish();
+            register_unicode(0x2103);
             print("You pressed the Degrees key 4 times!\n");
             reset_tap_dance(state);
             break;
         case 3:
             //℉
-            unicode_input_start();
-            register_hex(0x2109);
-            unicode_input_finish();
+            register_unicode(0x2109);
             print("You pressed the Degrees key 3 times!\n");
             reset_tap_dance(state);
             break;
         case 2:
             // €
-            unicode_input_start();
-            register_hex(0x20AC);
-            unicode_input_finish();
+            register_unicode(0x20AC);
             print("You pressed the Degrees key 2 times!\n");
             reset_tap_dance(state);
             break;
         case 1:
             // °
-            unicode_input_start();
-            register_hex(0x00B0);
-            unicode_input_finish();
+            register_unicode(0x00B0);
             print("You pressed the Degrees key 1 time!\n");
             reset_tap_dance(state);
             break;

--- a/users/romus/romus.c
+++ b/users/romus/romus.c
@@ -291,13 +291,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case TUR_A:
             if (record->event.pressed) {
                 if ( is_capital ) {
-                    unicode_input_start();
-                    register_hex(0x00c2);
-                    unicode_input_finish();
+                    register_unicode(0x00c2);
                 } else {
-                    unicode_input_start();
-                    register_hex(0x00e2);
-                    unicode_input_finish();
+                    register_unicode(0x00e2);
                 }
             }
             return false;
@@ -305,13 +301,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case TUR_O:
             if (record->event.pressed) {
                 if ( is_capital ) {
-                    unicode_input_start();
-                    register_hex(0x00d6);
-                    unicode_input_finish();
+                    register_unicode(0x00d6);
                 } else {
-                    unicode_input_start();
-                    register_hex(0x00f6);
-                    unicode_input_finish();
+                    register_unicode(0x00f6);
                 }
             }
             return false;
@@ -319,13 +311,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case TUR_U:
             if (record->event.pressed) {
                 if ( is_capital ) {
-                    unicode_input_start();
-                    register_hex(0x00dc);
-                    unicode_input_finish();
+                    register_unicode(0x00dc);
                 } else {
-                    unicode_input_start();
-                    register_hex(0x00fc);
-                    unicode_input_finish();
+                    register_unicode(0x00fc);
                 }
             }
             return false;
@@ -333,13 +321,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case TUR_I:
             if (record->event.pressed) {
                 if ( is_capital ) {
-                    unicode_input_start();
-                    register_hex(0x0130);
-                    unicode_input_finish();
+                    register_unicode(0x0130);
                 } else {
-                    unicode_input_start();
-                    register_hex(0x0131);
-                    unicode_input_finish();
+                    register_unicode(0x0131);
                 }
             }
             return false;
@@ -347,13 +331,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case TUR_G:
             if (record->event.pressed) {
                 if ( is_capital ) {
-                    unicode_input_start();
-                    register_hex(0x011e);
-                    unicode_input_finish();
+                    register_unicode(0x011e);
                 } else {
-                    unicode_input_start();
-                    register_hex(0x011f);
-                    unicode_input_finish();
+                    register_unicode(0x011f);
                 }
             }
             return false;
@@ -361,13 +341,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case TUR_C:
             if (record->event.pressed) {
                 if ( is_capital ) {
-                    unicode_input_start();
-                    register_hex(0x00c7);
-                    unicode_input_finish();
+                    register_unicode(0x00c7);
                 } else {
-                    unicode_input_start();
-                    register_hex(0x00e7);
-                    unicode_input_finish();
+                    register_unicode(0x00e7);
                 }
             }
             return false;
@@ -375,13 +351,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case TUR_S:
             if (record->event.pressed) {
                 if ( is_capital ) {
-                    unicode_input_start();
-                    register_hex(0x015e);
-                    unicode_input_finish();
+                    register_unicode(0x015e);
                 } else {
-                    unicode_input_start();
-                    register_hex(0x015f);
-                    unicode_input_finish();
+                    register_unicode(0x015f);
                 }
             }
             return false;

--- a/users/rupa/unicode.c
+++ b/users/rupa/unicode.c
@@ -125,12 +125,14 @@ bool u_xp(bool is_shifted, const char *shifted, const char *plain) {
 };
 
 void zalgo(void) {
+    unicode_input_start();
     int number = (rand() % (8 + 1 - 2)) + 2;
     unsigned int index;
     for (index=0; index<number; index++) {
         uint16_t hex = (rand() % (0x036F + 1 - 0x0300)) + 0x0300;
         register_hex(hex);
     }
+    unicode_input_finish();
 }
 
 bool combined_text(uint16_t keycode) {
@@ -138,16 +140,16 @@ bool combined_text(uint16_t keycode) {
         return false;
     }
     tap_code(keycode);
-    unicode_input_start();
+
     switch (combined_mode) {
         case CM_CIRCLE:
-          register_hex(0x20DD);
+          register_unicode(0x20DD);
           break;
         case CM_NO:
-          register_hex(0x20E0);
+          register_unicode(0x20E0);
           break;
         case CM_KEYCAP:
-          register_hex(0x20E3);
+          register_unicode(0x20E3);
           break;
         case CM_ZALGO:
           zalgo();
@@ -155,7 +157,6 @@ bool combined_text(uint16_t keycode) {
         default:
           break;
     }
-    unicode_input_finish();
     return true;
 }
 

--- a/users/spidey3/spidey3.c
+++ b/users/spidey3/spidey3.c
@@ -73,19 +73,13 @@ static uint32_t math_glyph_exceptions(const uint16_t keycode, const bool shifted
 }
 
 bool process_record_glyph_replacement(uint16_t keycode, keyrecord_t *record, uint32_t baseAlphaLower, uint32_t baseAlphaUpper, uint32_t zeroGlyph, uint32_t baseNumberOne, uint32_t spaceGlyph, uint32_t (*exceptions)(const uint16_t keycode, const bool shifted), uint8_t temp_mod, uint8_t temp_osm) {
-    void _register(uint32_t codepoint) {
-        unicode_input_start();
-        register_hex32(codepoint);
-        unicode_input_finish();
-    }
-
     if ((((temp_mod | temp_osm) & (MOD_MASK_CTRL | MOD_MASK_ALT | MOD_MASK_GUI))) == 0) {
         bool shifted = ((temp_mod | temp_osm) & MOD_MASK_SHIFT);
         if (exceptions) {
             uint32_t res = exceptions(keycode, shifted);
             if (res) {
                 if (record->event.pressed) {
-                    _register(res);
+                    register_unicode(res);
                 }
                 return false;
             }
@@ -100,7 +94,7 @@ bool process_record_glyph_replacement(uint16_t keycode, keyrecord_t *record, uin
 
                     bool     caps = host_keyboard_led_state().caps_lock;
                     uint32_t base = ((shifted == caps) ? baseAlphaLower : baseAlphaUpper);
-                    _register(base + (keycode - KC_A));
+                    register_unicode(base + (keycode - KC_A));
                     set_mods(temp_mod);
                 }
                 return false;
@@ -109,7 +103,7 @@ bool process_record_glyph_replacement(uint16_t keycode, keyrecord_t *record, uin
                     return true;
                 }
                 if (record->event.pressed) {
-                    _register(zeroGlyph);
+                    register_unicode(zeroGlyph);
                 }
                 return false;
             case KC_1 ... KC_9:
@@ -117,12 +111,12 @@ bool process_record_glyph_replacement(uint16_t keycode, keyrecord_t *record, uin
                     return true;
                 }
                 if (record->event.pressed) {
-                    _register(baseNumberOne + (keycode - KC_1));
+                    register_unicode(baseNumberOne + (keycode - KC_1));
                 }
                 return false;
             case KC_SPACE:
                 if (record->event.pressed) {
-                    _register(spaceGlyph); // em space
+                    register_unicode(spaceGlyph); // em space
                 }
                 return false;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`register_unicode()` and `send_unicode_string()` being needlessly reimplemented.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
