### PR TITLE
Allow generic_features to handle subdirectories

### DIFF
--- a/builddefs/generic_features.mk
+++ b/builddefs/generic_features.mk
@@ -44,7 +44,9 @@ GENERIC_FEATURES = \
 define HANDLE_GENERIC_FEATURE
     # $$(info "Processing: $1_ENABLE $2.c")
     SRC += $$(wildcard $$(QUANTUM_DIR)/process_keycode/process_$2.c)
+    SRC += $$(wildcard $$(QUANTUM_DIR)/$2/$2.c)
     SRC += $$(wildcard $$(QUANTUM_DIR)/$2.c)
+    VPATH += $$(wildcard $$(QUANTUM_DIR)/$2/)
     OPT_DEFS += -D$1_ENABLE
 endef
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Will allow sections like the following to instead use generic:
```makefile
ifeq ($(strip $(SEND_STRING_ENABLE)), yes)
    OPT_DEFS += -DSEND_STRING_ENABLE
    COMMON_VPATH += $(QUANTUM_DIR)/send_string
    SRC += $(QUANTUM_DIR)/send_string/send_string.c
endif
```

Which refactors to the single line:
```diff
diff --git a/builddefs/generic_features.mk b/builddefs/generic_features.mk
index 261da564b2..1caf447923 100644
--- a/builddefs/generic_features.mk
+++ b/builddefs/generic_features.mk
@@ -34,6 +34,7 @@ GENERIC_FEATURES = \
     PROGRAMMABLE_BUTTON \
     REPEAT_KEY \
     SECURE \
+    SEND_STRING \
     SPACE_CADET \
     SWAP_HANDS \
     TAP_DANCE \
```

Or,
```
ifeq ($(strip $(SEQUENCER_ENABLE)), yes)
    OPT_DEFS += -DSEQUENCER_ENABLE
    MUSIC_ENABLE = yes
    SRC += $(QUANTUM_DIR)/sequencer/sequencer.c
    SRC += $(QUANTUM_DIR)/process_keycode/process_sequencer.c
endif

MUSIC_ENABLE ?= no
ifeq ($(MUSIC_ENABLE), yes)
    SRC += $(QUANTUM_DIR)/process_keycode/process_music.c
endif
```

To just the following dependency logic (plus `MUSIC` and `SEQUENCER` lines added to `generic_features.mk` ):
```
ifeq ($(strip $(SEQUENCER_ENABLE)), yes)
    MUSIC_ENABLE = yes
endif
```
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
