### PR TITLE
Add leonardo build target for leonardo + usb2.0 shield based projects

### DIFF
--- a/keyboards/converter/usb_usb/hasu/rules.mk
+++ b/keyboards/converter/usb_usb/hasu/rules.mk
@@ -1,2 +1,3 @@
 # Processor frequency
-F_CPU = 16000000
+# 16000000 is default for 32U4
+# F_CPU = 16000000

--- a/keyboards/converter/usb_usb/hasu/rules.mk
+++ b/keyboards/converter/usb_usb/hasu/rules.mk
@@ -1,3 +1,1 @@
-# Processor frequency
-# 16000000 is default for 32U4
-# F_CPU = 16000000
+# This file intentionally left blank

--- a/keyboards/converter/usb_usb/leonardo/info.json
+++ b/keyboards/converter/usb_usb/leonardo/info.json
@@ -1,0 +1,3 @@
+{
+    "bootloader": "caterina"
+}

--- a/keyboards/converter/usb_usb/leonardo/rules.mk
+++ b/keyboards/converter/usb_usb/leonardo/rules.mk
@@ -1,0 +1,2 @@
+# Processor frequency
+F_CPU = 16000000

--- a/keyboards/converter/usb_usb/leonardo/rules.mk
+++ b/keyboards/converter/usb_usb/leonardo/rules.mk
@@ -1,2 +1,3 @@
 # Processor frequency
-F_CPU = 16000000
+# 16000000 is default for 32U4
+# F_CPU = 16000000

--- a/keyboards/converter/usb_usb/leonardo/rules.mk
+++ b/keyboards/converter/usb_usb/leonardo/rules.mk
@@ -1,3 +1,1 @@
-# Processor frequency
-# 16000000 is default for 32U4
-# F_CPU = 16000000
+# This file intentionally left blank

--- a/keyboards/converter/usb_usb/readme.md
+++ b/keyboards/converter/usb_usb/readme.md
@@ -28,9 +28,6 @@ If you are sure you have this correct, try changeing the default in `usb_usb/rul
 The Pro Micro variant uses a 3.3V Pro Micro and thus runs at 8MHz, hence the following line in `usb_usb/pro_micro/rules.mk`:
 `F_CPU = 8000000`
 
-The converter sold by Hasu runs at 16MHz and so the corresponding line in `usb_usb/hasu/rules.mk` is:
-`F_CPU = 16000000`
-
 Getting the Hardware
 --------------------
 There are two options to get a converter: You can buy one from Hasu or build one yourself.

--- a/keyboards/converter/usb_usb/readme.md
+++ b/keyboards/converter/usb_usb/readme.md
@@ -11,6 +11,10 @@ Make example for this keyboard (after setting up your build environment):
 
     make converter/usb_usb:default
 
+If you use Arduino Leonardo with a USB Host Shield:
+
+    make converter/usb_usb/leonardo:default
+
 See [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) then the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information.
 
 Note that you have to choose the right hardware variant as your subproject, otherwise you will probably have issues.
@@ -23,6 +27,7 @@ If you are sure you have this correct, try changeing the default in `usb_usb/rul
 
 The Pro Micro variant uses a 3.3V Pro Micro and thus runs at 8MHz, hence the following line in `usb_usb/pro_micro/rules.mk`:
 `F_CPU = 8000000`
+
 The converter sold by Hasu runs at 16MHz and so the corresponding line in `usb_usb/hasu/rules.mk` is:
 `F_CPU = 16000000`
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->
There is no ready-to-use usb-usb converter build target for Leonardo based board with USB 2.0 host shield.
Leonardo is similar to the default hasu board but uses caterina as bootloader.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Added a 'leonardo' folder, which is based on the default hasu folder.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X ] Enhancement/optimization
- [] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
