### PR TITLE
Remove duplication of RP2040 EEPROM defaults

### DIFF
--- a/keyboards/cannonkeys/brutalv2_1800/rules.mk
+++ b/keyboards/cannonkeys/brutalv2_1800/rules.mk
@@ -1,2 +1,1 @@
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = rp2040_flash
+# This file intentionally left blank

--- a/keyboards/cannonkeys/caerdroia/rules.mk
+++ b/keyboards/cannonkeys/caerdroia/rules.mk
@@ -1,2 +1,1 @@
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = rp2040_flash
+# This file intentionally left blank

--- a/keyboards/cannonkeys/ortho48v2/rules.mk
+++ b/keyboards/cannonkeys/ortho48v2/rules.mk
@@ -1,2 +1,1 @@
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = rp2040_flash
+# This file intentionally left blank

--- a/keyboards/cannonkeys/ortho60v2/rules.mk
+++ b/keyboards/cannonkeys/ortho60v2/rules.mk
@@ -1,2 +1,1 @@
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = rp2040_flash
+# This file intentionally left blank

--- a/keyboards/cannonkeys/typeb/rules.mk
+++ b/keyboards/cannonkeys/typeb/rules.mk
@@ -1,2 +1,1 @@
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = rp2040_flash
+# This file intentionally left blank


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Default `vendor` driver equates to wear leveling + rp2040_flash so specifying it at the keyboard level is redundant.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
