### PR TITLE
Remove 2 cases of superfluous neutralizer taps and add unit tests for key overrides

### DIFF
--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -213,10 +213,10 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
         schedule_deferred_register(trigger);
     }
 
-    #ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
-        // Tap dummy mod neutralizer again after reregistering mod key
-        neutralize_flashing_modifiers(active_override->trigger_mods);
-    #endif
+#ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
+	// Tap dummy mod neutralizer again after reregistering mod key
+	neutralize_flashing_modifiers(active_override->trigger_mods);
+#endif
 
     send_keyboard_report();
 

--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -213,6 +213,11 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
         schedule_deferred_register(trigger);
     }
 
+    #ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
+        // Tap dummy mod neutralizer again after reregistering mod key
+        neutralize_flashing_modifiers(active_override->trigger_mods);
+    #endif
+
     send_keyboard_report();
 
     active_override                 = NULL;

--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -325,12 +325,19 @@ static bool try_activating_override(const uint16_t keycode, const uint8_t layer,
         clear_active_override(false);
 
 #ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
-        // Send a dummy keycode before unregistering the modifier(s)
-        // so that suppressing the modifier(s) doesn't falsely get interpreted
-        // by the host OS as a tap of a modifier key.
-        // For example, unintended activations of the start menu on Windows when
-        // using a GUI+<kc> key override with suppressed mods.
-        neutralize_flashing_modifiers(active_mods);
+        // If the replacement is a modded keycode, the activation of those mods
+        // will happen in the same keyboard report as the deactivation of the
+        // suppressed mods, so there is no “flashing modifiers” problem.
+        if (!QK_MODS_GET_MODS(override->replacement)) {
+            // Send a dummy keycode before unregistering the modifier(s)
+            // so that suppressing the modifier(s) doesn't falsely get interpreted
+            // by the host OS as a tap of a modifier key.
+            // For example, unintended activations of the start menu on Windows when
+            // using a GUI+<kc> key override with suppressed mods.
+            neutralize_flashing_modifiers(active_mods & override->suppressed_mods);
+            // The `& override->suppressed_mods` is to make sure we don't waste our time
+            // neutralizing modifiers that aren't even going to be suppressed anyways.
+        }
 #endif
 
         active_override                 = override;

--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -333,7 +333,7 @@ static bool try_activating_override(const uint16_t keycode, const uint8_t layer,
         // If the replacement is a modded keycode, the activation of those mods
         // will happen in the same keyboard report as the deactivation of the
         // suppressed mods, so there is no “flashing modifiers” problem.
-        if (!QK_MODS_GET_MODS(override->replacement)) {
+        if (!(IS_QK_MODS(override->replacement) && QK_MODS_GET_MODS(override->replacement))) {
             // Send a dummy keycode before unregistering the modifier(s)
             // so that suppressing the modifier(s) doesn't falsely get interpreted
             // by the host OS as a tap of a modifier key.

--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -214,8 +214,8 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
     }
 
 #ifdef DUMMY_MOD_NEUTRALIZER_KEYCODE
-	// Tap dummy mod neutralizer again after reregistering mod key
-	neutralize_flashing_modifiers(active_override->trigger_mods);
+    // Tap dummy mod neutralizer again after reregistering mod key
+    neutralize_flashing_modifiers(active_override->trigger_mods);
 #endif
 
     send_keyboard_report();

--- a/tests/key_overrides/mod_neutralizer/config.h
+++ b/tests/key_overrides/mod_neutralizer/config.h
@@ -8,4 +8,5 @@
 #define DUMMY_MOD_NEUTRALIZER_KEYCODE KC_F18
 
 // Neutralize left alt and left GUI (Default value)
-#define MODS_TO_NEUTRALIZE { MOD_BIT(KC_LEFT_ALT), MOD_BIT(KC_LEFT_GUI) }
+#define MODS_TO_NEUTRALIZE \
+    { MOD_BIT(KC_LEFT_ALT), MOD_BIT(KC_LEFT_GUI) }

--- a/tests/key_overrides/mod_neutralizer/config.h
+++ b/tests/key_overrides/mod_neutralizer/config.h
@@ -1,0 +1,11 @@
+// Copyright 2023 Vladislav Kucheriavykh (@precondition)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define DUMMY_MOD_NEUTRALIZER_KEYCODE KC_F18
+
+// Neutralize left alt and left GUI (Default value)
+#define MODS_TO_NEUTRALIZE { MOD_BIT(KC_LEFT_ALT), MOD_BIT(KC_LEFT_GUI) }

--- a/tests/key_overrides/mod_neutralizer/custom_key_overrides.c
+++ b/tests/key_overrides/mod_neutralizer/custom_key_overrides.c
@@ -3,25 +3,21 @@
 #include "quantum.h"
 
 const key_override_t **key_overrides = (const key_override_t *[]){
-  &ko_make_basic(MOD_MASK_SHIFT, KC_BSPC, KC_DEL),
-  &ko_make_basic(MOD_BIT_LGUI, KC_H, KC_6),
-  &ko_make_basic(MOD_BIT_LGUI, KC_D, LGUI(KC_V)),
-  &ko_make_basic(MOD_BIT_LCTRL, KC_D, LCTL(KC_V)),
-  &((const key_override_t){
-       .trigger_mods           = MOD_BIT(KC_LALT),
-       .layers                 = ~0x0,
-       .suppressed_mods        = 0, // Don't suppress anything
-       .options                = 0,
-       .negative_mod_mask      = 0,
-       .custom_action          = NULL,
-       .context                = NULL,
-       .trigger                = KC_1,
-       .replacement            = KC_P1,
-       .enabled                = NULL
-  }),
-  &ko_make_basic(MOD_BIT_LGUI|MOD_BIT_LALT, KC_Y, LCTL(LGUI(KC_W))),
-  &ko_make_basic(MOD_BIT_LGUI, KC_GRAVE, LCTL(LALT(KC_ESCAPE))),
-  NULL // NULL terminates the array of overrides
+    &ko_make_basic(MOD_MASK_SHIFT, KC_BSPC, KC_DEL),
+    &ko_make_basic(MOD_BIT_LGUI, KC_H, KC_6),
+    &ko_make_basic(MOD_BIT_LGUI, KC_D, LGUI(KC_V)),
+    &ko_make_basic(MOD_BIT_LCTRL, KC_D, LCTL(KC_V)),
+    &((const key_override_t){.trigger_mods      = MOD_BIT(KC_LALT),
+                             .layers            = ~0x0,
+                             .suppressed_mods   = 0, // Don't suppress anything
+                             .options           = 0,
+                             .negative_mod_mask = 0,
+                             .custom_action     = NULL,
+                             .context           = NULL,
+                             .trigger           = KC_1,
+                             .replacement       = KC_P1,
+                             .enabled           = NULL}),
+    &ko_make_basic(MOD_BIT_LGUI | MOD_BIT_LALT, KC_Y, LCTL(LGUI(KC_W))),
+    &ko_make_basic(MOD_BIT_LGUI, KC_GRAVE, LCTL(LALT(KC_ESCAPE))),
+    NULL // NULL terminates the array of overrides
 };
-
-

--- a/tests/key_overrides/mod_neutralizer/custom_key_overrides.c
+++ b/tests/key_overrides/mod_neutralizer/custom_key_overrides.c
@@ -1,0 +1,27 @@
+// Copyright 2023 Vladislav Kucheriavykh (@precondition)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+
+const key_override_t **key_overrides = (const key_override_t *[]){
+  &ko_make_basic(MOD_MASK_SHIFT, KC_BSPC, KC_DEL),
+  &ko_make_basic(MOD_BIT_LGUI, KC_H, KC_6),
+  &ko_make_basic(MOD_BIT_LGUI, KC_D, LGUI(KC_V)),
+  &ko_make_basic(MOD_BIT_LCTRL, KC_D, LCTL(KC_V)),
+  &((const key_override_t){
+       .trigger_mods           = MOD_BIT(KC_LALT),
+       .layers                 = ~0x0,
+       .suppressed_mods        = 0, // Don't suppress anything
+       .options                = 0,
+       .negative_mod_mask      = 0,
+       .custom_action          = NULL,
+       .context                = NULL,
+       .trigger                = KC_1,
+       .replacement            = KC_P1,
+       .enabled                = NULL
+  }),
+  &ko_make_basic(MOD_BIT_LGUI|MOD_BIT_LALT, KC_Y, LCTL(LGUI(KC_W))),
+  &ko_make_basic(MOD_BIT_LGUI, KC_GRAVE, LCTL(LALT(KC_ESCAPE))),
+  NULL // NULL terminates the array of overrides
+};
+
+

--- a/tests/key_overrides/mod_neutralizer/test.mk
+++ b/tests/key_overrides/mod_neutralizer/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2023 Vladislav Kucheriavykh (@precondition)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+KEY_OVERRIDE_ENABLE = yes
+
+INTROSPECTION_KEYMAP_C = custom_key_overrides.c

--- a/tests/key_overrides/mod_neutralizer/test_key_overrides.cpp
+++ b/tests/key_overrides/mod_neutralizer/test_key_overrides.cpp
@@ -25,9 +25,9 @@ TEST_F(NeutralizedKeyOverrides, modifier_is_suppressed_but_not_neutralized) {
     // suppressed nonetheless.
 
     TestDriver driver;
-    KeymapKey key_lctrl(0, 0, 0, KC_LEFT_CTRL);
-    KeymapKey key_lsft(0, 0, 1, KC_LEFT_SHIFT);
-    KeymapKey key_bspc(0, 1, 0, KC_BACKSPACE);
+    KeymapKey  key_lctrl(0, 0, 0, KC_LEFT_CTRL);
+    KeymapKey  key_lsft(0, 0, 1, KC_LEFT_SHIFT);
+    KeymapKey  key_bspc(0, 1, 0, KC_BACKSPACE);
 
     set_keymap({key_lctrl, key_lsft, key_bspc});
 
@@ -57,18 +57,17 @@ TEST_F(NeutralizedKeyOverrides, modifier_is_suppressed_but_not_neutralized) {
     VERIFY_AND_CLEAR(driver);
 }
 
-
 TEST_F(NeutralizedKeyOverrides, modifier_is_suppressed_and_neutralized) {
     // Tested key override:
     // ko_make_basic(MOD_BIT_LGUI, KC_H, KC_6)
     //
-    // MOD_BIT_LGUI is part of the MODS_TO_NEUTRALIZE so the 
+    // MOD_BIT_LGUI is part of the MODS_TO_NEUTRALIZE so the
     // DUMMY_MOD_NEUTRALIZER_KEYCODE should get sent during
     // the suppression of the GUI modifier.
 
     TestDriver driver;
-    KeymapKey key_lgui(0, 0, 0, KC_LEFT_GUI);
-    KeymapKey key_h(0, 1, 0, KC_H);
+    KeymapKey  key_lgui(0, 0, 0, KC_LEFT_GUI);
+    KeymapKey  key_h(0, 1, 0, KC_H);
 
     set_keymap({key_lgui, key_h});
 
@@ -96,13 +95,12 @@ TEST_F(NeutralizedKeyOverrides, modifier_is_suppressed_and_neutralized) {
     key_lgui.release();
     // The two following reports should also be sent but they're not.
     // See qmk_firmware issue #22208.
-    //EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
-    //EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    // EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    // EXPECT_REPORT(driver, (KC_LEFT_GUI));
     EXPECT_EMPTY_REPORT(driver);
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
-
 
 TEST_F(NeutralizedKeyOverrides, active_mods_must_match_exactly) {
     // Tested key override:
@@ -115,9 +113,9 @@ TEST_F(NeutralizedKeyOverrides, active_mods_must_match_exactly) {
     // Shift+Backspace into Delete.
 
     TestDriver driver;
-    KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
-    KeymapKey key_lsft(0, 0, 1, KC_LEFT_SHIFT);
-    KeymapKey key_bspc(0, 1, 0, KC_BACKSPACE);
+    KeymapKey  key_lalt(0, 0, 0, KC_LEFT_ALT);
+    KeymapKey  key_lsft(0, 0, 1, KC_LEFT_SHIFT);
+    KeymapKey  key_bspc(0, 1, 0, KC_BACKSPACE);
 
     set_keymap({key_lalt, key_lsft, key_bspc});
 
@@ -152,7 +150,6 @@ TEST_F(NeutralizedKeyOverrides, active_mods_must_match_exactly) {
     VERIFY_AND_CLEAR(driver);
 }
 
-
 TEST_F(NeutralizedKeyOverrides, do_not_suppress_if_replacement_uses_same_mods) {
     // Tested key override:
     // ko_make_basic(MOD_BIT_LCTRL, KC_D, LCTL(KC_V))
@@ -161,8 +158,8 @@ TEST_F(NeutralizedKeyOverrides, do_not_suppress_if_replacement_uses_same_mods) {
     // mod suppression and consequently no need for mod neutralization.
 
     TestDriver driver;
-    KeymapKey key_lctrl(0, 0, 0, KC_LEFT_CTRL);
-    KeymapKey key_d(0, 1, 0, KC_D);
+    KeymapKey  key_lctrl(0, 0, 0, KC_LEFT_CTRL);
+    KeymapKey  key_d(0, 1, 0, KC_D);
 
     set_keymap({key_lctrl, key_d});
 
@@ -192,7 +189,6 @@ TEST_F(NeutralizedKeyOverrides, do_not_suppress_if_replacement_uses_same_mods) {
     VERIFY_AND_CLEAR(driver);
 }
 
-
 TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_same_mods) {
     // Tested key override:
     // ko_make_basic(MOD_BIT_LGUI, KC_D, LGUI(KC_V))
@@ -201,8 +197,8 @@ TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_same_mods)
     // mod suppression and consequently no need for mod neutralization.
 
     TestDriver driver;
-    KeymapKey key_lgui(0, 0, 0, KC_LEFT_GUI);
-    KeymapKey key_d(0, 1, 0, KC_D);
+    KeymapKey  key_lgui(0, 0, 0, KC_LEFT_GUI);
+    KeymapKey  key_d(0, 1, 0, KC_D);
 
     set_keymap({key_lgui, key_d});
 
@@ -219,7 +215,7 @@ TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_same_mods)
     key_lgui.release();
     {
         InSequence seq;
-        
+
         EXPECT_REPORT(driver, (KC_LEFT_GUI));
         EXPECT_EMPTY_REPORT(driver);
     }
@@ -232,7 +228,6 @@ TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_same_mods)
     VERIFY_AND_CLEAR(driver);
 }
 
-
 TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_any_mods) {
     // Tested key override:
     // ko_make_basic(MOD_BIT_LGUI, KC_GRAVE, LCTL(LALT(KC_ESCAPE)))
@@ -243,8 +238,8 @@ TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_any_mods) 
     // neutralize the trigger mods for us.
 
     TestDriver driver;
-    KeymapKey key_lgui(0, 0, 0, KC_LEFT_GUI);
-    KeymapKey key_grv(0, 1, 0, KC_GRAVE);
+    KeymapKey  key_lgui(0, 0, 0, KC_LEFT_GUI);
+    KeymapKey  key_grv(0, 1, 0, KC_GRAVE);
 
     set_keymap({key_lgui, key_grv});
 
@@ -274,15 +269,14 @@ TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_any_mods) 
     VERIFY_AND_CLEAR(driver);
 }
 
-
 TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_no_mods_are_suppressed) {
     // Tested key override:
-    // like ko_make_basic(MOD_BIT_LALT, KC_1, KC_P1)  but with 
+    // like ko_make_basic(MOD_BIT_LALT, KC_1, KC_P1)  but with
     // `suppressed_mods` forcibly set to 0
 
     TestDriver driver;
-    KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
-    KeymapKey key_1(0, 1, 0, KC_1);
+    KeymapKey  key_lalt(0, 0, 0, KC_LEFT_ALT);
+    KeymapKey  key_1(0, 1, 0, KC_1);
 
     set_keymap({key_lalt, key_1});
 
@@ -315,23 +309,22 @@ TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_no_mods_are_suppressed) {
     VERIFY_AND_CLEAR(driver);
 }
 
-
 TEST_F(NeutralizedKeyOverrides, do_not_neutralize_set_diff_between_trigger_and_replacement_mods) {
     // Tested key override:
     // ko_make_basic(MOD_BIT_LGUI|MOD_BIT_LALT, KC_Y, LCTL(LGUI(KC_W)))
     //
     // Although the set difference between the trigger mods (MOD_BIT_LGUI|MOD_BIT_LALT) and
-    // replacement mods (MOD_BIT_LCTL|MOD_BIT_LGUI) is a bitset (MOD_BIT_LALT) in the 
+    // replacement mods (MOD_BIT_LCTL|MOD_BIT_LGUI) is a bitset (MOD_BIT_LALT) in the
     // MODS_TO_NEUTRALIZE, the DUMMY_MOD_NEUTRALIZER_KEYCODE should not be sent.
     {
         InSequence seq;
 
         TestDriver driver;
-        KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
-        KeymapKey key_lgui(0, 0, 1, KC_LEFT_GUI);
-        KeymapKey key_lctrl(0, 0, 2, KC_LEFT_CTRL);
-        KeymapKey key_lsft(0, 0, 3, KC_LEFT_SHIFT);
-        KeymapKey key_y(0, 1, 0, KC_Y);
+        KeymapKey  key_lalt(0, 0, 0, KC_LEFT_ALT);
+        KeymapKey  key_lgui(0, 0, 1, KC_LEFT_GUI);
+        KeymapKey  key_lctrl(0, 0, 2, KC_LEFT_CTRL);
+        KeymapKey  key_lsft(0, 0, 3, KC_LEFT_SHIFT);
+        KeymapKey  key_y(0, 1, 0, KC_Y);
 
         set_keymap({key_lalt, key_lgui, key_lctrl, key_lsft, key_y});
 
@@ -368,22 +361,21 @@ TEST_F(NeutralizedKeyOverrides, do_not_neutralize_set_diff_between_trigger_and_r
     }
 }
 
-
 TEST_F(NeutralizedKeyOverrides, chaining_overrides_with_same_trigger_mods) {
     // Tested key overrides:
     // ko_make_basic(MOD_BIT_LGUI, KC_H, KC_6)
     // ko_make_basic(MOD_BIT_LGUI, KC_D, LGUI(KC_V))
 
-    { 
+    {
         InSequence seq;
 
         TestDriver driver;
-        KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
-        KeymapKey key_lgui(0, 0, 1, KC_LEFT_GUI);
-        KeymapKey key_lctrl(0, 0, 2, KC_LEFT_CTRL);
-        KeymapKey key_lsft(0, 0, 3, KC_LEFT_SHIFT);
-        KeymapKey key_d(0, 1, 0, KC_D);
-        KeymapKey key_h(0, 1, 1, KC_H);
+        KeymapKey  key_lalt(0, 0, 0, KC_LEFT_ALT);
+        KeymapKey  key_lgui(0, 0, 1, KC_LEFT_GUI);
+        KeymapKey  key_lctrl(0, 0, 2, KC_LEFT_CTRL);
+        KeymapKey  key_lsft(0, 0, 3, KC_LEFT_SHIFT);
+        KeymapKey  key_d(0, 1, 0, KC_D);
+        KeymapKey  key_h(0, 1, 1, KC_H);
 
         set_keymap({key_lalt, key_lgui, key_lctrl, key_lsft, key_d, key_h});
 
@@ -404,7 +396,7 @@ TEST_F(NeutralizedKeyOverrides, chaining_overrides_with_same_trigger_mods) {
 
         key_h.press();
         // Ideally, we wouldn't have to send DUMMY_MOD_NEUTRALIZER_KEYCODE since
-        // the previous GUI+D→GUI+V already “consumed” the LGUI but solving that 
+        // the previous GUI+D→GUI+V already “consumed” the LGUI but solving that
         // issue might require more code than is worth it (perhaps?)
         EXPECT_REPORT(driver, (DUMMY_MOD_NEUTRALIZER_KEYCODE, KC_LEFT_GUI));
         EXPECT_REPORT(driver, (KC_LEFT_GUI));
@@ -419,7 +411,7 @@ TEST_F(NeutralizedKeyOverrides, chaining_overrides_with_same_trigger_mods) {
 
         key_h.press();
         // Ideally, we wouldn't have to send DUMMY_MOD_NEUTRALIZER_KEYCODE since
-        // the previous GUI+V *and* GUI+H→6 already “consumed” the LGUI but solving 
+        // the previous GUI+V *and* GUI+H→6 already “consumed” the LGUI but solving
         // that issue might require more code than is worth it (perhaps?)
         EXPECT_REPORT(driver, (DUMMY_MOD_NEUTRALIZER_KEYCODE, KC_LEFT_GUI));
         EXPECT_REPORT(driver, (KC_LEFT_GUI));

--- a/tests/key_overrides/mod_neutralizer/test_key_overrides.cpp
+++ b/tests/key_overrides/mod_neutralizer/test_key_overrides.cpp
@@ -1,0 +1,440 @@
+// Copyright 2023 Vladislav Kucheriavykh (@precondition)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "keyboard_report_util.hpp"
+#include "quantum.h"
+#include "keycode.h"
+#include "test_common.h"
+#include "test_driver.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+class NeutralizedKeyOverrides : public TestFixture {};
+
+TEST_F(NeutralizedKeyOverrides, modifier_is_suppressed_but_not_neutralized) {
+    // Tested key override:
+    // ko_make_basic(MOD_MASK_SHIFT, KC_BSPC, KC_DEL),
+    //
+    // MOD_MASK_SHIFT is not part of MODS_TO_NEUTRALIZE so we need to make
+    // sure that no dummy mod neutralizer keycode gets sent when this key
+    // override is getting triggered. However, the replacement (KC_DEL) is
+    // not a shifted keycode, so the shift of the trigger should be
+    // suppressed nonetheless.
+
+    TestDriver driver;
+    KeymapKey key_lctrl(0, 0, 0, KC_LEFT_CTRL);
+    KeymapKey key_lsft(0, 0, 1, KC_LEFT_SHIFT);
+    KeymapKey key_bspc(0, 1, 0, KC_BACKSPACE);
+
+    set_keymap({key_lctrl, key_lsft, key_bspc});
+
+    key_lsft.press();
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    // Left shift should be removed from the report but no dummy keycode
+    // should be inserted because left shift is not in the list of mods
+    // to neutralize.
+    key_bspc.press();
+    EXPECT_REPORT(driver, (KC_DELETE));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    // Left shift is still held down so we should restore it after
+    // sending the overriden key with suppressed mods.
+    key_bspc.release();
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lsft.release();
+    EXPECT_EMPTY_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(NeutralizedKeyOverrides, modifier_is_suppressed_and_neutralized) {
+    // Tested key override:
+    // ko_make_basic(MOD_BIT_LGUI, KC_H, KC_6)
+    //
+    // MOD_BIT_LGUI is part of the MODS_TO_NEUTRALIZE so the 
+    // DUMMY_MOD_NEUTRALIZER_KEYCODE should get sent during
+    // the suppression of the GUI modifier.
+
+    TestDriver driver;
+    KeymapKey key_lgui(0, 0, 0, KC_LEFT_GUI);
+    KeymapKey key_h(0, 1, 0, KC_H);
+
+    set_keymap({key_lgui, key_h});
+
+    key_lgui.press();
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_h.press();
+    {
+        InSequence seq;
+
+        EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        EXPECT_REPORT(driver, (KC_6));
+    }
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_h.release();
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lgui.release();
+    // The two following reports should also be sent but they're not.
+    // See qmk_firmware issue #22208.
+    //EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    //EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    EXPECT_EMPTY_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(NeutralizedKeyOverrides, active_mods_must_match_exactly) {
+    // Tested key override:
+    // ko_make_basic(MOD_MASK_SHIFT, KC_BSPC, KC_DEL),
+    //
+    // The active modifiers should match exactly one of neutralized mod masks.
+    // If MOD_BIT_LALT is part of MODS_TO_NEUTRALIZE, that doesn't mean that
+    // Shift+Alt+Backspace should trigger the DUMMY_MOD_NEUTRALIZER_KEYCODE,
+    // even though it should trigger the key override and replace
+    // Shift+Backspace into Delete.
+
+    TestDriver driver;
+    KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
+    KeymapKey key_lsft(0, 0, 1, KC_LEFT_SHIFT);
+    KeymapKey key_bspc(0, 1, 0, KC_BACKSPACE);
+
+    set_keymap({key_lalt, key_lsft, key_bspc});
+
+    key_lsft.press();
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lalt.press();
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_ALT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_bspc.press();
+    EXPECT_REPORT(driver, (KC_LEFT_ALT, KC_DELETE));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_bspc.release();
+    EXPECT_REPORT(driver, (KC_LEFT_ALT, KC_LEFT_SHIFT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lsft.release();
+    EXPECT_REPORT(driver, (KC_LEFT_ALT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lalt.release();
+    EXPECT_EMPTY_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(NeutralizedKeyOverrides, do_not_suppress_if_replacement_uses_same_mods) {
+    // Tested key override:
+    // ko_make_basic(MOD_BIT_LCTRL, KC_D, LCTL(KC_V))
+    //
+    // If the replacement mods correspond to the trigger mods, there is no need for
+    // mod suppression and consequently no need for mod neutralization.
+
+    TestDriver driver;
+    KeymapKey key_lctrl(0, 0, 0, KC_LEFT_CTRL);
+    KeymapKey key_d(0, 1, 0, KC_D);
+
+    set_keymap({key_lctrl, key_d});
+
+    key_lctrl.press();
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_d.press();
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL, KC_V));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lctrl.release();
+    {
+        InSequence seq;
+
+        EXPECT_REPORT(driver, (KC_LEFT_CTRL));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_d.release();
+    EXPECT_NO_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_same_mods) {
+    // Tested key override:
+    // ko_make_basic(MOD_BIT_LGUI, KC_D, LGUI(KC_V))
+    //
+    // If the replacement mods correspond to the trigger mods, there is no need for
+    // mod suppression and consequently no need for mod neutralization.
+
+    TestDriver driver;
+    KeymapKey key_lgui(0, 0, 0, KC_LEFT_GUI);
+    KeymapKey key_d(0, 1, 0, KC_D);
+
+    set_keymap({key_lgui, key_d});
+
+    key_lgui.press();
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_d.press();
+    EXPECT_REPORT(driver, (KC_LEFT_GUI, KC_V));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lgui.release();
+    {
+        InSequence seq;
+        
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_d.release();
+    EXPECT_NO_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_replacement_uses_any_mods) {
+    // Tested key override:
+    // ko_make_basic(MOD_BIT_LGUI, KC_GRAVE, LCTL(LALT(KC_ESCAPE)))
+    //
+    // The mods of the replacement are activated in the same keyboard report as
+    // the deactivation of the suppressed mods so there is no need to send the
+    // DUMMY_MOD_NEUTRALIZER_KEYCODE; the replacement mods will already
+    // neutralize the trigger mods for us.
+
+    TestDriver driver;
+    KeymapKey key_lgui(0, 0, 0, KC_LEFT_GUI);
+    KeymapKey key_grv(0, 1, 0, KC_GRAVE);
+
+    set_keymap({key_lgui, key_grv});
+
+    key_lgui.press();
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_grv.press();
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL, KC_LEFT_ALT, KC_ESCAPE));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lgui.release();
+    {
+        InSequence seq;
+
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_grv.release();
+    EXPECT_NO_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(NeutralizedKeyOverrides, do_not_neutralize_if_no_mods_are_suppressed) {
+    // Tested key override:
+    // like ko_make_basic(MOD_BIT_LALT, KC_1, KC_P1)  but with 
+    // `suppressed_mods` forcibly set to 0
+
+    TestDriver driver;
+    KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
+    KeymapKey key_1(0, 1, 0, KC_1);
+
+    set_keymap({key_lalt, key_1});
+
+    key_lalt.press();
+    EXPECT_REPORT(driver, (KC_LEFT_ALT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_1.press();
+    EXPECT_REPORT(driver, (KC_LEFT_ALT, KC_P1));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    key_lalt.release();
+    {
+        InSequence seq;
+
+        EXPECT_REPORT(driver, (KC_LEFT_ALT));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_1));
+    idle_for(10000);
+
+    key_1.release();
+    EXPECT_EMPTY_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(NeutralizedKeyOverrides, do_not_neutralize_set_diff_between_trigger_and_replacement_mods) {
+    // Tested key override:
+    // ko_make_basic(MOD_BIT_LGUI|MOD_BIT_LALT, KC_Y, LCTL(LGUI(KC_W)))
+    //
+    // Although the set difference between the trigger mods (MOD_BIT_LGUI|MOD_BIT_LALT) and
+    // replacement mods (MOD_BIT_LCTL|MOD_BIT_LGUI) is a bitset (MOD_BIT_LALT) in the 
+    // MODS_TO_NEUTRALIZE, the DUMMY_MOD_NEUTRALIZER_KEYCODE should not be sent.
+    {
+        InSequence seq;
+
+        TestDriver driver;
+        KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
+        KeymapKey key_lgui(0, 0, 1, KC_LEFT_GUI);
+        KeymapKey key_lctrl(0, 0, 2, KC_LEFT_CTRL);
+        KeymapKey key_lsft(0, 0, 3, KC_LEFT_SHIFT);
+        KeymapKey key_y(0, 1, 0, KC_Y);
+
+        set_keymap({key_lalt, key_lgui, key_lctrl, key_lsft, key_y});
+
+        key_lalt.press();
+        EXPECT_REPORT(driver, (KC_LEFT_ALT));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_lgui.press();
+        EXPECT_REPORT(driver, (KC_LEFT_GUI, KC_LEFT_ALT));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_y.press();
+        EXPECT_REPORT(driver, (KC_LEFT_CTRL, KC_LEFT_GUI, KC_W));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_lalt.release();
+        EXPECT_REPORT(driver, (KC_LEFT_ALT, KC_LEFT_GUI));
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_y.release();
+        EXPECT_NO_REPORT(driver);
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_lgui.release();
+        EXPECT_EMPTY_REPORT(driver);
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+    }
+}
+
+
+TEST_F(NeutralizedKeyOverrides, chaining_overrides_with_same_trigger_mods) {
+    // Tested key overrides:
+    // ko_make_basic(MOD_BIT_LGUI, KC_H, KC_6)
+    // ko_make_basic(MOD_BIT_LGUI, KC_D, LGUI(KC_V))
+
+    { 
+        InSequence seq;
+
+        TestDriver driver;
+        KeymapKey key_lalt(0, 0, 0, KC_LEFT_ALT);
+        KeymapKey key_lgui(0, 0, 1, KC_LEFT_GUI);
+        KeymapKey key_lctrl(0, 0, 2, KC_LEFT_CTRL);
+        KeymapKey key_lsft(0, 0, 3, KC_LEFT_SHIFT);
+        KeymapKey key_d(0, 1, 0, KC_D);
+        KeymapKey key_h(0, 1, 1, KC_H);
+
+        set_keymap({key_lalt, key_lgui, key_lctrl, key_lsft, key_d, key_h});
+
+        key_lgui.press();
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_d.press();
+        EXPECT_REPORT(driver, (KC_LEFT_GUI, KC_V));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_d.release();
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_h.press();
+        // Ideally, we wouldn't have to send DUMMY_MOD_NEUTRALIZER_KEYCODE since
+        // the previous GUI+D→GUI+V already “consumed” the LGUI but solving that 
+        // issue might require more code than is worth it (perhaps?)
+        EXPECT_REPORT(driver, (DUMMY_MOD_NEUTRALIZER_KEYCODE, KC_LEFT_GUI));
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        EXPECT_REPORT(driver, (KC_6));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_h.release();
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_h.press();
+        // Ideally, we wouldn't have to send DUMMY_MOD_NEUTRALIZER_KEYCODE since
+        // the previous GUI+V *and* GUI+H→6 already “consumed” the LGUI but solving 
+        // that issue might require more code than is worth it (perhaps?)
+        EXPECT_REPORT(driver, (DUMMY_MOD_NEUTRALIZER_KEYCODE, KC_LEFT_GUI));
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        EXPECT_REPORT(driver, (KC_6));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_h.release();
+        EXPECT_REPORT(driver, (KC_LEFT_GUI));
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        key_lgui.release();
+        EXPECT_EMPTY_REPORT(driver);
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Inspired by [sigprof's comment](https://github.com/qmk/qmk_firmware/pull/22209#issuecomment-1749535319) in #22209, I made a few code additions to `quantum/process_keycode/process_key_overrides.c` with negligible increase in firmware size  (my AVR keymap with 3 key overrides created for testing only increased by 14 bytes) that aim to remove some superfluous taps of the `DUMMY_MOD_NEUTRALIZER_KEYCODE`.

There are two main use cases aimed by this pull request:
1. The replacement keycode is a modded keycode (covered by test `do_not_neutralize_if_replacement_uses_any_mods`)
1.1. The replacement keycode's mods are the same as the trigger mods (covered by test `do_not_neutralize_if_replacement_uses_same_mods`)
2. The trigger mods are not suppressed (covered by test `do_not_neutralize_if_no_mods_are_suppressed`)

While I was at it, I added a few more unit tests related to the interplay between key overrides and `DUMMY_MOD_NEUTRALIZER_KEYCODE`, which includes a unit test to illustrate issue #22208 called `modifier_is_suppressed_and_neutralized`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
