### PR TITLE
nullbitsco/snap: reduce size of bongo_reactive

### DIFF
--- a/keyboards/nullbitsco/snap/keymaps/bongo_reactive/config.h
+++ b/keyboards/nullbitsco/snap/keymaps/bongo_reactive/config.h
@@ -29,6 +29,7 @@
 // VIA support won't fit otherwise
 #ifdef RGBLIGHT_ENABLE
 #undef RGBLIGHT_EFFECT_TWINKLE
+#undef RGBLIGHT_EFFECT_RGB_TEST
 #endif //RGB LIGHT_ENABLE
 
 // Split Options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The SNAP bongo_reactive keymap is too large by a pitiful 6 bytes. Reduce the size so that it compiles. 142 bytes free after.

```
Checking file size of nullbitsco_snap_bongo_reactive.hex                                           
 * The firmware is too large! 28678/28672 (6 bytes over)
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
