### PR TITLE
Attempt to fix configurator.

### DIFF
--- a/lib/python/qmk/userspace.py
+++ b/lib/python/qmk/userspace.py
@@ -15,11 +15,12 @@ def qmk_userspace_paths():
     test_dirs = []
 
     # If we're already in a directory with a qmk.json and a keyboards or layouts directory, interpret it as userspace
-    current_dir = Path(environ['ORIG_CWD'])
-    while len(current_dir.parts) > 1:
-        if (current_dir / 'qmk.json').is_file():
-            test_dirs.append(current_dir)
-        current_dir = current_dir.parent
+    if 'ORIG_CWD' in environ:
+        current_dir = Path(environ['ORIG_CWD'])
+        while len(current_dir.parts) > 1:
+            if (current_dir / 'qmk.json').is_file():
+                test_dirs.append(current_dir)
+            current_dir = current_dir.parent
 
     # If we have a QMK_USERSPACE environment variable, use that
     if environ.get('QMK_USERSPACE') is not None:

--- a/lib/python/qmk/userspace.py
+++ b/lib/python/qmk/userspace.py
@@ -15,7 +15,7 @@ def qmk_userspace_paths():
     test_dirs = []
 
     # If we're already in a directory with a qmk.json and a keyboards or layouts directory, interpret it as userspace
-    if 'ORIG_CWD' in environ:
+    if environ.get('ORIG_CWD') is not None:
         current_dir = Path(environ['ORIG_CWD'])
         while len(current_dir.parts) > 1:
             if (current_dir / 'qmk.json').is_file():
@@ -24,7 +24,7 @@ def qmk_userspace_paths():
 
     # If we have a QMK_USERSPACE environment variable, use that
     if environ.get('QMK_USERSPACE') is not None:
-        current_dir = Path(environ.get('QMK_USERSPACE'))
+        current_dir = Path(environ['QMK_USERSPACE'])
         if current_dir.is_dir():
             test_dirs.append(current_dir)
 


### PR DESCRIPTION
## Description

From configurator's logs, it seems `$ORIG_CWD` is not being set. Userspace searches it, and bombs out due to nonexistence.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
