### PR TITLE
[Enhancement/Fix] Checks on `painter-convert-font-image`

### DIFF
--- a/lib/python/qmk/painter_qff.py
+++ b/lib/python/qmk/painter_qff.py
@@ -238,7 +238,6 @@ class QFFFont:
                     exit(1)
                 glyph_pixel_offsets.append(x)
 
-
                 width = x - last_offset
                 if width > QFFGlyphInfo.GLYPH_WIDTH_MASK:
                     self.logger.error("A glyph is too wide for QFF's encoding")


### PR DESCRIPTION
## Description

Currently the `image->QFF` converter allows images with metadata bigger than the space reserved for those fields, this causes issues when trying to draw them. Added some checks to the CLI to prevent generating the QFF file at all.

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Reported by a Discord user, feel free to scroll up a bit from [here](<https://discord.com/channels/440868230475677696/869749041074937936/1183891627220156477>)

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
