### PR TITLE
Allocation-free debouncing

### DIFF
--- a/docs/custom_matrix.md
+++ b/docs/custom_matrix.md
@@ -74,7 +74,7 @@ void matrix_init(void) {
     // TODO: initialize hardware and global matrix state here
 
     // Unless hardware debouncing - Init the configured debounce routine
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     // This *must* be called for correct keyboard behavior
     matrix_init_kb();
@@ -86,7 +86,7 @@ uint8_t matrix_scan(void) {
     // TODO: add matrix scanning routine here
 
     // Unless hardware debouncing - use the configured debounce routine
-    changed = debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+    changed = debounce(raw_matrix, matrix, changed);
 
     // This *must* be called for correct keyboard behavior
     matrix_scan_kb();

--- a/keyboards/bpiphany/pegasushoof/2015/matrix.c
+++ b/keyboards/bpiphany/pegasushoof/2015/matrix.c
@@ -89,7 +89,7 @@ uint8_t matrix_scan(void)
     }
   }
 
-  debounce(matrix_debouncing, matrix, matrix_rows(), changed);
+  debounce(matrix_debouncing, matrix, changed);
   matrix_scan_kb();
 
   return (uint8_t)changed;

--- a/keyboards/gboards/gergo/matrix.c
+++ b/keyboards/gboards/gergo/matrix.c
@@ -147,7 +147,7 @@ void matrix_init(void) {
     raw_matrix[i] = 0;
   }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
     matrix_init_kb();
 }
 
@@ -254,7 +254,7 @@ uint8_t matrix_scan(void) {
         unselect_rows();
     }
 
-    debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+    debounce(raw_matrix, matrix, changed);
     matrix_scan_kb();
 
     enableInterrupts();

--- a/keyboards/gboards/gergoplex/matrix.c
+++ b/keyboards/gboards/gergoplex/matrix.c
@@ -82,7 +82,7 @@ void matrix_init(void) {
         raw_matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
     matrix_init_kb();
 }
 void matrix_power_up(void) {
@@ -140,7 +140,7 @@ uint8_t matrix_scan(void) {
         unselect_rows();
     }
 
-    debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+    debounce(raw_matrix, matrix, changed);
     matrix_scan_kb();
 
 #ifdef DEBUG_MATRIX

--- a/keyboards/halfcliff/matrix.c
+++ b/keyboards/halfcliff/matrix.c
@@ -23,8 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define ERROR_DISCONNECT_COUNT 5
 
-#define ROWS_PER_HAND (MATRIX_ROWS / 2)
-
 static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 
@@ -201,7 +199,7 @@ void matrix_init(void) {
         matrix[i]     = 0;
     }
 
-    debounce_init(ROWS_PER_HAND);
+    debounce_init();
 
     matrix_init_kb();
 
@@ -267,7 +265,7 @@ uint8_t matrix_scan(void) {
         }
     }
 
-    debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, local_changed);
+    debounce(raw_matrix, matrix + thisHand, local_changed);
 
     bool remote_changed = matrix_post_scan();
     return (uint8_t)(local_changed || remote_changed);

--- a/keyboards/handwired/owlet60/matrix.c
+++ b/keyboards/handwired/owlet60/matrix.c
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
+#include "debounce.h"
 #include "timer.h"
 
 #if (MATRIX_COLS <= 8)
@@ -64,8 +65,6 @@ static const uint8_t num_in_binary[8][3] = {
 
 static void select_col_analog(uint8_t col);
 static void mux_pin_control(const uint8_t binary[]);
-void debounce_init(uint8_t num_rows);
-void debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed);
 
 
 __attribute__ ((weak))
@@ -196,7 +195,7 @@ void matrix_init(void) {
         matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 
@@ -213,7 +212,7 @@ uint8_t matrix_scan(void)
         changed |= read_cols_on_row(raw_matrix, current_row);
     }
 
-    debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+    debounce(raw_matrix, matrix, changed);
 
     matrix_scan_kb();
     return (uint8_t)changed;
@@ -231,7 +230,7 @@ uint8_t matrix_scan(void)
   }
 #endif
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
   return (uint8_t)changed;

