### PR TITLE
RGB/LED matrix use limits size optimisation

### DIFF
--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -377,14 +377,7 @@ void led_matrix_indicators_advanced(effect_params_t *params) {
      * and not sure which would be better. Otherwise, this should be called from
      * led_task_render, right before the iter++ line.
      */
-#if defined(LED_MATRIX_LED_PROCESS_LIMIT) && LED_MATRIX_LED_PROCESS_LIMIT > 0 && LED_MATRIX_LED_PROCESS_LIMIT < LED_MATRIX_LED_COUNT
-    uint8_t min = LED_MATRIX_LED_PROCESS_LIMIT * (params->iter - 1);
-    uint8_t max = min + LED_MATRIX_LED_PROCESS_LIMIT;
-    if (max > LED_MATRIX_LED_COUNT) max = LED_MATRIX_LED_COUNT;
-#else
-    uint8_t min = 0;
-    uint8_t max = LED_MATRIX_LED_COUNT;
-#endif
+    LED_MATRIX_USE_LIMITS_ITER(min, max, params->iter - 1);
     led_matrix_indicators_advanced_kb(min, max);
     led_matrix_indicators_advanced_user(min, max);
 }

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -397,6 +397,36 @@ __attribute__((weak)) bool led_matrix_indicators_advanced_user(uint8_t led_min, 
     return true;
 }
 
