### PR TITLE
QP getters correction

### DIFF
--- a/quantum/painter/qp.c
+++ b/quantum/painter/qp.c
@@ -148,11 +148,11 @@ uint16_t qp_get_width(painter_device_t device) {
         case QP_ROTATION_0:
         case QP_ROTATION_180:
             width = driver->panel_width;
-        break;
+            break;
         case QP_ROTATION_90:
         case QP_ROTATION_270:
             width = driver->panel_height;
-        break;
+            break;
     }
 
     qp_dprintf("qp_get_width: ok\n");
@@ -174,11 +174,11 @@ uint16_t qp_get_height(painter_device_t device) {
         case QP_ROTATION_0:
         case QP_ROTATION_180:
             height = driver->panel_height;
-        break;
+            break;
         case QP_ROTATION_90:
         case QP_ROTATION_270:
             height = driver->panel_width;
-        break;
+            break;
     }
 
     qp_dprintf("qp_get_height: ok\n");

--- a/quantum/painter/qp.c
+++ b/quantum/painter/qp.c
@@ -148,10 +148,11 @@ uint16_t qp_get_width(painter_device_t device) {
         case QP_ROTATION_0:
         case QP_ROTATION_180:
             width = driver->panel_width;
-
+        break;
         case QP_ROTATION_90:
         case QP_ROTATION_270:
             width = driver->panel_height;
+        break;
     }
 
     qp_dprintf("qp_get_width: ok\n");
@@ -173,10 +174,11 @@ uint16_t qp_get_height(painter_device_t device) {
         case QP_ROTATION_0:
         case QP_ROTATION_180:
             height = driver->panel_height;
-
+        break;
         case QP_ROTATION_90:
         case QP_ROTATION_270:
             height = driver->panel_width;
+        break;
     }
 
     qp_dprintf("qp_get_height: ok\n");


### PR DESCRIPTION
 <!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Found this bug the hard way: recently updating to develop caused my QP/LVGL-driven OLED to stop working properly. The function I assign to LVGL's `set_px_cb()` requires the panel's width and height information. The code was swapping the panel's width and height regardless of display orientation, but is easily fixed by adding the missing breaks to the case statements.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
