### PR TITLE
Add basic presence check for cirque trackpad. 

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -158,12 +158,13 @@ This supports the Cirque Pinnacle 1CA027 Touch Controller, which is used in the 
 
 #### Common settings
 
-| Setting                          | Description                                                | Default                                     |
-| -------------------------------- | ---------------------------------------------------------- | ------------------------------------------- |
-| `CIRQUE_PINNACLE_DIAMETER_MM`    | (Optional) Diameter of the trackpad sensor in millimeters. | `40`                                        |
-| `CIRQUE_PINNACLE_ATTENUATION`    | (Optional) Sets the attenuation of the sensor data.        | `EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_4X` |
-| `CIRQUE_PINNACLE_CURVED_OVERLAY` | (Optional) Applies settings tuned for curved overlay.      | _not defined_                               |
-| `CIRQUE_PINNACLE_POSITION_MODE`  | (Optional) Mode of operation.                              | _not defined_                               |
+| Setting                              | Description                                                | Default                                     |
+| ------------------------------------ | ---------------------------------------------------------- | ------------------------------------------- |
+| `CIRQUE_PINNACLE_DIAMETER_MM`        | (Optional) Diameter of the trackpad sensor in millimeters. | `40`                                        |
+| `CIRQUE_PINNACLE_ATTENUATION`        | (Optional) Sets the attenuation of the sensor data.        | `EXTREG__TRACK_ADCCONFIG__ADC_ATTENUATE_4X` |
+| `CIRQUE_PINNACLE_CURVED_OVERLAY`     | (Optional) Applies settings tuned for curved overlay.      | _not defined_                               |
+| `CIRQUE_PINNACLE_POSITION_MODE`      | (Optional) Mode of operation.                              | _not defined_                               |
+| `CIRQUE_PINNACLE_SKIP_SENSOR_CHECK`  | (Optional) Skips sensor presence check                     | _not defined_                               |
 
 **`CIRQUE_PINNACLE_ATTENUATION`** is a measure of how much data is suppressed in regards to sensitivity. The higher the attenuation, the less sensitive the touchpad will be.
 

--- a/drivers/sensors/cirque_pinnacle.c
+++ b/drivers/sensors/cirque_pinnacle.c
@@ -216,6 +216,13 @@ void cirque_pinnacle_cursor_smoothing(bool enable) {
     RAP_Write(HOSTREG__FEEDCONFIG3, feedconfig3);
 }
 
+// Check sensor is connected
+bool cirque_pinnacle_connected(void) {
+    uint8_t  zidle = 0;
+    RAP_ReadBytes(HOSTREG__ZIDLE, &zidle, 1);
+    return zidle == HOSTREG__ZIDLE_DEFVAL;
+}
+
 /*  Pinnacle-based TM040040/TM035035/TM023023 Functions  */
 void cirque_pinnacle_init(void) {
 #if defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_spi)
@@ -274,6 +281,11 @@ void cirque_pinnacle_init(void) {
     }
 
     cirque_pinnacle_enable_feed(true);
+
+#ifndef CIRQUE_PINNACLE_SKIP_SENSOR_CHECK
+    touchpad_init = cirque_pinnacle_connected();
+#endif
+
 }
 
 pinnacle_data_t cirque_pinnacle_read_data(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Just adds a simple check that the cirque trackpad is connected and working, not completely foolproof but better than how it behaves currently. This stops spurious inputs when SPI is reading random data due to a failed or incorrectly wired cirque.

We don't currently set a default ZIDLE value so seemed a good candidate for the check.

I've only got a SPI cirque from a steam controller to check this with so some feedback from other setups would be useful and appreciated.

I've added `CIRQUE_PINNACLE_SKIP_SENSOR_CHECK` mostly for debugging purposes, the data sheet only specifies one default value but you never know.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
