### PR TITLE
Programmatically send steno chords via new function send_custom_steno_chord()

### DIFF
--- a/docs/feature_stenography.md
+++ b/docs/feature_stenography.md
@@ -118,6 +118,8 @@ To test your keymap, you can chord keys on your keyboard and either look at the 
 
 ## Interfacing with the code :id=interfacing-with-the-code
 
+### Using hooks
+
 The steno code has three interceptable hooks. If you define these functions, they will be called at certain points in processing; if they return true, processing continues, otherwise it's assumed you handled things.
 
 ```c
@@ -146,6 +148,22 @@ The `n_pressed_keys` argument is the number of physical keys actually being held
 This is not always equal to the number of bits set to 1 (aka the [Hamming weight](https://en.wikipedia.org/wiki/Hamming_weight)) in `chord` because it is possible to simultaneously press down four keys, then release three of those four keys and then press yet another key while the fourth finger is still holding down its key.
 At the end of this scenario given as an example, `chord` would have five bits set to 1 but
 `n_pressed_keys` would be set to 2 because there are only two keys currently being pressed down.
+
+### Programmatically sending steno chords
+
+You can programmatically send chords to Plover using the following function:
+```c
+bool send_custom_steno_chord(const uint16_t *stenochord);
+// Returns true upon successful processing and sending, and false otherwise.
+```
+
+To use the function, first manually construct an array of standard steno keycodes that is terminated by `CHORD_END`, then pass the arary to the function:
+
+```c
+static const uint16_t myChord[] PROGMEM  = {STN_SL, STN_TL, STN_O, STN_E, STN_U, STN_PR, STN_BR, CHORD_END};
+send_custom_steno_chord(myChord);
+```
+The keycodes do not need to be in proper steno order, but the array must terminate with `CHORD_END`.
 
 ## Keycode Reference :id=keycode-reference
 

--- a/quantum/process_keycode/process_steno.c
+++ b/quantum/process_keycode/process_steno.c
@@ -165,7 +165,7 @@ bool send_custom_steno_chord(const uint16_t *stenochord) {
         But if CHORD_END is not provided by user, the keyrange check below sometimes triggers first. */
         if (stenochord[i] == CHORD_END) {
             break;
-        } else if (i == MAX_LOOP-1) { // Reached the last item but still no CHORD_END
+        } else if (i == MAX_LOOP - 1) { // Reached the last item but still no CHORD_END
             steno_clear_chord();
             return false;
         } else if (stenochord[i] < QK_STENO || stenochord[i] > QK_STENO_MAX) {

--- a/quantum/process_keycode/process_steno.h
+++ b/quantum/process_keycode/process_steno.h
@@ -24,6 +24,8 @@
 #define BOLT_STROKE_SIZE 4
 #define GEMINI_STROKE_SIZE 6
 
+#define CHORD_END 0
+
 #ifdef STENO_ENABLE_GEMINI
 #    define MAX_STROKE_SIZE GEMINI_STROKE_SIZE
 #else
@@ -40,3 +42,6 @@ bool process_steno(uint16_t keycode, keyrecord_t *record);
 void steno_init(void);
 void steno_set_mode(steno_mode_t mode);
 #endif // STENO_ENABLE_ALL
+
+// Can be called programmatically by the user. Returns true if successful, otherwise false.
+bool send_custom_steno_chord(const uint16_t *stenochord);


### PR DESCRIPTION
## Description

New feature to allow users to programmatically create an array of steno keycodes, terminated by a new `CHORD_END` constant, and send it to Plover. This is done by calling a new function `send_custom_steno_chord()`
 - New function in `process_steno.c`that is exposed in `process_steno.h` for users.
 - Example and description is given in the updated `feature_stenography.md` file
 - Tested on both GeminiPR and TXBolt protocols.


Copied & pasted example from new documentation for convenience:

> To use the function, first manually construct an array of standard steno keycodes that is terminated by `CHORD_END`, then pass the arary to the function:
> ```c
> static const uint16_t myChord[] PROGMEM  = {STN_SL, STN_TL, STN_O, STN_E, STN_U, STN_PR, STN_BR, CHORD_END};
> send_custom_steno_chord(myChord);
> ```
> The keycodes do not need to be in proper steno order, but the array must terminate with `CHORD_END`.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
