### PR TITLE
docs: brew has support for M1 since 2.6.0 [Dec/2020]

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -56,18 +56,12 @@ QMK maintains a Homebrew tap and formula which will automatically install the CL
 
 You will need to install Homebrew. Follow the instructions on https://brew.sh.
 
-!> **NOTE:** If you are using Apple Silicon, such as the M1, you will need to install a rosetta compatible version of Homebrew. This version does not override the base Homebrew. This can be done by running `arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`. See here: [Rosetta-compatible Homebrew](https://stackoverflow.com/questions/64882584/how-to-run-the-homebrew-installer-under-rosetta-2-on-m1-macbook)
-
 #### Installation
 
 Install the QMK CLI by running:
 
     brew install qmk/qmk/qmk
     
-Install the QMK CLI on an Apple Silicon Mac by running:
-
-    arch -x86_64 brew install qmk/qmk/qmk
-
 ### ** Linux/WSL **
 
 ?> **Note for WSL users**: By default, the installation process will clone the QMK repository into your WSL home directory, but if you have cloned manually, ensure that it is located inside the WSL instance instead of the Windows filesystem (ie. not in `/mnt`), as accessing it is currently [extremely slow](https://github.com/microsoft/WSL/issues/4197).


### PR DESCRIPTION
## Description

Update the docs removing the rosetta steps for m1/m2.

Here is the 2.6.0 release document https://brew.sh/2020/12/01/homebrew-2.6.0/

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation
