### PR TITLE
Changed order of layer-checking code to fix #22520

### DIFF
--- a/keyboards/splitkb/aurora/corne/corne.c
+++ b/keyboards/splitkb/aurora/corne/corne.c
@@ -212,14 +212,14 @@ static void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_LOWER)) {
+    if(layer_state_is(_ADJUST)) {
+        oled_write_P(adjust_layer, false);
+    } else if(layer_state_is(_LOWER)) {
         oled_write_P(lower_layer, false);
     } else if(layer_state_is(_RAISE)) {
         oled_write_P(raise_layer, false);
-    } else if(layer_state_is(_DEFAULT)) {
-        oled_write_P(default_layer, false);
     } else {
-        oled_write_P(adjust_layer, false);
+        oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/corne/corne.c
+++ b/keyboards/splitkb/aurora/corne/corne.c
@@ -212,14 +212,19 @@ static void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_ADJUST)) {
-        oled_write_P(adjust_layer, false);
-    } else if(layer_state_is(_LOWER)) {
-        oled_write_P(lower_layer, false);
-    } else if(layer_state_is(_RAISE)) {
-        oled_write_P(raise_layer, false);
-    } else {
-        oled_write_P(default_layer, false);
+
+    switch (get_highest_layer(layer_state | default_layer_state)) {
+        case _LOWER:
+            oled_write_P(lower_layer, false);
+            break;
+        case _RAISE:
+            oled_write_P(raise_layer, false);
+            break;
+        case _ADJUST:
+            oled_write_P(adjust_layer, false);
+            break;
+        default:
+            oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/helix/helix.c
+++ b/keyboards/splitkb/aurora/helix/helix.c
@@ -208,14 +208,19 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_ADJUST)) {
-        oled_write_P(adjust_layer, false);
-    } else if(layer_state_is(_LOWER)) {
-        oled_write_P(lower_layer, false);
-    } else if(layer_state_is(_RAISE)) {
-        oled_write_P(raise_layer, false);
-    } else {
-        oled_write_P(default_layer, false);
+
+    switch (get_highest_layer(layer_state | default_layer_state)) {
+        case _LOWER:
+            oled_write_P(lower_layer, false);
+            break;
+        case _RAISE:
+            oled_write_P(raise_layer, false);
+            break;
+        case _ADJUST:
+            oled_write_P(adjust_layer, false);
+            break;
+        default:
+            oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/helix/helix.c
+++ b/keyboards/splitkb/aurora/helix/helix.c
@@ -208,14 +208,14 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_LOWER)) {
+    if(layer_state_is(_ADJUST)) {
+        oled_write_P(adjust_layer, false);
+    } else if(layer_state_is(_LOWER)) {
         oled_write_P(lower_layer, false);
     } else if(layer_state_is(_RAISE)) {
         oled_write_P(raise_layer, false);
-    } else if(layer_state_is(_DEFAULT)) {
-        oled_write_P(default_layer, false);
     } else {
-        oled_write_P(adjust_layer, false);
+        oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/lily58/lily58.c
+++ b/keyboards/splitkb/aurora/lily58/lily58.c
@@ -212,14 +212,14 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_LOWER)) {
+    if(layer_state_is(_ADJUST)) {
+        oled_write_P(adjust_layer, false);
+    } else if(layer_state_is(_LOWER)) {
         oled_write_P(lower_layer, false);
     } else if(layer_state_is(_RAISE)) {
         oled_write_P(raise_layer, false);
-    } else if(layer_state_is(_DEFAULT)) {
-        oled_write_P(default_layer, false);
     } else {
-        oled_write_P(adjust_layer, false);
+        oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/lily58/lily58.c
+++ b/keyboards/splitkb/aurora/lily58/lily58.c
@@ -212,14 +212,19 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_ADJUST)) {
-        oled_write_P(adjust_layer, false);
-    } else if(layer_state_is(_LOWER)) {
-        oled_write_P(lower_layer, false);
-    } else if(layer_state_is(_RAISE)) {
-        oled_write_P(raise_layer, false);
-    } else {
-        oled_write_P(default_layer, false);
+
+    switch (get_highest_layer(layer_state | default_layer_state)) {
+        case _LOWER:
+            oled_write_P(lower_layer, false);
+            break;
+        case _RAISE:
+            oled_write_P(raise_layer, false);
+            break;
+        case _ADJUST:
+            oled_write_P(adjust_layer, false);
+            break;
+        default:
+            oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/sofle_v2/sofle_v2.c
+++ b/keyboards/splitkb/aurora/sofle_v2/sofle_v2.c
@@ -212,14 +212,14 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_LOWER)) {
+    if(layer_state_is(_ADJUST)) {
+        oled_write_P(adjust_layer, false);
+    } else if(layer_state_is(_LOWER)) {
         oled_write_P(lower_layer, false);
     } else if(layer_state_is(_RAISE)) {
         oled_write_P(raise_layer, false);
-    } else if(layer_state_is(_DEFAULT)) {
-        oled_write_P(default_layer, false);
     } else {
-        oled_write_P(adjust_layer, false);
+        oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/sofle_v2/sofle_v2.c
+++ b/keyboards/splitkb/aurora/sofle_v2/sofle_v2.c
@@ -212,14 +212,19 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_ADJUST)) {
-        oled_write_P(adjust_layer, false);
-    } else if(layer_state_is(_LOWER)) {
-        oled_write_P(lower_layer, false);
-    } else if(layer_state_is(_RAISE)) {
-        oled_write_P(raise_layer, false);
-    } else {
-        oled_write_P(default_layer, false);
+
+    switch (get_highest_layer(layer_state | default_layer_state)) {
+        case _LOWER:
+            oled_write_P(lower_layer, false);
+            break;
+        case _RAISE:
+            oled_write_P(raise_layer, false);
+            break;
+        case _ADJUST:
+            oled_write_P(adjust_layer, false);
+            break;
+        default:
+            oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/sweep/sweep.c
+++ b/keyboards/splitkb/aurora/sweep/sweep.c
@@ -212,14 +212,14 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_LOWER)) {
+    if(layer_state_is(_ADJUST)) {
+        oled_write_P(adjust_layer, false);
+    } else if(layer_state_is(_LOWER)) {
         oled_write_P(lower_layer, false);
     } else if(layer_state_is(_RAISE)) {
         oled_write_P(raise_layer, false);
-    } else if(layer_state_is(_DEFAULT)) {
-        oled_write_P(default_layer, false);
     } else {
-        oled_write_P(adjust_layer, false);
+        oled_write_P(default_layer, false);
     }
 }
 

