### PR TITLE
Add "AC Next Keyboard Layout Select" consumer usage entry (macOS Globe key)

### DIFF
--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -54,9 +54,9 @@ enum mouse_buttons {
  */
 enum consumer_usages {
     // 15.5 Display Controls
-    SNAPSHOT               = 0x065,
-    BRIGHTNESS_UP          = 0x06F, // https://www.usb.org/sites/default/files/hutrr41_0.pdf
-    BRIGHTNESS_DOWN        = 0x070,
+    SNAPSHOT        = 0x065,
+    BRIGHTNESS_UP   = 0x06F, // https://www.usb.org/sites/default/files/hutrr41_0.pdf
+    BRIGHTNESS_DOWN = 0x070,
     // 15.7 Transport Controls
     TRANSPORT_RECORD       = 0x0B2,
     TRANSPORT_FAST_FORWARD = 0x0B3,
@@ -69,43 +69,44 @@ enum consumer_usages {
     TRANSPORT_STOP_EJECT   = 0x0CC,
     TRANSPORT_PLAY_PAUSE   = 0x0CD,
     // 15.9.1 Audio Controls - Volume
-    AUDIO_MUTE             = 0x0E2,
-    AUDIO_VOL_UP           = 0x0E9,
-    AUDIO_VOL_DOWN         = 0x0EA,
+    AUDIO_MUTE     = 0x0E2,
+    AUDIO_VOL_UP   = 0x0E9,
+    AUDIO_VOL_DOWN = 0x0EA,
     // 15.15 Application Launch Buttons
-    AL_CC_CONFIG           = 0x183,
-    AL_EMAIL               = 0x18A,
-    AL_CALCULATOR          = 0x192,
-    AL_LOCAL_BROWSER       = 0x194,
-    AL_LOCK                = 0x19E,
-    AL_CONTROL_PANEL       = 0x19F,
-    AL_ASSISTANT           = 0x1CB,
-    AL_KEYBOARD_LAYOUT     = 0x1AE,
+    AL_CC_CONFIG       = 0x183,
+    AL_EMAIL           = 0x18A,
+    AL_CALCULATOR      = 0x192,
+    AL_LOCAL_BROWSER   = 0x194,
+    AL_LOCK            = 0x19E,
+    AL_CONTROL_PANEL   = 0x19F,
+    AL_ASSISTANT       = 0x1CB,
+    AL_KEYBOARD_LAYOUT = 0x1AE,
     // 15.16 Generic GUI Application Controls
-    AC_NEW                 = 0x201,
-    AC_OPEN                = 0x202,
-    AC_CLOSE               = 0x203,
-    AC_EXIT                = 0x204,
-    AC_MAXIMIZE            = 0x205,
-    AC_MINIMIZE            = 0x206,
-    AC_SAVE                = 0x207,
-    AC_PRINT               = 0x208,
-    AC_PROPERTIES          = 0x209,
-    AC_UNDO                = 0x21A,
-    AC_COPY                = 0x21B,
-    AC_CUT                 = 0x21C,
-    AC_PASTE               = 0x21D,
-    AC_SELECT_ALL          = 0x21E,
-    AC_FIND                = 0x21F,
-    AC_SEARCH              = 0x221,
-    AC_HOME                = 0x223,
-    AC_BACK                = 0x224,
-    AC_FORWARD             = 0x225,
-    AC_STOP                = 0x226,
-    AC_REFRESH             = 0x227,
-    AC_BOOKMARKS           = 0x22A,
-    AC_MISSION_CONTROL     = 0x29F,
-    AC_LAUNCHPAD           = 0x2A0
+    AC_NEW                         = 0x201,
+    AC_OPEN                        = 0x202,
+    AC_CLOSE                       = 0x203,
+    AC_EXIT                        = 0x204,
+    AC_MAXIMIZE                    = 0x205,
+    AC_MINIMIZE                    = 0x206,
+    AC_SAVE                        = 0x207,
+    AC_PRINT                       = 0x208,
+    AC_PROPERTIES                  = 0x209,
+    AC_UNDO                        = 0x21A,
+    AC_COPY                        = 0x21B,
+    AC_CUT                         = 0x21C,
+    AC_PASTE                       = 0x21D,
+    AC_SELECT_ALL                  = 0x21E,
+    AC_FIND                        = 0x21F,
+    AC_SEARCH                      = 0x221,
+    AC_HOME                        = 0x223,
+    AC_BACK                        = 0x224,
+    AC_FORWARD                     = 0x225,
+    AC_STOP                        = 0x226,
+    AC_REFRESH                     = 0x227,
+    AC_BOOKMARKS                   = 0x22A,
+    AC_NEXT_KEYBOARD_LAYOUT_SELECT = 0x29D,
+    AC_DESKTOP_SHOW_ALL_WINDOWS    = 0x29F,
+    AC_SOFT_KEY_LEFT               = 0x2A0
 };
 
 /* Generic Desktop Page (0x01)
@@ -321,9 +322,9 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
         case KC_WWW_FAVORITES:
             return AC_BOOKMARKS;
         case KC_MISSION_CONTROL:
-            return AC_MISSION_CONTROL;
+            return AC_DESKTOP_SHOW_ALL_WINDOWS;
         case KC_LAUNCHPAD:
-            return AC_LAUNCHPAD;
+            return AC_SOFT_KEY_LEFT;
         default:
             return 0;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Also renamed the enum entries for Mission Control and Launchpad to reflect their canonical names in the HID Usage Tables document - the keycode names remain the same.

This renders [my Apple Fn patch](https://gist.github.com/fauxpark/010dcf5d6377c3a71ac98ce37414c6c4) largely obsolete, although an Apple VID/PID is still required for it to be recognised as Fn.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
