### PR TITLE
Remove duplication of STM32L432 EEPROM defaults

### DIFF
--- a/keyboards/keychron/q0/rev_0130/rules.mk
+++ b/keyboards/keychron/q0/rev_0130/rules.mk
@@ -1,3 +1,1 @@
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-
+# This file intentionally left blank

--- a/keyboards/keychron/q0/rev_0131/rules.mk
+++ b/keyboards/keychron/q0/rev_0131/rules.mk
@@ -1,3 +1,1 @@
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-
+# This file intentionally left blank

--- a/keyboards/keychron/q10/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q10/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q10/iso_encoder/rules.mk
+++ b/keyboards/keychron/q10/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q11/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q11/ansi_encoder/rules.mk
@@ -1,6 +1,1 @@
-# Build Options
-#   change yes to no to disable
-#
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 SERIAL_DRIVER = usart

--- a/keyboards/keychron/q12/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q12/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q12/iso_encoder/rules.mk
+++ b/keyboards/keychron/q12/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q2/ansi/rules.mk
+++ b/keyboards/keychron/q2/ansi/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = no         # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q2/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q2/ansi_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q2/iso/rules.mk
+++ b/keyboards/keychron/q2/iso/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = no         # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q2/iso_encoder/rules.mk
+++ b/keyboards/keychron/q2/iso_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q2/jis/rules.mk
+++ b/keyboards/keychron/q2/jis/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q2/jis_encoder/rules.mk
+++ b/keyboards/keychron/q2/jis_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q3/ansi/rules.mk
+++ b/keyboards/keychron/q3/ansi/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q3/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q3/ansi_encoder/rules.mk
@@ -14,8 +14,6 @@ ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q3/iso/rules.mk
+++ b/keyboards/keychron/q3/iso/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q3/iso_encoder/rules.mk
+++ b/keyboards/keychron/q3/iso_encoder/rules.mk
@@ -14,8 +14,6 @@ ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q3/jis/rules.mk
+++ b/keyboards/keychron/q3/jis/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q3/jis_encoder/rules.mk
+++ b/keyboards/keychron/q3/jis_encoder/rules.mk
@@ -14,8 +14,6 @@ ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q4/ansi_v1/rules.mk
+++ b/keyboards/keychron/q4/ansi_v1/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = no
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q4/ansi_v2/rules.mk
+++ b/keyboards/keychron/q4/ansi_v2/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = no
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q4/iso/rules.mk
+++ b/keyboards/keychron/q4/iso/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = no
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q5/ansi/rules.mk
+++ b/keyboards/keychron/q5/ansi/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q5/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q5/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q5/iso/rules.mk
+++ b/keyboards/keychron/q5/iso/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q5/iso_encoder/rules.mk
+++ b/keyboards/keychron/q5/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q6/ansi/rules.mk
+++ b/keyboards/keychron/q6/ansi/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q6/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q6/ansi_encoder/rules.mk
@@ -14,8 +14,6 @@ ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q6/iso/rules.mk
+++ b/keyboards/keychron/q6/iso/rules.mk
@@ -14,8 +14,6 @@ DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 RAW_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q6/iso_encoder/rules.mk
+++ b/keyboards/keychron/q6/iso_encoder/rules.mk
@@ -15,8 +15,6 @@ DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 RAW_ENABLE = yes
 LTO_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q60/ansi/rules.mk
