### PR TITLE
revoke `community_layouts` from mode/m80v*/m80*h

### DIFF
--- a/keyboards/mode/m80v1/m80h/info.json
+++ b/keyboards/mode/m80v1/m80h/info.json
@@ -15,7 +15,6 @@
     "diode_direction": "COL2ROW",
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
-    "community_layouts": ["tkl_ansi"],
     "layout_aliases": {
         "LAYOUT_eighty_m80h": "LAYOUT_tkl_ansi"
     },

--- a/keyboards/mode/m80v2/m80v2h/info.json
+++ b/keyboards/mode/m80v2/m80v2h/info.json
@@ -19,7 +19,6 @@
     },
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
-    "community_layouts": ["tkl_ansi"],
     "layout_aliases": {
         "LAYOUT_m80v2h": "LAYOUT_tkl_ansi"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

sequence of keys in `layouts` doesn't conform to respectively declared Community Layout's sequence of keys, for keyboards:
- mode/m80v1/m80h
- mode/m80v2/m80v2h

Resulting keypresses, after F12 key, will not be as intended for compiled Community Layout keymaps.

later fix:
Backspace key is currently sequenced in Function row. To conform, move to Number row.

cc: @Gondolindrim 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
