### PR TITLE
Implement data driven wear leveling

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -49,6 +49,10 @@
     "DYNAMIC_KEYMAP_EEPROM_MAX_ADDR": {"info_key": "dynamic_keymap.eeprom_max_addr", "value_type": "int"},
     "DYNAMIC_KEYMAP_LAYER_COUNT": {"info_key": "dynamic_keymap.layer_count", "value_type": "int"},
 
+    // EEPROM
+    "WEAR_LEVELING_BACKING_SIZE": {"info_key": "eeprom.wear_leveling.backing_size", "value_type": "int"},
+    "WEAR_LEVELING_LOGICAL_SIZE": {"info_key": "eeprom.wear_leveling.logical_size", "value_type": "int"},
+
     // Indicators
     "LED_CAPS_LOCK_PIN": {"info_key": "indicators.caps_lock"},
     "LED_NUM_LOCK_PIN": {"info_key": "indicators.num_lock"},
@@ -158,10 +162,6 @@
     "USB_MAX_POWER_CONSUMPTION": {"info_key": "usb.max_power", "value_type": "int"},
     "USB_POLLING_INTERVAL_MS": {"info_key": "usb.polling_interval", "value_type": "int"},
     "USB_SUSPEND_WAKEUP_DELAY": {"info_key": "usb.suspend_wakeup_delay", "value_type": "int"},
-
-    // Wear-leveling
-    "WEAR_LEVELING_BACKING_SIZE": {"info_key": "wear_leveling.backing_size", "value_type": "int"},
-    "WEAR_LEVELING_LOGICAL_SIZE": {"info_key": "wear_leveling.logical_size", "value_type": "int"},
 
     // WS2812
     "WS2812_DI_PIN": {"info_key": "ws2812.pin"},

--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -50,8 +50,8 @@
     "DYNAMIC_KEYMAP_LAYER_COUNT": {"info_key": "dynamic_keymap.layer_count", "value_type": "int"},
 
     // EEPROM
-    "WEAR_LEVELING_BACKING_SIZE": {"info_key": "eeprom.wear_leveling.backing_size", "value_type": "int"},
-    "WEAR_LEVELING_LOGICAL_SIZE": {"info_key": "eeprom.wear_leveling.logical_size", "value_type": "int"},
+    "WEAR_LEVELING_BACKING_SIZE": {"info_key": "eeprom.wear_leveling.backing_size", "value_type": "int", "to_json": false},
+    "WEAR_LEVELING_LOGICAL_SIZE": {"info_key": "eeprom.wear_leveling.logical_size", "value_type": "int", "to_json": false},
 
     // Indicators
     "LED_CAPS_LOCK_PIN": {"info_key": "indicators.caps_lock"},

--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -159,6 +159,10 @@
     "USB_POLLING_INTERVAL_MS": {"info_key": "usb.polling_interval", "value_type": "int"},
     "USB_SUSPEND_WAKEUP_DELAY": {"info_key": "usb.suspend_wakeup_delay", "value_type": "int"},
 
+    // Wear-leveling
+    "WEAR_LEVELING_BACKING_SIZE": {"info_key": "wear_leveling.backing_size", "value_type": "int"},
+    "WEAR_LEVELING_LOGICAL_SIZE": {"info_key": "wear_leveling.logical_size", "value_type": "int"},
+
     // WS2812
     "WS2812_DI_PIN": {"info_key": "ws2812.pin"},
     "WS2812_I2C_ADDRESS": {"info_key": "ws2812.i2c_address", "value_type": "hex"},

--- a/data/mappings/info_rules.hjson
+++ b/data/mappings/info_rules.hjson
@@ -42,7 +42,7 @@
     "STENO_ENABLE": {"info_key": "stenography.enabled", "value_type": "bool"},
     "STENO_PROTOCOL": {"info_key": "stenography.protocol"},
     "WAIT_FOR_USB": {"info_key": "usb.wait_for", "value_type": "bool"},
-    "WEAR_LEVELING_DRIVER": {"info_key": "wear_leveling.driver"},
+    "WEAR_LEVELING_DRIVER": {"info_key": "eeprom.wear_leveling.driver"},
     "WS2812_DRIVER": {"info_key": "ws2812.driver"},
 
     // Items we want flagged in lint

--- a/data/mappings/info_rules.hjson
+++ b/data/mappings/info_rules.hjson
@@ -20,6 +20,7 @@
     "DEBOUNCE_TYPE": {"info_key": "build.debounce_type"},
     "EEPROM_DRIVER": {"info_key": "eeprom.driver"},
     "ENCODER_ENABLE": {"info_key": "encoder.enabled", "value_type": "bool"},
+    "ENCODER_MAP_ENABLE": {"info_key": "encoder.map", "value_type": "bool"},
     "FIRMWARE_FORMAT": {"info_key": "build.firmware_format"},
     "KEYBOARD_SHARED_EP": {"info_key": "usb.shared_endpoint.keyboard", "value_type": "bool"},
     "LAYOUTS": {"info_key": "community_layouts", "value_type": "list"},
@@ -42,6 +43,7 @@
     "STENO_ENABLE": {"info_key": "stenography.enabled", "value_type": "bool"},
     "STENO_PROTOCOL": {"info_key": "stenography.protocol"},
     "WAIT_FOR_USB": {"info_key": "usb.wait_for", "value_type": "bool"},
