### PR TITLE
geistmaschine/macropod: fix issues waking up after suspend on apple devices

### DIFF
--- a/keyboards/geistmaschine/macropod/config.h
+++ b/keyboards/geistmaschine/macropod/config.h
@@ -19,3 +19,6 @@
    IO expander setup would allow up to 1x16 + 1 from the MCU */
 #define MATRIX_ROWS 1
 #define MATRIX_COLS 17
+
+/* Fix for Apple Silicon Macs struggling to detect board after suspend/sleep */
+#define USB_SUSPEND_WAKEUP_DELAY 200

--- a/keyboards/geistmaschine/macropod/info.json
+++ b/keyboards/geistmaschine/macropod/info.json
@@ -15,7 +15,7 @@
         "command": false,
         "console": false,
         "extrakey": true,
-        "mousekey": false,
+        "mousekey": true,
         "nkro": false,
         "encoder": true
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Users reported issues with the device not working after their Apple hardware (mainly Apple silicon) woke up from suspend/sleep. Adding USB_SUSPEND_WAKEUP_DELAY of 200ms fixed this issue for all users.

<!--- Describe your changes in detail here. -->

## Types of Changes
* Add 200ms USB_SUSPEND_WAKEUP_DELAY
* Enable mousekey since users requested the change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Keyboard not responsive after Apple hardware wakes up from suspend/sleep
* Mousekeys support missing

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
