### PR TITLE
[Bug] Fixed OLED layers being all set to zero

### DIFF
--- a/keyboards/boardsource/unicorne/unicorne.c
+++ b/keyboards/boardsource/unicorne/unicorne.c
@@ -20,13 +20,13 @@ bool oled_task_kb(void) {
                 oled_write_raw(layer_zero, sizeof(layer_zero));
                 break;
             case 1:
-                oled_write_raw(layer_zero, sizeof(layer_zero));
+                oled_write_raw(layer_one, sizeof(layer_one));
                 break;
             case 2:
-                oled_write_raw(layer_zero, sizeof(layer_zero));
+                oled_write_raw(layer_two, sizeof(layer_two));
                 break;
             case 3:
-                oled_write_raw(layer_zero, sizeof(layer_zero));
+                oled_write_raw(layer_three, sizeof(layer_three));
                 break;
         }
     } else {


### PR DESCRIPTION
Modified the `unicorne.c` file fixing the switch case for each of the layers. They were all set to use `layer_zero`. I've tested the fix by flashing and verifying the OLED screen updates the layer being selected. i.e (1,2,3,4)

## Description
The following lines have been modified
https://github.com/qmk/qmk_firmware/blob/master/keyboards/boardsource/unicorne/unicorne.c#L19-L30

## Types of Changes
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #22388

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
