### PR TITLE
Fix installation instructions for M1 Mac

### DIFF
--- a/docs/newbs_getting_started.md
+++ b/docs/newbs_getting_started.md
@@ -66,7 +66,7 @@ Install the QMK CLI by running:
     
 Install the QMK CLI on an Apple Silicon Mac by running:
 
-    arch -x86_64 brew install qmk/qmk/qmk
+    arch -x86_64 /usr/local/bin/brew install qmk/qmk/qmk
 
 ### ** Linux/WSL **
 


### PR DESCRIPTION

## Description

Installing QMK on M1 Mac, I noticed that if you have aarch64 `brew` installed, then you can't run the command as suggested, as it returns the following error:

```
Error: Cannot install under Rosetta 2 in ARM default prefix (/opt/homebrew)!
To rerun under ARM use:
    arch -arm64 brew install ...
To install under x86_64, install Homebrew into /usr/local.
```

Apparently, if you have aarch64 `brew` in your path, you will try to run it under rosetta. To fix it, you must run it by its full path (`/usr/local/bin/brew` by default).

<!--- Describe your changes in detail here. -->