--- a/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
+++ b/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
@@ -292,7 +292,7 @@ void matrix_init(void) {
         matrix[i]     = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -317,7 +317,7 @@ uint8_t matrix_scan(void) {
     MATRIX_DEBUG_GAP();
 
     MATRIX_DEBUG_SCAN_START();
-    debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+    debounce(raw_matrix, matrix, changed);
     MATRIX_DEBUG_SCAN_END();
     MATRIX_DEBUG_GAP();
 

--- a/keyboards/handwired/symmetric70_proto/matrix_fast/matrix.c
+++ b/keyboards/handwired/symmetric70_proto/matrix_fast/matrix.c
@@ -166,7 +166,7 @@ void matrix_init(void) {
         matrix[i]     = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -221,7 +221,7 @@ uint8_t matrix_scan(void) {
     MATRIX_DEBUG_SCAN_END(); MATRIX_DEBUG_GAP(); MATRIX_DEBUG_SCAN_START();
 
     // debounce raw_matrix[] to matrix[]
-    debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+    debounce(raw_matrix, matrix, changed);
     MATRIX_DEBUG_SCAN_END(); MATRIX_DEBUG_GAP();
 
     MATRIX_DEBUG_SCAN_START();

--- a/keyboards/kakunpc/angel64/alpha/matrix.c
+++ b/keyboards/kakunpc/angel64/alpha/matrix.c
@@ -229,7 +229,7 @@ void matrix_init(void) {
         matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -248,7 +248,7 @@ uint8_t matrix_scan(void)
     changed |= read_rows_on_col(raw_matrix, current_col);
   }
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
   return (uint8_t)changed;

--- a/keyboards/kakunpc/angel64/rev1/matrix.c
+++ b/keyboards/kakunpc/angel64/rev1/matrix.c
@@ -229,7 +229,7 @@ void matrix_init(void) {
         matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -248,7 +248,7 @@ uint8_t matrix_scan(void)
     changed |= read_rows_on_col(raw_matrix, current_col);
   }
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
   return (uint8_t)changed;

--- a/keyboards/kakunpc/thedogkeyboard/matrix.c
+++ b/keyboards/kakunpc/thedogkeyboard/matrix.c
@@ -229,7 +229,7 @@ void matrix_init(void) {
         matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -248,7 +248,7 @@ uint8_t matrix_scan(void)
     changed |= read_rows_on_col(raw_matrix, current_col);
   }
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
   return (uint8_t)changed;

--- a/keyboards/kbdmania/kmac/matrix.c
+++ b/keyboards/kbdmania/kmac/matrix.c
@@ -182,7 +182,7 @@ void matrix_init(void) {
         matrix[i]     = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -194,7 +194,7 @@ uint8_t matrix_scan(void) {
         changed |= read_rows_on_col(raw_matrix, current_col);
     }
 
-    debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+    debounce(raw_matrix, matrix, changed);
 
     matrix_scan_kb();
 

--- a/keyboards/keychron/q10/matrix.c
+++ b/keyboards/keychron/q10/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/q12/matrix.c
+++ b/keyboards/keychron/q12/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/q1v2/matrix.c
+++ b/keyboards/keychron/q1v2/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/q5/matrix.c
+++ b/keyboards/keychron/q5/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/q6/matrix.c
+++ b/keyboards/keychron/q6/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 #ifndef NO_PIN_NUM
 #    define NO_PIN_NUM 8
 #endif

--- a/keyboards/keychron/q65/matrix.c
+++ b/keyboards/keychron/q65/matrix.c
@@ -32,8 +32,6 @@ static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void writePinLow_atomic(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_write_pin_low(pin);

--- a/keyboards/keychron/v1/matrix.c
+++ b/keyboards/keychron/v1/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND MATRIX_ROWS
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/v10/matrix.c
+++ b/keyboards/keychron/v10/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/v3/matrix.c
+++ b/keyboards/keychron/v3/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/v5/matrix.c
+++ b/keyboards/keychron/v5/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/keychron/v6/matrix.c
+++ b/keyboards/keychron/v6/matrix.c
@@ -32,8 +32,6 @@ static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 #endif // MATRIX_COL_PINS
 
-#define ROWS_PER_HAND (MATRIX_ROWS)
-
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
         gpio_set_pin_output(pin);

--- a/keyboards/moon/matrix.c
+++ b/keyboards/moon/matrix.c
@@ -182,7 +182,7 @@ void matrix_init(void) {
     matrix[i]     = 0;
   }
 
-  debounce_init(MATRIX_ROWS);
+  debounce_init();
 
   matrix_init_kb();
 }
@@ -194,7 +194,7 @@ uint8_t matrix_scan(void) {
     changed |= read_cols_on_row(raw_matrix, current_row);
   }
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
 

--- a/keyboards/nullbitsco/snap/matrix.c
+++ b/keyboards/nullbitsco/snap/matrix.c
@@ -20,7 +20,6 @@
 
 #define VIRT_COLS_PER_HAND 1
 #define PHYS_COLS_PER_HAND (MATRIX_COLS - VIRT_COLS_PER_HAND)
-#define ROWS_PER_HAND (MATRIX_ROWS / 2)
 #define COL_SHIFTER ((uint32_t)1)
 #define EXT_PIN_ROW 2
 #define EXT_PIN_COL 8

--- a/keyboards/redscarf_iiplus/verb/matrix.c
+++ b/keyboards/redscarf_iiplus/verb/matrix.c
@@ -330,7 +330,7 @@ void matrix_init(void) {
         matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -351,7 +351,7 @@ uint8_t matrix_scan(void)
   }
 #endif
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
   return 1;

--- a/keyboards/redscarf_iiplus/verc/matrix.c
+++ b/keyboards/redscarf_iiplus/verc/matrix.c
@@ -330,7 +330,7 @@ void matrix_init(void) {
         matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -351,7 +351,7 @@ uint8_t matrix_scan(void)
   }
 #endif
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
   return 1;

--- a/keyboards/redscarf_iiplus/verd/matrix.c
+++ b/keyboards/redscarf_iiplus/verd/matrix.c
@@ -330,7 +330,7 @@ void matrix_init(void) {
         matrix[i] = 0;
     }
 
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -351,7 +351,7 @@ uint8_t matrix_scan(void)
   }
 #endif
 
-  debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
+  debounce(raw_matrix, matrix, changed);
 
   matrix_scan_kb();
   return 1;

--- a/keyboards/sekigon/grs_70ec/matrix.c
+++ b/keyboards/sekigon/grs_70ec/matrix.c
@@ -33,8 +33,6 @@
 
 #define ERROR_DISCONNECT_COUNT 20
 
-#define ROWS_PER_HAND (MATRIX_ROWS / 2)
-
 /* matrix state(1:on, 0:off) */
 extern matrix_row_t raw_matrix[MATRIX_ROWS];  // raw values
 extern matrix_row_t matrix[MATRIX_ROWS];      // debounced values

--- a/keyboards/whale/sk/v3/v3.c
+++ b/keyboards/whale/sk/v3/v3.c
@@ -5,7 +5,6 @@
 #    include <avr/interrupt.h>
 #endif
 
-#define ROWS_PER_HAND (MATRIX_ROWS / 2)
 #define SLAVE_MATRIX_SYNC_ADDR (0x01)
 
 typedef struct {

--- a/keyboards/ymdk/sp64/matrix.c
+++ b/keyboards/ymdk/sp64/matrix.c
@@ -73,7 +73,7 @@ void matrix_init(void)
     matrix[row] = 0;
     matrix_debouncing[row] = 0;
   }
-  debounce_init(MATRIX_ROWS);
+  debounce_init();
   matrix_init_kb();
 }
 
@@ -125,7 +125,7 @@ uint8_t matrix_scan(void)
     }
   }
 
-  debounce(matrix_debouncing, matrix, MATRIX_ROWS, changed);
+  debounce(matrix_debouncing, matrix, changed);
 
   matrix_scan_kb();
 

--- a/quantum/debounce.h
+++ b/quantum/debounce.h
@@ -9,13 +9,12 @@
  *
  * @param raw The current key state
  * @param cooked The debounced key state
- * @param num_rows Number of rows to debounce
  * @param changed True if raw has changed since the last call
  * @return true Cooked has new keychanges after debouncing
  * @return false Cooked is the same as before
  */
-bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed);
+bool debounce(matrix_row_t raw[], matrix_row_t cooked[], bool changed);
 
