### PR TITLE
fix: improper usage of keyboard/user-level functions

### DIFF
--- a/keyboards/aeboards/ext65/rev2/rev2.c
+++ b/keyboards/aeboards/ext65/rev2/rev2.c
@@ -17,16 +17,18 @@
 #include "quantum.h"
 
 // Tested and verified working on ext65rev2
-void matrix_io_delay(void) { __asm__ volatile("nop\nnop\nnop\n"); }
+void matrix_io_delay(void) {
+    __asm__ volatile("nop\nnop\nnop\n");
+}
 
 #ifdef OLED_ENABLE
 void board_init(void) {
-  SYSCFG->CFGR1 |= SYSCFG_CFGR1_I2C1_DMA_RMP;
-  SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_SPI2_DMA_RMP);
+    SYSCFG->CFGR1 |= SYSCFG_CFGR1_I2C1_DMA_RMP;
+    SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_SPI2_DMA_RMP);
 }
 
 oled_rotation_t oled_init_kb(oled_rotation_t rotation) {
-    return OLED_ROTATION_90;  // rotates the display 90 degrees
+    return OLED_ROTATION_90; // rotates the display 90 degrees
 }
 
 void render_layer_state(void) {
@@ -57,24 +59,24 @@ void render_mod_status(uint8_t modifiers) {
 bool oled_task_kb(void) {
     render_layer_state();
     render_keylock_status(host_keyboard_led_state());
-    render_mod_status(get_mods()|get_oneshot_mods());
+    render_mod_status(get_mods() | get_oneshot_mods());
     return false;
 }
 
 #else
 
 void keyboard_pre_init_user(void) {
-  // Call the keyboard pre init code.
-  // Set our LED pins as output
-  setPinOutput(B4);
-  setPinOutput(B3);
-  setPinOutput(A15);
-  setPinOutput(A14);
+    // Call the keyboard pre init code.
+    // Set our LED pins as output
+    setPinOutput(B4);
+    setPinOutput(B3);
+    setPinOutput(A15);
+    setPinOutput(A14);
 }
 
 bool led_update_kb(led_t led_state) {
     bool res = led_update_user(led_state);
-    if(res) {
+    if (res) {
         writePin(B4, led_state.num_lock);
         writePin(B3, led_state.caps_lock);
         writePin(A15, led_state.scroll_lock);
@@ -84,14 +86,13 @@ bool led_update_kb(led_t led_state) {
 
 layer_state_t layer_state_set_kb(layer_state_t state) {
     switch (get_highest_layer(state)) {
-      case 1:
-        writePinHigh(A14);
-        break;
-      default: //  for any other layers, or the default layer
-        writePinLow(A14);
-        break;
-      }
+        case 1:
+            writePinHigh(A14);
+            break;
+        default: //  for any other layers, or the default layer
+            writePinLow(A14);
+            break;
+    }
     return layer_state_set_user(state);
 }
 #endif
-

--- a/keyboards/aeboards/ext65/rev2/rev2.c
+++ b/keyboards/aeboards/ext65/rev2/rev2.c
@@ -57,10 +57,13 @@ void render_mod_status(uint8_t modifiers) {
 }
 
 bool oled_task_kb(void) {
+    if (!oled_task_user()) {
+        return false;
+    }
     render_layer_state();
     render_keylock_status(host_keyboard_led_state());
     render_mod_status(get_mods() | get_oneshot_mods());
-    return false;
+    return true;
 }
 
 #else

--- a/keyboards/aeboards/ext65/rev2/rev2.c
+++ b/keyboards/aeboards/ext65/rev2/rev2.c
@@ -68,13 +68,15 @@ bool oled_task_kb(void) {
 
 #else
 
-void keyboard_pre_init_user(void) {
+void keyboard_pre_init_kb(void) {
     // Call the keyboard pre init code.
     // Set our LED pins as output
     setPinOutput(B4);
     setPinOutput(B3);
     setPinOutput(A15);
     setPinOutput(A14);
+
+    keyboard_pre_init_user();
 }
 
 bool led_update_kb(led_t led_state) {

--- a/keyboards/dumbpad/v1x_oled/v1x_oled.c
+++ b/keyboards/dumbpad/v1x_oled/v1x_oled.c
@@ -19,7 +19,10 @@
 char wpm_str[10];
 
 #ifdef ENCODER_ENABLE
-bool encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) {
+        return false;
+    }
     // Right encoder
     if (index == 0) {
         if (clockwise) {

--- a/keyboards/dumbpad/v1x_oled/v1x_oled.c
+++ b/keyboards/dumbpad/v1x_oled/v1x_oled.c
@@ -42,16 +42,16 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 #ifdef OLED_ENABLE
 // WPM-responsive animation stuff here
 #    define IDLE_FRAMES 5
-#    define IDLE_SPEED 20  // below this wpm value your animation will idle
+#    define IDLE_SPEED 20 // below this wpm value your animation will idle
 
 // #define PREP_FRAMES 1 // uncomment if >1
 
 #    define TAP_FRAMES 2
-#    define TAP_SPEED 40  // above this wpm value typing animation to trigger
+#    define TAP_SPEED 40 // above this wpm value typing animation to trigger
 
-#    define ANIM_FRAME_DURATION 200  // how long each frame lasts in ms
+#    define ANIM_FRAME_DURATION 200 // how long each frame lasts in ms
 // #define SLEEP_TIMER 60000 // should sleep after this period of 0 wpm, needs fixing
-#    define ANIM_SIZE 636  // number of bytes in array, minimize for adequate firmware size, max is 1024
+#    define ANIM_SIZE 636 // number of bytes in array, minimize for adequate firmware size, max is 1024
 
 uint32_t anim_timer         = 0;
 uint32_t anim_sleep         = 0;
@@ -111,7 +111,7 @@ static void render_anim(void) {
         }
         if (get_current_wpm() > IDLE_SPEED && get_current_wpm() < TAP_SPEED) {
             // oled_write_raw_P(prep[abs((PREP_FRAMES-1)-current_prep_frame)], ANIM_SIZE); // uncomment if IDLE_FRAMES >1
-            oled_write_raw_P(prep[0], ANIM_SIZE);  // remove if IDLE_FRAMES >1
+            oled_write_raw_P(prep[0], ANIM_SIZE); // remove if IDLE_FRAMES >1
         }
         if (get_current_wpm() >= TAP_SPEED) {
             current_tap_frame = (current_tap_frame + 1) % TAP_FRAMES;
@@ -119,7 +119,7 @@ static void render_anim(void) {
         }
     }
     if (get_current_wpm() != 000) {
-        oled_on();  // not essential but turns on animation OLED with any alpha keypress
+        oled_on(); // not essential but turns on animation OLED with any alpha keypress
         if (timer_elapsed32(anim_timer) > ANIM_FRAME_DURATION) {
             anim_timer = timer_read32();
             animation_phase();
@@ -139,14 +139,14 @@ static void render_anim(void) {
 
 // Used to draw on to the oled screen
 bool oled_task_user(void) {
-    render_anim();  // renders pixelart
+    render_anim(); // renders pixelart
 
-    oled_set_cursor(0, 0);                            // sets cursor to (row, column) using charactar spacing (5 rows on 128x32 screen, anything more will overflow back to the top)
+    oled_set_cursor(0, 0); // sets cursor to (row, column) using charactar spacing (5 rows on 128x32 screen, anything more will overflow back to the top)
     oled_write_P(PSTR("WPM: "), false);
     oled_write(get_u8_str(get_current_wpm(), '0'), false);
-    oled_write(wpm_str, false);                       // writes wpm on top left corner of string
+    oled_write(wpm_str, false); // writes wpm on top left corner of string
 
-    led_t led_state = host_keyboard_led_state();  // caps lock stuff, prints CAPS on new line if caps led is on
+    led_t led_state = host_keyboard_led_state(); // caps lock stuff, prints CAPS on new line if caps led is on
     oled_set_cursor(0, 1);
     oled_write_P(led_state.caps_lock ? PSTR("CAPS") : PSTR("       "), false);
 

--- a/keyboards/dumbpad/v1x_oled/v1x_oled.c
+++ b/keyboards/dumbpad/v1x_oled/v1x_oled.c
@@ -138,7 +138,10 @@ static void render_anim(void) {
 }
 
 // Used to draw on to the oled screen
-bool oled_task_user(void) {
+bool oled_task_kb(void) {
+    if (!oled_task_user()) {
+        return false;
+    }
     render_anim(); // renders pixelart
 
     oled_set_cursor(0, 0); // sets cursor to (row, column) using charactar spacing (5 rows on 128x32 screen, anything more will overflow back to the top)
@@ -150,6 +153,6 @@ bool oled_task_user(void) {
     oled_set_cursor(0, 1);
     oled_write_P(led_state.caps_lock ? PSTR("CAPS") : PSTR("       "), false);
 
-    return false;
+    return true;
 }
 #endif

--- a/keyboards/horrortroll/lemon40/lemon40.c
+++ b/keyboards/horrortroll/lemon40/lemon40.c
@@ -20,18 +20,18 @@
 #include "lib/bongocat.h"
 
 #ifdef OLED_ENABLE
-    bool oled_task_kb(void) {
-        led_t led_usb_state = host_keyboard_led_state();
+bool oled_task_kb(void) {
+    led_t led_usb_state = host_keyboard_led_state();
 
-        render_bongocat();
-        oled_set_cursor(14, 0); // sets cursor to (column, row) using charactar spacing (4 rows on 128x32 screen, anything more will overflow back to the top)
-        oled_write_P(PSTR("WPM:"), false);
-        oled_write(get_u8_str(get_current_wpm(), '0'), false); // writes wpm on top right corner of string
-        oled_set_cursor(17, 2);
-        oled_write_P(led_usb_state.caps_lock ? PSTR("CAPS") : PSTR("    "), false);
-        oled_set_cursor(17, 3);
-        oled_write_P(led_usb_state.scroll_lock ? PSTR("SCRL") : PSTR("    "), false);
+    render_bongocat();
+    oled_set_cursor(14, 0); // sets cursor to (column, row) using charactar spacing (4 rows on 128x32 screen, anything more will overflow back to the top)
+    oled_write_P(PSTR("WPM:"), false);
+    oled_write(get_u8_str(get_current_wpm(), '0'), false); // writes wpm on top right corner of string
+    oled_set_cursor(17, 2);
+    oled_write_P(led_usb_state.caps_lock ? PSTR("CAPS") : PSTR("    "), false);
+    oled_set_cursor(17, 3);
+    oled_write_P(led_usb_state.scroll_lock ? PSTR("SCRL") : PSTR("    "), false);
 
-        return true;
-    }
+    return true;
+}
 #endif

--- a/keyboards/horrortroll/lemon40/lemon40.c
+++ b/keyboards/horrortroll/lemon40/lemon40.c
@@ -21,6 +21,9 @@
 
 #ifdef OLED_ENABLE
 bool oled_task_kb(void) {
+    if (!oled_task_user()) {
+        return false;
+    }
     led_t led_usb_state = host_keyboard_led_state();
 
     render_bongocat();

--- a/keyboards/lime/rev1/rev1.c
+++ b/keyboards/lime/rev1/rev1.c
@@ -1,38 +1,37 @@
- /* Copyright 2021 HellSingCoder
-  *
-  * This program is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 2 of the License, or
-  * (at your option) any later version.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  */
+/* Copyright 2021 HellSingCoder
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "quantum.h"
 
 /* Encoders */
 #ifdef ENCODER_ENABLE
-    bool encoder_update_user(uint8_t index, bool clockwise) {
-
-        if (index == 0) {
-            if (clockwise) {
-                tap_code(KC_MNXT);
-            } else {
-                tap_code(KC_MPRV);
-            }
-        } else if (index == 1) {
-            if (clockwise) {
-                tap_code(KC_VOLU);
-            } else {
-                tap_code(KC_VOLD);
-            }
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    if (index == 0) {
+        if (clockwise) {
+            tap_code(KC_MNXT);
+        } else {
+            tap_code(KC_MPRV);
         }
-        return false;
+    } else if (index == 1) {
+        if (clockwise) {
+            tap_code(KC_VOLU);
+        } else {
+            tap_code(KC_VOLD);
+        }
     }
+    return false;
+}
 #endif

--- a/keyboards/lime/rev1/rev1.c
+++ b/keyboards/lime/rev1/rev1.c
@@ -18,7 +18,10 @@
 
 /* Encoders */
 #ifdef ENCODER_ENABLE
-bool encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_kb(uint8_t index, bool clockwise) {
+    if (!encoder_update_user(index, clockwise)) {
+        return false;
+    }
     if (index == 0) {
         if (clockwise) {
             tap_code(KC_MNXT);
@@ -32,6 +35,6 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             tap_code(KC_VOLD);
         }
     }
-    return false;
+    return true;
 }
 #endif

--- a/keyboards/mino_plus/mino_plus.c
+++ b/keyboards/mino_plus/mino_plus.c
@@ -237,12 +237,15 @@ oled_rotation_t oled_init_kb(oled_rotation_t rotation) {
 }
 
 bool oled_task_kb(void) {
+    if (!oled_task_user()) {
+        return false;
+    }
     render_animation();
     render_status();
 
     oled_write_ln_P(PSTR("WPM:"), false);
     oled_write_ln(get_u8_str(get_current_wpm(), '0'), false);
 
-    return false;
+    return true;
 }
 #endif

--- a/keyboards/mino_plus/mino_plus.c
+++ b/keyboards/mino_plus/mino_plus.c
@@ -3,13 +3,13 @@
 #include "quantum.h"
 
 #ifdef OLED_ENABLE
-#define FRAMES 5
-#define ANIMATION_SIZE 512
-#define TAP_SPEED 30
+#    define FRAMES 5
+#    define ANIMATION_SIZE 512
+#    define TAP_SPEED 30
 
-uint8_t  current_frame = 0;
-uint32_t anim_timer = 0;
-uint32_t anim_sleep = 0;
+uint8_t  current_frame       = 0;
+uint32_t anim_timer          = 0;
+uint32_t anim_sleep          = 0;
 uint32_t ANIM_FRAME_DURATION = 1000;
 
 static void render_animation(void) {
@@ -191,8 +191,8 @@ static void render_animation(void) {
     }
 
     if (get_current_wpm() != 000) {
-        oled_on();  // not essential but turns on animation OLED with any alpha keypress
-        if (get_current_wpm() > TAP_SPEED){
+        oled_on(); // not essential but turns on animation OLED with any alpha keypress
+        if (get_current_wpm() > TAP_SPEED) {
             ANIM_FRAME_DURATION = 100;
         } else {
             ANIM_FRAME_DURATION = 1000;
@@ -233,7 +233,7 @@ static void render_status(void) {
 }
 
 oled_rotation_t oled_init_kb(oled_rotation_t rotation) {
-        return OLED_ROTATION_270; 
+    return OLED_ROTATION_270;
 }
 
 bool oled_task_kb(void) {

--- a/keyboards/rura66/rev1/oled_display.c
+++ b/keyboards/rura66/rev1/oled_display.c
@@ -18,60 +18,58 @@
 
 // Defines names for use in layer keycodes and the keymap
 enum layer_names {
-  _QWERTY = 0,
-  _LOWER,
-  _RAISE,
-  _ADJUST
+    _QWERTY,
+    _LOWER,
+    _RAISE,
+    _ADJUST
 };
 
 #ifdef OLED_ENABLE
 
 void render_status(void) {
+    // Render to mode icon
+    static const char os_logo[][2][3] PROGMEM = {{{0x95, 0x96, 0}, {0xb5, 0xb6, 0}}, {{0x97, 0x98, 0}, {0xb7, 0xb8, 0}}};
+    if (is_mac_mode()) {
+        oled_write_P(os_logo[0][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write_P(os_logo[0][1], false);
+    } else {
+        oled_write_P(os_logo[1][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write_P(os_logo[1][1], false);
+    }
 
-  // Render to mode icon
-  static const char os_logo[][2][3] PROGMEM  ={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
-  if (is_mac_mode()) {
-    oled_write_P(os_logo[0][0], false);
+    oled_write_P(PSTR(" "), false);
+
+    // Host Keyboard Layer Status
+    oled_write_P(PSTR("Layer: "), false);
+
+    switch (get_highest_layer(layer_state)) {
+        case _QWERTY:
+            oled_write_P(PSTR("Default\n"), false);
+            break;
+        case _RAISE:
+            oled_write_P(PSTR("Raise\n"), false);
+            break;
+        case _LOWER:
+            oled_write_P(PSTR("Lower\n"), false);
+            break;
+        case _ADJUST:
+            oled_write_P(PSTR("Adjust\n"), false);
+            break;
+        default:
+            // Or use the write_ln shortcut over adding '\n' to the end of your string
+            oled_write_ln_P(PSTR("Undefined"), false);
+    }
+
     oled_write_P(PSTR("\n"), false);
-    oled_write_P(os_logo[0][1], false);
-  }else{
-    oled_write_P(os_logo[1][0], false);
-    oled_write_P(PSTR("\n"), false);
-    oled_write_P(os_logo[1][1], false);
-  }
 
-  oled_write_P(PSTR(" "), false);
-
-  // Host Keyboard Layer Status
-  oled_write_P(PSTR("Layer: "), false);
-
-  switch (get_highest_layer(layer_state)) {
-      case _QWERTY:
-          oled_write_P(PSTR("Default\n"), false);
-          break;
-      case _RAISE:
-          oled_write_P(PSTR("Raise\n"), false);
-          break;
-      case _LOWER:
-          oled_write_P(PSTR("Lower\n"), false);
-          break;
-      case _ADJUST:
-          oled_write_P(PSTR("Adjust\n"), false);
-          break;
-      default:
-          // Or use the write_ln shortcut over adding '\n' to the end of your string
-          oled_write_ln_P(PSTR("Undefined"), false);
-  }
-
-  oled_write_P(PSTR("\n"), false);
-
-  // Host Keyboard LED Status
-  led_t led_state = host_keyboard_led_state();
-  oled_write_P(led_state.num_lock ? PSTR("NUM ") : PSTR("    "), false);
-  oled_write_P(led_state.caps_lock ? PSTR("CAP ") : PSTR("    "), false);
-  oled_write_P(led_state.scroll_lock ? PSTR("SCR ") : PSTR("    "), false);
+    // Host Keyboard LED Status
+    led_t led_state = host_keyboard_led_state();
+    oled_write_P(led_state.num_lock ? PSTR("NUM ") : PSTR("    "), false);
+    oled_write_P(led_state.caps_lock ? PSTR("CAP ") : PSTR("    "), false);
+    oled_write_P(led_state.scroll_lock ? PSTR("SCR ") : PSTR("    "), false);
 }
-
 
 static void render_logo(void) {
     static const char PROGMEM qmk_logo[] = {
@@ -84,35 +82,35 @@ static void render_logo(void) {
 }
 
 static void render_rgbled_status(bool full) {
-#ifdef RGBLIGHT_ENABLE
-  if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
-    if (full) {
-      // " LED %d:%d,%d,%d"
-      oled_write_P(PSTR(" LED"), false);
-      oled_write(get_u8_str(rgblight_get_mode(), ' '), false);
-      oled_write_char(':', false);
-      oled_write(get_u8_str(rgblight_get_hue()/RGBLIGHT_HUE_STEP, ' '), false);
-      oled_write_char(',', false);
-      oled_write(get_u8_str(rgblight_get_sat()/RGBLIGHT_SAT_STEP, ' '), false);
-      oled_write_char(',', false);
-      oled_write(get_u8_str(rgblight_get_val()/RGBLIGHT_VAL_STEP, ' '), false);
-    } else {
-      // "[%2d] "
-      oled_write_char('[', false);
-      oled_write(get_u8_str(rgblight_get_mode(), ' '), false);
-      oled_write_char(']', false);
+#    ifdef RGBLIGHT_ENABLE
+    if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
+        if (full) {
+            // " LED %d:%d,%d,%d"
+            oled_write_P(PSTR(" LED"), false);
+            oled_write(get_u8_str(rgblight_get_mode(), ' '), false);
+            oled_write_char(':', false);
+            oled_write(get_u8_str(rgblight_get_hue() / RGBLIGHT_HUE_STEP, ' '), false);
+            oled_write_char(',', false);
+            oled_write(get_u8_str(rgblight_get_sat() / RGBLIGHT_SAT_STEP, ' '), false);
+            oled_write_char(',', false);
+            oled_write(get_u8_str(rgblight_get_val() / RGBLIGHT_VAL_STEP, ' '), false);
+        } else {
+            // "[%2d] "
+            oled_write_char('[', false);
+            oled_write(get_u8_str(rgblight_get_mode(), ' '), false);
+            oled_write_char(']', false);
+        }
     }
-  }
-#endif
+#    endif
 }
 
 bool oled_task_user(void) {
-  if(is_keyboard_master()){
-    render_status();
-  }else{
-    render_logo();
-    render_rgbled_status(true);
-  }
-  return false;
+    if (is_keyboard_master()) {
+        render_status();
+    } else {
+        render_logo();
+        render_rgbled_status(true);
+    }
+    return false;
 }
 #endif

--- a/keyboards/rura66/rev1/oled_display.c
+++ b/keyboards/rura66/rev1/oled_display.c
@@ -104,13 +104,16 @@ static void render_rgbled_status(bool full) {
 #    endif
 }
 
-bool oled_task_user(void) {
+bool oled_task_kb(void) {
+    if (!oled_task_user()) {
+        return false;
+    }
     if (is_keyboard_master()) {
         render_status();
     } else {
         render_logo();
         render_rgbled_status(true);
     }
-    return false;
+    return true;
 }
 #endif


### PR DESCRIPTION
## Description

Correct several instances of keyboard-level code incorrectly calling (or neglecting to call) user-level functions.

- `dumbpad/v1x_oled` and `rura66/rev1` call `oled_task_user()` for keyboard-level code.
- `dumbpad/v1x_oled` and `lime/rev1` call `encoder_update_user()` for keyboard-level code.

- `aeboards/ext65/rev2`, `mino_plus/*` and `horrortroll/lemon40` use the correct `oled_task_kb()`, but are missing the `if (!oled_task_user())` clause allowing user overrides.

- Since I was already modifying the file: `aeboards/ext65/rev2` calls `keyboard_pre_init_user()` only, instead of calling `keyboard_pre_init_user()` at the end of `keyboard_pre_init_kb()`.

The diff looks more extensive than this because I ran `qmk format-c` on all affected files before making changes. I'm leaving the commits unsquashed so that's easier to see.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
