### PR TITLE
Prevent `qmk migrate` processing unparsed info.json values

### DIFF
--- a/lib/python/qmk/cli/migrate.py
+++ b/lib/python/qmk/cli/migrate.py
@@ -47,9 +47,12 @@ def migrate(cli):
     files = _candidate_files(cli.args.keyboard)
 
     # Filter down keys if requested
-    keys = info_map.keys()
+    keys = list(filter(lambda key: info_map[key].get("to_json", True), info_map.keys()))
     if cli.args.filter:
         keys = list(set(keys) & set(cli.args.filter))
+        rejected = set(cli.args.filter) - set(keys)
+        for key in rejected:
+            cli.log.info(f'{{fg_yellow}}Skipping {key} as migration not possible...')
 
     cli.log.info(f'{{fg_green}}Migrating keyboard {{fg_cyan}}{cli.args.keyboard}{{fg_green}}.{{fg_reset}}')
 

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -465,6 +465,9 @@ def _config_to_json(key_type, config_value):
     """Convert config value using spec
     """
     if key_type.startswith('array'):
+        if key_type.count('.') > 1:
+            raise Exception(f"Conversion of {key_type} not possible")
+
         if '.' in key_type:
             key_type, array_type = key_type.split('.', 1)
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When the DD mappings are set to `"to_json": false`, there is no replacement data for migration. The result right now is the original is removed, with nothing added to `info.json`.

This PR makes migrate ignore these problematic values for now. Ive also added some logic to reject `array.array.x` types due to the incorrect parsing.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
