### PR TITLE
keymaps: Fix hacker_dvorak build.

### DIFF
--- a/keyboards/ergodox_ez/keymaps/hacker_dvorak/user/layer_set_state_user.c
+++ b/keyboards/ergodox_ez/keymaps/hacker_dvorak/user/layer_set_state_user.c
@@ -4,7 +4,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
     switch (layer) {
         case DVORAK:
-            rgblight_sethsv_noeeprom(GREEN);
+            rgblight_sethsv_noeeprom(HSV_GREEN);
             rgblight_mode_noeeprom(RGBLIGHT_MODE_STATIC_LIGHT);
 
             if (PLOVER_MODE) {


### PR DESCRIPTION
Partially fixes #22012.

* keyboards/ergodox_ez/keymaps/hacker_dvorak/user/layer_set_state_user.c (layer_state_set_user): Replace GREEN with HSV_GREEN.

## Description

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation
