### PR TITLE
turn caps_lock LED on while caps_word is active

### DIFF
--- a/keyboards/keychron/q6/q6.c
+++ b/keyboards/keychron/q6/q6.c
@@ -16,6 +16,7 @@
 
 #include "quantum.h"
 
+// clang-format off
 const matrix_row_t matrix_mask[] = {
     0b11111111111111111111,
     0b11111111111111111111,
@@ -24,6 +25,7 @@ const matrix_row_t matrix_mask[] = {
     0b11111111111111111111,
     0b11111111111111101111,
 };
+// clang-format on
 
 #ifdef DIP_SWITCH_ENABLE
 
@@ -73,7 +75,11 @@ bool rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
     }
     // RGB_MATRIX_INDICATOR_SET_COLOR(index, red, green, blue);
 #    if defined(CAPS_LOCK_LED_INDEX)
+#        if defined(CAPS_WORD_ENABLE)
+    if (host_keyboard_led_state().caps_lock || is_caps_word_on()) {
+#        else
     if (host_keyboard_led_state().caps_lock) {
+#        endif // CAPS_WORD_ENABLE
         RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_LED_INDEX, 255, 255, 255);
     } else {
         if (!rgb_matrix_get_flags()) {


### PR DESCRIPTION
## Description

With `CAPS_WORD_ENABLE = yes` when `caps_word` is active, the Keychron Q6 keymap wouldn't enable the `caps_lock` LED.
This PR considers if the `caps_word` feature is enabled and turns the `caps_lock` LED on as long `caps_word` is active.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* when caps_word is active, it's not reflected by the caps_lock LED

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
