### PR TITLE
Add CH_CFG_USE_MEMCORE == false guard to debounce/sym_defer_pr.c

### DIFF
--- a/quantum/debounce/sym_defer_pr.c
+++ b/quantum/debounce/sym_defer_pr.c
@@ -21,6 +21,12 @@ DEBOUNCE milliseconds have elapsed since the last change.
 #include "timer.h"
 #include <stdlib.h>
 
+#ifdef PROTOCOL_CHIBIOS
+#    if CH_CFG_USE_MEMCORE == FALSE
+#        error ChibiOS is configured without a memory allocator. Your keyboard may have set `#define CH_CFG_USE_MEMCORE FALSE`, which is incompatible with this debounce algorithm.
+#    endif
+#endif
+
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
 #endif


### PR DESCRIPTION
It is present in all the other debouncing algorithms that allocate memory.

e.g. https://github.com/qmk/qmk_firmware/blob/6dafcac71399d1d4a4af1b6bfb36d73c6c9155ce/quantum/debounce/sym_eager_pr.c#L26-L30

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The other debouncing algorithms ensure that it is possible to allocate memory if they make use of memory allocation. sym_defer_pr does not.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
