### PR TITLE
SapuSeven MacroPad12: rename LAYOUT to LAYOUT_ortho_3x4

### DIFF
--- a/keyboards/sapuseven/macropad12/info.json
+++ b/keyboards/sapuseven/macropad12/info.json
@@ -22,8 +22,11 @@
         "vid": "0x1209",
         "pid": "0x7337"
     },
+    "layout_aliases": {
+        "LAYOUT": "LAYOUT_ortho_3x4"
+    },
     "layouts": {
-        "LAYOUT": {
+        "LAYOUT_ortho_3x4": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/sapuseven/macropad12/keymaps/default/keymap.c
+++ b/keyboards/sapuseven/macropad12/keymaps/default/keymap.c
@@ -17,7 +17,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
+    [0] = LAYOUT_ortho_3x4(
         KC_1, KC_2, KC_3, KC_PLUS,
         KC_4, KC_5, KC_6, KC_MINUS,
         KC_7, KC_8, KC_9, KC_0

--- a/keyboards/sapuseven/macropad12/keymaps/via/keymap.c
+++ b/keyboards/sapuseven/macropad12/keymaps/via/keymap.c
@@ -17,22 +17,22 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT(
+    [0] = LAYOUT_ortho_3x4(
         KC_1, KC_2, KC_3, KC_PLUS,
         KC_4, KC_5, KC_6, KC_MINUS,
         KC_7, KC_8, KC_9, KC_0
     ),
-    [1] = LAYOUT(
+    [1] = LAYOUT_ortho_3x4(
         KC_F1, KC_F2, KC_F3, KC_F4,
         KC_F5, KC_F6, KC_F7, KC_F8,
         KC_F9, KC_F10, KC_F11, KC_F12
     ),
-    [2] = LAYOUT(
+    [2] = LAYOUT_ortho_3x4(
         KC_F13, KC_F14, KC_F15, KC_F16,
         KC_F17, KC_F18, KC_F19, KC_F20,
         KC_F21, KC_F22, KC_F23, KC_F24
     ),
-    [3] = LAYOUT(
+    [3] = LAYOUT_ortho_3x4(
         KC_NO, KC_NO, KC_NO, KC_NO,
         KC_NO, KC_NO, KC_NO, KC_NO,
         KC_NO, KC_NO, KC_NO, KC_NO


### PR DESCRIPTION
## Description

[title]

cc @SapuSeven (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
