### PR TITLE
Add RTC IRQ Priority to RP2040 board files

### DIFF
--- a/platforms/chibios/boards/GENERIC_PROMICRO_RP2040/configs/mcuconf.h
+++ b/platforms/chibios/boards/GENERIC_PROMICRO_RP2040/configs/mcuconf.h
@@ -54,6 +54,7 @@
 #define RP_IRQ_USB0_PRIORITY                3
 #define RP_IRQ_I2C0_PRIORITY                2
 #define RP_IRQ_I2C1_PRIORITY                2
+#define RP_IRQ_RTC_PRIORITY                 3
 
 /*
  * ADC driver system settings.

--- a/platforms/chibios/boards/GENERIC_RP_RP2040/configs/mcuconf.h
+++ b/platforms/chibios/boards/GENERIC_RP_RP2040/configs/mcuconf.h
@@ -54,6 +54,7 @@
 #define RP_IRQ_USB0_PRIORITY                3
 #define RP_IRQ_I2C0_PRIORITY                2
 #define RP_IRQ_I2C1_PRIORITY                2
+#define RP_IRQ_RTC_PRIORITY                 3
 
 /*
  * ADC driver system settings.

--- a/platforms/chibios/boards/QMK_BLOK/configs/mcuconf.h
+++ b/platforms/chibios/boards/QMK_BLOK/configs/mcuconf.h
@@ -54,6 +54,7 @@
 #define RP_IRQ_USB0_PRIORITY                3
 #define RP_IRQ_I2C0_PRIORITY                2
 #define RP_IRQ_I2C1_PRIORITY                2
+#define RP_IRQ_RTC_PRIORITY                 3
 
 /*
  * ADC driver system settings.

--- a/platforms/chibios/boards/QMK_PM2040/configs/mcuconf.h
+++ b/platforms/chibios/boards/QMK_PM2040/configs/mcuconf.h
@@ -54,6 +54,7 @@
 #define RP_IRQ_USB0_PRIORITY                3
 #define RP_IRQ_I2C0_PRIORITY                2
 #define RP_IRQ_I2C1_PRIORITY                2
+#define RP_IRQ_RTC_PRIORITY                 3
 
 /*
  * ADC driver system settings.


### PR DESCRIPTION
## Description

An issue I noticed when playing with the rtc hardware stuff.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
