### PR TITLE
[Bug] Fix default layer value in eeconfig_init

### DIFF
--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -49,8 +49,8 @@ void eeconfig_init_quantum(void) {
 
     eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_NUMBER);
     eeprom_update_byte(EECONFIG_DEBUG, 0);
-    eeprom_update_byte(EECONFIG_DEFAULT_LAYER, 0);
-    default_layer_state = 0;
+    default_layer_state = (layer_state_t)1<<0;
+    eeprom_update_byte(EECONFIG_DEFAULT_LAYER, default_layer_state);
     // Enable oneshot and autocorrect by default: 0b0001 0100 0000 0000
     eeprom_update_word(EECONFIG_KEYMAP, 0x1400);
     eeprom_update_byte(EECONFIG_BACKLIGHT, 0);


### PR DESCRIPTION

## Description

Ran into an issue with this, when replacing my burned out blackpill... and it not properly init'ing. 

This should be `1<<0` (0b1), rather than 0, and have verified that with everywhere default layers are set.

Could probably move these lines out of eeconfig.c too, but wasn't sure if should. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Testing

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
