### PR TITLE
snled27351: fix missing `i2c_init()`

### DIFF
--- a/drivers/led/snled27351-simple.c
+++ b/drivers/led/snled27351-simple.c
@@ -103,6 +103,8 @@ bool snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 }
 
 void snled27351_init_drivers(void) {
+    i2c_init();
+
     snled27351_init(SNLED27351_I2C_ADDRESS_1);
 #if defined(SNLED27351_I2C_ADDRESS_2)
     snled27351_init(SNLED27351_I2C_ADDRESS_2);

--- a/drivers/led/snled27351.c
+++ b/drivers/led/snled27351.c
@@ -102,6 +102,8 @@ bool snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 }
 
 void snled27351_init_drivers(void) {
+    i2c_init();
+
     snled27351_init(SNLED27351_I2C_ADDRESS_1);
 #if defined(SNLED27351_I2C_ADDRESS_2)
     snled27351_init(SNLED27351_I2C_ADDRESS_2);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Somehow missed this in #22365...I definitely did a pass to double check it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* report of Q3 not working on Discord

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
