### PR TITLE
[QP] Color inversion control functions. 

### DIFF
--- a/docs/quantum_painter.md
+++ b/docs/quantum_painter.md
@@ -551,6 +551,17 @@ void housekeeping_task_user(void) {
 }
 ```
 
+#### ** Display Color Inversion **
+
+```c
+bool qp_gc9a01_set_inversion(painter_device_t device, bool invert);
+bool qp_ili9xxx_set_inversion(painter_device_t device, bool invert);
+bool qp_ssd1351_set_inversion(painter_device_t device, bool invert);
+bool qp_st77xx_set_inversion(painter_device_t device, bool invert);
+```
+
+This set of functions allow changing the inversion (ie: red is drawn blue, and so on) of a display, this may be needed when the default init sequence for a device does not match your hardware.
+
 <!-- tabs:end -->
 
 ### ** Drawing Primitives **
@@ -730,9 +741,7 @@ The `qp_drawimage` and `qp_drawimage_recolor` functions draw the supplied image 
 static painter_image_handle_t my_image;
 void keyboard_post_init_kb(void) {
     my_image = qp_load_image_mem(gfx_my_image);
-    if (my_image != NULL) {
-        qp_drawimage(display, (239 - my_image->width), (319 - my_image->height), my_image);
-    }
+    qp_drawimage(display, (239 - my_image->width), (319 - my_image->height), my_image);
 }
 ```
 
@@ -755,9 +764,7 @@ static painter_image_handle_t my_image;
 static deferred_token my_anim;
 void keyboard_post_init_kb(void) {
     my_image = qp_load_image_mem(gfx_my_image);
-    if (my_image != NULL) {
-        my_anim = qp_animate(display, (239 - my_image->width), (319 - my_image->height), my_image);
-    }
+    my_anim = qp_animate(display, (239 - my_image->width), (319 - my_image->height), my_image);
 }
 ```
 
@@ -843,11 +850,9 @@ The `qp_drawtext` and `qp_drawtext_recolor` functions draw the supplied string t
 static painter_font_handle_t my_font;
 void keyboard_post_init_kb(void) {
     my_font = qp_load_font_mem(font_noto11);
-    if (my_font != NULL) {
-        static const char *text = "Hello from QMK!";
-        int16_t width = qp_textwidth(my_font, text);
-        qp_drawtext(display, (239 - width), (319 - my_font->line_height), my_font, text);
-    }
+    static const char *text = "Hello from QMK!";
+    int16_t width = qp_textwidth(my_font, text);
+    qp_drawtext(display, (239 - width), (319 - my_font->line_height), my_font, text);
 }
 ```
 

--- a/drivers/painter/gc9a01/qp_gc9a01.c
+++ b/drivers/painter/gc9a01/qp_gc9a01.c
@@ -90,6 +90,18 @@ __attribute__((weak)) bool qp_gc9a01_init(painter_device_t device, painter_rotat
     return true;
 }
 
