### PR TITLE
Fix `qmk doctor` not finding binaries on Windows

### DIFF
--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -217,8 +217,8 @@ if int(milc_version[0]) < 2 and int(milc_version[1]) < 4:
 # Make sure we can run binaries in the same directory as our Python interpreter
 python_dir = os.path.dirname(sys.executable)
 
-if python_dir not in os.environ['PATH'].split(':'):
-    os.environ['PATH'] = ":".join((python_dir, os.environ['PATH']))
+if python_dir not in os.environ['PATH'].split(os.pathsep):
+    os.environ['PATH'] = os.pathsep.join((python_dir, os.environ['PATH']))
 
 # Check to make sure we have all our dependencies
 msg_install = f'\nPlease run `{sys.executable} -m pip install -r %s` to install required python dependencies.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Windows uses `;` as the path separator not `:`.  Splitting and appending to path with the incorrect delimiter causes the shutil.where calls to fail.

Downside is that on Windows, `python_dir` never matches due to being a different format. Calling `cygpath` to resolve the path caused issues on terminal startup. End result is the path is always appended (now correctly) however it doesnt really cause much issue as its generally the same as the first entry anyway.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* <https://discord.com/channels/440868230475677696/473506116718952450/1180201007607722146>

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
