### PR TITLE
Add `qmk ci-validate-aliases`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,31 +74,10 @@ jobs:
         fi
         exit $exit_code
 
-    - name: Verify at most one added keyboard
+    - name: Verify keyboard aliases
       if: always()
       shell: 'bash {0}'
       run: |
         git reset --hard
         git clean -xfd
-
-        # Get the keyboard list and count for the target branch
-        git checkout -f ${{ github.base_ref }}
-        git pull --ff-only
-        QMK_KEYBOARDS_BASE=$(qmk list-keyboards)
-        QMK_KEYBOARDS_BASE_COUNT=$(qmk list-keyboards | wc -l)
-
-        # Get the keyboard list and count for the PR
-        git checkout -f ${{ github.head_ref }}
-        git merge --no-commit --squash ${{ github.base_ref }}
-        QMK_KEYBOARDS_PR=$(qmk list-keyboards)
-        QMK_KEYBOARDS_PR_COUNT=$(qmk list-keyboards | wc -l)
-
-        echo "::group::Keyboards changes in this PR"
-        diff -d -U 0 <(echo "$QMK_KEYBOARDS_BASE") <(echo "$QMK_KEYBOARDS_PR") | grep -vE '^(---|\+\+\+|@@)' | sed -e 's@^-@Removed: @g' -e 's@^+@  Added: @g'
-        echo "::endgroup::"
-
-        if [[ $QMK_KEYBOARDS_PR_COUNT -gt $(($QMK_KEYBOARDS_BASE_COUNT + 1)) ]]; then
-            echo "More than one keyboard added in this PR -- see the PR Checklist."
-            echo "::error::More than one keyboard added in this PR -- see the PR Checklist."
-            exit 1
-        fi
+        qmk ci-validate-aliases

--- a/data/mappings/keyboard_aliases.hjson
+++ b/data/mappings/keyboard_aliases.hjson
@@ -1315,5 +1315,10 @@
     },
     "zinc/reva": {
         "target": "25keys/zinc/reva"
-    }
+    },
+
+    /* This list of aliases is for testing purposes -- ensures "linked list" recursive traversal works correctly. */
+    "_test_a": { "target": "_test_b" },
+    "_test_b": { "target": "_test_c" },
+    "_test_c": { "target": "planck/rev6" }
 }

--- a/data/mappings/keyboard_aliases.hjson
+++ b/data/mappings/keyboard_aliases.hjson
@@ -4,6 +4,13 @@
     //     "target": "<keyboard_folder>"
     // }
     //
+
+    /* This list of aliases is for testing purposes -- ensures "linked list" recursive traversal works correctly. */
+    "_test_a": { "target": "_test_b" },
+    "_test_b": { "target": "_test_c" },
+    "_test_c": { "target": "planck/rev6" },
+
+    /* The main list of aliases for moved keyboards within QMK. */
     "2_milk": {
         "target": "spaceman/2_milk"
     },
@@ -1315,10 +1322,5 @@
     },
     "zinc/reva": {
         "target": "25keys/zinc/reva"
-    },
-
-    /* This list of aliases is for testing purposes -- ensures "linked list" recursive traversal works correctly. */
-    "_test_a": { "target": "_test_b" },
-    "_test_b": { "target": "_test_c" },
-    "_test_c": { "target": "planck/rev6" }
+    }
 }

