### PR TITLE
MonsGeek M1: Correct layout data

### DIFF
--- a/keyboards/monsgeek/m1/info.json
+++ b/keyboards/monsgeek/m1/info.json
@@ -246,7 +246,7 @@
                 { "label": ">", "matrix": [4, 9], "x": 10.25, "y": 4.25 },
                 { "label": "?", "matrix": [4, 10], "x": 11.25, "y": 4.25 },
                 { "label": "Shift", "matrix": [4, 13], "w": 1.75, "x": 12.25, "y": 4.25 },
-                { "label": "Up", "matrix": [4, 14], "x": 14.25, "y": 4.25 },
+                { "label": "Up", "matrix": [4, 14], "x": 14.25, "y": 4.5 },
                 { "label": "End", "matrix": [4, 15], "x": 15.5, "y": 4.25 },
                 { "label": "Ctrl", "matrix": [5, 0], "w": 1.25, "x": 0, "y": 5.25 },
                 { "label": "Win", "matrix": [5, 1], "w": 1.25, "x": 1.25, "y": 5.25 },
@@ -255,9 +255,9 @@
                 { "label": "Alt", "matrix": [5, 9], "x": 10, "y": 5.25 },
                 { "label": "Fn", "matrix": [5, 10], "x": 11, "y": 5.25 },
                 { "label": "Ctrl", "matrix": [5, 11], "x": 12, "y": 5.25 },
-                { "label": "Left", "matrix": [5, 13], "x": 13.25, "y": 5.25 },
-                { "label": "Down", "matrix": [5, 14], "x": 14.25, "y": 5.25 },
-                { "label": "Right", "matrix": [5, 15], "x": 15.25, "y": 5.25 }
+                { "label": "Left", "matrix": [5, 13], "x": 13.25, "y": 5.5 },
+                { "label": "Down", "matrix": [5, 14], "x": 14.25, "y": 5.5 },
+                { "label": "Right", "matrix": [5, 15], "x": 15.25, "y": 5.5 }
             ]
         },
         "LAYOUT_ansi": {
@@ -333,7 +333,7 @@
                 { "label": ">", "matrix": [4, 9], "x": 10.25, "y": 4.25 },
                 { "label": "?", "matrix": [4, 10], "x": 11.25, "y": 4.25 },
                 { "label": "Shift", "matrix": [4, 13], "w": 1.75, "x": 12.25, "y": 4.25 },
-                { "label": "Up", "matrix": [4, 14], "x": 14.25, "y": 4.25 },
+                { "label": "Up", "matrix": [4, 14], "x": 14.25, "y": 4.5 },
                 { "label": "End", "matrix": [4, 15], "x": 15.5, "y": 4.25 },
                 { "label": "Ctrl", "matrix": [5, 0], "w": 1.25, "x": 0, "y": 5.25 },
                 { "label": "Win", "matrix": [5, 1], "w": 1.25, "x": 1.25, "y": 5.25 },
@@ -342,9 +342,9 @@
                 { "label": "Alt", "matrix": [5, 9], "x": 10, "y": 5.25 },
                 { "label": "Fn", "matrix": [5, 10], "x": 11, "y": 5.25 },
                 { "label": "Ctrl", "matrix": [5, 11], "x": 12, "y": 5.25 },
-                { "label": "Left", "matrix": [5, 13], "x": 13.25, "y": 5.25 },
-                { "label": "Down", "matrix": [5, 14], "x": 14.25, "y": 5.25 },
-                { "label": "Right", "matrix": [5, 15], "x": 15.25, "y": 5.25 }
+                { "label": "Left", "matrix": [5, 13], "x": 13.25, "y": 5.5 },
+                { "label": "Down", "matrix": [5, 14], "x": 14.25, "y": 5.5 },
+                { "label": "Right", "matrix": [5, 15], "x": 15.25, "y": 5.5 }
             ]
         },
         "LAYOUT_iso": {
@@ -421,7 +421,7 @@
                 { "label": ">", "matrix": [4, 9], "x": 10.25, "y": 4.25 },
                 { "label": "?", "matrix": [4, 10], "x": 11.25, "y": 4.25 },
                 { "label": "Shift", "matrix": [4, 13], "w": 1.75, "x": 12.25, "y": 4.25 },
-                { "label": "Up", "matrix": [4, 14], "x": 14.25, "y": 4.25 },
+                { "label": "Up", "matrix": [4, 14], "x": 14.25, "y": 4.5 },
                 { "label": "End", "matrix": [4, 15], "x": 15.5, "y": 4.25 },
                 { "label": "Ctrl", "matrix": [5, 0], "w": 1.25, "x": 0, "y": 5.25 },
                 { "label": "Win", "matrix": [5, 1], "w": 1.25, "x": 1.25, "y": 5.25 },
@@ -430,9 +430,9 @@
                 { "label": "Alt", "matrix": [5, 9], "x": 10, "y": 5.25 },
                 { "label": "Fn", "matrix": [5, 10], "x": 11, "y": 5.25 },
                 { "label": "Ctrl", "matrix": [5, 11], "x": 12, "y": 5.25 },
-                { "label": "Left", "matrix": [5, 13], "x": 13.25, "y": 5.25 },
-                { "label": "Down", "matrix": [5, 14], "x": 14.25, "y": 5.25 },
-                { "label": "Right", "matrix": [5, 15], "x": 15.25, "y": 5.25 }
+                { "label": "Left", "matrix": [5, 13], "x": 13.25, "y": 5.5 },
+                { "label": "Down", "matrix": [5, 14], "x": 14.25, "y": 5.5 },
+                { "label": "Right", "matrix": [5, 15], "x": 15.25, "y": 5.5 }
             ]
         }
     }


### PR DESCRIPTION
## Description

Apply vertical offset to the arrow keys.
![image](https://github.com/qmk/qmk_firmware/assets/18669334/367afd93-af2d-4568-b19e-4632b2ddc662)

cc @jonylee1986 (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