+    "WEAR_LEVELING_DRIVER": {"info_key": "wear_leveling.driver"},
     "WS2812_DRIVER": {"info_key": "ws2812.driver"},
 
     // Items we want flagged in lint

--- a/data/mappings/info_rules.hjson
+++ b/data/mappings/info_rules.hjson
@@ -20,7 +20,6 @@
     "DEBOUNCE_TYPE": {"info_key": "build.debounce_type"},
     "EEPROM_DRIVER": {"info_key": "eeprom.driver"},
     "ENCODER_ENABLE": {"info_key": "encoder.enabled", "value_type": "bool"},
-    "ENCODER_MAP_ENABLE": {"info_key": "encoder.map", "value_type": "bool"},
     "FIRMWARE_FORMAT": {"info_key": "build.firmware_format"},
     "KEYBOARD_SHARED_EP": {"info_key": "usb.shared_endpoint.keyboard", "value_type": "bool"},
     "LAYOUTS": {"info_key": "community_layouts", "value_type": "list"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -247,7 +247,19 @@
         },
         "eeprom": {
             "properties": {
-                "driver": {"type": "string"}
+                "driver": {"type": "string"},
+                "wear_leveling": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "driver": {
+                            "type": "string",
+                            "enum": ["custom", "embedded_flash", "legacy", "rp2040_flash", "spi_flash"]
+                        },
+                        "backing_size": {"$ref": "qmk.definitions.v1#/unsigned_int"},
+                        "logical_size": {"$ref": "qmk.definitions.v1#/unsigned_int"}
+                    }
+                }
             }
         },
         "encoder": {
@@ -718,18 +730,6 @@
                 "esc_input": {"$ref": "qmk.definitions.v1#/mcu_pin"},
                 "led": {"$ref": "qmk.definitions.v1#/mcu_pin"},
                 "speaker": {"$ref": "qmk.definitions.v1#/mcu_pin"}
-            }
-        },
-        "wear_leveling": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "driver": {
-                    "type": "string",
-                    "enum": ["custom", "embedded_flash", "legacy", "none", "rp2040_flash", "spi_flash"]
-                },
-                "backing_size": {"$ref": "qmk.definitions.v1#/unsigned_int"},
-                "logical_size": {"$ref": "qmk.definitions.v1#/unsigned_int"}
             }
         },
         "ws2812": {

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -253,7 +253,8 @@
         "encoder": {
             "$ref": "#/definitions/encoder_config",
             "properties": {
-                "enabled": {"type": "boolean"}
+                "enabled": {"type": "boolean"},
+                "map": {"type": "boolean"}
             }
         },
         "features": {"$ref": "qmk.definitions.v1#/boolean_array"},
@@ -718,6 +719,13 @@
                 "esc_input": {"$ref": "qmk.definitions.v1#/mcu_pin"},
                 "led": {"$ref": "qmk.definitions.v1#/mcu_pin"},
                 "speaker": {"$ref": "qmk.definitions.v1#/mcu_pin"}
+            }
+        },
+        "wear_leveling": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "driver": {"type": "string"}
             }
         },
         "ws2812": {

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -253,8 +253,7 @@
         "encoder": {
             "$ref": "#/definitions/encoder_config",
             "properties": {
-                "enabled": {"type": "boolean"},
-                "map": {"type": "boolean"}
+                "enabled": {"type": "boolean"}
             }
         },
         "features": {"$ref": "qmk.definitions.v1#/boolean_array"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -727,7 +727,9 @@
                 "driver": {
                     "type": "string",
                     "enum": ["custom", "embedded_flash", "legacy", "none", "rp2040_flash", "spi_flash"]
-                }
+                },
+                "backing_size": {"$ref": "qmk.definitions.v1#/unsigned_int"},
+                "logical_size": {"$ref": "qmk.definitions.v1#/unsigned_int"}
             }
         },
         "ws2812": {

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -724,7 +724,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "driver": {"type": "string"}
+                "driver": {
+                    "type": "string",
+                    "enum": ["custom", "embedded_flash", "legacy", "none", "rp2040_flash", "spi_flash"]
+                }
             }
         },
         "ws2812": {

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -202,6 +202,13 @@ Configures the [EEPROM](eeprom_driver.md) driver.
     * `driver`
         * The EEPROM backend to use. Must be one of `custom`, `i2c`, `legacy_stm32_flash`, `spi`, `transient`, `vendor`, `wear_leveling`.
         * Default: `"vendor"`
+    * `wear_leveling`
+        * `driver`
+            * The driver to use. Must be one of `embedded_flash`, `legacy`, `rp2040_flash`, `spi_flash`, `custom`.
+        * `backing_size`
+            * Number of bytes used by the wear-leveling algorithm for its underlying storage, and needs to be a multiple of the logical size.
+        * `logical_size`
+            * Number of bytes “exposed” to the rest of QMK and denotes the size of the usable EEPROM.
 
 ## Encoder :id=encoder
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Supersedes #21604.

From some discussions, wear leveling has no intent to work with other subsystems. Having it as a top level key when its tightly coupled to eeprom just pollutes the json. Also added some defines for size, and updated docs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
