### PR TITLE
fixes null-character termination in ucis_add()

### DIFF
--- a/quantum/process_keycode/process_ucis.c
+++ b/quantum/process_keycode/process_ucis.c
@@ -36,6 +36,8 @@ bool process_ucis(uint16_t keycode, keyrecord_t *record) {
                 case KC_ENTER:
                     ucis_finish();
                     return false;
+                default:
+                    return false;
             }
         }
     }

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -37,8 +37,9 @@ static char keycode_to_char(uint16_t keycode) {
 
 bool ucis_add(uint16_t keycode) {
     char c = keycode_to_char(keycode);
-    if (c) {
+    if (c && count < UCIS_MAX_INPUT_LENGTH - 1) {
         input[count++] = c;
+        input[count] = 0;
         return true;
     }
     return false;

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -37,11 +37,14 @@ static char keycode_to_char(uint16_t keycode) {
 
 bool ucis_add(uint16_t keycode) {
     char c = keycode_to_char(keycode);
-    if (c && count < UCIS_MAX_INPUT_LENGTH - 1) {
-        input[count++] = c;
-        input[count]   = 0;
-        return true;
+    if (count < UCIS_MAX_INPUT_LENGTH - 1) {
+        if (c) {
+            input[count++] = c;
+            input[count]   = 0;
+            return true;
+        }
     }
+    tap_code(KC_BACKSPACE);
     return false;
 }
 

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -44,12 +44,12 @@ bool ucis_add(uint16_t keycode) {
             return true;
         }
     }
-    tap_code(KC_BACKSPACE);
     return false;
 }
 
 bool ucis_remove_last(void) {
     if (count) {
+        input[count] = 0;
         count--;
         return true;
     }
@@ -76,10 +76,11 @@ void ucis_finish(void) {
         }
     }
 
+    for (uint8_t j = 0; j <= count; j++) {
+        tap_code(KC_BACKSPACE);
+    }
+
     if (found) {
-        for (uint8_t j = 0; j <= count; j++) {
-            tap_code(KC_BACKSPACE);
-        }
         register_ucis(i);
     }
 
@@ -87,6 +88,10 @@ void ucis_finish(void) {
 }
 
 void ucis_cancel(void) {
+    for (uint8_t i = 0; i <= count; i++) {
+        tap_code(KC_BACKSPACE);
+    }
+
     count  = 0;
     active = false;
 }

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -39,7 +39,7 @@ bool ucis_add(uint16_t keycode) {
     char c = keycode_to_char(keycode);
     if (c && count < UCIS_MAX_INPUT_LENGTH - 1) {
         input[count++] = c;
-        input[count] = 0;
+        input[count]   = 0;
         return true;
     }
     return false;


### PR DESCRIPTION
## Description
With `UCIS_ENABLE = yes` and `UNICODE_COMMON = yes` when entering a wrong mnemonic, a second attempt with correct mnemonic would not trigger the ucis input. 

This change:
- adds a trailing `0` after the last added character in `ucis_add()`
- introduces boundary check on `ucis_add()` to not write out of bounds
- clears buffered character by `0` on `ucis_remove_last()`
- correctly handles abortion (ESC)
- correctly handles invalid characters (i.e.: ,.-/* ...)

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fixes following example:

`keymap.c`
```
const ucis_symbol_t ucis_symbol_table[] = UCIS_TABLE(
    UCIS_SYM("poop", 0x1F4A9),                // 💩
    UCIS_SYM("rofl", 0x1F923),                // 🤣
    UCIS_SYM("ukr", 0x1F1FA, 0x1F1E6),        // 🇺🇦
    UCIS_SYM("look", 0x0CA0, 0x005F, 0x0CA0)  // ಠ_ಠ
);
```
 1. enter `⌨poopxyz` (wrong mnemonic)
 2. enter `⌨poop` (correct mnemonic) would not trigger since the buffer is still `poopxyz'0''0'...`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Relates to https://github.com/qmk/qmk_firmware/pull/21659