--- a/keyboards/splitkb/aurora/sweep/sweep.c
+++ b/keyboards/splitkb/aurora/sweep/sweep.c
@@ -212,14 +212,19 @@ void render_layer_state(void) {
         0x20, 0x9d, 0x9e, 0x9f, 0x20,
         0x20, 0xbd, 0xbe, 0xbf, 0x20,
         0x20, 0xdd, 0xde, 0xdf, 0x20, 0};
-    if(layer_state_is(_ADJUST)) {
-        oled_write_P(adjust_layer, false);
-    } else if(layer_state_is(_LOWER)) {
-        oled_write_P(lower_layer, false);
-    } else if(layer_state_is(_RAISE)) {
-        oled_write_P(raise_layer, false);
-    } else {
-        oled_write_P(default_layer, false);
+
+    switch (get_highest_layer(layer_state | default_layer_state)) {
+        case _LOWER:
+            oled_write_P(lower_layer, false);
+            break;
+        case _RAISE:
+            oled_write_P(raise_layer, false);
+            break;
+        case _ADJUST:
+            oled_write_P(adjust_layer, false);
+            break;
+        default:
+            oled_write_P(default_layer, false);
     }
 }
 


### PR DESCRIPTION
The OLED screen will display the wrong layer when the ADJUST layer is entered, it will still show the previous layer entered (either RAISE or LOWER) because the layer checking code returns `true` before even checking whether the ADJUST layer is entered or not. 

The code changes remove the more fragile ordering of if-else checks to case-statement, and changes the called function from `layer_state_is(` to `get_highest_layer(` to ensure we capture the right layer. 

I only verified the bug and the fix on my Aurora Corne board, but as the same code is used over all Aurora boards and the code change is minimal, I submit this PR for the full line. 

## Description

(copied from the Bug report)
Expected behaviour: when pressing the mod keys to enter both the LOWER and RAISE layer, the ADJUST layer is entered, and the OLED screen animation changes accordingly.

Actual behaviour: when entering the ADJUST layer by first hitting the LOWER modifier and then the RAISE modifier, the OLED screen still displays as if the keyboard is in the LOWER layer.
Similarly, if the ADJUST layer is entered by first using the RAISE modifier and then the LOWER modifier, the OLED screen displays as if the board is still in the RAISE layer.

For clarity, this bug is solely on how the OLED screen displays which layer is active, the layers themselves activate and work just fine.
(end copy)

My theory is that the call to ```if(layer_state_is(_LOWER))``` returns `true` when the layer is indeed LOWER, but also when the ADJUST layer is entered by first entering the LOWER layer. And because the check for "is lower" happens before the clause for the adjust layer code, the OLED is updated with the wrong info.

The fix uses a I think better API, and a more robust case-statement. 

cc @leah-splitkb and @thomasbaart 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #22520

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
