### PR TITLE
is31fl3736: extract single-color API

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -350,7 +350,7 @@ LED_MATRIX_DRIVER := aw20216s
 endif
 
 LED_MATRIX_ENABLE ?= no
-VALID_LED_MATRIX_TYPES := is31fl3731 is31fl3742a is31fl3743a is31fl3745 is31fl3746a ckled2001 custom
+VALID_LED_MATRIX_TYPES := is31fl3731 is31fl3736 is31fl3742a is31fl3743a is31fl3745 is31fl3746a ckled2001 custom
 # TODO: is31fl3733 is31fl3737 is31fl3741
 
 ifeq ($(strip $(LED_MATRIX_ENABLE)), yes)
@@ -377,6 +377,13 @@ endif
         OPT_DEFS += -DHAL_USE_I2C=TRUE
         COMMON_VPATH += $(DRIVER_PATH)/led/issi
         SRC += is31fl3731-simple.c
+        QUANTUM_LIB_SRC += i2c_master.c
+    endif
+
+    ifeq ($(strip $(LED_MATRIX_DRIVER)), is31fl3736)
+        OPT_DEFS += -DHAL_USE_I2C=TRUE
+        COMMON_VPATH += $(DRIVER_PATH)/led/issi
+        SRC += is31fl3736-simple.c
         QUANTUM_LIB_SRC += i2c_master.c
     endif
 

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -329,7 +329,7 @@ Configures the [LED Matrix](feature_led_matrix.md) feature.
         * The centroid (geometric center) of the LEDs. Used for certain effects.
         * Default: `[112, 32]`
     * `driver` (Required)
-        * The driver to use. Must be one of `ckled2001`, `custom`, `is31fl3731`, `is31fl3742a`, `is31fl3743a`, `is31fl3745`, `is31fl3746a`.
+        * The driver to use. Must be one of `ckled2001`, `custom`, `is31fl3731`, `is31fl3736`, `is31fl3742a`, `is31fl3743a`, `is31fl3745`, `is31fl3746a`.
     * `layout` (Required)
         * List of LED configuration dictionaries. Each dictionary contains:
             * `flags` (Required)

