### PR TITLE
[Docs] Rework the tap-hold tap dance example using key releases

### DIFF
--- a/docs/feature_tap_dance.md
+++ b/docs/feature_tap_dance.md
@@ -159,7 +159,11 @@ tap_dance_action_t tap_dance_actions[] = {
 
 #### Example 3: Send `:` on Tap, `;` on Hold :id=example-3
 
-With a little effort, powerful tap-hold configurations can be implemented as tap dances. To emit taps as early as possible, we need to act on releases of the tap dance key. There is no callback for this in the tap dance framework, so we use `process_record_user()`.
+With a little effort, powerful tap-hold configurations can be implemented as tap dances. In this example, keys are sent to the host with the lowest possible latency:
+
+* A single tap sends a tap of `:` to the host on release (in `tap_dance_tap_hold_release`) without waiting out the whole tapping term.
+* For any subsequent tap or hold within the tapping term, the host gets sent a press of `:` immediately when the tap dance key is pressed (in `tap_dance_tap_hold_press`) and a release when the tap dance key is released again. This means that a tap-hold will send a tap of `:`, then a press of `:` that matches the duration of the hold.
+* A single hold (or an interrupt caused by another key, [if `PERMISSIVE_HOLD` is configured](tap_hold.md#permissive-hold)) presses `;` on the host after the tapping term (in `tap_dance_tap_hold_finished`), and releases it when the tap dance key is released.
 
 ```c
 typedef struct {
@@ -168,18 +172,17 @@ typedef struct {
     uint16_t held;
 } tap_dance_tap_hold_t;
 
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    tap_dance_action_t *action;
+void tap_dance_tap_hold_press(tap_dance_state_t *state, void *user_data) {
+    tap_dance_tap_hold_t *tap_hold = (tap_dance_tap_hold_t *)user_data;
 
-    switch (keycode) {
-        case TD(CT_CLN):  // list all tap dance keycodes with tap-hold configurations
-            action = &tap_dance_actions[TD_INDEX(keycode)];
-            if (!record->event.pressed && action->state.count && !action->state.finished) {
-                tap_dance_tap_hold_t *tap_hold = (tap_dance_tap_hold_t *)action->user_data;
-                tap_code16(tap_hold->tap);
-            }
+    if (state->count > 1
+#ifndef PERMISSIVE_HOLD
+        && !state->interrupted
+#endif
+    ) {
+        register_code16(tap_hold->tap);
+        tap_hold->held = tap_hold->tap;
     }
-    return true;
 }
 
 void tap_dance_tap_hold_finished(tap_dance_state_t *state, void *user_data) {
@@ -193,10 +196,22 @@ void tap_dance_tap_hold_finished(tap_dance_state_t *state, void *user_data) {
         ) {
             register_code16(tap_hold->hold);
             tap_hold->held = tap_hold->hold;
-        } else {
+        } else if (!tap_hold->held) {
             register_code16(tap_hold->tap);
             tap_hold->held = tap_hold->tap;
         }
+    }
+}
+
+void tap_dance_tap_hold_release(tap_dance_state_t *state, void *user_data) {
+    tap_dance_tap_hold_t *tap_hold = (tap_dance_tap_hold_t *)user_data;
+
+    if (!state->finished && (state->count == 1
+#ifndef PERMISSIVE_HOLD
+        || (state->count > 1 && state->interrupted)
+#endif
+        )) {
+        tap_code16(tap_hold->tap);
     }
 }
 
@@ -210,7 +225,7 @@ void tap_dance_tap_hold_reset(tap_dance_state_t *state, void *user_data) {
 }
 
 #define ACTION_TAP_DANCE_TAP_HOLD(tap, hold) \
-    { .fn = {NULL, tap_dance_tap_hold_finished, tap_dance_tap_hold_reset}, .user_data = (void *)&((tap_dance_tap_hold_t){tap, hold, 0}), }
+    { .fn = {tap_dance_tap_hold_press, tap_dance_tap_hold_finished, tap_dance_tap_hold_reset, tap_dance_tap_hold_release}, .user_data = (void *)&((tap_dance_tap_hold_t){tap, hold, 0}), }
 
 tap_dance_action_t tap_dance_actions[] = {
     [CT_CLN] = ACTION_TAP_DANCE_TAP_HOLD(KC_COLN, KC_SCLN),


### PR DESCRIPTION
## Description

In the Tap Dance documentation, one of the examples states: https://github.com/qmk/qmk_firmware/blob/f5366462353f0a14417dd9ee8feae6907f611bcc/docs/feature_tap_dance.md?plain=1#L160-L162

`process_record_user` is no longer required to get key releases working for the low-latency tap-hold tap dance code example. That used to be true, but now that the `ACTION_TAP_DANCE_FN_ADVANCED_WITH_RELEASE` action exists, we don't need to go through the leaky abstraction that is `process_record_user` and can keep the entire thing within the tap dance logic in QMK core.

I have reworked the tap-hold tap dance example to use key releases, to have even lower latency in some cases, and added an explanation of the functions and how they work together, as well as how the tap dance works as a whole and the max latency in all cases.

This PR is against `master` since this key release logic is there right now and can already be used. If required, I can switch the change to `develop`.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
