### PR TITLE
Fix lower cpi bound on PMW33XX

### DIFF
--- a/drivers/sensors/pmw3320.c
+++ b/drivers/sensors/pmw3320.c
@@ -178,7 +178,7 @@ uint16_t pmw3320_get_cpi(void) {
 }
 
 void pmw3320_set_cpi(uint16_t cpi) {
-    uint8_t cpival = constrain((cpi / PMW3320_CPI_STEP) - 1U, 0, (PMW3320_CPI_MAX / PMW3320_CPI_STEP) - 1U);
+    uint8_t cpival = constrain((cpi / PMW3320_CPI_STEP), (PMW3320_CPI_MIN / PMW3320_CPI_STEP), (PMW3320_CPI_MAX / PMW3320_CPI_STEP)) - 1U;
     // Fifth bit is probably a control bit.
     // PMW3320 datasheet don't have any info on this, so this is a pure guess.
     pmw3320_write_reg(REG_Resolution, 0x20 | cpival);

--- a/drivers/sensors/pmw3360.c
+++ b/drivers/sensors/pmw3360.c
@@ -23,7 +23,7 @@ void pmw33xx_set_cpi(uint8_t sensor, uint16_t cpi) {
         return;
     }
 
-    uint8_t cpival = CONSTRAIN((cpi / PMW33XX_CPI_STEP) - 1, 0, (PMW33XX_CPI_MAX / PMW33XX_CPI_STEP) - 1U);
+    uint8_t cpival = CONSTRAIN((cpi / PMW33XX_CPI_STEP), (PMW33XX_CPI_MIN / PMW33XX_CPI_STEP), (PMW33XX_CPI_MAX / PMW33XX_CPI_STEP)) - 1U;
     pmw33xx_write(sensor, REG_Config1, cpival);
 }
 

--- a/drivers/sensors/pmw3389.c
+++ b/drivers/sensors/pmw3389.c
@@ -22,7 +22,7 @@ void pmw33xx_set_cpi(uint8_t sensor, uint16_t cpi) {
         return;
     }
 
-    uint16_t cpival = CONSTRAIN((cpi / PMW33XX_CPI_STEP) - 1, 0, (PMW33XX_CPI_MAX / PMW33XX_CPI_STEP) - 1U);
+    uint16_t cpival = CONSTRAIN((cpi / PMW33XX_CPI_STEP), (PMW33XX_CPI_MIN / PMW33XX_CPI_STEP), (PMW33XX_CPI_MAX / PMW33XX_CPI_STEP)) - 1U;
     // Sets upper byte first for more consistent setting of cpi
     pmw33xx_write(sensor, REG_Resolution_H, (cpival >> 8) & 0xFF);
     pmw33xx_write(sensor, REG_Resolution_L, cpival & 0xFF);


### PR DESCRIPTION
Move subtraction after `CONSTRAIN` to prevent unsigned int wrap on PMW3320, PMW3360, PMW3389



<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
These sensors expect a value between `0` and `CPI_MAX/CPI_STEP - 1` Subtracting 1 from `cpi/CPI_STEP` within the `CONSTRAIN` macro causes a wrap to the maximum when attempting to set `cpi` less than `CPI_STEP`.

Setting the bounds for `CONSTRAIN` to be between `1` and `CPI_MAX/CPI_STEP` allows impossibly small `cpi` values to be set to the minumum CPI of the sensor, instead of the maximum.

Tested on Ploopy Classic Trackball (PMW3360)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix incorrect handling of cpi when setting a cpi that is smaller than the minimum cpi on PMW3360, PMW3389, PMW3320

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
