### PR TITLE
[Bug] Fix RGB Matrix max brightness for several splitkb.com keyboards

### DIFF
--- a/keyboards/splitkb/aurora/corne/rev1/info.json
+++ b/keyboards/splitkb/aurora/corne/rev1/info.json
@@ -163,6 +163,7 @@
             {"flags": 4, "matrix": [4, 0], "x": 224, "y": 7},  // R SW06
             {"flags": 4, "matrix": [5, 0], "x": 224, "y": 24}, // R SW12
             {"flags": 4, "matrix": [6, 0], "x": 224, "y": 41}  // R SW18
-        ]
+        ],
+        "max_brightness": 128
     }
 }

--- a/keyboards/splitkb/aurora/lily58/rev1/info.json
+++ b/keyboards/splitkb/aurora/lily58/rev1/info.json
@@ -188,6 +188,7 @@
             {"flags": 4, "matrix": [9, 4], "x": 159, "y": 64}, // R SW28
             {"flags": 4, "matrix": [9, 3], "x": 173, "y": 62}, // R SW27
             {"flags": 4, "matrix": [9, 2], "x": 188, "y": 62}  // R SW26
-        ]
+        ],
+        "max_brightness": 128
     }
 }

--- a/keyboards/splitkb/aurora/sweep/rev1/info.json
+++ b/keyboards/splitkb/aurora/sweep/rev1/info.json
@@ -152,6 +152,7 @@
             {"flags": 4, "matrix": [6, 4], "x": 224, "y": 47},
             {"flags": 4, "matrix": [7, 0], "x": 132, "y": 64},
             {"flags": 4, "matrix": [7, 1], "x": 153, "y": 60}
-        ]
+        ],
+        "max_brightness": 128
     }
 }

--- a/keyboards/splitkb/kyria/rev3/info.json
+++ b/keyboards/splitkb/kyria/rev3/info.json
@@ -186,6 +186,7 @@
             {"flags": 4, "matrix": [4, 4], "x": 195, "y": 4},  // R SW04
             {"flags": 4, "matrix": [4, 5], "x": 210, "y": 11}, // R SW05
             {"flags": 4, "matrix": [4, 6], "x": 224, "y": 11}  // R SW06
-        ]
+        ],
+        "max_brightness": 128
     }
 }


### PR DESCRIPTION
## Description

We've received some reports from customers about keyboards having flickering LEDs and occasionally disconnecting. After some investigation, it turns out we mistakenly defined `max_brightness` for `rgblight` but _not_ for `rgb_matrix`. It should obviously be defined for both as they are the very same LEDs, and manually defining rgb_matrix max_brightness on the keyboard level resolved the issues.

This PR aims to fix the issue for the keyboards involved.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

None filed 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