+struct led_matrix_limits_t led_matrix_get_limits(uint8_t iter) {
+    struct led_matrix_limits_t limits = {0};
+#if defined(LED_MATRIX_LED_PROCESS_LIMIT) && LED_MATRIX_LED_PROCESS_LIMIT > 0 && LED_MATRIX_LED_PROCESS_LIMIT < LED_MATRIX_LED_COUNT
+#    if defined(LED_MATRIX_SPLIT)
+    limits.led_min_index = LED_MATRIX_LED_PROCESS_LIMIT * (iter);
+    limits.led_max_index = limits.led_min_index + LED_MATRIX_LED_PROCESS_LIMIT;
+    if (limits.led_max_index > LED_MATRIX_LED_COUNT) limits.led_max_index = LED_MATRIX_LED_COUNT;
+    uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;
+    if (is_keyboard_left() && (limits.led_max_index > k_led_matrix_split[0])) limits.led_max_index = k_led_matrix_split[0];
+    if (!(is_keyboard_left()) && (limits.led_min_index < k_led_matrix_split[0])) limits.led_min_index = k_led_matrix_split[0];
+#    else
+    limits.led_min_index = LED_MATRIX_LED_PROCESS_LIMIT * (iter);
+    limits.led_max_index = limits.led_min_index + LED_MATRIX_LED_PROCESS_LIMIT;
+    if (limits.led_max_index > LED_MATRIX_LED_COUNT) limits.led_max_index = LED_MATRIX_LED_COUNT;
+#    endif
+#else
+#    if defined(LED_MATRIX_SPLIT)
+    limits.led_min_index                = 0;
+    limits.led_max_index                = LED_MATRIX_LED_COUNT;
+    const uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;
+    if (is_keyboard_left() && (limits.led_max_index > k_led_matrix_split[0])) limits.led_max_index = k_led_matrix_split[0];
+    if (!(is_keyboard_left()) && (limits.led_min_index < k_led_matrix_split[0])) limits.led_min_index = k_led_matrix_split[0];
+#    else
+    limits.led_min_index  = 0;
+    limits.led_max_index = LED_MATRIX_LED_COUNT;
+#    endif
+#endif
+    return limits;
+}
+
 void led_matrix_init(void) {
     led_matrix_driver.init();
 

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -413,7 +413,7 @@ struct led_matrix_limits_t led_matrix_get_limits(uint8_t iter) {
     if (is_keyboard_left() && (limits.led_max_index > k_led_matrix_split[0])) limits.led_max_index = k_led_matrix_split[0];
     if (!(is_keyboard_left()) && (limits.led_min_index < k_led_matrix_split[0])) limits.led_min_index = k_led_matrix_split[0];
 #    else
-    limits.led_min_index  = 0;
+    limits.led_min_index = 0;
     limits.led_max_index = LED_MATRIX_LED_COUNT;
 #    endif
 #endif

--- a/quantum/led_matrix/led_matrix.h
+++ b/quantum/led_matrix/led_matrix.h
@@ -90,35 +90,21 @@
 #endif
 #define LED_MATRIX_LED_PROCESS_MAX_ITERATIONS ((LED_MATRIX_LED_COUNT + LED_MATRIX_LED_PROCESS_LIMIT - 1) / LED_MATRIX_LED_PROCESS_LIMIT)
 
-#if defined(LED_MATRIX_LED_PROCESS_LIMIT) && LED_MATRIX_LED_PROCESS_LIMIT > 0 && LED_MATRIX_LED_PROCESS_LIMIT < LED_MATRIX_LED_COUNT
-#    if defined(LED_MATRIX_SPLIT)
-#        define LED_MATRIX_USE_LIMITS(min, max)                                                   \
-            uint8_t min = LED_MATRIX_LED_PROCESS_LIMIT * params->iter;                            \
-            uint8_t max = min + LED_MATRIX_LED_PROCESS_LIMIT;                                     \
-            if (max > LED_MATRIX_LED_COUNT) max = LED_MATRIX_LED_COUNT;                           \
-            uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;                                     \
-            if (is_keyboard_left() && (max > k_led_matrix_split[0])) max = k_led_matrix_split[0]; \
-            if (!(is_keyboard_left()) && (min < k_led_matrix_split[0])) min = k_led_matrix_split[0];
-#    else
-#        define LED_MATRIX_USE_LIMITS(min, max)                        \
-            uint8_t min = LED_MATRIX_LED_PROCESS_LIMIT * params->iter; \
-            uint8_t max = min + LED_MATRIX_LED_PROCESS_LIMIT;          \
-            if (max > LED_MATRIX_LED_COUNT) max = LED_MATRIX_LED_COUNT;
-#    endif
-#else
-#    if defined(LED_MATRIX_SPLIT)
-#        define LED_MATRIX_USE_LIMITS(min, max)                                                   \
-            uint8_t       min                   = 0;                                              \
-            uint8_t       max                   = LED_MATRIX_LED_COUNT;                           \
-            const uint8_t k_led_matrix_split[2] = LED_MATRIX_SPLIT;                               \
-            if (is_keyboard_left() && (max > k_led_matrix_split[0])) max = k_led_matrix_split[0]; \
-            if (!(is_keyboard_left()) && (min < k_led_matrix_split[0])) min = k_led_matrix_split[0];
-#    else
-#        define LED_MATRIX_USE_LIMITS(min, max) \
-            uint8_t min = 0;                    \
-            uint8_t max = LED_MATRIX_LED_COUNT;
-#    endif
-#endif
+struct led_matrix_limits_t {
+    uint8_t led_min_index;
+    uint8_t led_max_index;
+};
+
+struct led_matrix_limits_t led_matrix_get_limits(uint8_t iter);
+
+#define LED_MATRIX_USE_LIMITS_ITER(min, max, iter)                   \
+    struct led_matrix_limits_t limits = led_matrix_get_limits(iter); \
+    uint8_t                    min    = limits.led_min_index;        \
+    uint8_t                    max    = limits.led_max_index;        \
+    (void)min;                                                       \
+    (void)max;
+
+#define LED_MATRIX_USE_LIMITS(min, max) LED_MATRIX_USE_LIMITS_ITER(min, max, params->iter)
 
 #define LED_MATRIX_TEST_LED_FLAGS() \
     if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) continue

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -411,6 +411,36 @@ __attribute__((weak)) bool rgb_matrix_indicators_user(void) {
     return true;
 }
 
+struct rgb_matrix_limits_t rgb_matrix_get_limits(uint8_t iter) {
+    struct rgb_matrix_limits_t limits = {0};
+#if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < RGB_MATRIX_LED_COUNT
+#    if defined(RGB_MATRIX_SPLIT)
+    limits.led_min_index = RGB_MATRIX_LED_PROCESS_LIMIT * (iter);
+    limits.led_max_index = limits.led_min_index + RGB_MATRIX_LED_PROCESS_LIMIT;
+    if (limits.led_max_index > RGB_MATRIX_LED_COUNT) limits.led_max_index = RGB_MATRIX_LED_COUNT;
+    uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
+    if (is_keyboard_left() && (limits.led_max_index > k_rgb_matrix_split[0])) limits.led_max_index = k_rgb_matrix_split[0];
+    if (!(is_keyboard_left()) && (limits.led_min_index < k_rgb_matrix_split[0])) limits.led_min_index = k_rgb_matrix_split[0];
+#    else
+    limits.led_min_index = RGB_MATRIX_LED_PROCESS_LIMIT * (iter);
+    limits.led_max_index = limits.led_min_index + RGB_MATRIX_LED_PROCESS_LIMIT;
+    if (limits.led_max_index > RGB_MATRIX_LED_COUNT) limits.led_max_index = RGB_MATRIX_LED_COUNT;
+#    endif
+#else
+#    if defined(RGB_MATRIX_SPLIT)
+    limits.led_min_index                = 0;
+    limits.led_max_index                = RGB_MATRIX_LED_COUNT;
+    const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;
+    if (is_keyboard_left() && (limits.led_max_index > k_rgb_matrix_split[0])) limits.led_max_index = k_rgb_matrix_split[0];
+    if (!(is_keyboard_left()) && (limits.led_min_index < k_rgb_matrix_split[0])) limits.led_min_index = k_rgb_matrix_split[0];
+#    else
+    limits.led_min_index = 0;
+    limits.led_max_index = RGB_MATRIX_LED_COUNT;
+#    endif
+#endif
+    return limits;
+}
+
 void rgb_matrix_indicators_advanced(effect_params_t *params) {
     /* special handling is needed for "params->iter", since it's already been incremented.
      * Could move the invocations to rgb_task_render, but then it's missing a few checks

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -108,35 +108,19 @@
 #endif
 #define RGB_MATRIX_LED_PROCESS_MAX_ITERATIONS ((RGB_MATRIX_LED_COUNT + RGB_MATRIX_LED_PROCESS_LIMIT - 1) / RGB_MATRIX_LED_PROCESS_LIMIT)
 
-#if defined(RGB_MATRIX_LED_PROCESS_LIMIT) && RGB_MATRIX_LED_PROCESS_LIMIT > 0 && RGB_MATRIX_LED_PROCESS_LIMIT < RGB_MATRIX_LED_COUNT
-#    if defined(RGB_MATRIX_SPLIT)
-#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)                                        \
-            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (iter);                                  \
-            uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;                                     \
-            if (max > RGB_MATRIX_LED_COUNT) max = RGB_MATRIX_LED_COUNT;                           \
-            uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;                                     \
-            if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
-            if (!(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
-#    else
-#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)       \
-            uint8_t min = RGB_MATRIX_LED_PROCESS_LIMIT * (iter); \
-            uint8_t max = min + RGB_MATRIX_LED_PROCESS_LIMIT;    \
-            if (max > RGB_MATRIX_LED_COUNT) max = RGB_MATRIX_LED_COUNT;
-#    endif
-#else
-#    if defined(RGB_MATRIX_SPLIT)
-#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)                                        \
-            uint8_t       min                   = 0;                                              \
-            uint8_t       max                   = RGB_MATRIX_LED_COUNT;                           \
-            const uint8_t k_rgb_matrix_split[2] = RGB_MATRIX_SPLIT;                               \
-            if (is_keyboard_left() && (max > k_rgb_matrix_split[0])) max = k_rgb_matrix_split[0]; \
-            if (!(is_keyboard_left()) && (min < k_rgb_matrix_split[0])) min = k_rgb_matrix_split[0];
-#    else
-#        define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter) \
-            uint8_t min = 0;                               \
-            uint8_t max = RGB_MATRIX_LED_COUNT;
-#    endif
-#endif
+struct rgb_matrix_limits_t {
+    uint8_t led_min_index;
+    uint8_t led_max_index;
+};
+
+struct rgb_matrix_limits_t rgb_matrix_get_limits(uint8_t iter);
+
+#define RGB_MATRIX_USE_LIMITS_ITER(min, max, iter)                   \
+    struct rgb_matrix_limits_t limits = rgb_matrix_get_limits(iter); \
+    uint8_t                    min    = limits.led_min_index;        \
+    uint8_t                    max    = limits.led_max_index;        \
+    (void)min;                                                       \
+    (void)max;
 
 #define RGB_MATRIX_USE_LIMITS(min, max) RGB_MATRIX_USE_LIMITS_ITER(min, max, params->iter)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Implements a suggestion by sigprof to reduce firmware compile size.

While testing I noticed #21169 breaks compilation when `RGB_MATRIX_LED_PROCESS_LIMIT` is `0` I'll submit a follow up PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
