### PR TITLE
Added OLED SSD1306 128x64 to the verified working table

### DIFF
--- a/docs/feature_oled_driver.md
+++ b/docs/feature_oled_driver.md
@@ -10,6 +10,7 @@ Tested combinations:
 |SSD1306  |128x32 |AVR     |Primary support         |
 |SSD1306  |128x64 |AVR     |Verified working        |
 |SSD1306  |128x32 |Arm     |                        |
+|SSD1306  |128x64 |Arm     |Verified working        |
 |SH1106   |128x64 |AVR     |No scrolling            |
 |SH1107   |64x128 |AVR     |No scrolling            |
 |SH1107   |64x128 |Arm     |No scrolling            |


### PR DESCRIPTION
I validated the SSD1306 128x64 OLED works as expected with an ARM processor (Pico) while building this board: https://github.com/JellyTitan/Sofle-Pico

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
