### PR TITLE
Restrict "feature" and "animation" keys

### DIFF
--- a/data/schemas/definitions.jsonschema
+++ b/data/schemas/definitions.jsonschema
@@ -29,6 +29,10 @@
         "minLength": 1,
         "maxLength": 250
     },
+    "snake_case": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_]*$"
+    },
     "layout_macro": {
         "oneOf": [
             {

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -256,7 +256,11 @@
                 "enabled": {"type": "boolean"}
             }
         },
-        "features": {"$ref": "qmk.definitions.v1#/boolean_array"},
+        "features": {
+            "$ref": "qmk.definitions.v1#/boolean_array",
+            "propertyNames": { "$ref": "qmk.definitions.v1#/snake_case" }
+
+        },
         "indicators": {
             "type": "object",
             "properties": {
@@ -370,6 +374,7 @@
             "properties": {
                 "animations": {
                     "type": "object",
+                    "propertyNames": { "$ref": "qmk.definitions.v1#/snake_case" }
                     "additionalProperties": {
                         "type": "boolean"
                     }
@@ -419,6 +424,7 @@
             "properties": {
                 "animations": {
                     "type": "object",
+                    "propertyNames": { "$ref": "qmk.definitions.v1#/snake_case" }
                     "additionalProperties": {
                         "type": "boolean"
                     }
@@ -471,6 +477,7 @@
             "properties": {
                 "animations": {
                     "type": "object",
+                    "propertyNames": { "$ref": "qmk.definitions.v1#/snake_case" }
                     "additionalProperties": {
                         "type": "boolean"
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
On 21894 and 21893, the following is not flagged by lint:
```json
        "animations": {
            "SOLID_COLOR": true,
            "ALPHAS_MODS": true,
            "GRADIENT_UP_DOWN": true,
            "GRADIENT_LEFT_RIGHT": true,
            "BREATHING": true,
            "BAND_SAT  // white background ver. of _BAND_VAL": true,
```

Caps is one thing, but spaces and comments just would never work.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
