### PR TITLE
ChibiOS: Use 'usbTransmit' instead of custom function for 'send_report'

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -827,24 +827,7 @@ uint8_t keyboard_leds(void) {
 }
 
 void send_report(uint8_t endpoint, void *report, size_t size) {
-    osalSysLock();
-    if (usbGetDriverStateI(&USB_DRIVER) != USB_ACTIVE) {
-        osalSysUnlock();
-        return;
-    }
-
-    if (usbGetTransmitStatusI(&USB_DRIVER, endpoint)) {
-        /* Need to either suspend, or loop and call unlock/lock during
-         * every iteration - otherwise the system will remain locked,
-         * no interrupts served, so USB not going through as well.
-         * Note: for suspend, need USB_USE_WAIT == TRUE in halconf.h */
-        if (osalThreadSuspendTimeoutS(&(&USB_DRIVER)->epc[endpoint]->in_state->thread, TIME_MS2I(10)) == MSG_TIMEOUT) {
-            osalSysUnlock();
-            return;
-        }
-    }
-    usbStartTransmitI(&USB_DRIVER, endpoint, report, size);
-    osalSysUnlock();
+    usbTransmit(&USB_DRIVER, endpoint, report, size);
 }
 
 /* prepare and start sending a report IN


### PR DESCRIPTION
## Description

The current code is similar to usbTransmit with some key differences.  These differences seem to make the difference with properly resuming from sleep and not, for me.  For reference, the usbTransmit function from chibios:
https://github.com/qmk/ChibiOS/blob/11edb1610980f213b9f83161e1715a46fb7e4c51/os/hal/src/hal_usb.c#L586-L601

Tested on F303, F411, F405, RP2040. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Issues with resuming from sleep/suspend

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
