### PR TITLE
Fix paragon encoder pinout for soldered version

### DIFF
--- a/keyboards/artemis/paragon/hotswap/info.json
+++ b/keyboards/artemis/paragon/hotswap/info.json
@@ -3,6 +3,11 @@
         "cols": ["F7", "F6", "F5", "F4", "F1", "F0", "C7", "E6", "B0", "B3", "B6", "B5", "B4", "D7", "D4", "D6"],
         "rows": ["D2", "D1", "D0", "B2", "B1", "C6"]
     },
+    "encoder": {
+        "rotary": [
+            { "pin_a": "D3", "pin_b": "D5", "resolution": 2 }
+        ]
+    },
     "layouts": {
         "LAYOUT_ansi_rwkl": {
             "layout": [

--- a/keyboards/artemis/paragon/info.json
+++ b/keyboards/artemis/paragon/info.json
@@ -18,11 +18,6 @@
     },
     "processor": "atmega32u4",
     "url": "",
-    "encoder": {
-        "rotary": [
-            { "pin_a": "D3", "pin_b": "D5", "resolution": 2 }
-        ]
-    },
     "usb": {
         "device_version": "1.0.0",
         "pid": "0x3449",

--- a/keyboards/artemis/paragon/soldered/info.json
+++ b/keyboards/artemis/paragon/soldered/info.json
@@ -3,6 +3,11 @@
         "cols": ["E6", "F0", "F1", "F4", "F5", "F6", "F7", "B0", "B1", "B3", "D0", "D1", "D2", "D3", "D7", "D5"],
         "rows": ["B2", "C7", "C6", "B6", "B5", "B4"]
     },
+    "encoder": {
+        "rotary": [
+            { "pin_a": "D4", "pin_b": "D6", "resolution": 2 }
+        ]
+    },
     "layouts": {
         "LAYOUT_ansi_rwkl": {
             "layout": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For the paragon keyboard, the encoder pins are different on the hotswap and on the soldered PCB. It was not the case in the source code, although the binary files provided by the designer are fine.

Tested on both my official hotswap and soldered PCB, I can provide picture of the pcb trace leading to the PIN if necessary.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
