### PR TITLE
LED/RGB Matrix: prefix driver defines

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -376,42 +376,42 @@ endif
     CIE1931_CURVE := yes
 
     ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3731)
-        OPT_DEFS += -DIS31FL3731 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DLED_MATRIX_IS31FL3731 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3731-simple.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3742a)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3742A -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3742A -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3743a)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3743A -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3743A -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3745)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3745 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3745 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3746a)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3746A -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3746A -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), ckled2001)
-        OPT_DEFS += -DCKLED2001 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DLED_MATRIX_CKLED2001 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led
         SRC += ckled2001-simple.c
         QUANTUM_LIB_SRC += i2c_master.c
@@ -448,96 +448,96 @@ endif
     RGB_KEYCODES_ENABLE := yes
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), aw20216s)
-        OPT_DEFS += -DAW20216S -DSTM32_SPI -DHAL_USE_SPI=TRUE
+        OPT_DEFS += -DRGB_MATRIX_AW20216S -DHAL_USE_SPI=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led
         SRC += aw20216s.c
         QUANTUM_LIB_SRC += spi_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3218)
-        OPT_DEFS += -DIS31FL3218 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DRGB_MATRIX_IS31FL3218 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3218.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3731)
-        OPT_DEFS += -DIS31FL3731 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DRGB_MATRIX_IS31FL3731 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3731.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3733)
-        OPT_DEFS += -DIS31FL3733 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DRGB_MATRIX_IS31FL3733 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3733.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3736)
-        OPT_DEFS += -DIS31FL3736 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DRGB_MATRIX_IS31FL3736 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3736.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3737)
-        OPT_DEFS += -DIS31FL3737 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DRGB_MATRIX_IS31FL3737 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3737.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3741)
-        OPT_DEFS += -DIS31FL3741 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DRGB_MATRIX_IS31FL3741 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3741.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3742a)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3742A -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3742A -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3743a)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3743A -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3743A -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3745)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3745 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3745 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3746a)
-        OPT_DEFS += -DIS31FLCOMMON -DIS31FL3746A -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3746A -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), ckled2001)
-        OPT_DEFS += -DCKLED2001 -DSTM32_I2C -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DRGB_MATRIX_CKLED2001 -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led
         SRC += ckled2001.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), ws2812)
-        OPT_DEFS += -DWS2812
+        OPT_DEFS += -DRGB_MATRIX_WS2812
         WS2812_DRIVER_REQUIRED := yes
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), apa102)
-        OPT_DEFS += -DAPA102
+        OPT_DEFS += -DRGB_MATRIX_APA102
         APA102_DRIVER_REQUIRED := yes
     endif
 

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -361,6 +361,7 @@ ifeq ($(strip $(LED_MATRIX_ENABLE)), yes)
         $(call CATASTROPHIC_ERROR,Invalid LED_MATRIX_DRIVER,LED_MATRIX_DRIVER="$(LED_MATRIX_DRIVER)" is not a valid matrix type)
     endif
     OPT_DEFS += -DLED_MATRIX_ENABLE
+    OPT_DEFS += -DLED_MATRIX_$(strip $(shell echo $(LED_MATRIX_DRIVER) | tr '[:lower:]' '[:upper:]'))
 ifneq (,$(filter $(MCU), atmega16u2 atmega32u2 at90usb162))
     # ATmegaxxU2 does not have hardware MUL instruction - lib8tion must be told to use software multiplication routines
     OPT_DEFS += -DLIB8_ATTINY
@@ -376,42 +377,42 @@ endif
     CIE1931_CURVE := yes
 
     ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3731)
-        OPT_DEFS += -DLED_MATRIX_IS31FL3731 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3731-simple.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3742a)
-        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3742A -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3743a)
-        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3743A -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3745)
-        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3745 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3746a)
-        OPT_DEFS += -DIS31FLCOMMON -DLED_MATRIX_IS31FL3746A -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(LED_MATRIX_DRIVER)), ckled2001)
-        OPT_DEFS += -DLED_MATRIX_CKLED2001 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led
         SRC += ckled2001-simple.c
         QUANTUM_LIB_SRC += i2c_master.c
@@ -432,6 +433,7 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)
         $(call CATASTROPHIC_ERROR,Invalid RGB_MATRIX_DRIVER,RGB_MATRIX_DRIVER="$(RGB_MATRIX_DRIVER)" is not a valid matrix type)
     endif
     OPT_DEFS += -DRGB_MATRIX_ENABLE