--- a/drivers/led/issi/is31fl3736-simple.c
+++ b/drivers/led/issi/is31fl3736-simple.c
@@ -187,7 +187,7 @@ void is31fl3736_set_led_control_register(uint8_t index, bool value) {
     // A1-A4=0x00 A5-A8=0x01
 
     uint8_t control_register = led.v / 8;
-    uint8_t bit_value = led.v % 8;
+    uint8_t bit_value        = led.v % 8;
 
     if (value) {
         g_led_control_registers[led.driver][control_register] |= (1 << bit_value);

--- a/drivers/led/issi/is31fl3736-simple.c
+++ b/drivers/led/issi/is31fl3736-simple.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "is31fl3736.h"
+#include "is31fl3736-simple.h"
 #include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
@@ -157,28 +157,26 @@ void is31fl3736_init(uint8_t addr) {
     wait_ms(10);
 }
 
-void is31fl3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
+void is31fl3736_set_value(int index, uint8_t value) {
     is31_led led;
-    if (index >= 0 && index < RGB_MATRIX_LED_COUNT) {
+    if (index >= 0 && index < LED_MATRIX_LED_COUNT) {
         memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
-        if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
+        if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
-        g_pwm_buffer[led.driver][led.r]          = red;
-        g_pwm_buffer[led.driver][led.g]          = green;
-        g_pwm_buffer[led.driver][led.b]          = blue;
+        g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }
 }
 
-void is31fl3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
-    for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
-        is31fl3736_set_color(i, red, green, blue);
+void is31fl3736_set_value_all(uint8_t value) {
+    for (int i = 0; i < LED_MATRIX_LED_COUNT; i++) {
+        is31fl3736_set_value(i, value);
     }
 }
 
-void is31fl3736_set_led_control_register(uint8_t index, bool red, bool green, bool blue) {
+void is31fl3736_set_led_control_register(uint8_t index, bool value) {
     is31_led led;
     memcpy_P(&led, (&g_is31_leds[index]), sizeof(led));
 
@@ -188,28 +186,13 @@ void is31fl3736_set_led_control_register(uint8_t index, bool red, bool green, bo
     // But also, the LED control registers (0x00 to 0x17) are also interleaved, so:
     // A1-A4=0x00 A5-A8=0x01
 
-    uint8_t control_register_r = led.r / 8;
-    uint8_t control_register_g = led.g / 8;
-    uint8_t control_register_b = led.b / 8;
+    uint8_t control_register = led.v / 8;
+    uint8_t bit_value = led.v % 8;
 
-    uint8_t bit_r = led.r % 8;
-    uint8_t bit_g = led.g % 8;
-    uint8_t bit_b = led.b % 8;
-
-    if (red) {
-        g_led_control_registers[led.driver][control_register_r] |= (1 << bit_r);
+    if (value) {
+        g_led_control_registers[led.driver][control_register] |= (1 << bit_value);
     } else {
-        g_led_control_registers[led.driver][control_register_r] &= ~(1 << bit_r);
-    }
-    if (green) {
-        g_led_control_registers[led.driver][control_register_g] |= (1 << bit_g);
-    } else {
-        g_led_control_registers[led.driver][control_register_g] &= ~(1 << bit_g);
-    }
-    if (blue) {
-        g_led_control_registers[led.driver][control_register_b] |= (1 << bit_b);
-    } else {
-        g_led_control_registers[led.driver][control_register_b] &= ~(1 << bit_b);
+        g_led_control_registers[led.driver][control_register] &= ~(1 << bit_value);
     }
 
     g_led_control_registers_update_required[led.driver] = true;

--- a/drivers/led/issi/is31fl3736-simple.h
+++ b/drivers/led/issi/is31fl3736-simple.h
@@ -70,21 +70,19 @@
 
 typedef struct is31_led {
     uint8_t driver : 2;
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
+    uint8_t v;
 } __attribute__((packed)) is31_led;
 
-extern const is31_led PROGMEM g_is31_leds[RGB_MATRIX_LED_COUNT];
+extern const is31_led PROGMEM g_is31_leds[LED_MATRIX_LED_COUNT];
 
 void is31fl3736_init(uint8_t addr);
 void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 
-void is31fl3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
-void is31fl3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
+void is31fl3736_set_value(int index, uint8_t value);
+void is31fl3736_set_value_all(uint8_t value);
 
-void is31fl3736_set_led_control_register(uint8_t index, bool red, bool green, bool blue);
+void is31fl3736_set_led_control_register(uint8_t index, bool value);
 
 // This should not be called from an interrupt
 // (eg. from a timer interrupt).

--- a/keyboards/wilba_tech/wt60_a/config.h
+++ b/keyboards/wilba_tech/wt60_a/config.h
@@ -62,5 +62,5 @@
 // dynamic keymaps start after this.
 #define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
 
-#define IS31FL3736_DRIVER_COUNT 2
-#define RGB_MATRIX_LED_COUNT 96
+#define IS31FL3736_DRIVER_COUNT 1
+#define LED_MATRIX_LED_COUNT 96

--- a/keyboards/wilba_tech/wt60_a/rules.mk
+++ b/keyboards/wilba_tech/wt60_a/rules.mk
@@ -11,7 +11,7 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
 # project specific files
-SRC =	drivers/led/issi/is31fl3736.c \
+SRC =	drivers/led/issi/is31fl3736-simple.c \
 		i2c_master.c \
 		quantum/color.c \
 		keyboards/wilba_tech/wt_mono_backlight.c \

--- a/keyboards/wilba_tech/wt65_a/config.h
+++ b/keyboards/wilba_tech/wt65_a/config.h
@@ -62,5 +62,5 @@
 // dynamic keymaps start after this.
 #define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
 
-#define IS31FL3736_DRIVER_COUNT 2
-#define RGB_MATRIX_LED_COUNT 96
+#define IS31FL3736_DRIVER_COUNT 1
+#define LED_MATRIX_LED_COUNT 96

--- a/keyboards/wilba_tech/wt65_a/rules.mk
+++ b/keyboards/wilba_tech/wt65_a/rules.mk
@@ -11,7 +11,7 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
 # project specific files
-SRC =	drivers/led/issi/is31fl3736.c \
+SRC =	drivers/led/issi/is31fl3736-simple.c \
 		i2c_master.c \
 		quantum/color.c \
 		keyboards/wilba_tech/wt_mono_backlight.c \

--- a/keyboards/wilba_tech/wt65_b/config.h
+++ b/keyboards/wilba_tech/wt65_b/config.h
@@ -62,5 +62,5 @@
 // dynamic keymaps start after this.
 #define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
 
-#define IS31FL3736_DRIVER_COUNT 2
-#define RGB_MATRIX_LED_COUNT 96
+#define IS31FL3736_DRIVER_COUNT 1
+#define LED_MATRIX_LED_COUNT 96

--- a/keyboards/wilba_tech/wt65_b/rules.mk
+++ b/keyboards/wilba_tech/wt65_b/rules.mk
@@ -11,7 +11,7 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
 # project specific files
-SRC =	drivers/led/issi/is31fl3736.c \
+SRC =	drivers/led/issi/is31fl3736-simple.c \
 		i2c_master.c \
 		quantum/color.c \
 		keyboards/wilba_tech/wt_mono_backlight.c \

--- a/keyboards/wilba_tech/wt75_a/config.h
+++ b/keyboards/wilba_tech/wt75_a/config.h
@@ -62,5 +62,5 @@
 // dynamic keymaps start after this.
 #define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
 
-#define IS31FL3736_DRIVER_COUNT 2
-#define RGB_MATRIX_LED_COUNT 96
+#define IS31FL3736_DRIVER_COUNT 1
+#define LED_MATRIX_LED_COUNT 96

--- a/keyboards/wilba_tech/wt75_a/rules.mk
+++ b/keyboards/wilba_tech/wt75_a/rules.mk
@@ -11,7 +11,7 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
 # project specific files
-SRC =	drivers/led/issi/is31fl3736.c \
+SRC =	drivers/led/issi/is31fl3736-simple.c \
 		i2c_master.c \
 		quantum/color.c \
 		keyboards/wilba_tech/wt_mono_backlight.c \

--- a/keyboards/wilba_tech/wt75_b/config.h
+++ b/keyboards/wilba_tech/wt75_b/config.h
@@ -62,5 +62,5 @@
 // dynamic keymaps start after this.
 #define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
 
-#define IS31FL3736_DRIVER_COUNT 2
-#define RGB_MATRIX_LED_COUNT 96
+#define IS31FL3736_DRIVER_COUNT 1
+#define LED_MATRIX_LED_COUNT 96

--- a/keyboards/wilba_tech/wt75_b/rules.mk
+++ b/keyboards/wilba_tech/wt75_b/rules.mk
@@ -11,7 +11,7 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
 # project specific files
-SRC =	drivers/led/issi/is31fl3736.c \
+SRC =	drivers/led/issi/is31fl3736-simple.c \
 		i2c_master.c \
 		quantum/color.c \
 		keyboards/wilba_tech/wt_mono_backlight.c \

--- a/keyboards/wilba_tech/wt75_c/config.h
+++ b/keyboards/wilba_tech/wt75_c/config.h
@@ -62,5 +62,5 @@
 // dynamic keymaps start after this.
 #define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
 
-#define IS31FL3736_DRIVER_COUNT 2
-#define RGB_MATRIX_LED_COUNT 96
+#define IS31FL3736_DRIVER_COUNT 1
+#define LED_MATRIX_LED_COUNT 96

--- a/keyboards/wilba_tech/wt75_c/rules.mk
+++ b/keyboards/wilba_tech/wt75_c/rules.mk
@@ -11,7 +11,7 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
 # project specific files
-SRC =	drivers/led/issi/is31fl3736.c \
+SRC =	drivers/led/issi/is31fl3736-simple.c \
 		i2c_master.c \
 		quantum/color.c \
 		keyboards/wilba_tech/wt_mono_backlight.c \

--- a/keyboards/wilba_tech/wt80_a/config.h
+++ b/keyboards/wilba_tech/wt80_a/config.h
@@ -62,5 +62,5 @@
 // dynamic keymaps start after this.
 #define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
 
-#define IS31FL3736_DRIVER_COUNT 2
-#define RGB_MATRIX_LED_COUNT 96
+#define IS31FL3736_DRIVER_COUNT 1
+#define LED_MATRIX_LED_COUNT 96

--- a/keyboards/wilba_tech/wt80_a/rules.mk
+++ b/keyboards/wilba_tech/wt80_a/rules.mk
@@ -11,7 +11,7 @@ BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
 # project specific files
-SRC =	drivers/led/issi/is31fl3736.c \
+SRC =	drivers/led/issi/is31fl3736-simple.c \
 		i2c_master.c \
 		quantum/color.c \
 		keyboards/wilba_tech/wt_mono_backlight.c \

--- a/keyboards/wilba_tech/wt_mono_backlight.c
+++ b/keyboards/wilba_tech/wt_mono_backlight.c
@@ -33,7 +33,7 @@
 #error VIA_EEPROM_CUSTOM_CONFIG_SIZE was not defined to store backlight_config struct
 #endif
 
-#include "drivers/led/issi/is31fl3736.h"
+#include "drivers/led/issi/is31fl3736-simple.h"
 
 #define ISSI_ADDR_DEFAULT 0x50
 
@@ -52,6 +52,116 @@ backlight_config g_config = {
     .color_1 = MONO_BACKLIGHT_COLOR_1,
 };
 
+const is31_led PROGMEM g_is31_leds[LED_MATRIX_LED_COUNT] = {
+    {0, A_1},
+    {0, A_2},
+    {0, A_3},
+    {0, A_4},
+    {0, A_5},
+    {0, A_6},
+    {0, A_7},
+    {0, A_8},
+
+    {0, B_1},
+    {0, B_2},
+    {0, B_3},
+    {0, B_4},
+    {0, B_5},
+    {0, B_6},
+    {0, B_7},
+    {0, B_8},
+
+    {0, C_1},
+    {0, C_2},
+    {0, C_3},
+    {0, C_4},
+    {0, C_5},
+    {0, C_6},
+    {0, C_7},
+    {0, C_8},
+
+    {0, D_1},
+    {0, D_2},
+    {0, D_3},
+    {0, D_4},
+    {0, D_5},
+    {0, D_6},
+    {0, D_7},
+    {0, D_8},
+
+    {0, E_1},
+    {0, E_2},
+    {0, E_3},
+    {0, E_4},
+    {0, E_5},
+    {0, E_6},
+    {0, E_7},
+    {0, E_8},
+
+    {0, F_1},
+    {0, F_2},
+    {0, F_3},
+    {0, F_4},
+    {0, F_5},
+    {0, F_6},
+    {0, F_7},
+    {0, F_8},
+
+    {0, G_1},
+    {0, G_2},
+    {0, G_3},
+    {0, G_4},
+    {0, G_5},
+    {0, G_6},
+    {0, G_7},
+    {0, G_8},
+
+    {0, H_1},
+    {0, H_2},
+    {0, H_3},
+    {0, H_4},
+    {0, H_5},
+    {0, H_6},
+    {0, H_7},
+    {0, H_8},
+
+    {0, I_1},
+    {0, I_2},
+    {0, I_3},
+    {0, I_4},
+    {0, I_5},
+    {0, I_6},
+    {0, I_7},
+    {0, I_8},
+
+    {0, J_1},
+    {0, J_2},
+    {0, J_3},
+    {0, J_4},
+    {0, J_5},
+    {0, J_6},
+    {0, J_7},
+    {0, J_8},
+
+    {0, K_1},
+    {0, K_2},
+    {0, K_3},
+    {0, K_4},
+    {0, K_5},
+    {0, K_6},
+    {0, K_7},
+    {0, K_8},
+
+    {0, L_1},
+    {0, L_2},
+    {0, L_3},
+    {0, L_4},
+    {0, L_5},
+    {0, L_6},
+    {0, L_7},
+    {0, L_8}
+};
+
 bool g_suspend_state = false;
 
 // Global tick at 20 Hz
@@ -67,9 +177,9 @@ void backlight_init_drivers(void)
 	is31fl3736_init( ISSI_ADDR_DEFAULT );
 
 	for ( uint8_t index = 0; index < 96; index++ )	{
-		is31fl3736_mono_set_led_control_register( index, true );
+		is31fl3736_set_led_control_register( index, true );
 	}
-	is31fl3736_update_led_control_registers( ISSI_ADDR_DEFAULT, 0x00 );
+	is31fl3736_update_led_control_registers( ISSI_ADDR_DEFAULT, 0 );
 }
 
 void backlight_set_key_hit(uint8_t row, uint8_t column)
@@ -119,17 +229,17 @@ void backlight_set_suspend_state(bool state)
 
 void backlight_set_brightness_all( uint8_t value )
 {
-	is31fl3736_mono_set_brightness_all( value );
+	is31fl3736_set_value_all( value );
 }
 
 void backlight_effect_all_off(void)
 {
-	is31fl3736_mono_set_brightness_all( 0 );
+	is31fl3736_set_value_all( 0 );
 }
 
 void backlight_effect_all_on(void)
 {
-	is31fl3736_mono_set_brightness_all( g_config.brightness );
+	is31fl3736_set_value_all( g_config.brightness );
 }
 
 void backlight_effect_raindrops(bool initialize)
@@ -143,7 +253,7 @@ void backlight_effect_raindrops(bool initialize)
         // If not, all but one will stay the same as before.
         if ( initialize || i == led_to_change )
         {
-            is31fl3736_mono_set_brightness(i, rand() & 0xFF );
+            is31fl3736_set_value(i, rand() & 0xFF );
         }
     }
 }
@@ -165,9 +275,9 @@ void backlight_effect_indicators(void)
     // SW7,CS8 = (6*8+7) = 55
     // SW8,CS8 = (7*8+7) = 63
     // SW9,CS8 = (8*8+7) = 71
-    is31fl3736_mono_set_brightness(55, rgb.r);
-    is31fl3736_mono_set_brightness(63, rgb.g);
-    is31fl3736_mono_set_brightness(71, rgb.b);
+    is31fl3736_set_value(55, rgb.r);
+    is31fl3736_set_value(63, rgb.g);
+    is31fl3736_set_value(71, rgb.b);
 #endif // MONO_BACKLIGHT_WT75_A
 
 // This pairs with "All Off" already setting zero brightness,
@@ -181,19 +291,19 @@ defined(MONO_BACKLIGHT_WT75_C) || \
 defined(MONO_BACKLIGHT_WT80_A)
     if ( host_keyboard_led_state().caps_lock ) {
         // SW3,CS1 = (2*8+0) = 16
-        is31fl3736_mono_set_brightness(16, 255);
+        is31fl3736_set_value(16, 255);
     }
 #endif
 #if defined(MONO_BACKLIGHT_WT80_A)
     if ( host_keyboard_led_state().scroll_lock ) {
         // SW7,CS7 = (6*8+6) = 54
-        is31fl3736_mono_set_brightness(54, 255);
+        is31fl3736_set_value(54, 255);
     }
 #endif
 #if defined(MONO_BACKLIGHT_WT75_C)
     if ( host_keyboard_led_state().scroll_lock ) {
         // SW7,CS8 = (6*8+7) = 55
-        is31fl3736_mono_set_brightness(55, 255);
+        is31fl3736_set_value(55, 255);
     }
 #endif
 }
@@ -361,7 +471,7 @@ void backlight_config_save(void)
 
 void backlight_update_pwm_buffers(void)
 {
-	is31fl3736_update_pwm_buffers(ISSI_ADDR_DEFAULT,0x00);
+	is31fl3736_update_pwm_buffers(ISSI_ADDR_DEFAULT, 0);
 }
 
 bool process_record_backlight(uint16_t keycode, keyrecord_t *record)

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -27,11 +27,15 @@
 
 #ifdef LED_MATRIX_IS31FL3731
 #    include "is31fl3731-simple.h"
-#elif defined(IS31FLCOMMON)
-#    include "is31flcommon.h"
 #endif
 #ifdef LED_MATRIX_IS31FL3733
 #    include "is31fl3733-simple.h"
+#endif
+#ifdef LED_MATRIX_IS31FL3736
+#    include "is31fl3736-simple.h"
+#endif
+#if defined(IS31FLCOMMON)
+#    include "is31flcommon.h"
 #endif
 #ifdef LED_MATRIX_CKLED2001
 #    include "ckled2001-simple.h"

--- a/quantum/led_matrix/led_matrix_drivers.c
+++ b/quantum/led_matrix/led_matrix_drivers.c
@@ -25,7 +25,7 @@
  * in their own files.
  */
 
-#if defined(LED_MATRIX_IS31FL3731) || defined(LED_MATRIX_IS31FL3733) || defined(IS31FLCOMMON) || defined(LED_MATRIX_CKLED2001)
+#if defined(LED_MATRIX_IS31FL3731) || defined(LED_MATRIX_IS31FL3733) || defined(LED_MATRIX_IS31FL3736) || defined(IS31FLCOMMON) || defined(LED_MATRIX_CKLED2001)
 #    include "i2c_master.h"
 
 static void init(void) {
@@ -67,6 +67,18 @@ static void init(void) {
 #            endif
 #        endif
 
+#    elif defined(LED_MATRIX_IS31FL3736)
+    is31fl3736_init(LED_DRIVER_ADDR_1);
+#        if defined(LED_DRIVER_ADDR_2)
+    is31fl3736_init(LED_DRIVER_ADDR_2);
+#            if defined(LED_DRIVER_ADDR_3)
+    is31fl3736_init(LED_DRIVER_ADDR_3);
+#                if defined(LED_DRIVER_ADDR_4)
+    is31fl3736_init(LED_DRIVER_ADDR_4);
+#                endif
+#            endif
+#        endif
+
 #    elif defined(IS31FLCOMMON)
     IS31FL_common_init(DRIVER_ADDR_1, ISSI_SSR_1);
 #        if defined(LED_DRIVER_ADDR_2)
@@ -101,6 +113,8 @@ static void init(void) {
         is31fl3731_set_led_control_register(index, true);
 #    elif defined(LED_MATRIX_IS31FL3733)
         is31fl3733_set_led_control_register(index, true);
+#    elif defined(LED_MATRIX_IS31FL3736)
+        is31fl3736_set_led_control_register(index, true);
 #    elif defined(IS31FLCOMMON)
         IS31FL_simple_set_scaling_buffer(index, true);
 #    elif defined(LED_MATRIX_CKLED2001)
@@ -129,6 +143,18 @@ static void init(void) {
     is31fl3733_update_led_control_registers(LED_DRIVER_ADDR_3, 2);
 #                if defined(LED_DRIVER_ADDR_4)
     is31fl3733_update_led_control_registers(LED_DRIVER_ADDR_4, 3);
+#                endif
+#            endif
+#        endif
+
+#    elif defined(LED_MATRIX_IS31FL3736)
+    is31fl3736_update_led_control_registers(LED_DRIVER_ADDR_1, 0);
+#        if defined(LED_DRIVER_ADDR_2)
+    is31fl3736_update_led_control_registers(LED_DRIVER_ADDR_2, 1);
+#            if defined(LED_DRIVER_ADDR_3)
+    is31fl3736_update_led_control_registers(LED_DRIVER_ADDR_3, 2);
+#                if defined(LED_DRIVER_ADDR_4)
+    is31fl3736_update_led_control_registers(LED_DRIVER_ADDR_4, 3);
 #                endif
 #            endif
 #        endif
@@ -201,6 +227,27 @@ const led_matrix_driver_t led_matrix_driver = {
     .flush = flush,
     .set_value = is31fl3733_set_value,
     .set_value_all = is31fl3733_set_value_all,
+};
+
+#    elif defined(LED_MATRIX_IS31FL3736)
+static void flush(void) {
+    is31fl3736_update_pwm_buffers(LED_DRIVER_ADDR_1, 0);
+#        if defined(LED_DRIVER_ADDR_2)
+    is31fl3736_update_pwm_buffers(LED_DRIVER_ADDR_2, 1);
+#            if defined(LED_DRIVER_ADDR_3)
+    is31fl3736_update_pwm_buffers(LED_DRIVER_ADDR_3, 2);
+#                if defined(LED_DRIVER_ADDR_4)
+    is31fl3736_update_pwm_buffers(LED_DRIVER_ADDR_4, 3);
+#                endif
+#            endif
+#        endif
+}
+
+const led_matrix_driver_t led_matrix_driver = {
+    .init = init,
+    .flush = flush,
+    .set_value = is31fl3736_set_value,
+    .set_value_all = is31fl3736_set_value_all,
 };
 
 #    elif defined(IS31FLCOMMON)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The 3736 driver had some specialised functions for the WT mono backlight code. For consistency, I've split this out into `is31fl3736-simple`, added LED Matrix support, and updated the affected boards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
