### PR TITLE
Fix JSON keymap URLs generated by the API

### DIFF
--- a/lib/python/qmk/cli/generate/api.py
+++ b/lib/python/qmk/cli/generate/api.py
@@ -6,6 +6,7 @@ import json
 
 from milc import cli
 
+import qmk.path
 from qmk.datetime import current_datetime
 from qmk.info import info_json
 from qmk.json_schema import json_load
@@ -126,9 +127,10 @@ def generate_api(cli):
 
         # Populate the list of JSON keymaps
         for keymap in list_keymaps(keyboard_name, c=False, fullpath=True):
+            keymap_rel = qmk.path.under_qmk_firmware(keymap)
             kb_json['keymaps'][keymap.name] = {
                 # TODO: deprecate 'url' as consumer needs to know its potentially hjson
-                'url': f'https://raw.githubusercontent.com/qmk/qmk_firmware/master/{keymap}/keymap.json',
+                'url': f'https://raw.githubusercontent.com/qmk/qmk_firmware/master/{keymap_rel}/keymap.json',
 
                 # Instead consumer should grab from API and not repo directly
                 'path': (keymap / 'keymap.json').as_posix(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It seems that `list_keymaps()` now returns the absolute paths to each found keymap when `fullpath=True` - I suspect this was the intended behaviour all along.

However, this has broken api_tasks when it goes to download the default JSON keymap for compilation:
```
fetch_json(https://keyboards.qmk.fm/v1/keyboards/idank/sweeq/info.json)
fetch_json(https://raw.githubusercontent.com/qmk/qmk_firmware/master//__w/qmk_firmware/qmk_firmware/keyboards/idank/sweeq/keymaps/default/keymap.json)
ERROR: https://raw.githubusercontent.com/qmk/qmk_firmware/master//__w/qmk_firmware/qmk_firmware/keyboards/idank/sweeq/keymaps/default/keymap.json returned 404: 404: Not Found
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