-void debounce_init(uint8_t num_rows);
+void debounce_init(void);
 
 void debounce_free(void);

--- a/quantum/debounce/none.c
+++ b/quantum/debounce/none.c
@@ -17,13 +17,13 @@
 #include "debounce.h"
 #include <string.h>
 
-void debounce_init(uint8_t num_rows) {}
+void debounce_init(void) {}
 
-bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+bool debounce(matrix_row_t raw[], matrix_row_t cooked[], bool changed) {
     bool cooked_changed = false;
 
     if (changed) {
-        size_t matrix_size = num_rows * sizeof(matrix_row_t);
+        size_t matrix_size = ROWS_PER_HAND * sizeof(matrix_row_t);
         if (memcmp(cooked, raw, matrix_size) != 0) {
             memcpy(cooked, raw, matrix_size);
             cooked_changed = true;

--- a/quantum/debounce/sym_defer_g.c
+++ b/quantum/debounce/sym_defer_g.c
@@ -34,16 +34,16 @@ When no state changes have occured for DEBOUNCE milliseconds, we push the state.
 static bool         debouncing = false;
 static fast_timer_t debouncing_time;
 
-void debounce_init(uint8_t num_rows) {}
+void debounce_init(void) {}
 
-bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+bool debounce(matrix_row_t raw[], matrix_row_t cooked[], bool changed) {
     bool cooked_changed = false;
 
     if (changed) {
         debouncing      = true;
         debouncing_time = timer_read_fast();
     } else if (debouncing && timer_elapsed_fast(debouncing_time) >= DEBOUNCE) {
-        size_t matrix_size = num_rows * sizeof(matrix_row_t);
+        size_t matrix_size = ROWS_PER_HAND * sizeof(matrix_row_t);
         if (memcmp(cooked, raw, matrix_size) != 0) {
             memcpy(cooked, raw, matrix_size);
             cooked_changed = true;

--- a/quantum/debounce/sym_defer_pk.c
+++ b/quantum/debounce/sym_defer_pk.c
@@ -23,12 +23,6 @@ When no state changes have occured for DEBOUNCE milliseconds, we push the state.
 #include "timer.h"
 #include <stdlib.h>
 
-#ifdef PROTOCOL_CHIBIOS
-#    if CH_CFG_USE_MEMCORE == FALSE
-#        error ChibiOS is configured without a memory allocator. Your keyboard may have set `#define CH_CFG_USE_MEMCORE FALSE`, which is incompatible with this debounce algorithm.
-#    endif
-#endif
-
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
 #endif
@@ -44,33 +38,28 @@ When no state changes have occured for DEBOUNCE milliseconds, we push the state.
 typedef uint8_t debounce_counter_t;
 
 #if DEBOUNCE > 0
-static debounce_counter_t *debounce_counters;
-static fast_timer_t        last_time;
-static bool                counters_need_update;
-static bool                cooked_changed;
+static debounce_counter_t debounce_counters[ROWS_PER_HAND * MATRIX_COLS];
+static fast_timer_t       last_time;
+static bool               counters_need_update;
+static bool               cooked_changed;
 
 #    define DEBOUNCE_ELAPSED 0
 
-static void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t elapsed_time);
-static void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows);
+static void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[], matrix_row_t cooked[], uint8_t elapsed_time);
+static void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[]);
 
-// we use num_rows rather than MATRIX_ROWS to support split keyboards
-void debounce_init(uint8_t num_rows) {
-    debounce_counters = (debounce_counter_t *)malloc(num_rows * MATRIX_COLS * sizeof(debounce_counter_t));
-    int i             = 0;
-    for (uint8_t r = 0; r < num_rows; r++) {
+void debounce_init(void) {
+    int i = 0;
+    for (uint8_t r = 0; r < ROWS_PER_HAND; r++) {
         for (uint8_t c = 0; c < MATRIX_COLS; c++) {
             debounce_counters[i++] = DEBOUNCE_ELAPSED;
         }
     }
 }
 
-void debounce_free(void) {
-    free(debounce_counters);
-    debounce_counters = NULL;
-}
+void debounce_free(void) {}
 
-bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+bool debounce(matrix_row_t raw[], matrix_row_t cooked[], bool changed) {
     bool updated_last = false;
     cooked_changed    = false;
 
@@ -85,7 +74,7 @@ bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool 
         }
 
         if (elapsed_time > 0) {
-            update_debounce_counters_and_transfer_if_expired(raw, cooked, num_rows, elapsed_time);
+            update_debounce_counters_and_transfer_if_expired(raw, cooked, elapsed_time);
         }
     }
 
@@ -94,16 +83,16 @@ bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool 
             last_time = timer_read_fast();
         }
 
-        start_debounce_counters(raw, cooked, num_rows);
+        start_debounce_counters(raw, cooked);
     }
 
     return cooked_changed;
 }
 