+    OPT_DEFS += -DRGB_MATRIX_$(strip $(shell echo $(RGB_MATRIX_DRIVER) | tr '[:lower:]' '[:upper:]'))
 ifneq (,$(filter $(MCU), atmega16u2 atmega32u2 at90usb162))
     # ATmegaxxU2 does not have hardware MUL instruction - lib8tion must be told to use software multiplication routines
     OPT_DEFS += -DLIB8_ATTINY
@@ -448,96 +450,94 @@ endif
     RGB_KEYCODES_ENABLE := yes
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), aw20216s)
-        OPT_DEFS += -DRGB_MATRIX_AW20216S -DHAL_USE_SPI=TRUE
+        OPT_DEFS += -DHAL_USE_SPI=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led
         SRC += aw20216s.c
         QUANTUM_LIB_SRC += spi_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3218)
-        OPT_DEFS += -DRGB_MATRIX_IS31FL3218 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3218.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3731)
-        OPT_DEFS += -DRGB_MATRIX_IS31FL3731 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3731.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3733)
-        OPT_DEFS += -DRGB_MATRIX_IS31FL3733 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3733.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3736)
-        OPT_DEFS += -DRGB_MATRIX_IS31FL3736 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3736.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3737)
-        OPT_DEFS += -DRGB_MATRIX_IS31FL3737 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3737.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3741)
-        OPT_DEFS += -DRGB_MATRIX_IS31FL3741 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3741.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3742a)
-        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3742A -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3743a)
-        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3743A -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3745)
-        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3745 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
 	ifeq ($(strip $(RGB_MATRIX_DRIVER)), is31fl3746a)
-        OPT_DEFS += -DIS31FLCOMMON -DRGB_MATRIX_IS31FL3746A -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DIS31FLCOMMON -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31flcommon.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), ckled2001)
-        OPT_DEFS += -DRGB_MATRIX_CKLED2001 -DHAL_USE_I2C=TRUE
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led
         SRC += ckled2001.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), ws2812)
-        OPT_DEFS += -DRGB_MATRIX_WS2812
         WS2812_DRIVER_REQUIRED := yes
     endif
 
     ifeq ($(strip $(RGB_MATRIX_DRIVER)), apa102)
-        OPT_DEFS += -DRGB_MATRIX_APA102
         APA102_DRIVER_REQUIRED := yes
     endif
 

--- a/drivers/led/issi/is31flcommon.h
+++ b/drivers/led/issi/is31flcommon.h
@@ -25,13 +25,13 @@
 #include "progmem.h"
 
 // Which variant header file to use
-#ifdef IS31FL3742A
+#if defined(LED_MATRIX_IS31FL3742A) || defined(RGB_MATRIX_IS31FL3742A)
 #    include "is31fl3742.h"
-#elif defined(IS31FL3743A)
+#elif defined(LED_MATRIX_IS31FL3743A) || defined(RGB_MATRIX_IS31FL3743A)
 #    include "is31fl3743.h"
-#elif defined(IS31FL3745)
+#elif defined(LED_MATRIX_IS31FL3745) || defined(RGB_MATRIX_IS31FL3745)
 #    include "is31fl3745.h"
-#elif defined(IS31FL3746A)
+#elif defined(LED_MATRIX_IS31FL3746A) || defined(RGB_MATRIX_IS31FL3746A)
 #    include "is31fl3746.h"
 #endif
 

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -25,15 +25,15 @@
 #include "led_matrix_types.h"
 #include "keyboard.h"
 
-#ifdef IS31FL3731
+#ifdef LED_MATRIX_IS31FL3731
 #    include "is31fl3731-simple.h"
 #elif defined(IS31FLCOMMON)
 #    include "is31flcommon.h"
 #endif
-#ifdef IS31FL3733
+#ifdef LED_MATRIX_IS31FL3733
 #    include "is31fl3733-simple.h"
 #endif
-#ifdef CKLED2001
+#ifdef LED_MATRIX_CKLED2001
 #    include "ckled2001-simple.h"
 #endif
 

--- a/quantum/led_matrix/led_matrix_drivers.c
+++ b/quantum/led_matrix/led_matrix_drivers.c
@@ -25,13 +25,13 @@
  * in their own files.
  */
 
-#if defined(IS31FL3731) || defined(IS31FL3733) || defined(IS31FLCOMMON) || defined(CKLED2001)
+#if defined(LED_MATRIX_IS31FL3731) || defined(LED_MATRIX_IS31FL3733) || defined(IS31FLCOMMON) || defined(LED_MATRIX_CKLED2001)
 #    include "i2c_master.h"
 
 static void init(void) {
     i2c_init();
 
-#    if defined(IS31FL3731)
+#    if defined(LED_MATRIX_IS31FL3731)
     is31fl3731_init(LED_DRIVER_ADDR_1);
 #        if defined(LED_DRIVER_ADDR_2)
     is31fl3731_init(LED_DRIVER_ADDR_2);
@@ -43,7 +43,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3733)
+#    elif defined(LED_MATRIX_IS31FL3733)
 #        if !defined(LED_DRIVER_SYNC_1)
 #            define LED_DRIVER_SYNC_1 0
 #        endif