+bool qp_gc9a01_set_inversion(painter_device_t device, bool invert) {
+    if (!device) {
+        qp_dprintf("qp_gc9a01_set_inversion: fail (un-initialized pointer)\n");
+        return false;
+    }
+
+    qp_comms_command(device, invert ? GC9A01_CMD_INVERT_ON : GC9A01_CMD_INVERT_OFF);
+
+    qp_dprintf("qp_gc9a01_set_inversion: ok\n");
+    return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Driver vtable
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/gc9a01/qp_gc9a01.h
+++ b/drivers/painter/gc9a01/qp_gc9a01.h
@@ -36,4 +36,11 @@
 painter_device_t qp_gc9a01_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
 #endif // QUANTUM_PAINTER_GC9A01_SPI_ENABLE
 
+/**
+ * Function to control color inversion on a GC9A01 device.
+ *
+ * @param device[in] device handle to operate on.
+ * @param invert[in] whether to invert colors or not.
+ * @return Whether the operation was successful.
+ */
 bool qp_gc9a01_set_inversion(painter_device_t device, bool invert);

--- a/drivers/painter/gc9a01/qp_gc9a01.h
+++ b/drivers/painter/gc9a01/qp_gc9a01.h
@@ -35,3 +35,5 @@
  */
 painter_device_t qp_gc9a01_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
 #endif // QUANTUM_PAINTER_GC9A01_SPI_ENABLE
+
+bool qp_gc9a01_set_inversion(painter_device_t device, bool invert);

--- a/drivers/painter/ili9xxx/qp_ili9xxx.c
+++ b/drivers/painter/ili9xxx/qp_ili9xxx.c
@@ -1,0 +1,17 @@
+// Copyright 2023 Pablo Martinez (@elpekenin) <elpekenin@elpekenin.dev>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qp_comms.h"
+#include "qp_ili9xxx_opcodes.h"
+
+bool qp_ili9xxx_set_inversion(painter_device_t device, bool invert) {
+    if (!device) {
+        qp_dprintf("qp_ili9xxx_set_inversion: fail (un-initialized pointer).\n");
+        return false;
+    }
+
+    qp_comms_command(device, invert ? ILI9XXX_CMD_INVERT_ON : ILI9XXX_CMD_INVERT_OFF);
+
+    qp_dprintf("qp_ili9xxx_set_inversion: ok.\n");
+    return true;
+}

--- a/drivers/painter/ili9xxx/qp_ili9xxx.c
+++ b/drivers/painter/ili9xxx/qp_ili9xxx.c
@@ -6,12 +6,12 @@
 
 bool qp_ili9xxx_set_inversion(painter_device_t device, bool invert) {
     if (!device) {
-        qp_dprintf("qp_ili9xxx_set_inversion: fail (un-initialized pointer).\n");
+        qp_dprintf("qp_ili9xxx_set_inversion: fail (un-initialized pointer)\n");
         return false;
     }
 
     qp_comms_command(device, invert ? ILI9XXX_CMD_INVERT_ON : ILI9XXX_CMD_INVERT_OFF);
 
-    qp_dprintf("qp_ili9xxx_set_inversion: ok.\n");
+    qp_dprintf("qp_ili9xxx_set_inversion: ok\n");
     return true;
 }

--- a/drivers/painter/ili9xxx/qp_ili9xxx.h
+++ b/drivers/painter/ili9xxx/qp_ili9xxx.h
@@ -5,4 +5,11 @@
 
 #include "qp.h"
 
+/**
+ * Function to control color inversion on a ILI9XXX device.
+ *
+ * @param device[in] device handle to operate on.
+ * @param invert[in] whether to invert colors or not.
+ * @return Whether the operation was successful.
+ */
 bool qp_ili9xxx_set_inversion(painter_device_t device, bool invert);

--- a/drivers/painter/ili9xxx/qp_ili9xxx.h
+++ b/drivers/painter/ili9xxx/qp_ili9xxx.h
@@ -1,0 +1,8 @@
+// Copyright 2023 Pablo Martinez (@elpekenin) <elpekenin@elpekenin.dev>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "qp.h"
+
+bool qp_ili9xxx_set_inversion(painter_device_t device, bool invert);

--- a/drivers/painter/ssd1351/qp_ssd1351.c
+++ b/drivers/painter/ssd1351/qp_ssd1351.c
@@ -59,6 +59,18 @@ __attribute__((weak)) bool qp_ssd1351_init(painter_device_t device, painter_rota
     return true;
 }
 
+bool qp_ssd1351_set_inversion(painter_device_t device, bool invert) {
+    if (!device) {
+        qp_dprintf("qp_ssd1351_set_inversion: fail (un-initialized pointer)\n");
+        return false;
+    }
+
+    qp_comms_command(device, invert ? SSD1351_INVERTDISPLAY : SSD1351_NORMALDISPLAY);
+
+    qp_dprintf("qp_ssd1351_set_inversion: ok\n");
+    return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Driver vtable
 

--- a/drivers/painter/ssd1351/qp_ssd1351.h
+++ b/drivers/painter/ssd1351/qp_ssd1351.h
@@ -36,4 +36,11 @@
 painter_device_t qp_ssd1351_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
 #endif // QUANTUM_PAINTER_SSD1351_SPI_ENABLE
 
+/**
+ * Function to control color inversion on a SSD1351 device.
+ *
+ * @param device[in] device handle to operate on.
+ * @param invert[in] whether to invert colors or not.
+ * @return Whether the operation was successful.
+ */
 bool qp_ssd1351_set_inversion(painter_device_t device, bool invert);

--- a/drivers/painter/ssd1351/qp_ssd1351.h
+++ b/drivers/painter/ssd1351/qp_ssd1351.h
@@ -35,3 +35,5 @@
  */
 painter_device_t qp_ssd1351_make_spi_device(uint16_t panel_width, uint16_t panel_height, pin_t chip_select_pin, pin_t dc_pin, pin_t reset_pin, uint16_t spi_divisor, int spi_mode);
 #endif // QUANTUM_PAINTER_SSD1351_SPI_ENABLE
+
+bool qp_ssd1351_set_inversion(painter_device_t device, bool invert);

--- a/drivers/painter/st77xx/qp_st77xx.c
+++ b/drivers/painter/st77xx/qp_st77xx.c
@@ -6,12 +6,12 @@
 
 bool qp_st77xx_set_inversion(painter_device_t device, bool invert) {
     if (!device) {
-        qp_dprintf("qp_st77xx_set_inversion: fail (un-initialized pointer).\n");
+        qp_dprintf("qp_st77xx_set_inversion: fail (un-initialized pointer)\n");
         return false;
     }
 
     qp_comms_command(device, invert ? ST77XX_CMD_INVERT_ON : ST77XX_CMD_INVERT_OFF);
 
-    qp_dprintf("qp_st77xx_set_inversion: ok.\n");
+    qp_dprintf("qp_st77xx_set_inversion: ok\n");
     return true;
 }

--- a/drivers/painter/st77xx/qp_st77xx.c
+++ b/drivers/painter/st77xx/qp_st77xx.c
@@ -1,0 +1,17 @@
+// Copyright 2023 Pablo Martinez (@elpekenin) <elpekenin@elpekenin.dev>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qp_comms.h"
+#include "qp_st77xx_opcodes.h"
+
+bool qp_st77xx_set_inversion(painter_device_t device, bool invert) {
+    if (!device) {
+        qp_dprintf("qp_st77xx_set_inversion: fail (un-initialized pointer).\n");
+        return false;
+    }
+
+    qp_comms_command(device, invert ? ST77XX_CMD_INVERT_ON : ST77XX_CMD_INVERT_OFF);
+
+    qp_dprintf("qp_st77xx_set_inversion: ok.\n");
+    return true;
+}

--- a/drivers/painter/st77xx/qp_st77xx.h
+++ b/drivers/painter/st77xx/qp_st77xx.h
@@ -5,4 +5,11 @@
 
 #include "qp.h"
 
+/**
+ * Function to control color inversion on a ST77XX device.
+ *
+ * @param device[in] device handle to operate on.
+ * @param invert[in] whether to invert colors or not.
+ * @return Whether the operation was successful.
+ */
 bool qp_st77xx_set_inversion(painter_device_t device, bool invert);

--- a/drivers/painter/st77xx/qp_st77xx.h
+++ b/drivers/painter/st77xx/qp_st77xx.h
@@ -1,0 +1,8 @@
+// Copyright 2023 Pablo Martinez (@elpekenin) <elpekenin@elpekenin.dev>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "qp.h"
+
+bool qp_st77xx_set_inversion(painter_device_t device, bool invert);

--- a/quantum/painter/qp.h
+++ b/quantum/painter/qp.h
@@ -454,6 +454,17 @@ int16_t qp_drawtext(painter_device_t device, uint16_t x, uint16_t y, painter_fon
 int16_t qp_drawtext_recolor(painter_device_t device, uint16_t x, uint16_t y, painter_font_handle_t font, const char *str, uint8_t hue_fg, uint8_t sat_fg, uint8_t val_fg, uint8_t hue_bg, uint8_t sat_bg, uint8_t val_bg);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Quantum Painter Families
+
+#ifdef QUANTUM_PAINTER_ILI9XXX_ENABLE
+#    include "qp_ili9xxx.h"
+#endif // QUANTUM_PAINTER_ILI9XXX_ENABLE
+
+#ifdef QUANTUM_PAINTER_ST77XX_ENABLE
+#    include "qp_st77xx.h"
+#endif // QUANTUM_PAINTER_ST77XX_ENABLE
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Quantum Painter Drivers
 
 #ifdef QUANTUM_PAINTER_RGB565_SURFACE_ENABLE

--- a/quantum/painter/rules.mk
+++ b/quantum/painter/rules.mk
@@ -44,6 +44,10 @@ endif
 # Comms flags
 QUANTUM_PAINTER_NEEDS_COMMS_SPI ?= no
 
+# Family flags
+QUANTUM_PAINTER_ILI9XXX ?= no
+QUANTUM_PAINTER_ST77XX ?= no
+
 # Handler for each driver
 define handle_quantum_painter_driver
     CURRENT_PAINTER_DRIVER := $1
@@ -59,59 +63,29 @@ define handle_quantum_painter_driver
             $(DRIVER_PATH)/painter/generic/qp_rgb565_surface.c \
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),ili9163_spi)
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+        QUANTUM_PAINTER_ILI9XXX := yes
         OPT_DEFS += -DQUANTUM_PAINTER_ILI9163_ENABLE -DQUANTUM_PAINTER_ILI9163_SPI_ENABLE
-        COMMON_VPATH += \
-            $(DRIVER_PATH)/painter/tft_panel \
-            $(DRIVER_PATH)/painter/ili9xxx
-        SRC += \
-            $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
-            $(DRIVER_PATH)/painter/ili9xxx/qp_ili9163.c \
+        SRC += $(DRIVER_PATH)/painter/ili9xxx/qp_ili9163.c
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),ili9341_spi)
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+        QUANTUM_PAINTER_ILI9XXX := yes
         OPT_DEFS += -DQUANTUM_PAINTER_ILI9341_ENABLE -DQUANTUM_PAINTER_ILI9341_SPI_ENABLE