-static void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, uint8_t elapsed_time) {
+static void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[], matrix_row_t cooked[], uint8_t elapsed_time) {
     counters_need_update                 = false;
     debounce_counter_t *debounce_pointer = debounce_counters;
-    for (uint8_t row = 0; row < num_rows; row++) {
+    for (uint8_t row = 0; row < ROWS_PER_HAND; row++) {
         for (uint8_t col = 0; col < MATRIX_COLS; col++) {
             if (*debounce_pointer != DEBOUNCE_ELAPSED) {
                 if (*debounce_pointer <= elapsed_time) {
@@ -121,9 +110,9 @@ static void update_debounce_counters_and_transfer_if_expired(matrix_row_t raw[],
     }
 }
 
-static void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows) {
+static void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[]) {
     debounce_counter_t *debounce_pointer = debounce_counters;
-    for (uint8_t row = 0; row < num_rows; row++) {
+    for (uint8_t row = 0; row < ROWS_PER_HAND; row++) {
         matrix_row_t delta = raw[row] ^ cooked[row];
         for (uint8_t col = 0; col < MATRIX_COLS; col++) {
             if (delta & (ROW_SHIFTER << col)) {

--- a/quantum/debounce/sym_defer_pr.c
+++ b/quantum/debounce/sym_defer_pr.c
@@ -20,6 +20,7 @@ DEBOUNCE milliseconds have elapsed since the last change.
 #include "debounce.h"
 #include "timer.h"
 #include <stdlib.h>
+#include <string.h>
 
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
@@ -27,25 +28,20 @@ DEBOUNCE milliseconds have elapsed since the last change.
 
 static uint16_t last_time;
 // [row] milliseconds until key's state is considered debounced.
-static uint8_t* countdowns;
+static uint8_t countdowns[ROWS_PER_HAND];
 // [row]
-static matrix_row_t* last_raw;
+static matrix_row_t last_raw[ROWS_PER_HAND];
 
-void debounce_init(uint8_t num_rows) {
-    countdowns = (uint8_t*)calloc(num_rows, sizeof(uint8_t));
-    last_raw   = (matrix_row_t*)calloc(num_rows, sizeof(matrix_row_t));
+void debounce_init(void) {
+    memset(countdowns, 0, sizeof(countdowns));
+    memset(last_raw, 0, sizeof(last_raw));
 
     last_time = timer_read();
 }
 
-void debounce_free(void) {
-    free(countdowns);
-    countdowns = NULL;
-    free(last_raw);
-    last_raw = NULL;
-}
+void debounce_free(void) {}
 
-bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+bool debounce(matrix_row_t raw[], matrix_row_t cooked[], bool changed) {
     uint16_t now           = timer_read();
     uint16_t elapsed16     = TIMER_DIFF_16(now, last_time);
     last_time              = now;
@@ -54,7 +50,7 @@ bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool 
 
     uint8_t* countdown = countdowns;
 
-    for (uint8_t row = 0; row < num_rows; ++row, ++countdown) {
+    for (uint8_t row = 0; row < ROWS_PER_HAND; ++row, ++countdown) {
         matrix_row_t raw_row = raw[row];
 
         if (raw_row != last_raw[row]) {

--- a/quantum/debounce/sym_eager_pk.c
+++ b/quantum/debounce/sym_eager_pk.c
@@ -23,12 +23,6 @@ No further inputs are accepted until DEBOUNCE milliseconds have occurred.
 #include "timer.h"
 #include <stdlib.h>
 
-#ifdef PROTOCOL_CHIBIOS
-#    if CH_CFG_USE_MEMCORE == FALSE
-#        error ChibiOS is configured without a memory allocator. Your keyboard may have set `#define CH_CFG_USE_MEMCORE FALSE`, which is incompatible with this debounce algorithm.
-#    endif
-#endif
-
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
 #endif
@@ -44,34 +38,29 @@ No further inputs are accepted until DEBOUNCE milliseconds have occurred.
 typedef uint8_t debounce_counter_t;
 
 #if DEBOUNCE > 0
-static debounce_counter_t *debounce_counters;
-static fast_timer_t        last_time;
-static bool                counters_need_update;
-static bool                matrix_need_update;
-static bool                cooked_changed;
+static debounce_counter_t debounce_counters[ROWS_PER_HAND * MATRIX_COLS];
+static fast_timer_t       last_time;
+static bool               counters_need_update;
+static bool               matrix_need_update;
+static bool               cooked_changed;
 
 #    define DEBOUNCE_ELAPSED 0
 
-static void update_debounce_counters(uint8_t num_rows, uint8_t elapsed_time);
-static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows);
+static void update_debounce_counters(uint8_t elapsed_time);
+static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[]);
 
-// we use num_rows rather than MATRIX_ROWS to support split keyboards
-void debounce_init(uint8_t num_rows) {
-    debounce_counters = (debounce_counter_t *)malloc(num_rows * MATRIX_COLS * sizeof(debounce_counter_t));
-    int i             = 0;
-    for (uint8_t r = 0; r < num_rows; r++) {
+void debounce_init(void) {
+    int i = 0;
+    for (uint8_t r = 0; r < ROWS_PER_HAND; r++) {
         for (uint8_t c = 0; c < MATRIX_COLS; c++) {
             debounce_counters[i++] = DEBOUNCE_ELAPSED;
         }
     }
 }
 
-void debounce_free(void) {
-    free(debounce_counters);
-    debounce_counters = NULL;
-}
+void debounce_free(void) {}
 
-bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool changed) {
+bool debounce(matrix_row_t raw[], matrix_row_t cooked[], bool changed) {
     bool updated_last = false;
     cooked_changed    = false;
 
@@ -86,7 +75,7 @@ bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool 
         }
 
         if (elapsed_time > 0) {
-            update_debounce_counters(num_rows, elapsed_time);
+            update_debounce_counters(elapsed_time);
         }
     }
 
@@ -95,18 +84,18 @@ bool debounce(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows, bool 
             last_time = timer_read_fast();
         }
 
-        transfer_matrix_values(raw, cooked, num_rows);
+        transfer_matrix_values(raw, cooked);
     }
 
     return cooked_changed;
 }
 
 // If the current time is > debounce counter, set the counter to enable input.
-static void update_debounce_counters(uint8_t num_rows, uint8_t elapsed_time) {
+static void update_debounce_counters(uint8_t elapsed_time) {
     counters_need_update                 = false;
     matrix_need_update                   = false;
     debounce_counter_t *debounce_pointer = debounce_counters;
-    for (uint8_t row = 0; row < num_rows; row++) {
+    for (uint8_t row = 0; row < ROWS_PER_HAND; row++) {
         for (uint8_t col = 0; col < MATRIX_COLS; col++) {
             if (*debounce_pointer != DEBOUNCE_ELAPSED) {
                 if (*debounce_pointer <= elapsed_time) {
@@ -123,10 +112,10 @@ static void update_debounce_counters(uint8_t num_rows, uint8_t elapsed_time) {
 }
 
 // upload from raw_matrix to final matrix;
-static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t num_rows) {
+static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[]) {
     matrix_need_update                   = false;
     debounce_counter_t *debounce_pointer = debounce_counters;
-    for (uint8_t row = 0; row < num_rows; row++) {
+    for (uint8_t row = 0; row < ROWS_PER_HAND; row++) {
         matrix_row_t delta        = raw[row] ^ cooked[row];
         matrix_row_t existing_row = cooked[row];
         for (uint8_t col = 0; col < MATRIX_COLS; col++) {

--- a/quantum/debounce/tests/debounce_test_common.cpp
+++ b/quantum/debounce/tests/debounce_test_common.cpp
@@ -60,7 +60,7 @@ void DebounceTest::runEventsInternal() {
     bool         first    = true;
 
     /* Initialise keyboard with start time (offset to avoid testing at 0) and all keys UP */
-    debounce_init(MATRIX_ROWS);
+    debounce_init();
     set_time(time_offset_);
     simulate_async_tick(async_time_jumps_);
     std::fill(std::begin(input_matrix_), std::end(input_matrix_), 0);
@@ -131,7 +131,7 @@ void DebounceTest::runDebounce(bool changed) {
 
     reset_access_counter();
 
-    bool cooked_changed = debounce(raw_matrix_, cooked_matrix_, MATRIX_ROWS, changed);
+    bool cooked_changed = debounce(raw_matrix_, cooked_matrix_, changed);
 
     if (!std::equal(std::begin(input_matrix_), std::end(input_matrix_), std::begin(raw_matrix_))) {
         FAIL() << "Fatal error: debounce() modified raw matrix at " << strTime() << "\ninput_matrix: changed=" << changed << "\n" << strMatrix(input_matrix_) << "\nraw_matrix:\n" << strMatrix(raw_matrix_);

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -22,15 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "debounce.h"
 #include "atomic_util.h"
 
-#ifdef SPLIT_KEYBOARD
-#    include "split_common/split_util.h"
-#    include "split_common/transactions.h"
-
-#    define ROWS_PER_HAND (MATRIX_ROWS / 2)
-#else
-#    define ROWS_PER_HAND (MATRIX_ROWS)
-#endif
-
 #ifdef DIRECT_PINS_RIGHT
 #    define SPLIT_MUTABLE
 #else
@@ -307,7 +298,7 @@ void matrix_init(void) {
     memset(matrix, 0, sizeof(matrix));
     memset(raw_matrix, 0, sizeof(raw_matrix));
 
-    debounce_init(ROWS_PER_HAND);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -340,9 +331,9 @@ uint8_t matrix_scan(void) {
     if (changed) memcpy(raw_matrix, curr_matrix, sizeof(curr_matrix));
 
 #ifdef SPLIT_KEYBOARD
-    changed = debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, changed) | matrix_post_scan();
+    changed = debounce(raw_matrix, matrix + thisHand, changed) | matrix_post_scan();
 #else
-    changed = debounce(raw_matrix, matrix, ROWS_PER_HAND, changed);
+    changed = debounce(raw_matrix, matrix, changed);
     matrix_scan_kb();
 #endif
     return (uint8_t)changed;

--- a/quantum/matrix.h
+++ b/quantum/matrix.h
@@ -35,6 +35,15 @@ typedef uint32_t matrix_row_t;
 #    error "MATRIX_COLS: invalid value"
 #endif
 
+#ifdef SPLIT_KEYBOARD
+#    include "split_common/split_util.h"
+#    include "split_common/transactions.h"
+
+#    define ROWS_PER_HAND (MATRIX_ROWS / 2)
+#else
+#    define ROWS_PER_HAND (MATRIX_ROWS)
+#endif
+
 #define MATRIX_ROW_SHIFTER ((matrix_row_t)1)
 
 #ifdef __cplusplus

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -9,27 +9,22 @@
 #    include "split_common/transactions.h"
 #    include <string.h>
 
-#    define ROWS_PER_HAND (MATRIX_ROWS / 2)
-#else
-#    define ROWS_PER_HAND (MATRIX_ROWS)
-#endif
-
-#ifndef MATRIX_IO_DELAY
-#    define MATRIX_IO_DELAY 30
-#endif
+#    ifndef MATRIX_IO_DELAY
+#        define MATRIX_IO_DELAY 30
+#    endif
 
 /* matrix state(1:on, 0:off) */
 matrix_row_t raw_matrix[MATRIX_ROWS];
 matrix_row_t matrix[MATRIX_ROWS];
 
-#ifdef SPLIT_KEYBOARD
+#    ifdef SPLIT_KEYBOARD
 // row offsets for each hand
 uint8_t thisHand, thatHand;
-#endif
+#    endif
 
-#ifdef MATRIX_MASKED
+#    ifdef MATRIX_MASKED
 extern const matrix_row_t matrix_mask[];
-#endif
+#    endif
 
 // user-defined overridable functions
 
@@ -62,23 +57,23 @@ inline bool matrix_is_on(uint8_t row, uint8_t col) {
 inline matrix_row_t matrix_get_row(uint8_t row) {
     // Matrix mask lets you disable switches in the returned matrix data. For example, if you have a
     // switch blocker installed and the switch is always pressed.
-#ifdef MATRIX_MASKED
+#    ifdef MATRIX_MASKED
     return matrix[row] & matrix_mask[row];
-#else
+#    else
     return matrix[row];
-#endif
+#    endif
 }
 
-#if (MATRIX_COLS <= 8)
-#    define print_matrix_header() print("\nr/c 01234567\n")
-#    define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
-#elif (MATRIX_COLS <= 16)
-#    define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
-#    define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
-#elif (MATRIX_COLS <= 32)
-#    define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
-#    define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
-#endif
+#    if (MATRIX_COLS <= 8)
+#        define print_matrix_header() print("\nr/c 01234567\n")
+#        define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
+#    elif (MATRIX_COLS <= 16)
+#        define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
+#        define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
+#    elif (MATRIX_COLS <= 32)
+#        define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
+#        define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
+#    endif
 
 void matrix_print(void) {
     print_matrix_header();
@@ -91,7 +86,7 @@ void matrix_print(void) {
     }
 }
 
-#ifdef SPLIT_KEYBOARD
+#    ifdef SPLIT_KEYBOARD
 bool matrix_post_scan(void) {
     bool changed = false;
     if (is_keyboard_master()) {
@@ -120,7 +115,7 @@ bool matrix_post_scan(void) {
 
     return changed;
 }
-#endif
+#    endif
 
 /* `matrix_io_delay ()` exists for backwards compatibility. From now on, use matrix_output_unselect_delay(). */
 __attribute__((weak)) void matrix_io_delay(void) {
@@ -139,18 +134,18 @@ __attribute__((weak)) bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     return true;
 }
 
-#ifdef SPLIT_KEYBOARD
+#    ifdef SPLIT_KEYBOARD
 __attribute__((weak)) void matrix_slave_scan_kb(void) {
     matrix_slave_scan_user();
 }
 __attribute__((weak)) void matrix_slave_scan_user(void) {}
-#endif
+#    endif
 
 __attribute__((weak)) void matrix_init(void) {
-#ifdef SPLIT_KEYBOARD
+#    ifdef SPLIT_KEYBOARD
     thisHand = isLeftHand ? 0 : (ROWS_PER_HAND);
     thatHand = ROWS_PER_HAND - thisHand;
-#endif
+#    endif
 
     matrix_init_custom();
 
@@ -160,7 +155,7 @@ __attribute__((weak)) void matrix_init(void) {
         matrix[i]     = 0;
     }
 
-    debounce_init(ROWS_PER_HAND);
+    debounce_init();
 
     matrix_init_kb();
 }
@@ -168,12 +163,12 @@ __attribute__((weak)) void matrix_init(void) {
 __attribute__((weak)) uint8_t matrix_scan(void) {
     bool changed = matrix_scan_custom(raw_matrix);
 
-#ifdef SPLIT_KEYBOARD
-    changed = debounce(raw_matrix, matrix + thisHand, ROWS_PER_HAND, changed) | matrix_post_scan();
-#else
-    changed = debounce(raw_matrix, matrix, ROWS_PER_HAND, changed);
+#    ifdef SPLIT_KEYBOARD
+    changed = debounce(raw_matrix, matrix + thisHand, changed) | matrix_post_scan();
+#    else
+    changed = debounce(raw_matrix, matrix, changed);
     matrix_scan_kb();
-#endif
+#    endif
 
     return changed;
 }

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -8,23 +8,24 @@
 #    include "split_common/split_util.h"
 #    include "split_common/transactions.h"
 #    include <string.h>
+#endif
 
-#    ifndef MATRIX_IO_DELAY
-#        define MATRIX_IO_DELAY 30
-#    endif
+#ifndef MATRIX_IO_DELAY
+#    define MATRIX_IO_DELAY 30
+#endif
 
 /* matrix state(1:on, 0:off) */
 matrix_row_t raw_matrix[MATRIX_ROWS];
 matrix_row_t matrix[MATRIX_ROWS];
 
-#    ifdef SPLIT_KEYBOARD
+#ifdef SPLIT_KEYBOARD
 // row offsets for each hand
 uint8_t thisHand, thatHand;
-#    endif
+#endif
 
-#    ifdef MATRIX_MASKED
+#ifdef MATRIX_MASKED
 extern const matrix_row_t matrix_mask[];
-#    endif
+#endif
 
 // user-defined overridable functions
 
@@ -57,23 +58,23 @@ inline bool matrix_is_on(uint8_t row, uint8_t col) {
 inline matrix_row_t matrix_get_row(uint8_t row) {
     // Matrix mask lets you disable switches in the returned matrix data. For example, if you have a
     // switch blocker installed and the switch is always pressed.
-#    ifdef MATRIX_MASKED
+#ifdef MATRIX_MASKED
     return matrix[row] & matrix_mask[row];
-#    else
+#else
     return matrix[row];
-#    endif
+#endif
 }
 
-#    if (MATRIX_COLS <= 8)
-#        define print_matrix_header() print("\nr/c 01234567\n")
-#        define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
-#    elif (MATRIX_COLS <= 16)
-#        define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
-#        define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
-#    elif (MATRIX_COLS <= 32)
-#        define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
-#        define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
-#    endif
+#if (MATRIX_COLS <= 8)
+#    define print_matrix_header() print("\nr/c 01234567\n")
+#    define print_matrix_row(row) print_bin_reverse8(matrix_get_row(row))
+#elif (MATRIX_COLS <= 16)
+#    define print_matrix_header() print("\nr/c 0123456789ABCDEF\n")
+#    define print_matrix_row(row) print_bin_reverse16(matrix_get_row(row))
+#elif (MATRIX_COLS <= 32)
+#    define print_matrix_header() print("\nr/c 0123456789ABCDEF0123456789ABCDEF\n")
+#    define print_matrix_row(row) print_bin_reverse32(matrix_get_row(row))
+#endif
 
 void matrix_print(void) {
     print_matrix_header();
@@ -86,7 +87,7 @@ void matrix_print(void) {
     }
 }
 
-#    ifdef SPLIT_KEYBOARD
+#ifdef SPLIT_KEYBOARD
 bool matrix_post_scan(void) {
     bool changed = false;
     if (is_keyboard_master()) {
@@ -115,7 +116,7 @@ bool matrix_post_scan(void) {
 
     return changed;
 }
-#    endif
+#endif
 
 /* `matrix_io_delay ()` exists for backwards compatibility. From now on, use matrix_output_unselect_delay(). */
 __attribute__((weak)) void matrix_io_delay(void) {
@@ -134,18 +135,18 @@ __attribute__((weak)) bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     return true;
 }
 
-#    ifdef SPLIT_KEYBOARD
+#ifdef SPLIT_KEYBOARD
 __attribute__((weak)) void matrix_slave_scan_kb(void) {
     matrix_slave_scan_user();
 }
 __attribute__((weak)) void matrix_slave_scan_user(void) {}
-#    endif
+#endif
 
 __attribute__((weak)) void matrix_init(void) {
-#    ifdef SPLIT_KEYBOARD
+#ifdef SPLIT_KEYBOARD
     thisHand = isLeftHand ? 0 : (ROWS_PER_HAND);
     thatHand = ROWS_PER_HAND - thisHand;
-#    endif
+#endif
 
     matrix_init_custom();
 
@@ -163,12 +164,12 @@ __attribute__((weak)) void matrix_init(void) {
 __attribute__((weak)) uint8_t matrix_scan(void) {
     bool changed = matrix_scan_custom(raw_matrix);
 
-#    ifdef SPLIT_KEYBOARD
+#ifdef SPLIT_KEYBOARD
     changed = debounce(raw_matrix, matrix + thisHand, changed) | matrix_post_scan();
-#    else
+#else
     changed = debounce(raw_matrix, matrix, changed);
     matrix_scan_kb();
-#    endif
+#endif
 
     return changed;
 }


### PR DESCRIPTION
Allocate memory for debouncing algorithms statically.

## Description

Some keyboards do not support memory allocation and this commit makes it possible to use debouncing algorithms that previously required allocation on those keyboards.

The `num_rows` variable was added to `debounce_init` and `debounce` to support split keyboards but the value passed to those functions is always `ROWS_PER_HAND` so it is safe to use the `ROWS_PER_HAND` macro instead similarly to how `MATRIX_COLS` is assumed to be correct.

<!--- Describe your changes in detail here. -->

Beyond changes to `quantum`, some of the `keyboards` had to be updated to support the change of signature, and documentation for custom matrix was also updated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
