### PR TITLE
Implement interface for triggering keycodes

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -285,16 +285,13 @@ void process_record(keyrecord_t *record) {
 }
 
 void process_record_handler(keyrecord_t *record) {
-#if defined(COMBO_ENABLE) || defined(REPEAT_KEY_ENABLE)
     action_t action;
     if (record->keycode) {
         action = action_for_keycode(record->keycode);
     } else {
         action = store_or_get_action(record->event.pressed, record->event.key);
     }
-#else
-    action_t action = store_or_get_action(record->event.pressed, record->event.key);
-#endif
+
     ac_dprintf("ACTION: ");
     debug_action(action);
 #ifndef NO_ACTION_LAYER
@@ -1116,16 +1113,13 @@ bool is_tap_record(keyrecord_t *record) {
         return false;
     }
 
-#if defined(COMBO_ENABLE) || defined(REPEAT_KEY_ENABLE)
     action_t action;
     if (record->keycode) {
         action = action_for_keycode(record->keycode);
     } else {
         action = layer_switch_get_action(record->event.key);
     }
-#else
-    action_t action = layer_switch_get_action(record->event.key);
-#endif
+
     return is_tap_action(action);
 }
 
@@ -1219,4 +1213,36 @@ void debug_action(action_t action) {
             break;
     }
     ac_dprintf("[%X:%02X]", action.kind.param >> 8, action.kind.param & 0xff);
+}
+
+/* Convert record into usable keycode via the contained event. */
+uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache) {
+    if (record->keycode) {
+        return record->keycode;
+    }
+    return get_event_keycode(record->event, update_layer_cache);
+}
+
+/* Convert event into usable keycode. Checks the layer cache to ensure that it
+ * retains the correct keycode after a layer change, if the key is still pressed.
+ * "update_layer_cache" is to ensure that it only updates the layer cache when
+ * appropriate, otherwise, it will update it and cause layer tap (and other keys)
+ * from triggering properly.
+ */
+uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache) {
+#if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)
+    /* TODO: Use store_or_get_action() or a similar function. */
+    if (!disable_action_cache) {
+        uint8_t layer;
+
+        if (event.pressed && update_layer_cache) {
+            layer = layer_switch_get_layer(event.key);
+            update_source_layers_cache(event.key, layer);
+        } else {
+            layer = read_source_layers_cache(event.key);
+        }
+        return keymap_key_to_keycode(layer, event.key);
+    } else
+#endif
+        return keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
 }

--- a/quantum/action.h
+++ b/quantum/action.h
@@ -47,7 +47,7 @@ typedef struct {
 /* Key event container for recording */
 typedef struct {
     keyevent_t event;
-    uint16_t keycode;
+    uint16_t   keycode;
 #ifndef NO_ACTION_TAPPING
     tap_t tap;
 #endif

--- a/quantum/action.h
+++ b/quantum/action.h
@@ -47,11 +47,9 @@ typedef struct {
 /* Key event container for recording */
 typedef struct {
     keyevent_t event;
+    uint16_t keycode;
 #ifndef NO_ACTION_TAPPING
     tap_t tap;
-#endif
-#if defined(COMBO_ENABLE) || defined(REPEAT_KEY_ENABLE)
-    uint16_t keycode;
 #endif
 } keyrecord_t;
 
@@ -61,6 +59,9 @@ void action_exec(keyevent_t event);
 /* action for key */
 action_t action_for_key(uint8_t layer, keypos_t key);
 action_t action_for_keycode(uint16_t keycode);
+
+uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache);
+uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache);
 
 /* keyboard-specific key event (pre)processing */
 bool process_record_quantum(keyrecord_t *record);

--- a/quantum/action_tapping.h
+++ b/quantum/action_tapping.h
@@ -35,9 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define WAITING_BUFFER_SIZE 8
 
 #ifndef NO_ACTION_TAPPING
-uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache);
-uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache);
-void     action_tapping_process(keyrecord_t record);
+void action_tapping_process(keyrecord_t record);
 #endif
 
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record);

--- a/quantum/keyboard.h
+++ b/quantum/keyboard.h
@@ -32,7 +32,7 @@ typedef struct {
     uint8_t row;
 } keypos_t;
 