@@ -78,7 +78,7 @@ static void init(void) {
 #                endif
 #            endif
 #        endif
-#    elif defined(CKLED2001)
+#    elif defined(LED_MATRIX_CKLED2001)
 #        if defined(LED_DRIVER_SHUTDOWN_PIN)
     setPinOutput(LED_DRIVER_SHUTDOWN_PIN);
     writePinHigh(LED_DRIVER_SHUTDOWN_PIN);
@@ -97,19 +97,19 @@ static void init(void) {
 #    endif
 
     for (int index = 0; index < LED_MATRIX_LED_COUNT; index++) {
-#    if defined(IS31FL3731)
+#    if defined(LED_MATRIX_IS31FL3731)
         is31fl3731_set_led_control_register(index, true);
-#    elif defined(IS31FL3733)
+#    elif defined(LED_MATRIX_IS31FL3733)
         is31fl3733_set_led_control_register(index, true);
 #    elif defined(IS31FLCOMMON)
         IS31FL_simple_set_scaling_buffer(index, true);
-#    elif defined(CKLED2001)
+#    elif defined(LED_MATRIX_CKLED2001)
         ckled2001_set_led_control_register(index, true);
 #    endif
     }
 
 // This actually updates the LED drivers
-#    if defined(IS31FL3731)
+#    if defined(LED_MATRIX_IS31FL3731)
     is31fl3731_update_led_control_registers(LED_DRIVER_ADDR_1, 0);
 #        if defined(LED_DRIVER_ADDR_2)
     is31fl3731_update_led_control_registers(LED_DRIVER_ADDR_2, 1);
@@ -121,7 +121,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3733)
+#    elif defined(LED_MATRIX_IS31FL3733)
     is31fl3733_update_led_control_registers(LED_DRIVER_ADDR_1, 0);
 #        if defined(LED_DRIVER_ADDR_2)
     is31fl3733_update_led_control_registers(LED_DRIVER_ADDR_2, 1);
@@ -147,7 +147,7 @@ static void init(void) {
 #                endif
 #            endif
 #        endif
-#    elif defined(CKLED2001)
+#    elif defined(LED_MATRIX_CKLED2001)
     ckled2001_update_led_control_registers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
     ckled2001_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -161,7 +161,7 @@ static void init(void) {
 #    endif
 }
 
-#    if defined(IS31FL3731)
+#    if defined(LED_MATRIX_IS31FL3731)
 static void flush(void) {
     is31fl3731_update_pwm_buffers(LED_DRIVER_ADDR_1, 0);
 #        if defined(LED_DRIVER_ADDR_2)
@@ -182,7 +182,7 @@ const led_matrix_driver_t led_matrix_driver = {
     .set_value_all = is31fl3731_set_value_all,
 };
 
-#    elif defined(IS31FL3733)
+#    elif defined(LED_MATRIX_IS31FL3733)
 static void flush(void) {
     is31fl3733_update_pwm_buffers(LED_DRIVER_ADDR_1, 0);
 #        if defined(LED_DRIVER_ADDR_2)
@@ -223,7 +223,7 @@ const led_matrix_driver_t led_matrix_driver = {
     .set_value = IS31FL_simple_set_brightness,
     .set_value_all = IS31FL_simple_set_brigntness_all,
 };
-#    elif defined(CKLED2001)
+#    elif defined(LED_MATRIX_CKLED2001)
 static void flush(void) {
     ckled2001_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -24,25 +24,25 @@
 #include "color.h"
 #include "keyboard.h"
 
-#if defined(IS31FL3218)
+#if defined(RGB_MATRIX_IS31FL3218)
 #    include "is31fl3218.h"
-#elif defined(IS31FL3731)
+#elif defined(RGB_MATRIX_IS31FL3731)
 #    include "is31fl3731.h"
-#elif defined(IS31FL3733)
+#elif defined(RGB_MATRIX_IS31FL3733)
 #    include "is31fl3733.h"
-#elif defined(IS31FL3736)
+#elif defined(RGB_MATRIX_IS31FL3736)
 #    include "is31fl3736.h"
-#elif defined(IS31FL3737)
+#elif defined(RGB_MATRIX_IS31FL3737)
 #    include "is31fl3737.h"
-#elif defined(IS31FL3741)
+#elif defined(RGB_MATRIX_IS31FL3741)
 #    include "is31fl3741.h"
 #elif defined(IS31FLCOMMON)
 #    include "is31flcommon.h"
-#elif defined(CKLED2001)
+#elif defined(RGB_MATRIX_CKLED2001)
 #    include "ckled2001.h"
-#elif defined(AW20216S)
+#elif defined(RGB_MATRIX_AW20216S)
 #    include "aw20216s.h"
-#elif defined(WS2812)
+#elif defined(RGB_MATRIX_WS2812)
 #    include "ws2812.h"
 #endif
 

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -24,7 +24,7 @@
  * be here if shared between boards.
  */
 
-#if defined(IS31FL3218) || defined(IS31FL3731) || defined(IS31FL3733) || defined(IS31FL3736) || defined(IS31FL3737) || defined(IS31FL3741) || defined(IS31FLCOMMON) || defined(CKLED2001)
+#if defined(RGB_MATRIX_IS31FL3218) || defined(RGB_MATRIX_IS31FL3731) || defined(RGB_MATRIX_IS31FL3733) || defined(RGB_MATRIX_IS31FL3736) || defined(RGB_MATRIX_IS31FL3737) || defined(RGB_MATRIX_IS31FL3741) || defined(IS31FLCOMMON) || defined(RGB_MATRIX_CKLED2001)
 #    include "i2c_master.h"
 
 // TODO: Remove this at some later date
@@ -37,10 +37,10 @@
 static void init(void) {
     i2c_init();
 
-#    if defined(IS31FL3218)
+#    if defined(RGB_MATRIX_IS31FL3218)
     is31fl3218_init();
 
-#    elif defined(IS31FL3731)
+#    elif defined(RGB_MATRIX_IS31FL3731)
     is31fl3731_init(DRIVER_ADDR_1);
 #        if defined(DRIVER_ADDR_2)
     is31fl3731_init(DRIVER_ADDR_2);
@@ -52,7 +52,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3733)
+#    elif defined(RGB_MATRIX_IS31FL3733)
 #        if !defined(DRIVER_SYNC_1)
 #            define DRIVER_SYNC_1 0
 #        endif
@@ -76,7 +76,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3736)
+#    elif defined(RGB_MATRIX_IS31FL3736)
     is31fl3736_init(DRIVER_ADDR_1);
 #        if defined(DRIVER_ADDR_2)
     is31fl3736_init(DRIVER_ADDR_2);
@@ -88,7 +88,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3737)
+#    elif defined(RGB_MATRIX_IS31FL3737)
     is31fl3737_init(DRIVER_ADDR_1);
 #        if defined(DRIVER_ADDR_2)
     is31fl3737_init(DRIVER_ADDR_2);
@@ -100,7 +100,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3741)
+#    elif defined(RGB_MATRIX_IS31FL3741)
     is31fl3741_init(DRIVER_ADDR_1);
 #        if defined(DRIVER_ADDR_2)
     is31fl3741_init(DRIVER_ADDR_2);
@@ -124,7 +124,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(CKLED2001)
+#    elif defined(RGB_MATRIX_CKLED2001)
     ckled2001_init(DRIVER_ADDR_1);
 #        if defined(DRIVER_ADDR_2)
     ckled2001_init(DRIVER_ADDR_2);
@@ -141,30 +141,30 @@ static void init(void) {
         bool enabled = true;
 
         // This only caches it for later
-#    if defined(IS31FL3218)
+#    if defined(RGB_MATRIX_IS31FL3218)
         is31fl3218_set_led_control_register(index, enabled, enabled, enabled);
-#    elif defined(IS31FL3731)
+#    elif defined(RGB_MATRIX_IS31FL3731)
         is31fl3731_set_led_control_register(index, enabled, enabled, enabled);
-#    elif defined(IS31FL3733)
+#    elif defined(RGB_MATRIX_IS31FL3733)
         is31fl3733_set_led_control_register(index, enabled, enabled, enabled);
-#    elif defined(IS31FL3736)
+#    elif defined(RGB_MATRIX_IS31FL3736)
         is31fl3736_set_led_control_register(index, enabled, enabled, enabled);
-#    elif defined(IS31FL3737)
+#    elif defined(RGB_MATRIX_IS31FL3737)
         is31fl3737_set_led_control_register(index, enabled, enabled, enabled);
-#    elif defined(IS31FL3741)
+#    elif defined(RGB_MATRIX_IS31FL3741)
         is31fl3741_set_led_control_register(index, enabled, enabled, enabled);
 #    elif defined(IS31FLCOMMON)
         IS31FL_RGB_set_scaling_buffer(index, enabled, enabled, enabled);
-#    elif defined(CKLED2001)
+#    elif defined(RGB_MATRIX_CKLED2001)
         ckled2001_set_led_control_register(index, enabled, enabled, enabled);
 #    endif
     }
 
     // This actually updates the LED drivers
-#    if defined(IS31FL3218)
+#    if defined(RGB_MATRIX_IS31FL3218)
     is31fl3218_update_led_control_registers();
 
-#    elif defined(IS31FL3731)
+#    elif defined(RGB_MATRIX_IS31FL3731)
     is31fl3731_update_led_control_registers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
     is31fl3731_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -176,7 +176,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3733)
+#    elif defined(RGB_MATRIX_IS31FL3733)
     is31fl3733_update_led_control_registers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
     is31fl3733_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -188,7 +188,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3736)
