### PR TITLE
chibios: disable RWX segment warning on newer GNU lds

### DIFF
--- a/builddefs/common_rules.mk
+++ b/builddefs/common_rules.mk
@@ -15,6 +15,13 @@ VPATH :=
 # Helper to return the distinct elements of a list
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
+cc-option = $(shell \
+	if $(CC) $(1) -shared -o /dev/null -xc /dev/null > /dev/null 2>&1; \
+	then echo "$(1)"; else echo "$(2)"; fi)
+
+# helper to pass comma character to make functions
+, := ,
+
 # Convert all SRC to OBJ
 define OBJ_FROM_SRC
 $(patsubst %.c,$1/%.o,$(patsubst %.cpp,$1/%.o,$(patsubst %.cc,$1/%.o,$(patsubst %.S,$1/%.o,$(patsubst %.clib,$1/%.a,$($1_SRC))))))
@@ -66,9 +73,7 @@ CFLAGS += $(CDEFS)
 CFLAGS += -O$(OPT)
 # add color
 ifeq ($(COLOR),true)
-ifeq ("$(shell echo "int main(){}" | $(CC) -fdiagnostics-color -x c - -o /dev/null 2>&1)", "")
-	CFLAGS+= -fdiagnostics-color
-endif
+	CFLAGS+= $(call cc-option, -fdiagnostics-color)
 endif
 CFLAGS += -Wall
 CFLAGS += -Wstrict-prototypes

--- a/platforms/avr/platform.mk
+++ b/platforms/avr/platform.mk
@@ -12,9 +12,7 @@ HEX = $(OBJCOPY) -O $(FORMAT) -R .eeprom -R .fuse -R .lock -R .signature
 EEP = $(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" --change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT)
 BIN =
 
-ifeq ("$(shell echo "int main(){}" | $(CC) --param=min-pagesize=0 -x c - -o /dev/null 2>&1)", "")
-COMPILEFLAGS += --param=min-pagesize=0
-endif
+COMPILEFLAGS += $(call cc-option, --param=min-pagesize=0)
 
 COMPILEFLAGS += -funsigned-char
 COMPILEFLAGS += -funsigned-bitfields

--- a/platforms/chibios/platform.mk
+++ b/platforms/chibios/platform.mk
@@ -476,6 +476,9 @@ HEX     = $(OBJCOPY) -O $(FORMAT)
 EEP     =
 BIN     = $(OBJCOPY) -O binary
 
+# disable warning about RWX triggered by ChibiOS linker scripts
+SHARED_LDFLAGS += $(call cc-option, -Wl$(,)--no-warn-rwx-segments)
+
 ##############################################################################
 # Make targets
 #


### PR DESCRIPTION
The cc-option and try-run functions are GPL2 from the Linux kernel.
cc-option was adapted to also handle -Wl,foo linker arguments.

See discussion in #21986
Cc @tzarc @KarlK90