### PR TITLE
Monstargear XO87 Soldered: correct layout data

### DIFF
--- a/keyboards/monstargear/xo87/solderable/info.json
+++ b/keyboards/monstargear/xo87/solderable/info.json
@@ -346,9 +346,9 @@
                 {"label": "\u2191", "matrix": [4, 14], "x": 16.25, "y": 4.25},
 
                 {"label": "Ctrl", "matrix": [5, 0], "x": 0, "y": 5.25, "w": 1.5},
-                {"label": "GUI", "matrix": [5, 1], "x": 1.25, "y": 5.25},
+                {"label": "GUI", "matrix": [5, 1], "x": 1.5, "y": 5.25},
                 {"label": "Alt", "matrix": [5, 2], "x": 2.5, "y": 5.25, "w": 1.5},
-                {"label": "Space", "matrix": [5, 6], "x": 3.75, "y": 5.25, "w": 7},
+                {"label": "Space", "matrix": [5, 6], "x": 4, "y": 5.25, "w": 7},
                 {"label": "Alt", "matrix": [5, 11], "x": 11, "y": 5.25, "w": 1.5},
                 {"label": "Fn", "matrix": [5, 12], "x": 12.5, "y": 5.25},
                 {"label": "Ctrl", "matrix": [4, 15], "x": 13.5, "y": 5.25, "w": 1.5},


### PR DESCRIPTION
## Description

Correct key positions on the bottom row for `LAYOUT_tkl_ansi_tsangan`.

## Issues Fixed or Closed by This PR

![image](https://github.com/qmk/qmk_firmware/assets/18669334/9a5cbd47-a93b-4c26-b965-871cc6941232)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
