### PR TITLE
Remove use of broken split.main

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -681,10 +681,6 @@
                         }
                     }
                 },
-                "main": {
-                    "type": "string",
-                    "enum": ["eeprom", "left", "matrix_grid", "pin", "right"]
-                },
                 "soft_serial_pin": {"$ref": "qmk.definitions.v1#/mcu_pin"},
                 "soft_serial_speed": {
                     "type": "integer",
@@ -735,6 +731,11 @@
                         "polling_interval": {"$ref": "qmk.definitions.v1#/unsigned_int"},
                         "timeout": {"$ref": "qmk.definitions.v1#/unsigned_int"}
                     }
+                },
+                "main": {
+                    "type": "string",
+                    "enum": ["eeprom", "left", "matrix_grid", "pin", "right"],
+                    "$comment": "Deprecated: use config.h options for now"
                 }
             }
         },

--- a/keyboards/controllerworks/mini42/info.json
+++ b/keyboards/controllerworks/mini42/info.json
@@ -29,7 +29,6 @@
     },
     "split": {
         "enabled": true,
-        "main": "left",
         "matrix_pins": {
             "right": {
                 "direct": [

--- a/keyboards/hillside/48/0_1/info.json
+++ b/keyboards/hillside/48/0_1/info.json
@@ -23,7 +23,6 @@
     },
     "split": {
         "soft_serial_pin": "D2",
-        "main": "left",
         "encoder": {
             "right": {
                 "rotary": [

--- a/keyboards/splitkb/aurora/corne/rev1/info.json
+++ b/keyboards/splitkb/aurora/corne/rev1/info.json
@@ -83,7 +83,6 @@
             "matrix": [4, 5]
         },
         "soft_serial_pin": "D2",
-        "main": "pin",
         "matrix_pins": {
             "right": {
                 "rows": ["B1", "B3", "B2", "B6"],

--- a/keyboards/splitkb/aurora/helix/rev1/info.json
+++ b/keyboards/splitkb/aurora/helix/rev1/info.json
@@ -118,7 +118,6 @@
                 ]
             }
         },
-        "main": "matrix_grid",
         "matrix_pins": {
             "right": {
                 "cols": ["D4", "C6", "D7", "E6", "B4", "B5", "B6"],

--- a/keyboards/splitkb/aurora/lily58/rev1/info.json
+++ b/keyboards/splitkb/aurora/lily58/rev1/info.json
@@ -94,7 +94,6 @@
             "matrix": [5, 0]
         },
         "soft_serial_pin": "D2",
-        "main": "matrix_grid",
         "matrix_pins": {
             "right": {
                 "rows": ["F4", "D4", "B3", "B2", "B6"],

--- a/keyboards/splitkb/aurora/sofle_v2/rev1/info.json
+++ b/keyboards/splitkb/aurora/sofle_v2/rev1/info.json
@@ -112,7 +112,6 @@
                 ]
             }
         },
-        "main": "matrix_grid",
         "matrix_pins": {
             "right": {
                 "cols": ["D7", "E6", "B4", "B5", "D4", "C6"],

--- a/keyboards/splitkb/aurora/sweep/rev1/info.json
+++ b/keyboards/splitkb/aurora/sweep/rev1/info.json
@@ -79,7 +79,6 @@
             "matrix": [4, 4]
         },
         "soft_serial_pin": "D2",
-        "main": "pin",
         "matrix_pins": {
             "right": {
                 "rows": ["B1", "F7", "F6", "B3"],

--- a/keyboards/splitkb/kyria/rev3/info.json
+++ b/keyboards/splitkb/kyria/rev3/info.json
@@ -98,7 +98,6 @@
             "matrix": [4, 6]
         },
         "soft_serial_pin": "D2",
-        "main": "matrix_grid",
         "matrix_pins": {
             "right": {
                 "rows": ["F6", "F7", "B1", "B3"],

--- a/keyboards/tzarc/djinn/info.json
+++ b/keyboards/tzarc/djinn/info.json
@@ -45,7 +45,6 @@
   },
   "split": {
     "enabled": true,
-    "main": "pin",
     "encoder": {
       "right": {
         "rotary": [

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -141,24 +141,6 @@ def generate_encoder_config(encoder_json, config_h_lines, postfix=''):
 
 def generate_split_config(kb_info_json, config_h_lines):
     """Generate the config.h lines for split boards."""
-    if 'primary' in kb_info_json['split']:
-        if kb_info_json['split']['primary'] in ('left', 'right'):
-            config_h_lines.append('')
-            config_h_lines.append('#ifndef MASTER_LEFT')
-            config_h_lines.append('#    ifndef MASTER_RIGHT')
-            if kb_info_json['split']['primary'] == 'left':
-                config_h_lines.append('#        define MASTER_LEFT')
-            elif kb_info_json['split']['primary'] == 'right':
-                config_h_lines.append('#        define MASTER_RIGHT')
-            config_h_lines.append('#    endif // MASTER_RIGHT')
-            config_h_lines.append('#endif // MASTER_LEFT')
-        elif kb_info_json['split']['primary'] == 'pin':
-            config_h_lines.append(generate_define('SPLIT_HAND_PIN'))
-        elif kb_info_json['split']['primary'] == 'matrix_grid':
-            config_h_lines.append(generate_define('SPLIT_HAND_MATRIX_GRID', f'{{ {",".join(kb_info_json["split"]["matrix_grid"])} }}'))
-        elif kb_info_json['split']['primary'] == 'eeprom':
-            config_h_lines.append(generate_define('EE_HANDS'))
-
     if 'protocol' in kb_info_json['split'].get('transport', {}):
         if kb_info_json['split']['transport']['protocol'] == 'i2c':
             config_h_lines.append(generate_define('USE_I2C'))

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -42,9 +42,6 @@ def _strip_api_content(info_json):
         if info_json.get(feature, {}).get("layout", None):
             info_json[feature].pop('led_count', None)
 
-    if 'split' in info_json:
-        info_json['split'].pop('main', None)
-
     return info_json
 
 

--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -42,6 +42,9 @@ def _strip_api_content(info_json):
         if info_json.get(feature, {}).get("layout", None):
             info_json[feature].pop('led_count', None)
 
+    if 'split' in info_json:
+        info_json['split'].pop('main', None)
+
     return info_json
 
 

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -352,57 +352,6 @@ def _extract_secure_unlock(info_data, config_c):
         info_data['secure']['unlock_sequence'] = unlock_array
 
 
-def _extract_split_main(info_data, config_c):
-    """Populate data about the split configuration
-    """
-    # Figure out how the main half is determined
-    if config_c.get('SPLIT_HAND_PIN') is True:
-        if 'split' not in info_data:
-            info_data['split'] = {}
-
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (SPLIT_HAND_PIN) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
-
-        info_data['split']['main'] = 'pin'
-
-    if config_c.get('SPLIT_HAND_MATRIX_GRID'):
-        if 'split' not in info_data:
-            info_data['split'] = {}
-
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (SPLIT_HAND_MATRIX_GRID) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
-
-        info_data['split']['main'] = 'matrix_grid'
-        info_data['split']['matrix_grid'] = _extract_pins(config_c['SPLIT_HAND_MATRIX_GRID'])
-
-    if config_c.get('EE_HANDS') is True:
-        if 'split' not in info_data:
-            info_data['split'] = {}
-
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (EE_HANDS) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
-
-        info_data['split']['main'] = 'eeprom'
-
-    if config_c.get('MASTER_RIGHT') is True:
-        if 'split' not in info_data:
-            info_data['split'] = {}
-
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (MASTER_RIGHT) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
-
-        info_data['split']['main'] = 'right'
-
-    if config_c.get('MASTER_LEFT') is True:
-        if 'split' not in info_data:
-            info_data['split'] = {}
-
-        if 'main' in info_data['split']:
-            _log_warning(info_data, 'Split main hand is specified in both config.h (MASTER_LEFT) and info.json (split.main) (Value: %s), the config.h value wins.' % info_data['split']['main'])
-
-        info_data['split']['main'] = 'left'
-
-
 def _extract_split_transport(info_data, config_c):
     # Figure out the transport method
     if config_c.get('USE_I2C') is True:
@@ -594,7 +543,6 @@ def _extract_config_h(info_data, config_c):
     _extract_matrix_info(info_data, config_c)
     _extract_audio(info_data, config_c)
     _extract_secure_unlock(info_data, config_c)
-    _extract_split_main(info_data, config_c)
     _extract_split_transport(info_data, config_c)
     _extract_split_right_pins(info_data, config_c)
     _extract_encoders(info_data, config_c)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Nothing works in this area anyway - the plan is still to rework everything with something like #18254. Keyboard changes,

* `"main": "left"` - redundant as default behaviour anyway
* `"main": "matrix_grid"` - set on boards using SPLIT_HAND_PIN
* `"main": "pin"` - does nothing as dependent logic is still `config.h` 

Additional changes around 18254 incoming shortly after this PR. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
