### PR TITLE
Enable RP2040 support for apa102 RGB LED driver

### DIFF
--- a/drivers/led/apa102.c
+++ b/drivers/led/apa102.c
@@ -24,7 +24,7 @@
 #    elif defined(PROTOCOL_CHIBIOS)
 #        include "hal.h"
 #        include "chibios_config.h"
-#        if defined(STM32F0XX) || defined(STM32F1XX) || defined(STM32F3XX) || defined(STM32F4XX) || defined(STM32L0XX) || defined(GD32VF103)
+#        if defined(STM32F0XX) || defined(STM32F1XX) || defined(STM32F3XX) || defined(STM32F4XX) || defined(STM32L0XX) || defined(GD32VF103) || defined(MCU_RP)
 #            define APA102_NOPS (100 / (1000000000L / (CPU_CLOCK / 4))) // This calculates how many loops of 4 nops to run to delay 100 ns
 #        else
 #            error APA102_NOPS configuration required


### PR DESCRIPTION
## Description

Not sure if this is the best way to handle this... but I can confirm that it does work. (tested on micromod "input and display" carrier board, with RP2040 processor board)

## Types of Changes

- [x] Core

## Issues Fixed or Closed by This PR

* Compilation issue when testing

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
