### PR TITLE
fix: make clicky delay silent

### DIFF
--- a/quantum/process_keycode/process_clicky.c
+++ b/quantum/process_keycode/process_clicky.c
@@ -28,7 +28,7 @@ float clicky_freq = AUDIO_CLICKY_FREQ_DEFAULT;
 float clicky_rand = AUDIO_CLICKY_FREQ_RANDOMNESS;
 
 // the first "note" is an intentional delay; the 2nd and 3rd notes are the "clicky"
-float clicky_song[][2] = {{AUDIO_CLICKY_FREQ_MIN, AUDIO_CLICKY_DELAY_DURATION}, {AUDIO_CLICKY_FREQ_DEFAULT, 3}, {AUDIO_CLICKY_FREQ_DEFAULT, 1}}; // 3 and 1 --> durations
+float clicky_song[][2] = {{0.0f, AUDIO_CLICKY_DELAY_DURATION}, {AUDIO_CLICKY_FREQ_DEFAULT, 3}, {AUDIO_CLICKY_FREQ_DEFAULT, 1}}; // 3 and 1 --> durations
 
 extern audio_config_t audio_config;
 


### PR DESCRIPTION
## Description
The delay that `AUDIO_CLICKY_DELAY_DURATION` leverages is not actually silent. This results in discordant notes when using clicky mode on certain configurations—e.g., [this keyboard](https://github.com/qmk/qmk_firmware/tree/master/keyboards/mechwild/waka60), but configured to use `pwm_hardware` for audio.

```config.h
#define AUDIO_PWM_DRIVER PWMD3
#define AUDIO_PWM_CHANNEL 2
#define AUDIO_PWM_PAL_MODE 2
```
⚠️ **Testing assistance from anyone with audio hardware is appreciated.**
I am only able to verify this works for STM32F401/F411 at this time, but it appears that [silence may no longer be broken in general](https://github.com/qmk/qmk_firmware/pull/11820).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
