### PR TITLE
[Bugfix] `qmk {compile, flash}` return code

### DIFF
--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -80,4 +80,4 @@ def compile(cli):
         return False
 
     target.configure(parallel=cli.config.compile.parallel, clean=cli.args.clean, compiledb=cli.args.compiledb)
-    target.compile(cli.args.target, dry_run=cli.args.dry_run, **envs)
+    return target.compile(cli.args.target, dry_run=cli.args.dry_run, **envs)

--- a/lib/python/qmk/cli/flash.py
+++ b/lib/python/qmk/cli/flash.py
@@ -113,4 +113,4 @@ def flash(cli):
         return False
 
     target.configure(parallel=cli.config.flash.parallel, clean=cli.args.clean)
-    target.compile(cli.args.bootloader, dry_run=cli.args.dry_run, **envs)
+    return target.compile(cli.args.bootloader, dry_run=cli.args.dry_run, **envs)


### PR DESCRIPTION
## Description

Noticed this while using my custom tool for automating the build process, as it logic broke a little :)

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* `qmk` not raising `make`'s return code.

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