-        COMMON_VPATH += \
-            $(DRIVER_PATH)/painter/tft_panel \
-            $(DRIVER_PATH)/painter/ili9xxx
-        SRC += \
-            $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
-            $(DRIVER_PATH)/painter/ili9xxx/qp_ili9341.c \
+        SRC += $(DRIVER_PATH)/painter/ili9xxx/qp_ili9341.c
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),ili9488_spi)
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+        QUANTUM_PAINTER_ILI9XXX := yes
         OPT_DEFS += -DQUANTUM_PAINTER_ILI9488_ENABLE -DQUANTUM_PAINTER_ILI9488_SPI_ENABLE
-        COMMON_VPATH += \
-            $(DRIVER_PATH)/painter/tft_panel \
-            $(DRIVER_PATH)/painter/ili9xxx
-        SRC += \
-            $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
-            $(DRIVER_PATH)/painter/ili9xxx/qp_ili9488.c \
+        SRC += $(DRIVER_PATH)/painter/ili9xxx/qp_ili9488.c
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),st7735_spi)
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+        QUANTUM_PAINTER_ST77XX := yes
         OPT_DEFS += -DQUANTUM_PAINTER_ST7735_ENABLE -DQUANTUM_PAINTER_ST7735_SPI_ENABLE
-        COMMON_VPATH += \
-            $(DRIVER_PATH)/painter/tft_panel \
-            $(DRIVER_PATH)/painter/st77xx
-        SRC += \
-            $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
-            $(DRIVER_PATH)/painter/st77xx/qp_st7735.c
+        SRC += $(DRIVER_PATH)/painter/st77xx/qp_st7735.c
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),st7789_spi)
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
-        QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+        QUANTUM_PAINTER_ST77XX := yes
         OPT_DEFS += -DQUANTUM_PAINTER_ST7789_ENABLE -DQUANTUM_PAINTER_ST7789_SPI_ENABLE