+#    elif defined(RGB_MATRIX_IS31FL3736)
     is31fl3736_update_led_control_registers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
     is31fl3736_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -200,7 +200,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3737)
+#    elif defined(RGB_MATRIX_IS31FL3737)
     is31fl3737_update_led_control_registers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
     is31fl3737_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -212,7 +212,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(IS31FL3741)
+#    elif defined(RGB_MATRIX_IS31FL3741)
     is31fl3741_update_led_control_registers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
     is31fl3741_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -239,7 +239,7 @@ static void init(void) {
 #            endif
 #        endif
 
-#    elif defined(CKLED2001)
+#    elif defined(RGB_MATRIX_CKLED2001)
     ckled2001_update_led_control_registers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
     ckled2001_update_led_control_registers(DRIVER_ADDR_2, 1);
@@ -253,7 +253,7 @@ static void init(void) {
 #    endif
 }
 
-#    if defined(IS31FL3218)
+#    if defined(RGB_MATRIX_IS31FL3218)
 static void flush(void) {
     is31fl3218_update_pwm_buffers();
 }
@@ -265,7 +265,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = is31fl3218_set_color_all,
 };
 
-#    elif defined(IS31FL3731)
+#    elif defined(RGB_MATRIX_IS31FL3731)
 static void flush(void) {
     is31fl3731_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
@@ -286,7 +286,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = is31fl3731_set_color_all,
 };
 
