### PR TITLE
[CLI] Remove duplicates from search results

### DIFF
--- a/lib/python/qmk/build_targets.py
+++ b/lib/python/qmk/build_targets.py
@@ -31,6 +31,17 @@ class BuildTarget:
     def __repr__(self):
         return f'BuildTarget(keyboard={self.keyboard}, keymap={self.keymap})'
 
+    def __eq__(self, __value: object) -> bool:
+        if not isinstance(__value, BuildTarget):
+            return False
+        return (self.keyboard, self.keymap) == (__value.keyboard, __value.keymap)
+
+    def __ne__(self, __value: object) -> bool:
+        return not self.__eq__(__value)
+
+    def __hash__(self) -> int:
+        return self.__repr__().__hash__()
+
     def configure(self, parallel: int = None, clean: bool = None, compiledb: bool = None) -> None:
         if parallel is not None:
             self._parallel = parallel

--- a/lib/python/qmk/build_targets.py
+++ b/lib/python/qmk/build_targets.py
@@ -34,7 +34,7 @@ class BuildTarget:
     def __eq__(self, __value: object) -> bool:
         if not isinstance(__value, BuildTarget):
             return False
-        return (self.keyboard, self.keymap) == (__value.keyboard, __value.keymap)
+        return self.__repr__() == __value.__repr__()
 
     def __ne__(self, __value: object) -> bool:
         return not self.__eq__(__value)

--- a/lib/python/qmk/search.py
+++ b/lib/python/qmk/search.py
@@ -122,7 +122,7 @@ def _filter_keymap_targets(target_list: List[Tuple[str, str]], filters: List[str
     """
     if len(filters) == 0:
         cli.log.info('Preparing target list...')
-        targets = list(parallel_map(_construct_build_target_kb_km, target_list))
+        targets = list(set(parallel_map(_construct_build_target_kb_km, target_list)))
     else:
         cli.log.info('Parsing data for all matching keyboard/keymap combinations...')
         valid_keymaps = [(e[0], e[1], dotty(e[2])) for e in parallel_map(_load_keymap_info, target_list)]
@@ -183,7 +183,7 @@ def _filter_keymap_targets(target_list: List[Tuple[str, str]], filters: List[str
 
         cli.log.info('Preparing target list...')
         valid_keymaps = [(e[0], e[1], e[2].to_dict() if isinstance(e[2], Dotty) else e[2]) for e in valid_keymaps]  # need to convert dotty_dict back to dict because it doesn't survive parallelisation
-        targets = list(parallel_map(_construct_build_target_kb_km_json, list(valid_keymaps)))
+        targets = list(set(parallel_map(_construct_build_target_kb_km_json, list(valid_keymaps))))
 
     return targets
 


### PR DESCRIPTION
## Description

After #22221 duplicates started showing up in `qmk find` and `qmk mass-compile`. This removes them.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
