### PR TITLE
New winry315 revision with STM32F072 microcontroller

### DIFF
--- a/keyboards/winry/winry315/info.json
+++ b/keyboards/winry/winry315/info.json
@@ -31,16 +31,16 @@
     },
     "encoder": {
         "rotary": [
-            {"pin_a": "F1", "pin_b": "F0"},
-            {"pin_a": "B0", "pin_b": "B1"},
-            {"pin_a": "B3", "pin_b": "B7"}
+            {"pin_a": "A9", "pin_b": "A8"},
+            {"pin_a": "B4", "pin_b": "B3"},
+            {"pin_a": "B7", "pin_b": "B6"}
         ]
     },
-    "processor": "atmega32u4",
-    "bootloader": "atmel-dfu",
+    "processor": "STM32F072",
+    "bootloader": "stm32-dfu",
     "matrix_pins": {
         "direct": [
-            ["F4", "C7", "D4", "D5", "D1", "F5", "C6", "D6", "D3", "D2", "F6", "B6", "D7", "B4", "B5", "B2", "D0", "E6", null, null, null, null, null, null]
+            ["B14", "A1", "A2", "A3", "A4", "B13", "A6", "A7", "B0", "A5", "B12", "B11", "B10", "B2", "B1", "A10", "A15", "B5", null, null, null, null, null, null]
         ]
     },
     "ws2812": {

--- a/keyboards/winry/winry315/keymaps/via/config.h
+++ b/keyboards/winry/winry315/keymaps/via/config.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-#define DYNAMIC_KEYMAP_LAYER_COUNT 8
+#define DYNAMIC_KEYMAP_LAYER_COUNT 16


### PR DESCRIPTION
Since September 2023, new winry315 keyboards use the STM32F072 microcontroller (source: chat with the vendor on Taobao). The pins have also changed. The storage is also now big enough to accomodate 16 dynamic layers rather than 8 in VIA.

**This PR is not ready to merge as-is**. I simply changed the existing winry315 config files but I assume we'll want to keep both the old and the new versions around (as people still use the old version), and reuse the common parts as much as possible (the difference isn't that large).

I'm new to QMK, and I haven't been able to find instructions in the doc on the best practice of handling hardware revisions. So instead of coming up a scheme myself, I'm opening this PR in its current state to get some advice on how to do that. It's also easier to see exactly what's different.

Tagging maintainer of winry315 @sigprof

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
