### PR TITLE
Add `mousekey.h` include to `quantum.h`

### DIFF
--- a/keyboards/bpiphany/kitten_paw/keymaps/ickerwx/keymap.c
+++ b/keyboards/bpiphany/kitten_paw/keymaps/ickerwx/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "mousekey.h"
 
 #define MEDAPP LT(MEDIA, KC_APP)
 

--- a/keyboards/crkbd/keymaps/vlukash_trackpad_right/keymap.c
+++ b/keyboards/crkbd/keymaps/vlukash_trackpad_right/keymap.c
@@ -1,13 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "bootloader.h"
-#include "mousekey.h"
-#include "pointing_device.h"
-#include "report.h"
-
-#ifdef PROTOCOL_LUFA
-  #include "lufa.h"
-  #include "split_util.h"
-#endif
 
 extern bool isScrollMode;
 

--- a/keyboards/dm9records/plaid/keymaps/gipsy-king/keymap.c
+++ b/keyboards/dm9records/plaid/keymaps/gipsy-king/keymap.c
@@ -15,8 +15,6 @@
  */
 
 #include QMK_KEYBOARD_H
-#include "mousekey.h"
-
 
 enum plaid_layers {
   _QWERTY,

--- a/keyboards/ergodox_ez/keymaps/pvinis/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/pvinis/keymap.c
@@ -20,7 +20,6 @@
 
 #include QMK_KEYBOARD_H
 #include "pvinis.h"
-#include "mousekey.h"
 
 // layers
 enum {

--- a/keyboards/gboards/butterstick/sten.h
+++ b/keyboards/gboards/butterstick/sten.h
@@ -8,9 +8,7 @@
 #pragma once
 
 #include QMK_KEYBOARD_H
-#include "mousekey.h"
 #include "keymap_steno.h"
-#include "wait.h"
 
 extern size_t keymapsCount;			// Total keymaps
 extern uint32_t cChord;				// Current Chord

--- a/keyboards/gboards/georgi/sten.h
+++ b/keyboards/gboards/georgi/sten.h
@@ -7,9 +7,7 @@
 #pragma once
 
 #include "georgi.h"
-#include "mousekey.h"
 #include "keymap_steno.h"
-#include "wait.h"
 
 extern size_t keymapsCount;			// Total keymaps
 extern uint32_t cChord;				// Current Chord

--- a/keyboards/handwired/traveller/keymaps/default/keymap.c
+++ b/keyboards/handwired/traveller/keymaps/default/keymap.c
@@ -1,5 +1,4 @@
 #include QMK_KEYBOARD_H
-#include "mousekey.h"
 
 enum layer_names {
     _QW,

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -209,6 +209,10 @@ extern layer_state_t layer_state;
 #    include "pointing_device.h"
 #endif
 
+#ifdef MOUSEKEY_ENABLE
+#    include "mousekey.h"
+#endif
+
 #ifdef CAPS_WORD_ENABLE
 #    include "caps_word.h"
 #    include "process_caps_word.h"

--- a/users/romus/romus.c
+++ b/users/romus/romus.c
@@ -1,25 +1,5 @@
 #include "romus.h"
 
-/*---------------*\
-|*-----MOUSE-----*|
-\*---------------*/
-#ifdef MOUSEKEY_ENABLE
-#include "mousekey.h"
-#endif
-
-/*-------------*\
-|*-----RGB-----*|
-\*-------------*/
-#ifdef RGBLIGHT_ENABLE
-#include "rgblight.h"
-#endif
-
-/*-------------*\
-|*---UNICODE---*|
-\*-------------*/
-#ifdef UNICODE_ENABLE
-#endif
-
 /*-----------------*\
 |*-----SECRETS-----*|
 \*-----------------*/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`mousekey.h` should be implicitly available to keymap code through `quantum.h` if it is enabled. See https://github.com/qmk/qmk_firmware/pull/19801#pullrequestreview-1513525678

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
