### PR TITLE
[Core/CLI] Add QMK and Keycode versions as hex

### DIFF
--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -44,10 +44,15 @@ def generate_version_h(cli):
         keycode_version = list_versions()[0]
         keycode_bcd_version = triplet_to_bcd(*(list(map(int, keycode_version.split('.')))))
         git_version = git_get_version() or current_time
-        git_bcd_version = triplet_to_bcd(*(list(map(int, (git_version.split('-')[0]).split('.')))))
         git_qmk_hash = git_get_qmk_hash() or "Unknown"
         chibios_version = git_get_version("chibios", "os") or current_time
         chibios_contrib_version = git_get_version("chibios-contrib", "os") or current_time
+
+        git_bcd_version = list(map(int, (git_version.split('-')[0]).split('.')))
+        if (len(git_bcd_version) != 3):
+            git_bcd_version = "0x00000000"
+        else:
+            git_bcd_version = triplet_to_bcd(*(git_bcd_version))
 
     # Build the version.h file.
     version_h_lines = [GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE, '#pragma once']

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -49,7 +49,6 @@ def generate_version_h(cli):
         chibios_version = git_get_version("chibios", "os") or current_time
         chibios_contrib_version = git_get_version("chibios-contrib", "os") or current_time
 
-
     # Build the version.h file.
     version_h_lines = [GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE, '#pragma once']
 

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -8,6 +8,7 @@ from qmk.path import normpath
 from qmk.commands import dump_lines
 from qmk.git import git_get_qmk_hash, git_get_version, git_is_dirty
 from qmk.constants import GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE
+from qmk.keycodes import list_versions
 
 TIME_FMT = '%Y-%m-%d-%H:%M:%S'
 
@@ -30,12 +31,14 @@ def generate_version_h(cli):
 
     if cli.args.skip_git:
         git_dirty = False
+        keycode_version = "NA"
         git_version = "NA"
         git_qmk_hash = "NA"
         chibios_version = "NA"
         chibios_contrib_version = "NA"
     else:
         git_dirty = git_is_dirty()
+        keycode_version = convert_version_to_hex(list_versions()[0])
         git_version = git_get_version() or current_time
         git_qmk_hash = git_get_qmk_hash() or "Unknown"
         chibios_version = git_get_version("chibios", "os") or current_time
