### PR TITLE
nullbitsco/snap: fix broken keymaps

### DIFF
--- a/keyboards/nullbitsco/snap/keymaps/bongo_reactive/keymap.c
+++ b/keyboards/nullbitsco/snap/keymaps/bongo_reactive/keymap.c
@@ -92,7 +92,7 @@ static void render_status(void) {
 
     // Only update if the LED state has changed
     // Otherwise, the OLED will not turn off if an LED is on.
-    if (persistent_led_state != led_state) {
+    if (persistent_led_state.raw != led_state.raw) {
         persistent_led_state = led_state;
         
         oled_write_ln_P(PSTR(""), false);

--- a/keyboards/nullbitsco/snap/keymaps/oled/keymap.c
+++ b/keyboards/nullbitsco/snap/keymaps/oled/keymap.c
@@ -119,7 +119,7 @@ static void render_status(void) {
 
     // Only update if the LED state has changed
     // Otherwise, the OLED will not turn off if an LED is on.
-    if (persistent_led_state != led_state) {
+    if (persistent_led_state.raw != led_state.raw) {
         persistent_led_state = led_state;
         
         oled_write_ln_P(PSTR(""), false);

--- a/keyboards/nullbitsco/snap/keymaps/typehud/keymap.c
+++ b/keyboards/nullbitsco/snap/keymaps/typehud/keymap.c
@@ -99,7 +99,7 @@ static void render_status(void) {
 
     // Only update if the LED state has changed
     // Otherwise, the OLED will not turn off if an LED is on.
-    if (persistent_led_state != led_state) {
+    if (persistent_led_state.raw != led_state.raw) {
         persistent_led_state = led_state;
 
         oled_write_ln_P(PSTR("            "), false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

One of the breaking changes this cycle broke the SNAP OLED keymaps due to an invalid comparison:

```
./keyboards/nullbitsco/snap/keymaps/oled/keymap.c:122:30: error: invalid operands to binary != (have 'led_t' {aka 'union <anonymous>'} and 'led_t' {aka 'union <anonymous>'})
     if (persistent_led_state != led_state) {
```

Comparing the raw LED state fixes it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
