### PR TITLE
Emit neutralizer in clear_active_override()

### DIFF
--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -213,10 +213,10 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
         schedule_deferred_register(trigger);
     }
 
-    #ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
-        // Tap dummy mod neutralizer again after reregistering mod key
-        neutralize_flashing_modifiers(active_override->trigger_mods);
-    #endif
+#ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
+	// Tap dummy mod neutralizer again after reregistering mod key
+	neutralize_flashing_modifiers(active_override->trigger_mods);
+#endif
 
     send_keyboard_report();
 

--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -213,6 +213,11 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
         schedule_deferred_register(trigger);
     }
 
+    #ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
+        // Tap dummy mod neutralizer again after reregistering mod key
+        neutralize_flashing_modifiers(active_override->trigger_mods);
+    #endif
+
     send_keyboard_report();
 
     active_override                 = NULL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I've tried to emit the neutralizer in the `clear_active_override()` function, but I'd like a suggestion, where should I pull the `active_mods` from? Is this a good general direction for this issue? I confirmed that this code here works 100%, but it will be sending not needed neutralizers here and there because we are not passing `active_mods`, but `active_trigger->trigger_mods` to the `neutralize_flashing_modifiers` function. Should we require `active_mods` as an argument to the `clear_active_override()` function? @precondition @sigprof 
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #22208 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