@@ -47,6 +50,8 @@ def generate_version_h(cli):
     version_h_lines.append(
         f"""
 #define QMK_VERSION "{git_version}"
+#define QMK_VERSION_HEX {convert_version_to_hex(git_version.split('-')[0])}
+#define KEYCODE_VERSION_HEX {keycode_version}
 #define QMK_BUILDDATE "{current_time}"
 #define QMK_GIT_HASH  "{git_qmk_hash}{'*' if git_dirty else ''}"
 #define CHIBIOS_VERSION "{chibios_version}"
@@ -56,3 +61,12 @@ def generate_version_h(cli):
 
     # Show the results
     dump_lines(cli.args.output, version_h_lines, cli.args.quiet)
+
+def convert_version_to_hex(version):
+    hex_conversion = version.split('.')
+    if len(hex_conversion) != 3:
+        return None
+
+    hex_conversion = [hex(int(item))[2:].zfill(2) for item in hex_conversion]
+    hex_conversion[2] = hex_conversion[2].zfill(4)
+    return "".join(hex_conversion)

--- a/lib/python/qmk/cli/generate/version_h.py
+++ b/lib/python/qmk/cli/generate/version_h.py
@@ -42,17 +42,13 @@ def generate_version_h(cli):
     else:
         git_dirty = git_is_dirty()
         keycode_version = list_versions()[0]
-        keycode_bcd_version = triplet_to_bcd(*(list(map(int, keycode_version.split('.')))))
+        keycode_bcd_version = triplet_to_bcd(keycode_version) or "0x00000000"
         git_version = git_get_version() or current_time
+        git_bcd_version = triplet_to_bcd(git_version) or "0x00000000"
         git_qmk_hash = git_get_qmk_hash() or "Unknown"
         chibios_version = git_get_version("chibios", "os") or current_time
         chibios_contrib_version = git_get_version("chibios-contrib", "os") or current_time
 
-        git_bcd_version = list(map(int, (git_version.split('-')[0]).split('.')))
-        if (len(git_bcd_version) != 3):
-            git_bcd_version = "0x00000000"
-        else:
-            git_bcd_version = triplet_to_bcd(*(git_bcd_version))
 
     # Build the version.h file.
     version_h_lines = [GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE, '#pragma once']

--- a/lib/python/qmk/util.py
+++ b/lib/python/qmk/util.py
@@ -8,6 +8,7 @@ from milc import cli
 
 TRIPLET_PATTERN = re.compile(r'^(\d+)\.(\d+)\.(\d+)')
 
+
 @contextlib.contextmanager
 def parallelize():
     """Returns a function that can be used in place of a map() call.

--- a/lib/python/qmk/util.py
+++ b/lib/python/qmk/util.py
@@ -59,8 +59,8 @@ def parallel_map(*args, **kwargs):
         return list(map_fn(*args, **kwargs))
 
 
-def triplet_to_bcd(stringVersion: str):
-    m = TRIPLET_PATTERN.match(stringVersion)
+def triplet_to_bcd(ver: str):
+    m = TRIPLET_PATTERN.match(ver)
     if not m:
         return '0x00000000'
     return f'0x{int(m.group(1)):02d}{int(m.group(2)):02d}{int(m.group(3)):04d}'

--- a/lib/python/qmk/util.py
+++ b/lib/python/qmk/util.py
@@ -54,3 +54,7 @@ def parallel_map(*args, **kwargs):
         # before the results are returned. Returning a list ensures results are
         # materialised before any worker pool is shut down.
         return list(map_fn(*args, **kwargs))
+
+
+def triplet_to_bcd(major: int, minor: int, patch: int):
+    return f"0x{major:02d}{minor:02d}{patch:04d}"

--- a/lib/python/qmk/util.py
+++ b/lib/python/qmk/util.py
@@ -61,5 +61,5 @@ def parallel_map(*args, **kwargs):
 def triplet_to_bcd(stringVersion: str):
     m = TRIPLET_PATTERN.match(stringVersion)
     if not m:
-        return '0'
+        return '0x00000000'
     return f'0x{int(m.group(1)):02d}{int(m.group(2)):02d}{int(m.group(3)):04d}'

--- a/lib/python/qmk/util.py
+++ b/lib/python/qmk/util.py
@@ -2,9 +2,11 @@
 """
 import contextlib
 import multiprocessing
+import re
 
 from milc import cli
 
+TRIPLET_PATTERN = re.compile(r'^(\d+)\.(\d+)\.(\d+)')
 
 @contextlib.contextmanager
 def parallelize():
@@ -56,5 +58,8 @@ def parallel_map(*args, **kwargs):
         return list(map_fn(*args, **kwargs))
 
 
-def triplet_to_bcd(major: int, minor: int, patch: int):
-    return f"0x{major:02d}{minor:02d}{patch:04d}"
+def triplet_to_bcd(stringVersion: str):
+    m = TRIPLET_PATTERN.match(stringVersion)
+    if not m:
+        return '0'
+    return f'0x{int(m.group(1)):02d}{int(m.group(2)):02d}{int(m.group(3)):04d}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Converts the current versioning of the keycodes/qmk versions from their number format X.Y.Z into
0xXXYYZZZZ as per the XAP documentation.

> Returns the BCD-encoded version in the format of XX.YY.ZZZZ => 0xXXYYZZZZ
> e.g. 3.2.115 will match 0x03020115, or bytes {0x15,0x01,0x02,0x03}.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Adds QMK and Keycode versioning as a hex string

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
