### PR TITLE
Feature: joystick weights

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -73,6 +73,21 @@ The Analog Joystick is an analog (ADC) driven sensor.  There are a variety of jo
 | `ANALOG_JOYSTICK_READ_INTERVAL`   | (Optional) The interval in milliseconds between reads.                     | `10`          |
 | `ANALOG_JOYSTICK_SPEED_MAX`       | (Optional) The maximum value used for motion.                              | `2`           |
 | `ANALOG_JOYSTICK_CLICK_PIN`       | (Optional) The pin wired up to the press switch of the analog stick.       | _not defined_ |
+| `ANALOG_JOYSTICK_WEIGHTS`         | (Optional) Use custom weights for lever positions.                         | _not defined_ |
+
+By default analog joystick implementation uses `x^2` weighting for lever positions. `ANALOG_JOYSTICK_WEIGHTS` allows to experiment with different configurations that might feel better.
+
+E.g. This is weights for `((x-0.4)^3+0.064)/0.282`:
+
+```c
+#define ANALOG_JOYSTICK_WEIGHTS {0,2,4,5,7,8,9,10,12,13,14,15,15,16,17,18,18,19,19,20,20,21,21,21,22,22,22,22,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,24,24,24,24,24,24,25,25,25,26,26,26,27,28,28,29,29,30,31,32,33,34,35,36,37,38,40,41,43,44,46,48,49,51,53,56,58,60,62,65,68,70,73,76,79,82,85,89,92,96,100}
+```
+
+You can use following JS code to generate weights for different formulas:
+
+```js
+JSON.stringify(Array.from(Array(101).keys()).map(x => Math.ceil((((x/100-0.4)**3+0.064)/0.282*100))))
+```
 
 ### Cirque Trackpad
 

--- a/drivers/sensors/analog_joystick.c
+++ b/drivers/sensors/analog_joystick.c
@@ -28,6 +28,10 @@ uint16_t maxAxisValue = ANALOG_JOYSTICK_AXIS_MAX;
 uint8_t maxCursorSpeed = ANALOG_JOYSTICK_SPEED_MAX;
 uint8_t speedRegulator = ANALOG_JOYSTICK_SPEED_REGULATOR; // Lower Values Create Faster Movement
 
+#ifdef ANALOG_JOYSTICK_WEIGHTS
+int8_t weights[101] = ANALOG_JOYSTICK_WEIGHTS;
+#endif
+
 int16_t xOrigin, yOrigin;
 
 uint16_t lastCursor = 0;
@@ -64,12 +68,16 @@ int16_t axisCoordinate(pin_t pin, uint16_t origin) {
 
 int8_t axisToMouseComponent(pin_t pin, int16_t origin, uint8_t maxSpeed) {
     int16_t coordinate = axisCoordinate(pin, origin);
+#ifndef ANALOG_JOYSTICK_WEIGHTS
     if (coordinate != 0) {
         float percent = (float)coordinate / 100;
         return percent * maxCursorSpeed * (abs(coordinate) / speedRegulator);
     } else {
         return 0;
     }
+#else
+    return weights[abs(coordinate)] * (coordinate < 0 ? -1 : 1) * maxCursorSpeed / speedRegulator;
+#endif
 }
 
 report_analog_joystick_t analog_joystick_read(void) {


### PR DESCRIPTION
Joystick weights.

## Description

I have played around with different algorithms how joystick should work and found out that default x^2 weighting is not necessary optimal. Therefore I have added possibility for user to override weighting for lever positions.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
