### PR TITLE
Add dd mapping for hardware based split handedness

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -154,6 +154,8 @@
     // Split Keyboard
     "SOFT_SERIAL_PIN": {"info_key": "split.soft_serial_pin"},
     "SOFT_SERIAL_SPEED": {"info_key": "split.soft_serial_speed"},
+    "SPLIT_HAND_MATRIX_GRID": {"info_key": "split.handedness.matrix_grid", "value_type": "array", "to_c": false},
+    "SPLIT_HAND_PIN": {"info_key": "split.handedness.pin"},
     "SPLIT_USB_DETECT": {"info_key": "split.usb_detect.enabled", "value_type": "bool"},
     "SPLIT_USB_TIMEOUT": {"info_key": "split.usb_detect.timeout", "value_type": "int"},
     "SPLIT_USB_TIMEOUT_POLL": {"info_key": "split.usb_detect.polling_interval", "value_type": "int"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -640,10 +640,6 @@
                         }
                     }
                 },
-                "matrix_grid": {
-                    "type": "array",
-                    "items": {"$ref": "qmk.definitions.v1#/mcu_pin"}
-                },
                 "matrix_pins": {
                     "type": "object",
                     "additionalProperties": false,
@@ -678,6 +674,18 @@
                     "properties": {
                         "right": {
                             "$ref": "#/definitions/encoder_config"
+                        }
+                    }
+                },
+                "handedness": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "pin": {"$ref": "qmk.definitions.v1#/mcu_pin"},
+                        "matrix_grid": {
+                            "$ref": "qmk.definitions.v1#/mcu_pin_array",
+                            "minItems": 2,
+                            "maxItems": 2
                         }
                     }
                 },
@@ -736,6 +744,11 @@
                     "type": "string",
                     "enum": ["eeprom", "left", "matrix_grid", "pin", "right"],
                     "$comment": "Deprecated: use config.h options for now"
+                },
+                "matrix_grid": {
+                    "type": "array",
+                    "items": {"$ref": "qmk.definitions.v1#/mcu_pin"},
+                    "$comment": "Deprecated: use split.handedness.matrix_grid instead"
                 }
             }
         },

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -647,6 +647,12 @@ Configures the [Split Keyboard](feature_split_keyboard.md) feature.
         * `right`
             * `rotary`
                 * See [Encoder](#encoder) config.
+    * `handedness`
+        * `pin`
+            * The GPIO pin connected to determine handedness.
+        * `matrix_grid`
+            * The GPIO pins of the matrix position which determines the handedness.
+            * Example: `["A1", "B5"]`
     * `matrix_pins`
         * `right`
             * See [Matrix](#matrix) config.

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -74,7 +74,14 @@ def generate_matrix_size(kb_info_json, config_h_lines):
 
 def generate_matrix_masked(kb_info_json, config_h_lines):
     """"Enable matrix mask if required"""
+    mask_required = False
+
     if 'matrix_grid' in kb_info_json.get('dip_switch', {}):
+        mask_required = True
+    if 'matrix_grid' in kb_info_json.get('split', {}).get('handedness', {}):
+        mask_required = True
+
+    if mask_required:
         config_h_lines.append(generate_define('MATRIX_MASKED'))
 
 

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -141,6 +141,12 @@ def generate_encoder_config(encoder_json, config_h_lines, postfix=''):
 
 def generate_split_config(kb_info_json, config_h_lines):
     """Generate the config.h lines for split boards."""
+    if 'handedness' in kb_info_json['split']:
+        # TODO: change SPLIT_HAND_MATRIX_GRID to require brackets
+        handedness = kb_info_json['split']['handedness']
+        if 'matrix_grid' in handedness:
+            config_h_lines.append(generate_define('SPLIT_HAND_MATRIX_GRID', ', '.join(handedness['matrix_grid'])))
+
     if 'protocol' in kb_info_json['split'].get('transport', {}):
         if kb_info_json['split']['transport']['protocol'] == 'i2c':
             config_h_lines.append(generate_define('USE_I2C'))

--- a/lib/python/qmk/cli/generate/keyboard_c.py
+++ b/lib/python/qmk/cli/generate/keyboard_c.py
@@ -63,13 +63,14 @@ def _gen_matrix_mask(info_data):
     cols = info_data['matrix_size']['cols']
     rows = info_data['matrix_size']['rows']
 
-    # Default mask to everything enabled
-    mask = [['1'] * cols for i in range(rows)]
+    # Default mask to everything disabled
+    mask = [['0'] * cols for i in range(rows)]
 
-    # Automatically mask out dip_switch.matrix_grid locations
-    matrix_grid = info_data.get('dip_switch', {}).get('matrix_grid', [])
-    for row, col in matrix_grid:
-        mask[row][col] = '0'
+    # Mirror layout macros squashed on top of each other
+    for layout_data in info_data['layouts'].values():
+        for key_data in layout_data['layout']:
+            row, col = key_data['matrix']
+            mask[row][col] = '1'
 
     lines = []
     lines.append('#ifdef MATRIX_MASKED')

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -352,6 +352,14 @@ def _extract_secure_unlock(info_data, config_c):
         info_data['secure']['unlock_sequence'] = unlock_array
 
 
+def _extract_split_handedness(info_data, config_c):
+    # Migrate
+    split = info_data.get('split', {})
+    if 'matrix_grid' in split:
+        split['handedness'] = split.get('handedness', {})
+        split['handedness']['matrix_grid'] = split.pop('matrix_grid')
+
+
 def _extract_split_transport(info_data, config_c):
     # Figure out the transport method
     if config_c.get('USE_I2C') is True:
@@ -543,6 +551,7 @@ def _extract_config_h(info_data, config_c):
     _extract_matrix_info(info_data, config_c)
     _extract_audio(info_data, config_c)
     _extract_secure_unlock(info_data, config_c)
+    _extract_split_handedness(info_data, config_c)
     _extract_split_transport(info_data, config_c)
     _extract_split_right_pins(info_data, config_c)
     _extract_encoders(info_data, config_c)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Adds mapping for:
* `SPLIT_HAND_MATRIX_GRID`
* `SPLIT_HAND_PIN`

Reworks some of 18254, where no further discussion was needed. Built in parsing/generation is used where possible. 

`SPLIT_HAND_MATRIX_GRID` still needs bespoke generation. Fixing this will take further develop cycles to implement the usual breaking changes process. For example, once migrated to `info.json`, we can rework the implementation to generate the following instead
```c
#define SPLIT_HAND_MATRIX_GRID {D4,D3}
```

As with dip switches, the automatic generation of `matrix_mask` is also triggered. The aim is to reduce keyboard level configuration, which in turn avoids errors such as 21655. However to simplify the logic, it has been changed to use the result of all layouts squashed on top of each other. This should mostly cover both cases, while being more generic in code. As the codegen spits out a weak symbol, keyboards still get the opportunity to override this (like if they do something gross with a layout that becomes available if you disable a matrix_grid feature?).

Will continue discussions outside this PR on how best to handle the other handedness options (eeprom, assumed left/right), as well as `SPLIT_HAND_MATRIX_GRID_LOW_IS_RIGHT` and `SPLIT_HAND_PIN_LOW_IS_LEFT`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
