### PR TITLE
add missing gpio and chibios defs to uart.h

### DIFF
--- a/platforms/chibios/drivers/uart.h
+++ b/platforms/chibios/drivers/uart.h
@@ -21,6 +21,9 @@
 
 #include <hal.h>
 
+#include "gpio.h"
+#include "chibios_config.h"
+
 #ifndef SERIAL_DRIVER
 #    define SERIAL_DRIVER SD1
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

After [quantum.h was removed from several driver files](https://github.com/qmk/qmk_firmware/commit/b6d9409d2f8eaa9888fce1611bcb9a23d97be150), I was unable to compile by firmware, which is redox-w-esque, due to missing pin and chibios defs.

<!--- Describe your changes in detail here. -->

## Types of Changes

After working with @infinityis, [who reached out on discord](https://discord.com/channels/440868230475677696/867530715192885269/1151599331086970880), we decided to add the appropriate chibios header files to uart.h.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* No issue was created for this PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
