### PR TITLE
Fix missed shutdown callbacks

### DIFF
--- a/keyboards/bastardkb/dilemma/4x6_4/keymaps/via/keymap.c
+++ b/keyboards/bastardkb/dilemma/4x6_4/keymaps/via/keymap.c
@@ -123,10 +123,3 @@ const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
 };
 // clang-format on
 #endif // ENCODER_MAP_ENABLE
-
-void shutdown_user(void) {
-#ifdef RGB_MATRIX_ENABLE
-    rgb_matrix_sethsv_noeeprom(HSV_RED);
-    rgb_matrix_update_pwm_buffers();
-#endif // RGB_MATRIX_ENABLE
-}


### PR DESCRIPTION
## Description

Fix a couple of keyboards's shutdown_* callbacks
## Types of Changes


- [x] Bugfix
- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* CI

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
