### PR TITLE
Avoid exceptions when generating matrix mask from layouts containing OOB matrix values

### DIFF
--- a/lib/python/qmk/cli/generate/keyboard_c.py
+++ b/lib/python/qmk/cli/generate/keyboard_c.py
@@ -64,12 +64,15 @@ def _gen_matrix_mask(info_data):
     rows = info_data['matrix_size']['rows']
 
     # Default mask to everything disabled
-    mask = [['0'] * cols for i in range(rows)]
+    mask = [['0'] * cols for _ in range(rows)]
 
     # Mirror layout macros squashed on top of each other
-    for layout_data in info_data['layouts'].values():
+    for layout_name, layout_data in info_data['layouts'].items():
         for key_data in layout_data['layout']:
             row, col = key_data['matrix']
+            if row >= rows or col >= cols:
+                cli.log.error(f'Skipping matrix_mask due to {layout_name} containing invalid matrix values')
+                return []
             mask[row][col] = '1'
 
     lines = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`generate_keyboard_h` spits out better errors so i figured its not worth duplicating. Ideally these would be caught earlier but having the generate code more defensive should only help.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
