### PR TITLE
Remove duplication of EEPROM defaults

### DIFF
--- a/keyboards/binepad/bnr1/v2/rules.mk
+++ b/keyboards/binepad/bnr1/v2/rules.mk
@@ -1,5 +1,1 @@
-# This file only contains EFL/WL settings and enables F103 low-power mode
-
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-
+# This file intentionally left blank

--- a/keyboards/doio/kb16/rev2/rules.mk
+++ b/keyboards/doio/kb16/rev2/rules.mk
@@ -25,7 +25,3 @@ RGB_MATRIX_ENABLE = yes
 
 # Encoder enabled
 ENCODER_ENABLE = yes
-
-# Wear-levelling driver
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash

--- a/keyboards/gmmk/gmmk2/p65/ansi/rules.mk
+++ b/keyboards/gmmk/gmmk2/p65/ansi/rules.mk
@@ -11,5 +11,3 @@ BACKLIGHT_ENABLE = no        # Enable keyboard backlight functionality.
 RGBLIGHT_ENABLE = no         # Enable keyboard RGB underglow.
 AUDIO_ENABLE = no            # Audio output.
 RGB_MATRIX_ENABLE = yes      # Enable RGB matrix effects.
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash

--- a/keyboards/gmmk/gmmk2/p65/iso/rules.mk
+++ b/keyboards/gmmk/gmmk2/p65/iso/rules.mk
@@ -11,5 +11,3 @@ BACKLIGHT_ENABLE = no        # Enable keyboard backlight functionality.
 RGBLIGHT_ENABLE = no         # Enable keyboard RGB underglow.
 AUDIO_ENABLE = no            # Audio output.
 RGB_MATRIX_ENABLE = yes      # Enable RGB matrix effects.
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash

--- a/keyboards/phage_studio/pila87/rules.mk
+++ b/keyboards/phage_studio/pila87/rules.mk
@@ -16,7 +16,3 @@ AUDIO_ENABLE = no           # Audio output
 
 # RGB Matrix enabled
 RGB_MATRIX_ENABLE = yes
-
-# Wear-levelling driver
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash

--- a/keyboards/xelus/kangaroo/rev2/rules.mk
+++ b/keyboards/xelus/kangaroo/rev2/rules.mk
@@ -9,8 +9,3 @@ COMMAND_ENABLE = yes        # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-EEPROM_DRIVER = i2c
-
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-

--- a/keyboards/xelus/rs60/rev2_1/rules.mk
+++ b/keyboards/xelus/rs60/rev2_1/rules.mk
@@ -11,9 +11,6 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
 
-EEPROM_DRIVER = wear_leveling
-WEAR_LEVELING_DRIVER = embedded_flash
-
 # Save hid interface
 KEYBOARD_SHARED_EP = yes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`wear leveling + efl` is the default for `STM32L412`. `STM32F103`, and `WB32F3G71`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