--- a/data/mappings/keyboard_aliases.hjson
+++ b/data/mappings/keyboard_aliases.hjson
@@ -35,7 +35,7 @@
         "target": "amjkeyboard/amjpad"
     },
     "angel64": {
-        "target": "angel64/alpha"
+        "target": "kakunpc/angel64/alpha"
     },
     "ashpil/modelm_usbc": {
         "target": "ibm/model_m/ashpil_usbc"
@@ -47,10 +47,10 @@
         "target": "viktus/at101_bh"
     },
     "atom47/rev2": {
-        "target": "maartenwut/atom47/rev2"
+        "target": "evyd13/atom47/rev2"
     },
     "atom47/rev3": {
-        "target": "maartenwut/atom47/rev3"
+        "target": "evyd13/atom47/rev3"
     },
     "bakeneko60": {
         "target": "kkatano/bakeneko60"
@@ -65,7 +65,7 @@
         "target": "bear_face/v1"
     },
     "bm16a": {
-        "target": "kprepublic/bm16a"
+        "target": "kprepublic/bm16a/v1"
     },
     "bm16s": {
         "target": "kprepublic/bm16s"
@@ -77,16 +77,16 @@
         "target": "kprepublic/bm43a"
     },
     "bm60poker": {
-        "target": "kprepublic/bm60poker"
+        "target": "kprepublic/bm60hsrgb_poker/rev1"
     },
     "bm60rgb": {
-        "target": "kprepublic/bm60rgb"
+        "target": "kprepublic/bm60hsrgb/rev1"
     },
     "bm60rgb_iso": {
-        "target": "kprepublic/bm60rgb_iso"
+        "target": "kprepublic/bm60hsrgb_iso/rev1"
     },
     "bm68rgb": {
-        "target": "kprepublic/bm68rgb"
+        "target": "kprepublic/bm68hsrgb/rev1"
     },
     "bpiphany/pegasushoof": {
         "target": "bpiphany/pegasushoof/2013"
@@ -140,7 +140,10 @@
         "target": "jagdpietr/drakon"
     },
     "durgod/k320": {
-        "target": "durgod/k3x0/k320"
+        "target": "durgod/k320/base"
+    },
+    "durgod/k3x0/k320": {
+        "target": "durgod/k320/base"
     },
     "durgod/hades": {
         "target": "durgod/dgk6x/hades_ansi"
@@ -269,7 +272,7 @@
         "target": "idb/idb_60"
     },
     "idobo": {
-        "target": "idobao/id75"
+        "target": "idobao/id75/v1"
     },
     "jacky_studio/piggy60": {
         "target": "jacky_studio/piggy60/rev1"
@@ -401,7 +404,7 @@
         "target": "mechlovin/adelais/rgb_led/rev1"
     },
     "mechlovin/adelais/standard_led": {
-        "target": "mechlovin/adelais/standard_led/rev2"
+        "target": "mechlovin/adelais/standard_led/arm/rev2"
     },
     "mechlovin/delphine": {
         "target": "mechlovin/delphine/mono_led"
@@ -455,10 +458,10 @@
         "target": "pabile/p20/ver1"
     },
     "pancake/feather": {
-        "target": "spaceman/pancake/feather"
+        "target": "spaceman/pancake/rev1/feather"
     },
     "pancake/promicro": {
-        "target": "spaceman/pancake/promicro"
+        "target": "spaceman/pancake/rev1/promicro"
     },
     "peiorisboards/ixora": {
         "target": "coarse/ixora"
@@ -467,7 +470,7 @@
         "target": "dm9records/plaid"
     },
     "plain60": {
-        "target": "maartenwut/plain60"
+        "target": "evyd13/plain60"
     },
     "ploopyco/trackball": {
         "target": "ploopyco/trackball/rev1_005"
@@ -503,10 +506,10 @@
         "target": "wilba_tech/rama_works_u80_a"
     },
     "ramonimbao/herringbone": {
-        "target": "ramonimbao/herringbone/v1"
+        "target": "rmi_kb/herringbone/v1"
     },
     "ramonimbao/mona": {
-        "target": "ramonimbao/mona/v1"
+        "target": "rmi_kb/mona/v1"
     },
     "rgbkb/pan": {
         "target": "rgbkb/pan/rev1/32a"
@@ -542,10 +545,10 @@
         "target": "tkw/stoutgat/v1"
     },
     "suihankey": {
-        "target": "suihankey/split/alpha"
+        "target": "kakunpc/suihankey/split/alpha"
     },
     "ta65": {
-        "target": "maartenwut/ta65"
+        "target": "evyd13/ta65"
     },
     "tartan": {
         "target": "dm9records/tartan"
@@ -563,13 +566,13 @@
         "target": "matthewdias/txuu"
     },
     "underscore33": {
-        "target": "underscore33/rev1"
+        "target": "tominabox1/underscore33/rev1"
     },
     "vinta": {
         "target": "coarse/vinta"
     },
     "wasdat": {
-        "target": "maartenwut/wasdat"
+        "target": "evyd13/wasdat"
     },
     "westfoxtrot/cypher": {
         "target": "westfoxtrot/cypher/rev1"
@@ -581,10 +584,10 @@
         "target": "xiudi/xd002"
     },
     "xd004": {
-        "target": "xiudi/xd004"
+        "target": "xiudi/xd004/v1"
     },
     "xd60": {
-        "target": "xiudi/xd60"
+        "target": "xiudi/xd60/rev2"
     },
     "xd68": {
         "target": "xiudi/xd68"
@@ -831,7 +834,7 @@
         "target": "kagizaraya/halberd"
     },
     "handwired/hillside/0_1": {
-        "target": "handwired/hillside/48"
+        "target": "hillside/48/0_1"
     },
     "hecomi/alpha": {
         "target": "takashiski/hecomi/alpha"
@@ -843,10 +846,10 @@
         "target": "bpiphany/hid_liber"
     },
     "id67/default_rgb": {
-        "target": "idobao/id67/default_rgb"
+        "target": "idobao/id67"
     },
     "id67/rgb": {
-        "target": "idobao/id67/rgb"
+        "target": "idobao/id67"
     },
     "id80": {
         "target": "idobao/id80/v2/ansi"
@@ -1236,7 +1239,7 @@
         "target": "marksard/treadstone48/rev2"
     },
     "tronguylabs/m122_3270": {
-        "target": "ibm/model_m_122/m122_3270"
+        "target": "ibm/model_m_122/m122_3270/teensy"
     },
     "ua62": {
         "target": "nacly/ua62"
@@ -1290,7 +1293,7 @@
         "target": "ydkb/yd68"
     },
     "ymd75": {
-        "target": "ymdk/ymd75"
+        "target": "ymdk/ymd75/rev1"
     },
     "ymd96": {
         "target": "ymdk/ymd96"

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -31,6 +31,7 @@ safe_commands = [
 ]
 
 subcommands = [
+    'qmk.cli.ci.validate_aliases',
     'qmk.cli.bux',
     'qmk.cli.c2json',
     'qmk.cli.cd',

--- a/lib/python/qmk/cli/ci/validate_aliases.py
+++ b/lib/python/qmk/cli/ci/validate_aliases.py
@@ -15,6 +15,7 @@ def _safe_keyboard_folder(target):
     except Exception:
         return None
 
+
 def _target_keyboard_exists(target):
     # If there's no target, then we can't build it.
     if not target:

--- a/lib/python/qmk/cli/ci/validate_aliases.py
+++ b/lib/python/qmk/cli/ci/validate_aliases.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from milc import cli
 
-from qmk.constants import QMK_FIRMWARE
 from qmk.json_schema import json_load
 from qmk.keyboard import resolve_keyboard, keyboard_folder
 

--- a/lib/python/qmk/cli/ci/validate_aliases.py
+++ b/lib/python/qmk/cli/ci/validate_aliases.py
@@ -1,0 +1,27 @@
+"""Validates the list of keyboard aliases.
+"""
+from pathlib import Path
+
+from milc import cli
+
+from qmk.constants import QMK_FIRMWARE
+from qmk.json_schema import json_load
+from qmk.keyboard import resolve_keyboard, keyboard_folder
+
+
+def _safe_keyboard_folder(target):
+    try:
+        return keyboard_folder(target)
+    except Exception:
+        return None
+
+
+@cli.subcommand('Validates the list of keyboard aliases.', hidden=True)
+def ci_validate_aliases(cli):
+    aliases = json_load(Path('data/mappings/keyboard_aliases.hjson'))
+    for alias in aliases.keys():
+        if alias == 'bm16a':
+            pass
+        target = aliases[alias].get('target', None)
+        if not target or not (QMK_FIRMWARE / 'keyboards' / target).exists() or not resolve_keyboard(target) or not _safe_keyboard_folder(target):
+            cli.log.error(f'Keyboard alias {alias} has a target that doesn\'t exist: {target}')

--- a/lib/python/qmk/cli/ci/validate_aliases.py
+++ b/lib/python/qmk/cli/ci/validate_aliases.py
@@ -19,9 +19,14 @@ def _safe_keyboard_folder(target):
 @cli.subcommand('Validates the list of keyboard aliases.', hidden=True)
 def ci_validate_aliases(cli):
     aliases = json_load(Path('data/mappings/keyboard_aliases.hjson'))
+
+    success = True
     for alias in aliases.keys():
         if alias == 'bm16a':
             pass
         target = aliases[alias].get('target', None)
         if not target or not (QMK_FIRMWARE / 'keyboards' / target).exists() or not resolve_keyboard(target) or not _safe_keyboard_folder(target):
             cli.log.error(f'Keyboard alias {alias} has a target that doesn\'t exist: {target}')
+            success = False
+
+    return success

--- a/lib/python/qmk/cli/ci/validate_aliases.py
+++ b/lib/python/qmk/cli/ci/validate_aliases.py
@@ -21,10 +21,6 @@ def _target_keyboard_exists(target):
     if not target:
         return False
 
-    # If the target directory doesn't exist, then we can't build it.
-    if not (QMK_FIRMWARE / 'keyboards' / target).exists():
-        return False
-
     # If the target directory existed but there was no rules.mk or rules.mk was incorrectly parsed, then we can't build it.
     if not resolve_keyboard(target):
         return False

--- a/lib/python/qmk/cli/ci/validate_aliases.py
+++ b/lib/python/qmk/cli/ci/validate_aliases.py
@@ -11,9 +11,29 @@ from qmk.keyboard import resolve_keyboard, keyboard_folder
 
 def _safe_keyboard_folder(target):
     try:
-        return keyboard_folder(target)
+        return keyboard_folder(target)  # throws ValueError if it's invalid
     except Exception:
         return None
+
+def _target_keyboard_exists(target):
+    # If there's no target, then we can't build it.
+    if not target:
+        return False
+
+    # If the target directory doesn't exist, then we can't build it.
+    if not (QMK_FIRMWARE / 'keyboards' / target).exists():
+        return False
+
+    # If the target directory existed but there was no rules.mk or rules.mk was incorrectly parsed, then we can't build it.
+    if not resolve_keyboard(target):
+        return False
+
+    # If the target directory exists but it itself has an invalid alias or invalid rules.mk, then we can't build it either.
+    if not _safe_keyboard_folder(target):
+        return False
+
+    # As far as we can tell, we can build it!
+    return True
 
 
 @cli.subcommand('Validates the list of keyboard aliases.', hidden=True)
@@ -22,10 +42,8 @@ def ci_validate_aliases(cli):
 
     success = True
     for alias in aliases.keys():
-        if alias == 'bm16a':
-            pass
         target = aliases[alias].get('target', None)
-        if not target or not (QMK_FIRMWARE / 'keyboards' / target).exists() or not resolve_keyboard(target) or not _safe_keyboard_folder(target):
+        if not _target_keyboard_exists(target):
             cli.log.error(f'Keyboard alias {alias} has a target that doesn\'t exist: {target}')
             success = False
 

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -212,13 +212,16 @@ def parse_configurator_json(configurator_file):
         cli.log.error(f'Invalid JSON keymap: {configurator_file} : {e.message}')
         exit(1)
 
-    orig_keyboard = user_keymap['keyboard']
+    keyboard = user_keymap['keyboard']
     aliases = json_load(Path('data/mappings/keyboard_aliases.hjson'))
 
-    if orig_keyboard in aliases:
-        if 'target' in aliases[orig_keyboard]:
-            user_keymap['keyboard'] = aliases[orig_keyboard]['target']
+    while keyboard in aliases:
+        last_keyboard = keyboard
+        keyboard = aliases[keyboard].get('target', keyboard)
+        if keyboard == last_keyboard:
+            break
 
+    user_keymap['keyboard'] = keyboard
     return user_keymap
 
 

--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -92,8 +92,11 @@ def keyboard_folder(keyboard):
     """
     aliases = json_load(Path('data/mappings/keyboard_aliases.hjson'))
 
-    if keyboard in aliases:
+    while keyboard in aliases:
+        last_keyboard = keyboard
         keyboard = aliases[keyboard].get('target', keyboard)
+        if keyboard == last_keyboard:
+            break
 
     rules_mk_file = Path(base_path, keyboard, 'rules.mk')
 


### PR DESCRIPTION
## Description

* Validates that all aliases exist in the repo.
* Recursively follows aliases
* Adds aliases check to CI lint
* Removes non-functional keyboard count lint check -- will fix it up later.

As of now, some don't:
```
% qmk ci-validate-aliases                               
☒ Keyboard alias angel64 has a target that doesn't exist: angel64/alpha
☒ Keyboard alias atom47/rev2 has a target that doesn't exist: maartenwut/atom47/rev2
☒ Keyboard alias atom47/rev3 has a target that doesn't exist: maartenwut/atom47/rev3
☒ Keyboard alias bm16a has a target that doesn't exist: kprepublic/bm16a
☒ Keyboard alias bm60poker has a target that doesn't exist: kprepublic/bm60poker
☒ Keyboard alias bm60rgb has a target that doesn't exist: kprepublic/bm60rgb
☒ Keyboard alias bm60rgb_iso has a target that doesn't exist: kprepublic/bm60rgb_iso
☒ Keyboard alias bm68rgb has a target that doesn't exist: kprepublic/bm68rgb
☒ Keyboard alias durgod/k320 has a target that doesn't exist: durgod/k3x0/k320
☒ Keyboard alias idobo has a target that doesn't exist: idobao/id75
☒ Keyboard alias mechlovin/adelais/standard_led has a target that doesn't exist: mechlovin/adelais/standard_led/rev2
☒ Keyboard alias pancake/feather has a target that doesn't exist: spaceman/pancake/feather
☒ Keyboard alias pancake/promicro has a target that doesn't exist: spaceman/pancake/promicro
☒ Keyboard alias plain60 has a target that doesn't exist: maartenwut/plain60
☒ Keyboard alias ramonimbao/herringbone has a target that doesn't exist: ramonimbao/herringbone/v1
☒ Keyboard alias ramonimbao/mona has a target that doesn't exist: ramonimbao/mona/v1
☒ Keyboard alias suihankey has a target that doesn't exist: suihankey/split/alpha
☒ Keyboard alias ta65 has a target that doesn't exist: maartenwut/ta65
☒ Keyboard alias underscore33 has a target that doesn't exist: underscore33/rev1
☒ Keyboard alias wasdat has a target that doesn't exist: maartenwut/wasdat
☒ Keyboard alias xd004 has a target that doesn't exist: xiudi/xd004
☒ Keyboard alias xd60 has a target that doesn't exist: xiudi/xd60
☒ Keyboard alias handwired/hillside/0_1 has a target that doesn't exist: handwired/hillside/48
☒ Keyboard alias id67/default_rgb has a target that doesn't exist: idobao/id67/default_rgb
☒ Keyboard alias id67/rgb has a target that doesn't exist: idobao/id67/rgb
☒ Keyboard alias tronguylabs/m122_3270 has a target that doesn't exist: ibm/model_m_122/m122_3270
☒ Keyboard alias ymd75 has a target that doesn't exist: ymdk/ymd75
```

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
