### PR TITLE
Fix AD5258 I2C address for Leopold keyboards

### DIFF
--- a/keyboards/fc660c/ad5258.c
+++ b/keyboards/fc660c/ad5258.c
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // AD5258 I2C digital potentiometer
 // http://www.analog.com/media/en/technical-documentation/data-sheets/AD5258.pdf
 //
-#define AD5258_I2C_ADDRESS 0x18
+#define AD5258_I2C_ADDRESS (0x18<<1) // i2c_master API requires shifting address one bit to the left
 #define AD5258_INST_RDAC   0x00
 #define AD5258_INST_EEPROM 0x20
 

--- a/keyboards/fc660c/ad5258.c
+++ b/keyboards/fc660c/ad5258.c
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // AD5258 I2C digital potentiometer
 // http://www.analog.com/media/en/technical-documentation/data-sheets/AD5258.pdf
 //
-#define AD5258_I2C_ADDRESS (0x18<<1) // i2c_master API requires shifting address one bit to the left
+#define AD5258_I2C_ADDRESS 0x30
 #define AD5258_INST_RDAC   0x00
 #define AD5258_INST_EEPROM 0x20
 

--- a/keyboards/fc980c/ad5258.c
+++ b/keyboards/fc980c/ad5258.c
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // AD5258 I2C digital potentiometer
 // http://www.analog.com/media/en/technical-documentation/data-sheets/AD5258.pdf
 //
-#define AD5258_I2C_ADDRESS 0x18
+#define AD5258_I2C_ADDRESS (0x18<<1) // i2c_master API requires shifting address one bit to the left
 #define AD5258_INST_RDAC   0x00
 #define AD5258_INST_EEPROM 0x20
 

--- a/keyboards/fc980c/ad5258.c
+++ b/keyboards/fc980c/ad5258.c
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // AD5258 I2C digital potentiometer
 // http://www.analog.com/media/en/technical-documentation/data-sheets/AD5258.pdf
 //
-#define AD5258_I2C_ADDRESS (0x18<<1) // i2c_master API requires shifting address one bit to the left
+#define AD5258_I2C_ADDRESS 0x30
 #define AD5258_INST_RDAC   0x00
 #define AD5258_INST_EEPROM 0x20
 


### PR DESCRIPTION
The i2c_master API requires shifting the address [one bit to the left](https://docs.qmk.fm/#/i2c_driver?id=note-on-i2c-addresses).

## Description

Originally, the Leopold code included a custom I2c driver which took the I2C device address as-is. During the refactoring in #21964, the code was migrated to the generic `i2c_master` API which has the quirk that I2C device address have to be shifted by one. That detail was missed in the refactor.

The changes here were originally included with #22260, but that is still waiting on reviews. With the [recent breaking changes update](https://github.com/qmk/qmk_firmware/pull/22553) the I2C address issue has migrated into master, and since I'm unsure when (or if) my original Leopold refactor PR gets reviewed/merged, I've decided to split this out into a separate PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*None*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
