### PR TITLE
Fix entry into bootloader for STM32G431.

### DIFF
--- a/platforms/chibios/boards/GENERIC_STM32_F446XE/configs/config.h
+++ b/platforms/chibios/boards/GENERIC_STM32_F446XE/configs/config.h
@@ -14,10 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Address for jumping to bootloader on STM32 chips. */
-/* It is chip dependent, the correct number can be looked up by checking against ST's application note AN2606.
- */
-
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif

--- a/platforms/chibios/boards/GENERIC_STM32_G431XB/configs/config.h
+++ b/platforms/chibios/boards/GENERIC_STM32_G431XB/configs/config.h
@@ -1,0 +1,7 @@
+// Copyright 2023 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
+#    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
+#endif


### PR DESCRIPTION
## Description

As per the title. The default wasn't present in 'G431. The rest are fine.
Also a slight bit of cleanup for irrelevant comments.

Tested on `handwired/onekey/nucleo_g431rb:reset`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
