### PR TITLE
Document the RP2040-specific PS/2 implementation

### DIFF
--- a/docs/feature_ps2_mouse.md
+++ b/docs/feature_ps2_mouse.md
@@ -166,7 +166,7 @@ PIO state machine code.
 
 Example info.json content:
 
-```
+```json
     "ps2": {
         "clock_pin": "GP1",
         "data_pin": "GP0",

--- a/docs/feature_ps2_mouse.md
+++ b/docs/feature_ps2_mouse.md
@@ -155,6 +155,27 @@ In your keyboard config.h:
 #endif
 ```
 
+### RP2040 PIO Version :id=rp2040-pio-version
+
+This uses the RP2040's hardware feature called PIO and is therefore only
+available on boards that are based on the RP2040 MCU.
+
+The pin for the data signal must be followed directly by the pin for the clock
+within the GPIO pin numbering scheme. This is required due to the design of the
+PIO state machine code.
+
+Example info.json content:
+
+```
+    "ps2": {
+        "clock_pin": "GP1",
+        "data_pin": "GP0",
+        "driver": "vendor",
+        "enabled": true,
+        "mouse_enabled": true
+    }
+```
+
 ## Additional Settings :id=additional-settings
 
 ### PS/2 Mouse Features :id=ps2-mouse-features

--- a/docs/feature_ps2_mouse.md
+++ b/docs/feature_ps2_mouse.md
@@ -157,12 +157,14 @@ In your keyboard config.h:
 
 ### RP2040 PIO Version :id=rp2040-pio-version
 
-This uses the RP2040's hardware feature called PIO and is therefore only
-available on boards that are based on the RP2040 MCU.
+The `PIO` subsystem is a Raspberry Pi RP2040 specific implementation, using the integrated PIO peripheral and is therefore only available on this MCU.
 
-The pin for the data signal must be followed directly by the pin for the clock
-within the GPIO pin numbering scheme. This is required due to the design of the
-PIO state machine code.
+There are strict requirements for pin ordering but any pair of GPIO pins can be used. The GPIO used for clock must be directly after data, see the included info.json snippet for an example of correct order.
+
+You may optionally switch the PIO peripheral used with the following define in config.h:
+```c
+#define PS2_PIO_USE_PIO1 // Force the usage of PIO1 peripheral, by default the PS2 implementation uses the PIO0 peripheral
+```
 
 Example info.json content:
 

--- a/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
@@ -22,7 +22,7 @@
 #endif
 
 #if PS2_DATA_PIN + 1 != PS2_CLOCK_PIN
-#    error PS/2 data pin must be followed by clock pin!
+#    error PS/2 clock pin must be data pin + 1!
 #endif
 
 static inline void pio_serve_interrupt(void);

--- a/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
@@ -22,7 +22,7 @@
 #endif
 
 #if PS2_DATA_PIN + 1 != PS2_CLOCK_PIN
-#    error PS/2 Clock pin must be followed by data pin!
+#    error PS/2 data pin must be followed by clock pin!
 #endif
 
 static inline void pio_serve_interrupt(void);


### PR DESCRIPTION
Document the use of the PIO state machine code for RP2040 devices as an alternative implementation of a PS/2 interface.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I got help on Discord setting up the PS/2 feature with an RP2040. This is basically the info that I needed and the place where I would have expected it, so let's put this quick note here?!
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
