### PR TITLE
Fix corne keylog

### DIFF
--- a/keyboards/crkbd/crkbd.c
+++ b/keyboards/crkbd/crkbd.c
@@ -71,6 +71,10 @@ uint8_t  last_col;
 static const char PROGMEM code_to_name[60] = {' ', ' ', ' ', ' ', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'R', 'E', 'B', 'T', '_', '-', '=', '[', ']', '\\', '#', ';', '\'', '`', ',', '.', '/', ' ', ' ', ' '};
 
 static void set_keylog(uint16_t keycode, keyrecord_t *record) {
+    // save the row and column (useful even if we can't find a keycode to show)
+    last_row = record->event.key.row;
+    last_col = record->event.key.col;
+
     key_name     = ' ';
     last_keycode = keycode;
     if (IS_QK_MOD_TAP(keycode)) {
@@ -92,8 +96,6 @@ static void set_keylog(uint16_t keycode, keyrecord_t *record) {
 
     // update keylog
     key_name = pgm_read_byte(&code_to_name[keycode]);
-    last_row = record->event.key.row;
-    last_col = record->event.key.col;
 }
 
 static const char *depad_str(const char *depad_str, char depad_char) {

--- a/keyboards/crkbd/crkbd.c
+++ b/keyboards/crkbd/crkbd.c
@@ -105,11 +105,9 @@ static const char *depad_str(const char *depad_str, char depad_char) {
 }
 
 static void oled_render_keylog(void) {
-    const char *last_row_str = get_u8_str(last_row, ' ');
-    oled_write(depad_str(last_row_str, ' '), false);
+    oled_write_char('0' + last_row, false);
     oled_write_P(PSTR("x"), false);
-    const char *last_col_str = get_u8_str(last_col, ' ');
-    oled_write(depad_str(last_col_str, ' '), false);
+    oled_write_char('0' + last_col, false);
     oled_write_P(PSTR(", k"), false);
     const char *last_keycode_str = get_u16_str(last_keycode, ' ');
     oled_write(depad_str(last_keycode_str, ' '), false);


### PR DESCRIPTION
This pull request contains changes to how keylog is rendered to the oled.

## Description

First there was a bug where some rows/columns would not get properly updated depending on what was mapped to the key (pretty annoying when testing if the keymatrix works on a new build).

Second was a tiny improvement that was suggested to me in a code review for a different keyboard, that I thought I'd carry over since it applies to the crkbd too.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