+++ b/keyboards/keychron/q60/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q65/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q65/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/q7/ansi/rules.mk
+++ b/keyboards/keychron/q7/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q7/iso/rules.mk
+++ b/keyboards/keychron/q7/iso/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q8/ansi/rules.mk
+++ b/keyboards/keychron/q8/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q8/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q8/ansi_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q8/iso/rules.mk
+++ b/keyboards/keychron/q8/iso/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q8/iso_encoder/rules.mk
+++ b/keyboards/keychron/q8/iso_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q9/ansi/rules.mk
+++ b/keyboards/keychron/q9/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q9/ansi_encoder/rules.mk
+++ b/keyboards/keychron/q9/ansi_encoder/rules.mk
@@ -14,6 +14,3 @@ ENCODER_ENABLE = yes        # Enable Encoder
 ENCODER_MAP_ENBALE = no
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q9/iso/rules.mk
+++ b/keyboards/keychron/q9/iso/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/q9/iso_encoder/rules.mk
+++ b/keyboards/keychron/q9/iso_encoder/rules.mk
@@ -14,6 +14,3 @@ ENCODER_ENABLE = yes        # Enable Encoder
 ENCODER_MAP_ENBALE = no
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/s1/ansi/rgb/rules.mk
+++ b/keyboards/keychron/s1/ansi/rgb/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/s1/ansi/white/rules.mk
+++ b/keyboards/keychron/s1/ansi/white/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 LED_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v1/ansi/rules.mk
+++ b/keyboards/keychron/v1/ansi/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v1/ansi_encoder/rules.mk
+++ b/keyboards/keychron/v1/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v1/iso/rules.mk
+++ b/keyboards/keychron/v1/iso/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v1/iso_encoder/rules.mk
+++ b/keyboards/keychron/v1/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v1/jis/rules.mk
+++ b/keyboards/keychron/v1/jis/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v1/jis_encoder/rules.mk
+++ b/keyboards/keychron/v1/jis_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v10/ansi_encoder/rules.mk
+++ b/keyboards/keychron/v10/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v10/iso_encoder/rules.mk
+++ b/keyboards/keychron/v10/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v2/ansi/rules.mk
+++ b/keyboards/keychron/v2/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v2/ansi_encoder/rules.mk
+++ b/keyboards/keychron/v2/ansi_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v2/iso/rules.mk
+++ b/keyboards/keychron/v2/iso/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v2/iso_encoder/rules.mk
+++ b/keyboards/keychron/v2/iso_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v2/jis/rules.mk
+++ b/keyboards/keychron/v2/jis/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v2/jis_encoder/rules.mk
+++ b/keyboards/keychron/v2/jis_encoder/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v3/ansi/rules.mk
+++ b/keyboards/keychron/v3/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v3/ansi_encoder/rules.mk
+++ b/keyboards/keychron/v3/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v3/iso/rules.mk
+++ b/keyboards/keychron/v3/iso/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v3/iso_encoder/rules.mk
+++ b/keyboards/keychron/v3/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v3/jis/rules.mk
+++ b/keyboards/keychron/v3/jis/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v3/jis_encoder/rules.mk
+++ b/keyboards/keychron/v3/jis_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v4/ansi/rules.mk
+++ b/keyboards/keychron/v4/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v4/iso/rules.mk
+++ b/keyboards/keychron/v4/iso/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v5/ansi/rules.mk
+++ b/keyboards/keychron/v5/ansi/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v5/ansi_encoder/rules.mk
+++ b/keyboards/keychron/v5/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v5/iso/rules.mk
+++ b/keyboards/keychron/v5/iso/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v5/iso_encoder/rules.mk
+++ b/keyboards/keychron/v5/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v6/ansi/rules.mk
+++ b/keyboards/keychron/v6/ansi/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v6/ansi_encoder/rules.mk
+++ b/keyboards/keychron/v6/ansi_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v6/iso/rules.mk
+++ b/keyboards/keychron/v6/iso/rules.mk
@@ -12,8 +12,6 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v6/iso_encoder/rules.mk
+++ b/keyboards/keychron/v6/iso_encoder/rules.mk
@@ -13,8 +13,6 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = yes        # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
 
 # custom matrix setup
 CUSTOM_MATRIX = lite

--- a/keyboards/keychron/v7/ansi/rules.mk
+++ b/keyboards/keychron/v7/ansi/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v7/iso/rules.mk
+++ b/keyboards/keychron/v7/iso/rules.mk
@@ -12,6 +12,3 @@ RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v8/ansi/rules.mk
+++ b/keyboards/keychron/v8/ansi/rules.mk
@@ -14,6 +14,3 @@ ENCODER_ENABLE = no         # Enable Encoder
 ENCODER_MAP_ENABLE = no
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v8/ansi_encoder/rules.mk
+++ b/keyboards/keychron/v8/ansi_encoder/rules.mk
@@ -14,6 +14,3 @@ ENCODER_ENABLE = yes        # Enable Encoder
 ENCODER_MAP_ENABLE = no
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v8/iso/rules.mk
+++ b/keyboards/keychron/v8/iso/rules.mk
@@ -13,6 +13,3 @@ AUDIO_ENABLE = no           # Audio output
 ENCODER_ENABLE = no         # Enable Encoder
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/keychron/v8/iso_encoder/rules.mk
+++ b/keyboards/keychron/v8/iso_encoder/rules.mk
@@ -14,6 +14,3 @@ ENCODER_ENABLE = yes        # Enable Encoder
 ENCODER_MAP_ENABLE = no
 DIP_SWITCH_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Default `vendor` driver equates to wear leveling + embedded_flash so specifying it at the keyboard level is redundant.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
