### PR TITLE
stabilizes linux unicode input + ibus with UNICODE_TYPE_DELAY=20

### DIFF
--- a/quantum/unicode/unicode.c
+++ b/quantum/unicode/unicode.c
@@ -228,6 +228,7 @@ __attribute__((weak)) void unicode_input_start(void) {
             register_code(UNICODE_KEY_MAC);
             break;
         case UNICODE_MODE_LINUX:
+            wait_ms(UNICODE_TYPE_DELAY);
             tap_code16(UNICODE_KEY_LNX);
             break;
         case UNICODE_MODE_WINDOWS:
@@ -260,7 +261,9 @@ __attribute__((weak)) void unicode_input_finish(void) {
             unregister_code(UNICODE_KEY_MAC);
             break;
         case UNICODE_MODE_LINUX:
+            wait_ms(UNICODE_TYPE_DELAY);
             tap_code(KC_SPACE);
+            wait_ms(UNICODE_TYPE_DELAY);
             if (unicode_saved_led_state.caps_lock) {
                 tap_code(KC_CAPS_LOCK);
             }
@@ -288,7 +291,9 @@ __attribute__((weak)) void unicode_input_cancel(void) {
             unregister_code(UNICODE_KEY_MAC);
             break;
         case UNICODE_MODE_LINUX:
+            wait_ms(UNICODE_TYPE_DELAY);
             tap_code(KC_ESCAPE);
+            wait_ms(UNICODE_TYPE_DELAY);
             if (unicode_saved_led_state.caps_lock) {
                 tap_code(KC_CAPS_LOCK);
             }
@@ -320,6 +325,11 @@ static void send_nibble_wrapper(uint8_t digit) {
         tap_code(kc);
         return;
     }
+
+    if (unicode_config.input_mode == UNICODE_MODE_LINUX) {
+        wait_ms(UNICODE_TYPE_DELAY);
+    }
+
     send_nibble(digit);
 }
 


### PR DESCRIPTION

## Description

This PR adds more delays to overcome instability with ucis and the rather slow Linux ibus input (`UNICODE_SELECTED_MODES=UNICODE_MODE_LINUX`). 

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Printing unicode symbols (ucis) often caused issues on a Linux/Ubuntu 23.04 PC and a recent HW (AMD Ryzen 9 5900X 12-Core Processor). It was observed that printing the symbol table as a whole was a representative example to reproduce the problem. With a higher integrated editor like Libre Office Writer the issue was even better reproducible than with a standard text editor (i.e. Kate or Geany). It was also observed that it affects only the input while the ibus is in unicode input mode like with `Ctl+Shift+U + <code>`, Not in standard ascii mode.

To mitigate this circumstance one can 
- try to re-start ibus, and/or
- introduce more latencies in-between characters sent to the OS.

With `UCIS_ENABLE = yes` and a symbol table
```
const ucis_symbol_t ucis_symbol_table[] = UCIS_TABLE(
    UCIS_SYM("poop",    0x1F4A9), // 💩
    UCIS_SYM("grin",    0x1F600), // 😀
    UCIS_SYM("grin2",   0x1F601), // 😁
    UCIS_SYM("smile",   0x1F642), // 🙂
    UCIS_SYM("smile2",  0x1F60A), // 😊
    UCIS_SYM("smile3",  0x1F604), // 😄
    UCIS_SYM("smile4",  0x295, 0x298, 0x305, 0x35C, 0x298, 0x305, 0x29), // ʕʘ̅͜ʘ̅ʔ
    UCIS_SYM("rofl",    0x1F923), // 🤣
    UCIS_SYM("joy",     0x1F602), // 😂
    UCIS_SYM("kiss",    0x1F618), // 😘
    UCIS_SYM("heart",   0x1F60D), // 😘
    UCIS_SYM("sleep",   0x1F634), // 😴
    UCIS_SYM("tongue",  0x1F60B), // 😋
    UCIS_SYM("sunglass",0x1F60E), // 😎
    UCIS_SYM("look",    0xCA0, 0x5F, 0xCA0), // ಠ_ಠ
    UCIS_SYM("no",      0x1F648, 0x1F649, 0x1F64A), // monkey, no-see -hear -speak
    UCIS_SYM("shrug",   0xAF, 0x5C, 0x5F, 0x28, 0x30C4, 0x29, 0x5F, 0x2F, 0xAF), // ¯\_(ツ)_/¯
    UCIS_SYM("flip",    0x28, 0x256F, 0xFF9F, 0x2E, 0x20, 0xFF9F, 0xFF09, 0x256F, 0xFE35, 0x20, 0x253B, 0x2501, 0x253B), // (╯ﾟ. ﾟ）╯︵ ┻━┻
    UCIS_SYM("flip2",   0x28, 0x256F, 0x20, 0x360, 0xB0, 0x25DE, 0x20, 0xB0, 0xFF09, 0x256F, 0xFE35, 0x20, 0x253B, 0x2501, 0x253B), // (╯ ͠°◞ °）╯︵ ┻━┻
    UCIS_SYM("flip3",   0x28, 0x256F, 0x2035, 0x25A1, 0x2032, 0x29, 0x256F, 0xFE35, 0x2534, 0x2500, 0x2534), // (╯‵□′)╯︵┴─┴
    UCIS_SYM("flip4",   0x28, 0x30CE, 0xCA0, 0x76CA, 0xCA0, 0x29, 0x30CE, 0x5F61, 0x253B, 0x2501, 0x253B), // (ノಠ益ಠ)ノ彡┻━┻
    UCIS_SYM("ekury",   0x306), // ˘
    UCIS_SYM("dpunkt",  0x2D0) // ː
);
``` 

when printing/sending the symbol table, the input was mostly random garbage

```
Poop 💩💩💩1f60😁😁😊😊ãʕ̅0 
grin2 1f642 
smile2 1f604 
smile4 0298 ʘ))😂😂😂😍😍î03😎😎😎🙈🙊🙊🙊_\_ツ_/5c 0305 1f923 
joz (ﾟ1f618 
heart 1f634 
tongue .ﾟ╯━┻┻b 
sunglass 0ca0 0ca0 
no 1f649 00af (  ╯0028 0029 00af ━ ╯□︵─
flip 256f ┴┴ôಠ益)━┻┻0020 ff09 fe35 0020 253b lip2 256f 0360 0b0 25de 0b0 ff09 fe35 253b 253b 
flip3 0028 2035 2032 0029 256f 2534 0028 ce 0ca0 30ce 5f61 253b rz 0306 
dpunkt 02d0 

```

but expected was:

```
poop 💩
grin 😀
grin2 😁
smile 🙂
smile2 😊
smile3 😄
smile4 ʕʘ̅͜ʘ̅)
rofl 🤣
joz 😂
kiss 😘
heart 😍
sleep 😴
tongue 😋
sunglass 😎
look ಠ_ಠ
no 🙈🙉🙊
shrug ¯\_(ツ)_/¯
flip (╯ﾟ. ﾟ）╯︵ ┻━┻
flip2 (╯ ͠°◞ °）╯︵ ┻━┻
flip3 (╯‵□′)╯︵┴─┴
flip4 (ノಠ益ಠ)ノ彡┻━┻
ekurz ̆
dpunkt ː
```

Following was used to print the symbol table:

```
bool process_record_user(uint16_t keycode, keyrecord_t *record) 
{
    switch (keycode) {

        case PR_EMOJI:
            if (!record->event.pressed) {

                for (size_t idx = 0; NULL != ucis_symbol_table[idx].mnemonic ; idx++) {
                    send_string(ucis_symbol_table[idx].mnemonic);
                    send_char(' ');
                    wait_ms(UNICODE_TYPE_DELAY);
                    register_ucis(idx);
                    wait_ms(UNICODE_TYPE_DELAY);
                    send_char('\n');
                }
            }
            break;
    }
    return true;
}
```
where `UNICODE_TYPE_DELAY=20` milliseconds.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Relates to https://github.com/qmk/qmk_firmware/issues/17022