### PR TITLE
Support additional split sync items for info.json

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -146,13 +146,21 @@
     // Split Keyboard
     "SOFT_SERIAL_PIN": {"info_key": "split.soft_serial_pin"},
     "SOFT_SERIAL_SPEED": {"info_key": "split.soft_serial_speed"},
-    "SPLIT_MODS_ENABLE": {"info_key": "split.transport.sync_modifiers", "value_type": "bool"},
-    "SPLIT_TRANSPORT_MIRROR": {"info_key": "split.transport.sync_matrix_state", "value_type": "bool"},
     "SPLIT_USB_DETECT": {"info_key": "split.usb_detect.enabled", "value_type": "bool"},
     "SPLIT_USB_TIMEOUT": {"info_key": "split.usb_detect.timeout", "value_type": "int"},
     "SPLIT_USB_TIMEOUT_POLL": {"info_key": "split.usb_detect.polling_interval", "value_type": "int"},
     "SPLIT_WATCHDOG_ENABLE": {"info_key": "split.transport.watchdog", "value_type": "bool"},
     "SPLIT_WATCHDOG_TIMEOUT": {"info_key": "split.transport.watchdog_timeout", "value_type": "int"},
+    "SPLIT_ACTIVITY_ENABLE": {"info_key": "split.transport.sync.activity", "value_type": "bool"},
+    "SPLIT_DETECTED_OS_ENABLE": {"info_key": "split.transport.sync.detected_os", "value_type": "bool"},
+    "SPLIT_HAPTIC_ENABLE": {"info_key": "split.transport.sync.haptic", "value_type": "bool"},
+    "SPLIT_LAYER_STATE_ENABLE": {"info_key": "split.transport.sync.layer_state", "value_type": "bool"},
+    "SPLIT_LED_STATE_ENABLE": {"info_key": "split.transport.sync.indicators", "value_type": "bool"},
+    "SPLIT_TRANSPORT_MIRROR": {"info_key": "split.transport.sync.matrix_state", "value_type": "bool"},
+    "SPLIT_MODS_ENABLE": {"info_key": "split.transport.sync.modifiers", "value_type": "bool"},
+    "SPLIT_OLED_ENABLE": {"info_key": "split.transport.sync.oled", "value_type": "bool"},
+    "SPLIT_ST7565_ENABLE": {"info_key": "split.transport.sync.st7565", "value_type": "bool"},
+    "SPLIT_WPM_ENABLE": {"info_key": "split.transport.sync.wpm", "value_type": "bool"},
 
     // Tapping
     "HOLD_ON_OTHER_KEY_PRESS": {"info_key": "tapping.hold_on_other_key_press", "value_type": "bool"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -663,10 +663,32 @@
                             "type": "string",
                             "enum": ["custom", "i2c", "serial", "serial_usart"]
                         },
-                        "sync_matrix_state": {"type": "boolean"},
-                        "sync_modifiers": {"type": "boolean"},
+                        "sync": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "activity": {"type": "boolean"},
+                                "detected_os": {"type": "boolean"},
+                                "haptic": {"type": "boolean"},
+                                "layer_state": {"type": "boolean"},
+                                "indicators": {"type": "boolean"},
+                                "matrix_state": {"type": "boolean"},
+                                "modifiers": {"type": "boolean"},
+                                "oled": {"type": "boolean"},
+                                "st7565": {"type": "boolean"},
+                                "wpm": {"type": "boolean"}
+                            }
+                        }
                         "watchdog": {"type": "boolean"},
-                        "watchdog_timeout": {"$ref": "qmk.definitions.v1#/unsigned_int"}
+                        "watchdog_timeout": {"$ref": "qmk.definitions.v1#/unsigned_int"},
+                        "sync_matrix_state": {
+                            "type": "boolean",
+                            "$comment": "Deprecated: use sync.matrix_state instead"
+                        },
+                        "sync_modifiers": {
+                            "type": "boolean",
+                            "$comment": "Deprecated: use sync.modifiers instead"
+                        }
                     }
                 },
                 "usb_detect": {

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -633,12 +633,37 @@ Configures the [Split Keyboard](feature_split_keyboard.md) feature.
     * `transport`
         * `protocol`
             * The split transport protocol to use. Must be one of `custom`, `i2c`, `serial`, `serial_usart`.
-        * `sync_matrix_state`
-            * Mirror the main/primary half's matrix state to the secondary half.
-            * Default: `false`
-        * `sync_modifiers`
-            * Mirror the modifier state to the secondary half.
-            * Default: `false`
+        * `sync`
+            * `activity`
+                * Mirror the activity timestamps to the secondary half.
+                * Default: `false`
+            * `detected_os`
+                * Mirror the [detected OS](feature_os_detection.md) to the secondary half.
+                * Default: `false`
+            * `haptic`
+                * Mirror the haptic state and process haptic feedback to the secondary half.
+                * Default: `false`
+            * `layer_state`
+                * Mirror the layer state to the secondary half.
+                * Default: `false`
+            * `indicators`
+                * Mirror the indicator state to the secondary half.
+                * Default: `false`
+            * `matrix_state`
+                * Mirror the main/primary half's matrix state to the secondary half.
+                * Default: `false`
+            * `modifiers`
+                * Mirror the modifier state to the secondary half.
+                * Default: `false`
+            * `oled`
+                * Mirror the OLED on/off status to the secondary half.
+                * Default: `false`
+            * `st7565`
+                * Mirror the ST7565 on/off status to the secondary half.
+                * Default: `false`
+            * `wpm`
+                * Mirror the current WPM value to the secondary half.
+                * Default: `false`
         * `watchdog`
             * Reboot the secondary half if it loses connection.
             * Default: `false`

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -428,6 +428,15 @@ def _extract_split_transport(info_data, config_c):
         if 'protocol' not in info_data['split']['transport']:
             info_data['split']['transport']['protocol'] = 'serial'
 
+    # Migrate
+    transport = info_data.get('split', {}).get('transport', {})
+    if 'sync_matrix_state' in transport:
+        transport['sync'] = transport.get('sync', {})
+        transport['sync']['matrix_state'] = transport.pop('sync_matrix_state')
+    if 'sync_modifiers' in transport:
+        transport['sync'] = transport.get('sync', {})
+        transport['sync']['modifiers'] = transport.pop('sync_modifiers')
+
 
 def _extract_split_right_pins(info_data, config_c):
     # Figure out the right half matrix pins


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Implements:
```json
{
    "split": {
        "transport":{
            "sync": {
                "activity": true,
                "detected_os": true,
                "haptic": true,
                "layer_state": true,
                "indicators": true
                "matrix_state": true,
                "modifiers": true,
                "oled": true,
                "st7565": true,
                "wpm": true
            }
        }
    }
}
```

Moves:
`split.transport.sync_matrix_state` -> `split.transport.sync.matrix_state`
`split.transport.sync_modifiers` -> `split.transport.sync.modifiers`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
