### PR TITLE
[Bug] Fix Aurora Helix encoder direction

### DIFF
--- a/keyboards/splitkb/aurora/helix/rev1/info.json
+++ b/keyboards/splitkb/aurora/helix/rev1/info.json
@@ -4,7 +4,7 @@
     "encoder": {
         "enabled": true,
         "rotary": [
-            {"pin_a": "E6", "pin_b": "B4"}
+            {"pin_a": "B4", "pin_b": "E6"}
         ]
     },
     "features": {


### PR DESCRIPTION
## Description

We accidentally flipped the A and B pins of one of the encoders, this fixes the issue.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Not filed

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
