### PR TITLE
Fix more `qmk generate-api` fallout from userspace support

### DIFF
--- a/lib/python/qmk/cli/generate/api.py
+++ b/lib/python/qmk/cli/generate/api.py
@@ -128,12 +128,15 @@ def generate_api(cli):
         # Populate the list of JSON keymaps
         for keymap in list_keymaps(keyboard_name, c=False, fullpath=True):
             keymap_rel = qmk.path.under_qmk_firmware(keymap)
+            if keymap_rel is None:
+                cli.log.debug('Skipping keymap %s (not in qmk_firmware)', keymap)
+                continue
             kb_json['keymaps'][keymap.name] = {
                 # TODO: deprecate 'url' as consumer needs to know its potentially hjson
                 'url': f'https://raw.githubusercontent.com/qmk/qmk_firmware/master/{keymap_rel}/keymap.json',
 
                 # Instead consumer should grab from API and not repo directly
-                'path': (keymap / 'keymap.json').as_posix(),
+                'path': (keymap_rel / 'keymap.json').as_posix(),
             }
 
         keyboard_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Description

After #22222 `list_keymaps(fullpath=True)` returns absolute paths which might point to the userspace directory tree; however, the implementation of `qmk generate-api` expected to get paths relative to `qmk_firmware`. The problem was partially fixed in #22618 for the generated `url` value; however, the `path` value for keymaps was still incorrect (this also made the subsequent code overwrite the `keymap.json` files in the working copy instead of writing those files converted to plain JSON into the API output directory).

Fix the `path` value for keymaps to contain the keymap path relative to `qmk_firmware` as it was before the userspace changes, and skip any userspace keymaps which might have been found.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* The generated API files for keyboards had broken `path` values for JSON keymaps (instead of paths relative to the `qmk_firmware` directory, which were also suitable to retrieve the `keymap.json` files from the API, these values contained absolute paths from the machine where the API files were generated).
* The generated API files did not contain any `keymap.json` files (the `generate-api` code was writing those files over the original `keymap.json` files in the working copy instead of placing them under the API output directory).
* Running `qmk generate-api` while also having `user.overlay_dir` configured could fail if the userspace overlay contained any JSON keymaps.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