-typedef enum keyevent_type_t { TICK_EVENT = 0, KEY_EVENT = 1, ENCODER_CW_EVENT = 2, ENCODER_CCW_EVENT = 3, COMBO_EVENT = 4 } keyevent_type_t;
+typedef enum keyevent_type_t { TICK_EVENT = 0, KEY_EVENT = 1, ENCODER_CW_EVENT = 2, ENCODER_CCW_EVENT = 3, COMBO_EVENT = 4, TAP_EVENT = 5 } keyevent_type_t;
 
 /* key event */
 typedef struct {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -146,22 +146,28 @@ __attribute__((weak)) void tap_code16(uint16_t code) {
     tap_code16_delay(code, code == KC_CAPS_LOCK ? TAP_HOLD_CAPS_DELAY : TAP_CODE_DELAY);
 }
 
-__attribute__((weak)) void tap_keycode_delay(uint16_t keycode, uint16_t delay) {
-    keyrecord_t record = {.keycode = keycode, .event = {.type = TAP_EVENT}};
+void register_keycode(uint16_t keycode) {
+    keyrecord_t record = {.keycode = keycode, .event = {.type = TAP_EVENT, .pressed = true, .time = timer_read()}};
 
-    record.event.pressed = true;
-    record.event.time    = timer_read();
-    process_record(&record);
-
-    wait_ms(delay);
-
-    record.event.pressed = false;
-    record.event.time    = timer_read();
     process_record(&record);
 }
 
+void unregister_keycode(uint16_t keycode) {
+    keyrecord_t record = {.keycode = keycode, .event = {.type = TAP_EVENT, .pressed = false, .time = timer_read()}};
+
+    process_record(&record);
+}
+
+__attribute__((weak)) void tap_keycode_delay(uint16_t keycode, uint16_t delay) {
+    register_keycode(keycode);
+    for (uint16_t i = delay; i > 0; i--) {
+        wait_ms(1);
+    }
+    unregister_keycode(keycode);
+}
+
 __attribute__((weak)) void tap_keycode(uint16_t keycode) {
-    tap_keycode_delay(keycode, TAP_CODE_DELAY);
+    tap_keycode_delay(keycode, keycode == KC_CAPS_LOCK ? TAP_HOLD_CAPS_DELAY : TAP_CODE_DELAY);
 }
 
 __attribute__((weak)) bool pre_process_record_kb(uint16_t keycode, keyrecord_t *record) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -146,6 +146,24 @@ __attribute__((weak)) void tap_code16(uint16_t code) {
     tap_code16_delay(code, code == KC_CAPS_LOCK ? TAP_HOLD_CAPS_DELAY : TAP_CODE_DELAY);
 }
 
+__attribute__((weak)) void tap_keycode_delay(uint16_t keycode, uint16_t delay) {
+    keyrecord_t record = {.keycode = keycode, .event = {.type = TAP_EVENT}};
+
+    record.event.pressed = true;
+    record.event.time    = timer_read();
+    process_record(&record);
+
+    wait_ms(delay);
+
+    record.event.pressed = false;
+    record.event.time    = timer_read();
+    process_record(&record);
+}
+
+__attribute__((weak)) void tap_keycode(uint16_t keycode) {
+    tap_keycode_delay(keycode, TAP_CODE_DELAY);
+}
+
 __attribute__((weak)) bool pre_process_record_kb(uint16_t keycode, keyrecord_t *record) {
     return pre_process_record_user(keycode, record);
 }
@@ -204,40 +222,6 @@ void reset_keyboard(void) {
 void soft_reset_keyboard(void) {
     shutdown_quantum(false);
     mcu_reset();
-}
-
-/* Convert record into usable keycode via the contained event. */
-uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache) {
-#if defined(COMBO_ENABLE) || defined(REPEAT_KEY_ENABLE)
-    if (record->keycode) {
-        return record->keycode;
-    }
-#endif
-    return get_event_keycode(record->event, update_layer_cache);
-}
-
-/* Convert event into usable keycode. Checks the layer cache to ensure that it
- * retains the correct keycode after a layer change, if the key is still pressed.
- * "update_layer_cache" is to ensure that it only updates the layer cache when
- * appropriate, otherwise, it will update it and cause layer tap (and other keys)
- * from triggering properly.
- */
-uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache) {
-#if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)
-    /* TODO: Use store_or_get_action() or a similar function. */
-    if (!disable_action_cache) {
-        uint8_t layer;
-
-        if (event.pressed && update_layer_cache) {
-            layer = layer_switch_get_layer(event.key);
-            update_source_layers_cache(event.key, layer);
-        } else {
-            layer = read_source_layers_cache(event.key);
-        }
-        return keymap_key_to_keycode(layer, event.key);
-    } else
-#endif
-        return keymap_key_to_keycode(layer_switch_get_layer(event.key), event.key);
 }
 
 /* Get keycode, and then process pre tapping functionality */

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -261,6 +261,18 @@ void unregister_code16(uint16_t code);
 void tap_code16(uint16_t code);
 void tap_code16_delay(uint16_t code, uint16_t delay);
 
+/** \brief Trigger a keydown of a keycode.
+ *
+ * Supports the full range of quantum keycodes.
+ */
+void register_keycode(uint16_t keycode);
+
+/** \brief Trigger a keyup of a keycode.
+ *
+ * Supports the full range of quantum keycodes.
+ */
+void unregister_keycode(uint16_t keycode);
+
 /** \brief Tap a keycode with a delay.
  *
  * Supports the full range of quantum keycodes.

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -241,16 +241,14 @@ void set_single_persistent_default_layer(uint8_t default_layer);
 #define IS_LAYER_ON_STATE(state, layer) layer_state_cmp(state, layer)
 #define IS_LAYER_OFF_STATE(state, layer) !layer_state_cmp(state, layer)
 
-uint16_t get_record_keycode(keyrecord_t *record, bool update_layer_cache);
-uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache);
-bool     pre_process_record_quantum(keyrecord_t *record);
-bool     pre_process_record_kb(uint16_t keycode, keyrecord_t *record);
-bool     pre_process_record_user(uint16_t keycode, keyrecord_t *record);
-bool     process_action_kb(keyrecord_t *record);
-bool     process_record_kb(uint16_t keycode, keyrecord_t *record);
-bool     process_record_user(uint16_t keycode, keyrecord_t *record);
-void     post_process_record_kb(uint16_t keycode, keyrecord_t *record);
-void     post_process_record_user(uint16_t keycode, keyrecord_t *record);
+bool pre_process_record_quantum(keyrecord_t *record);
+bool pre_process_record_kb(uint16_t keycode, keyrecord_t *record);
+bool pre_process_record_user(uint16_t keycode, keyrecord_t *record);
+bool process_action_kb(keyrecord_t *record);
+bool process_record_kb(uint16_t keycode, keyrecord_t *record);
+bool process_record_user(uint16_t keycode, keyrecord_t *record);
+void post_process_record_kb(uint16_t keycode, keyrecord_t *record);
+void post_process_record_user(uint16_t keycode, keyrecord_t *record);
 
 void reset_keyboard(void);
 void soft_reset_keyboard(void);
@@ -262,6 +260,18 @@ void register_code16(uint16_t code);
 void unregister_code16(uint16_t code);
 void tap_code16(uint16_t code);
 void tap_code16_delay(uint16_t code, uint16_t delay);
+
+/** \brief Tap a keycode with a delay.
+ *
+ * Supports the full range of quantum keycodes.
+ */
+void tap_keycode_delay(uint16_t keycode, uint16_t delay);
+
+/** \brief Tap a keycode with the default delay.
+ *
+ * Supports the full range of quantum keycodes.
+ */
+void tap_keycode(uint16_t keycode);
 
 const char *get_numeric_str(char *buf, size_t buf_len, uint32_t curr_num, char curr_pad);
 const char *get_u8_str(uint8_t curr_num, char curr_pad);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

### Draft as current implementation can cause recursion, which has nuance which should be avoided

Implements `tap_keycode(keycode)`.

For a while users have struggled with the existing `tap_code`/`tap_code16` limitations. This includes when to use `16`, why they cant handle certain keycodes. `tap_keycode` gives us a general solution to direct users to. Additional benefits are things like magic keycodes can be triggered without having to look up how they are implemented and duplicating it within keymaps.

Implementing this as the user facing interface has a few benefits.
* Gives us a solution now, rather than waiting for everything to _eventually_ be refactored 
* Allows the underlying "legacy" code to be refactored in the future while minimising the net impact
* Could extend the keycode compatibility of tap dance
* Reduces the implementation overhead involved in duplicating dummy matrix events
  * For example `ENCODER_CW_EVENT`/`ENCODER_CCW_EVENT` in encoder map
    * Though the position info is used for swap hands
  * Required for #22543

Also,
* Removes conditionality for `keyrecord_t.keycode`
  * small increase in firmware size
  * `tap_keycode` could be opt-in?
    * not the most user friendly
* Moves some quantum.c functions to a slightly more appropriate location while fixing some incorrect surrounding ifdefs and duplication of function declaration 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
