### PR TITLE
ANAVI Macro Pad 12: rename LAYOUT to LAYOUT_ortho_4x3

### DIFF
--- a/keyboards/anavi/macropad12/info.json
+++ b/keyboards/anavi/macropad12/info.json
@@ -43,8 +43,11 @@
     "backlight": {
         "pin": "GP26"
     },
+    "layout_aliases": {
+        "LAYOUT": "LAYOUT_ortho_4x3"
+    },
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_ortho_4x3": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/anavi/macropad12/keymaps/default/keymap.c
+++ b/keyboards/anavi/macropad12/keymaps/default/keymap.c
@@ -8,7 +8,7 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT(
+    [_BASE] = LAYOUT_ortho_4x3(
         KC_1, KC_2, KC_3,
         KC_4, KC_5, KC_6,
         KC_7, KC_8, KC_9,


### PR DESCRIPTION
## Description

[title]

cc @leon-anavi (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
