### PR TITLE
redragon/k667: Remove 2 layer VIA restriction

### DIFF
--- a/keyboards/redragon/k667/info.json
+++ b/keyboards/redragon/k667/info.json
@@ -6,9 +6,6 @@
         "matrix": [1, 0]
     },
     "diode_direction": "COL2ROW",
-    "dynamic_keymap": {
-        "layer_count": 2
-    },
     "encoder": {
         "rotary": [
             {"pin_a": "B5", "pin_b": "B4"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

From the original PR,
> Because this keyboard is designed to support only Windows, it is set up with only two layers.

Not really a good reason to artificially limit the layer count, when the default eeprom provisioning allows more.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
