### PR TITLE
`qmk find`: Fix failure with multiple filters

### DIFF
--- a/lib/python/qmk/search.py
+++ b/lib/python/qmk/search.py
@@ -172,7 +172,7 @@ def _filter_keymap_targets(target_list: List[Tuple[str, str]], filters: List[str
                 cli.log.warning(f'Unrecognized filter expression: {filter_expr}')
                 continue
 
-            targets = [KeyboardKeymapBuildTarget(keyboard=e[0], keymap=e[1], json=e[2]) for e in valid_keymaps]
+        targets = [KeyboardKeymapBuildTarget(keyboard=e[0], keymap=e[1], json=e[2]) for e in valid_keymaps]
 
     return targets
 


### PR DESCRIPTION
## Description

When multiple `-f FILTER` options were specified, `qmk find` did not return anything at all instead of printing the list of entries that matched all of the specified filters.

The problem was that the statement in `_filter_keymap_targets()` that filled `targets` had a wrong indent and therefore was executed for every filter instead of only once after applying all filters, and `valid_keymaps` was actually an iterator and therefore could be used only once.  Moving the statement outside of the loop fixes the problem.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Commands like `qmk find -f "protocol=V-USB" -f features.rgblight=true` with more than one `-f FILTER` option did not give any output even when there were some keyboards which matched the specified filters.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
