### PR TITLE
Dedup the list of tested userspace paths.

### DIFF
--- a/lib/python/qmk/userspace.py
+++ b/lib/python/qmk/userspace.py
@@ -19,20 +19,20 @@ def qmk_userspace_paths():
         current_dir = Path(environ['ORIG_CWD'])
         while len(current_dir.parts) > 1:
             if (current_dir / 'qmk.json').is_file():
-                test_dirs[Path(current_dir)] = True
+                test_dirs[current_dir] = True
             current_dir = current_dir.parent
 
     # If we have a QMK_USERSPACE environment variable, use that
     if environ.get('QMK_USERSPACE') is not None:
         current_dir = Path(environ['QMK_USERSPACE'])
         if current_dir.is_dir():
-            test_dirs[Path(current_dir)] = True
+            test_dirs[current_dir] = True
 
     # If someone has configured a directory, use that
     if cli.config.user.overlay_dir is not None:
         current_dir = Path(cli.config.user.overlay_dir)
         if current_dir.is_dir():
-            test_dirs[Path(current_dir)] = True
+            test_dirs[current_dir] = True
 
     return list(test_dirs.keys())
 

--- a/lib/python/qmk/userspace.py
+++ b/lib/python/qmk/userspace.py
@@ -12,29 +12,29 @@ from qmk.json_encoders import UserspaceJSONEncoder
 
 
 def qmk_userspace_paths():
-    test_dirs = []
+    test_dirs = {}
 
     # If we're already in a directory with a qmk.json and a keyboards or layouts directory, interpret it as userspace
     if environ.get('ORIG_CWD') is not None:
         current_dir = Path(environ['ORIG_CWD'])
         while len(current_dir.parts) > 1:
             if (current_dir / 'qmk.json').is_file():
-                test_dirs.append(current_dir)
+                test_dirs[Path(current_dir)] = True
             current_dir = current_dir.parent
 
     # If we have a QMK_USERSPACE environment variable, use that
     if environ.get('QMK_USERSPACE') is not None:
         current_dir = Path(environ['QMK_USERSPACE'])
         if current_dir.is_dir():
-            test_dirs.append(current_dir)
+            test_dirs[Path(current_dir)] = True
 
     # If someone has configured a directory, use that
     if cli.config.user.overlay_dir is not None:
         current_dir = Path(cli.config.user.overlay_dir)
         if current_dir.is_dir():
-            test_dirs.append(current_dir)
+            test_dirs[Path(current_dir)] = True
 
-    return test_dirs
+    return list(test_dirs.keys())
 
 
 def qmk_userspace_validate(path):


### PR DESCRIPTION
## Description

Removes duplicate searched userspace paths.
Python `dict` insert order is guaranteed to be kept since Python 3.7.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