-        COMMON_VPATH += \
-            $(DRIVER_PATH)/painter/tft_panel \
-            $(DRIVER_PATH)/painter/st77xx
-        SRC += \
-            $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
-            $(DRIVER_PATH)/painter/st77xx/qp_st7789.c
+        SRC += $(DRIVER_PATH)/painter/st77xx/qp_st7789.c
 
     else ifeq ($$(strip $$(CURRENT_PAINTER_DRIVER)),gc9a01_spi)
         QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
@@ -140,6 +114,38 @@ endef
 
 # Iterate through the listed drivers for the build, including what's necessary
 $(foreach qp_driver,$(QUANTUM_PAINTER_DRIVERS),$(eval $(call handle_quantum_painter_driver,$(qp_driver))))
+
+# If ILI9XXX is used, set up the required files
+ifeq ($(strip $(QUANTUM_PAINTER_ILI9XXX)), yes)
+    QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
+    QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+
+    OPT_DEFS += -DQUANTUM_PAINTER_ILI9XXX_ENABLE
+
+    COMMON_VPATH += \
+        $(DRIVER_PATH)/painter/tft_panel \
+        $(DRIVER_PATH)/painter/ili9xxx
+
+    SRC += \
+        $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
+        $(DRIVER_PATH)/painter/ili9xxx/qp_ili9xxx.c
+endif
+
+# If ST77XX is used, set up the required files
+ifeq ($(strip $(QUANTUM_PAINTER_ST77XX)), yes)
+    QUANTUM_PAINTER_NEEDS_COMMS_SPI := yes
+    QUANTUM_PAINTER_NEEDS_COMMS_SPI_DC_RESET := yes
+
+    OPT_DEFS += -DQUANTUM_PAINTER_ST77XX_ENABLE
+
+    COMMON_VPATH += \
+        $(DRIVER_PATH)/painter/tft_panel \
+        $(DRIVER_PATH)/painter/st77xx
+
+    SRC += \
+        $(DRIVER_PATH)/painter/tft_panel/qp_tft_panel.c \
+        $(DRIVER_PATH)/painter/st77xx/qp_st77xx.c
+endif
 
 # If SPI comms is needed, set up the required files
 ifeq ($(strip $(QUANTUM_PAINTER_NEEDS_COMMS_SPI)), yes)


### PR DESCRIPTION
## Description

This has two main goals:
- Easier configuration for end users, when their hw doesnt work with the default init sequence:
  Instead of overriding it (`__weak__` function) with the command flipped... Just call these functions.
- If user has several of the same device (lets say st7789) needing different inversion values, it is now easier to do (no need to use `qp_comms.h` functions from user code)

To avoid code duplication (eg all ili9xxx use the same pair of commands), i've added files for family-specific logic. As a bonus, since that needed to check "is this family of devices enabled?", `mk` logic was partly rewritten, reducing duplication.

As discussed on Discord, even tho this "bloats" the amount of functions, it is (for now?) preferred over adding it to the standarized API because some devices wouldnt be able to support it.

Extra: Took the chance to remove `!= NULL` checks from docs, since #20481 added those to the core code and users dont need them anymore.

## Types of Changes

- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).