### PR TITLE
Jaykeeb Sebelas: Standardize Layout Names

### DIFF
--- a/keyboards/jaykeeb/sebelas/info.json
+++ b/keyboards/jaykeeb/sebelas/info.json
@@ -50,7 +50,8 @@
     "layout_aliases": {
         "LAYOUT_65_ansi_blocker": "LAYOUT_ansi_blocker",
         "LAYOUT_65_ansi_blocker_split_bs": "LAYOUT_ansi_blocker_split_bs",
-        "LAYOUT_65_ansi_blocker_tsangan": "LAYOUT_ansi_blocker_tsangan"
+        "LAYOUT_65_ansi_blocker_tsangan": "LAYOUT_ansi_blocker_tsangan",
+        "LAYOUT_65_ansi_blocker_tsangan_split_bs": "LAYOUT_ansi_blocker_tsangan_split_bs"
     },
     "layouts": {
         "LAYOUT_all": {
@@ -351,7 +352,7 @@
                 {"label": "\u2192", "matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_65_ansi_blocker_tsangan_split_bs": {
+        "LAYOUT_ansi_blocker_tsangan_split_bs": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/jaykeeb/sebelas/info.json
+++ b/keyboards/jaykeeb/sebelas/info.json
@@ -48,7 +48,8 @@
         "vid": "0x414C"
     },
     "layout_aliases": {
-        "LAYOUT_65_ansi_blocker": "LAYOUT_ansi_blocker"
+        "LAYOUT_65_ansi_blocker": "LAYOUT_ansi_blocker",
+        "LAYOUT_65_ansi_blocker_split_bs": "LAYOUT_ansi_blocker_split_bs"
     },
     "layouts": {
         "LAYOUT_all": {
@@ -201,7 +202,7 @@
                 {"label": "\u2192", "matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_65_ansi_blocker_split_bs": {
+        "LAYOUT_ansi_blocker_split_bs": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/jaykeeb/sebelas/info.json
+++ b/keyboards/jaykeeb/sebelas/info.json
@@ -47,6 +47,9 @@
         "pid": "0x0767",
         "vid": "0x414C"
     },
+    "layout_aliases": {
+        "LAYOUT_65_ansi_blocker": "LAYOUT_ansi_blocker"
+    },
     "layouts": {
         "LAYOUT_all": {
             "layout": [
@@ -124,7 +127,7 @@
                 {"label": "\u2192", "matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_65_ansi_blocker": {
+        "LAYOUT_ansi_blocker": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/jaykeeb/sebelas/info.json
+++ b/keyboards/jaykeeb/sebelas/info.json
@@ -49,7 +49,8 @@
     },
     "layout_aliases": {
         "LAYOUT_65_ansi_blocker": "LAYOUT_ansi_blocker",
-        "LAYOUT_65_ansi_blocker_split_bs": "LAYOUT_ansi_blocker_split_bs"
+        "LAYOUT_65_ansi_blocker_split_bs": "LAYOUT_ansi_blocker_split_bs",
+        "LAYOUT_65_ansi_blocker_tsangan": "LAYOUT_ansi_blocker_tsangan"
     },
     "layouts": {
         "LAYOUT_all": {
@@ -277,7 +278,7 @@
                 {"label": "\u2192", "matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_65_ansi_blocker_tsangan": {
+        "LAYOUT_ansi_blocker_tsangan": {
             "layout": [
                 {"label": "Esc", "matrix": [0, 0], "x": 0, "y": 0},
                 {"label": "1", "matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/jaykeeb/sebelas/keymaps/default/keymap.c
+++ b/keyboards/jaykeeb/sebelas/keymaps/default/keymap.c
@@ -4,7 +4,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_65_ansi_blocker(
+    [0] = LAYOUT_ansi_blocker(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_PGUP,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGDN,
@@ -12,7 +12,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
     ),
 
-    [1] = LAYOUT_65_ansi_blocker(
+    [1] = LAYOUT_ansi_blocker(
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SCRL, KC_PAUS, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,

--- a/keyboards/jaykeeb/sebelas/keymaps/via/keymap.c
+++ b/keyboards/jaykeeb/sebelas/keymaps/via/keymap.c
@@ -4,7 +4,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_65_ansi_blocker(
+    [0] = LAYOUT_ansi_blocker(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_PGUP,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGDN,
@@ -12,7 +12,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                             MO(1),   KC_RCTL, KC_LEFT, KC_DOWN, KC_RGHT
     ),
 
-    [1] = LAYOUT_65_ansi_blocker(
+    [1] = LAYOUT_ansi_blocker(
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SCRL, KC_PAUS, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______,


### PR DESCRIPTION
## Description

Existing implementation uses Community Layout names, but the board layout doesn't conform to the layouts implied.

- Rename `LAYOUT_65_ansi_blocker` to `LAYOUT_ansi_blocker`
- Rename `LAYOUT_65_ansi_blocker_split_bs` to `LAYOUT_ansi_blocker_split_bs`
- Rename `LAYOUT_65_ansi_blocker_tsangan` to `LAYOUT_ansi_blocker_tsangan`
- Rename `LAYOUT_65_ansi_blocker_tsangan_split_bs` to `LAYOUT_ansi_blocker_tsangan_split_bs`

cc @alabahuy (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
