### PR TITLE
Programmatically create and send steno keycodes

### DIFF
--- a/docs/feature_stenography.md
+++ b/docs/feature_stenography.md
@@ -118,6 +118,8 @@ To test your keymap, you can chord keys on your keyboard and either look at the 
 
 ## Interfacing with the code :id=interfacing-with-the-code
 
+### Using hooks
+
 The steno code has three interceptable hooks. If you define these functions, they will be called at certain points in processing; if they return true, processing continues, otherwise it's assumed you handled things.
 
 ```c
@@ -146,6 +148,22 @@ The `n_pressed_keys` argument is the number of physical keys actually being held
 This is not always equal to the number of bits set to 1 (aka the [Hamming weight](https://en.wikipedia.org/wiki/Hamming_weight)) in `chord` because it is possible to simultaneously press down four keys, then release three of those four keys and then press yet another key while the fourth finger is still holding down its key.
 At the end of this scenario given as an example, `chord` would have five bits set to 1 but
 `n_pressed_keys` would be set to 2 because there are only two keys currently being pressed down.
+
+### Programmatically sending steno chords
+
+You can programmatically send chords to Plover using the following function:
+```c
+bool send_custom_steno_chord(const uint16_t *stenochord);
+// Returns true upon successful processing and sending, and false otherwise.
+```
+
+To use the function, first manually construct an array of standard steno keycodes that is terminated by `CHORD_END`, then pass the arary to the function:
+
+```c
+static const uint16_t myChord[] PROGMEM  = {STN_SL, STN_TL, STN_O, STN_E, STN_U, STN_PR, STN_BR, CHORD_END};
+send_custom_steno_chord(myChord);
+```
+The keycodes do not need to be in proper steno order, but the array must terminate with `CHORD_END`.
 
 ## Keycode Reference :id=keycode-reference
 

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -156,6 +156,60 @@ __attribute__((weak)) bool process_steno_user(uint16_t keycode, keyrecord_t *rec
     return true;
 }
 
+// Can be called programmatically by the user. Returns true if successful, otherwise false.
+bool send_custom_steno_chord(const uint16_t *stenochord) {
+    for(uint8_t i=0; i<42; i++){    // Upper limit of 42 is used as failsafe if user does not supply CHORD_END. 
+                                    // (There are 42 possible keycodes in Gemeni.)
+                                    // But if CHORD_END is not provided, the keyrange check below typically triggers first.
+
+        if (stenochord[i] == CHORD_END) {
+            break;
+        } else if (stenochord[i] < QK_STENO || stenochord[i] > QK_STENO_MAX) {  
+            return false; // User did not supply a steno key, or no CHORD_END was provided and element happened to not be in range.
+        }
+
+        // Pass the formatted keycode to one of the add_*_key_to_chord() functions
+        switch(mode) { 
+#ifdef STENO_ENABLE_GEMINI
+            case STENO_MODE_GEMINI:
+                add_gemini_key_to_chord(stenochord[i] - QK_STENO);
+                break;
+#endif // STENO_ENABE_GEMINI
+
+#ifdef STENO_ENABLE_BOLT
+            case STENO_MODE_BOLT:
+                add_bolt_key_to_chord(stenochord[i] - QK_STENO);
+                break;
+#endif // STENO_ENABLE_BOLT
+
+            default:
+                return false;
+        } // end switch
+    } // end for loop through user-supplied keycodes.
+
+    // The steno chord has been assembled in the 'chord' array.
+    // Call the correct send_steno_chord_* function.
+    switch(mode) { 
+#ifdef STENO_ENABLE_GEMINI
+        case STENO_MODE_GEMINI:
+            send_steno_chord_gemini();
+            break;
+#endif // STENO_ENABE_GEMINI
+
+#ifdef STENO_ENABLE_BOLT
+        case STENO_MODE_BOLT:
+            send_steno_chord_bolt();
+            break;
+#endif // STENO_ENABLE_BOLT
+
+        default:
+            return false;
+    } // end switch
+
+    steno_clear_chord();
+    return true; // Successful completion.
+}
+
 bool process_steno(uint16_t keycode, keyrecord_t *record) {
     if (keycode < QK_STENO || keycode > QK_STENO_MAX) {
         return true; // Not a steno key, pass it further along the chain

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -158,18 +158,19 @@ __attribute__((weak)) bool process_steno_user(uint16_t keycode, keyrecord_t *rec
 
 // Can be called programmatically by the user. Returns true if successful, otherwise false.
 bool send_custom_steno_chord(const uint16_t *stenochord) {
-    for(uint8_t i=0; i<42; i++){    // Upper limit of 42 is used as failsafe if user does not supply CHORD_END. 
-                                    // (There are 42 possible keycodes in Gemeni.)
-                                    // But if CHORD_END is not provided, the keyrange check below typically triggers first.
+    for (uint8_t i = 0; i < 42; i++) { 
+        /* Upper limit of 42 is used as failsafe if user does not supply CHORD_END. 
+        There are 42 possible keycodes in Gemeni.)
+        But if CHORD_END is not provided, the keyrange check below typically triggers first. */
 
         if (stenochord[i] == CHORD_END) {
             break;
-        } else if (stenochord[i] < QK_STENO || stenochord[i] > QK_STENO_MAX) {  
+        } else if (stenochord[i] < QK_STENO || stenochord[i] > QK_STENO_MAX) {
             return false; // User did not supply a steno key, or no CHORD_END was provided and element happened to not be in range.
         }
 
         // Pass the formatted keycode to one of the add_*_key_to_chord() functions
-        switch(mode) { 
+        switch (mode) { 
 #ifdef STENO_ENABLE_GEMINI
             case STENO_MODE_GEMINI:
                 add_gemini_key_to_chord(stenochord[i] - QK_STENO);
@@ -185,11 +186,11 @@ bool send_custom_steno_chord(const uint16_t *stenochord) {
             default:
                 return false;
         } // end switch
-    } // end for loop through user-supplied keycodes.
+    }     // end for loop through user-supplied keycodes.
 
     // The steno chord has been assembled in the 'chord' array.
     // Call the correct send_steno_chord_* function.
-    switch(mode) { 
+    switch (mode) { 
 #ifdef STENO_ENABLE_GEMINI
         case STENO_MODE_GEMINI:
             send_steno_chord_gemini();

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -158,8 +158,8 @@ __attribute__((weak)) bool process_steno_user(uint16_t keycode, keyrecord_t *rec
 
 // Can be called programmatically by the user. Returns true if successful, otherwise false.
 bool send_custom_steno_chord(const uint16_t *stenochord) {
-    for (uint8_t i = 0; i < 42; i++) { 
-        /* Upper limit of 42 is used as failsafe if user does not supply CHORD_END. 
+    for (uint8_t i = 0; i < 42; i++) {
+        /* Upper limit of 42 is used as failsafe if user does not supply CHORD_END.
         There are 42 possible keycodes in Gemeni.)
         But if CHORD_END is not provided, the keyrange check below typically triggers first. */
 
@@ -170,7 +170,7 @@ bool send_custom_steno_chord(const uint16_t *stenochord) {
         }
 
         // Pass the formatted keycode to one of the add_*_key_to_chord() functions
-        switch (mode) { 
+        switch (mode) {
 #ifdef STENO_ENABLE_GEMINI
             case STENO_MODE_GEMINI:
                 add_gemini_key_to_chord(stenochord[i] - QK_STENO);
@@ -190,7 +190,7 @@ bool send_custom_steno_chord(const uint16_t *stenochord) {
 
     // The steno chord has been assembled in the 'chord' array.
     // Call the correct send_steno_chord_* function.
-    switch (mode) { 
+    switch (mode) {
 #ifdef STENO_ENABLE_GEMINI
         case STENO_MODE_GEMINI:
             send_steno_chord_gemini();

--- a/quantum/process_keycode/process_steno.h
+++ b/quantum/process_keycode/process_steno.h
@@ -24,6 +24,8 @@
 #define BOLT_STROKE_SIZE 4
 #define GEMINI_STROKE_SIZE 6
 
+#define CHORD_END 0
+
 #ifdef STENO_ENABLE_GEMINI
 #    define MAX_STROKE_SIZE GEMINI_STROKE_SIZE
 #else
@@ -40,3 +42,6 @@ bool process_steno(uint16_t keycode, keyrecord_t *record);
 void steno_init(void);
 void steno_set_mode(steno_mode_t mode);
 #endif // STENO_ENABLE_ALL
+
+// Can be called programmatically by the user. Returns true if successful, otherwise false.
+bool send_custom_steno_chord(const uint16_t *stenochord);


### PR DESCRIPTION
## Description

New feature to allow users to programmatically create an array of steno keycodes, terminated by a new `CHORD_END` constant, and send it to Plover.
 - New function in `process_steno.c` with proper protocol checks.
 - This new function is exposed in `process_steno.h`
 - Example and description is given in the updated `feature_stenography.md` file
 - Tested on both Gemini and TXBolt protocols.
 - Fails gracefully if user does not append `CHORD_END` to their array.

Copied & pasted example for convenience:


> To use the function, first manually construct an array of standard steno keycodes that is terminated by `CHORD_END`, then pass the arary to the function:
> ```c
> static const uint16_t myChord[] PROGMEM  = {STN_SL, STN_TL, STN_O, STN_E, STN_U, STN_PR, STN_BR, CHORD_END};
> send_custom_steno_chord(myChord);
> ```
> The keycodes do not need to be in proper steno order, but the array must terminate with `CHORD_END`.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
