### PR TITLE
[Keyboard] Fix VID and PID for AnnePro2

### DIFF
--- a/keyboards/annepro2/c15/info.json
+++ b/keyboards/annepro2/c15/info.json
@@ -1,7 +1,7 @@
 {
     "keyboard_name": "Anne Pro 2 C15 (QMK)",
     "usb": {
-        "pid": "0xAC15"
+        "pid": "0x8008"
     },
     "rgb_matrix": {
         "driver": "custom"

--- a/keyboards/annepro2/c18/info.json
+++ b/keyboards/annepro2/c18/info.json
@@ -1,7 +1,7 @@
 {
     "keyboard_name": "Anne Pro 2 C18 (QMK)",
     "usb": {
-        "pid": "0xAC18"
+        "pid": "0x8009"
     },
     "rgb_matrix": {
         "driver": "custom"

--- a/keyboards/annepro2/info.json
+++ b/keyboards/annepro2/info.json
@@ -3,7 +3,7 @@
     "url": "https://openannepro.github.io/",
     "maintainer": "bwisn",
     "usb": {
-        "vid": "0xFEED",
+        "vid": "0x04D9",
         "device_version": "13.3.7"
     },
     "layouts": {

--- a/keyboards/annepro2/info.json
+++ b/keyboards/annepro2/info.json
@@ -3,7 +3,7 @@
     "url": "https://openannepro.github.io/",
     "maintainer": "bwisn",
     "usb": {
-        "vid": "0x04D9",
+        "vid": "0xAC20",
         "device_version": "13.3.7"
     },
     "layouts": {


### PR DESCRIPTION
Fix of the AnnePro2's VID and PID

## Description

I have changed AnnePro2's VID and PID to the original firmware's values, so it can be used with VIA (0xFEED is invalid VendorId).

I got the original values from AnnePro2-Tools website - https://openannepro.github.io/ap2_revisions/

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
