### PR TITLE
V-USB: Fix `GET_IDLE/SET_IDLE`

### DIFF
--- a/quantum/command.c
+++ b/quantum/command.c
@@ -222,21 +222,16 @@ static void print_status(void) {
         "\n\t- Status -\n"
 
         "host_keyboard_leds(): %02X\n"
-#ifndef PROTOCOL_VUSB
         "keyboard_protocol: %02X\n"
         "keyboard_idle: %02X\n"
-#endif
 #ifdef NKRO_ENABLE
         "keymap_config.nkro: %02X\n"
 #endif
         "timer_read32(): %08lX\n"
 
         , host_keyboard_leds()
-#ifndef PROTOCOL_VUSB
-        /* these aren't set on the V-USB protocol, so we just ignore them for now */
         , keyboard_protocol
         , keyboard_idle
-#endif
 #ifdef NKRO_ENABLE
         , keymap_config.nkro
 #endif

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -48,16 +48,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "os_detection.h"
 #endif
 
-#define NEXT_INTERFACE __COUNTER__
-
 /*
  * Interface indexes
  */
 enum usb_interfaces {
 #ifndef KEYBOARD_SHARED_EP
-    KEYBOARD_INTERFACE = NEXT_INTERFACE,
+    KEYBOARD_INTERFACE,
 #else
-    SHARED_INTERFACE = NEXT_INTERFACE,
+    SHARED_INTERFACE,
 #    define KEYBOARD_INTERFACE SHARED_INTERFACE
 #endif
 
@@ -65,23 +63,23 @@ enum usb_interfaces {
 // interface number, to support Linux/OSX platforms and chrome.hid
 // If Raw HID is enabled, let it be always 1.
 #ifdef RAW_ENABLE
-    RAW_INTERFACE = NEXT_INTERFACE,
+    RAW_INTERFACE,
 #endif
 
 #if defined(SHARED_EP_ENABLE) && !defined(KEYBOARD_SHARED_EP)
-    SHARED_INTERFACE = NEXT_INTERFACE,
+    SHARED_INTERFACE,
 #endif
 
 #ifdef CONSOLE_ENABLE
-    CONSOLE_INTERFACE = NEXT_INTERFACE,
+    CONSOLE_INTERFACE,
 #endif
 
-    TOTAL_INTERFACES = NEXT_INTERFACE
+    TOTAL_INTERFACES
 };
 
 #define MAX_INTERFACES 3
 
-#if (NEXT_INTERFACE - 1) > MAX_INTERFACES
+#if TOTAL_INTERFACES > MAX_INTERFACES
 #    error There are not enough available interfaces to support all functions. Please disable one or more of the following: Mouse Keys, Extra Keys, Raw HID, Console
 #endif
 
@@ -90,7 +88,7 @@ enum usb_interfaces {
 #endif
 
 static uint8_t keyboard_led_state = 0;
-static uint8_t vusb_idle_rate     = 0;
+uint8_t        keyboard_idle      = 0;
 uint8_t        keyboard_protocol  = 1;
 
 /* Keyboard report send buffer */
@@ -335,7 +333,7 @@ usbMsgLen_t usbFunctionSetup(uchar data[8]) {
                 break;
             case USBRQ_HID_GET_IDLE:
                 dprint("GET_IDLE:");
-                usbMsgPtr = (usbMsgPtr_t)&vusb_idle_rate;
+                usbMsgPtr = (usbMsgPtr_t)&keyboard_idle;
                 return 1;
             case USBRQ_HID_GET_PROTOCOL:
                 dprint("GET_PROTOCOL:");
@@ -351,8 +349,8 @@ usbMsgLen_t usbFunctionSetup(uchar data[8]) {
                 }
                 return USB_NO_MSG; // to get data in usbFunctionWrite
             case USBRQ_HID_SET_IDLE:
-                vusb_idle_rate = rq->wValue.bytes[1];
-                dprintf("SET_IDLE: %02X", vusb_idle_rate);
+                keyboard_idle = (rq->wValue.word & 0xFF00) >> 8;
+                dprintf("SET_IDLE: %02X", keyboard_idle);
                 break;
             case USBRQ_HID_SET_PROTOCOL:
                 if (rq->wIndex.word == KEYBOARD_INTERFACE) {
@@ -1044,7 +1042,7 @@ USB_PUBLIC usbMsgLen_t usbFunctionDescriptor(struct usbRequest *rq) {
 #endif
             break;
         case USBDESCR_HID:
-            switch (rq->wValue.bytes[0]) {
+            switch (rq->wIndex.word) {
 #ifndef KEYBOARD_SHARED_EP
                 case KEYBOARD_INTERFACE:
                     usbMsgPtr = (usbMsgPtr_t)&usbConfigurationDescriptor.keyboardHID;

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -79,9 +79,7 @@ enum usb_interfaces {
 
 #define MAX_INTERFACES 3
 
-#if TOTAL_INTERFACES > MAX_INTERFACES
-#    error There are not enough available interfaces to support all functions. Please disable one or more of the following: Mouse Keys, Extra Keys, Raw HID, Console
-#endif
+_Static_assert(TOTAL_INTERFACES <= MAX_INTERFACES, "There are not enough available interfaces to support all functions. Please disable one or more of the following: Mouse Keys, Extra Keys, Raw HID, Console.");
 
 #if (defined(MOUSE_ENABLE) || defined(EXTRAKEY_ENABLE)) && CONSOLE_ENABLE
 #    error Mouse/Extra Keys share an endpoint with Console. Please disable one of the two.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Out of curiosity I ran the Idle Test from the tool mentioned here: #22324.
It failed, and led me to discover a couple of small bugs. The switch block for HID Report descriptor requests was looking at the wrong byte, and the interface numbering was off by one.

![image](https://github.com/qmk/qmk_firmware/assets/4781841/8912fe45-a60c-487b-b225-d954a5839255)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