-#    elif defined(IS31FL3733)
+#    elif defined(RGB_MATRIX_IS31FL3733)
 static void flush(void) {
     is31fl3733_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
@@ -307,7 +307,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = is31fl3733_set_color_all,
 };
 
-#    elif defined(IS31FL3736)
+#    elif defined(RGB_MATRIX_IS31FL3736)
 static void flush(void) {
     is31fl3736_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
@@ -328,7 +328,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = is31fl3736_set_color_all,
 };
 
-#    elif defined(IS31FL3737)
+#    elif defined(RGB_MATRIX_IS31FL3737)
 static void flush(void) {
     is31fl3737_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
@@ -349,7 +349,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = is31fl3737_set_color_all,
 };
 
-#    elif defined(IS31FL3741)
+#    elif defined(RGB_MATRIX_IS31FL3741)
 static void flush(void) {
     is31fl3741_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
@@ -391,7 +391,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = IS31FL_RGB_set_color_all,
 };
 
-#    elif defined(CKLED2001)
+#    elif defined(RGB_MATRIX_CKLED2001)
 static void flush(void) {
     ckled2001_update_pwm_buffers(DRIVER_ADDR_1, 0);
 #        if defined(DRIVER_ADDR_2)
@@ -413,7 +413,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 };
 #    endif
 
-#elif defined(AW20216S)
+#elif defined(RGB_MATRIX_AW20216S)
 #    include "spi_master.h"
 
 static void init(void) {
@@ -439,7 +439,7 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
     .set_color_all = aw20216s_set_color_all,
 };
 
-#elif defined(WS2812)
+#elif defined(RGB_MATRIX_WS2812)
 #    if defined(RGBLIGHT_ENABLE) && !defined(RGBLIGHT_CUSTOM_DRIVER)
 #        pragma message "Cannot use RGBLIGHT and RGB Matrix using WS2812 at the same time."
 #        pragma message "You need to use a custom driver, or re-implement the WS2812 driver to use a different configuration."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For consistency, the idea being to do this for all features with driver selection: `FEATURENAME_DRIVERNAME`.

Removed `STM32_I2C` defines as well since they don't seem to be referenced anywhere?

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
