### PR TITLE
[Bugfix] Broken `qmk mass-compile -n`

### DIFF
--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -25,7 +25,7 @@ def mass_compile_targets(targets: List[BuildTarget], clean: bool, dry_run: bool,
     if dry_run:
         cli.log.info('Compilation targets:')
         for target in sorted(targets, key=lambda t: (t.keyboard, t.keymap)):
-            cli.log.info(f"{{fg_cyan}}qmk compile -kb {target[0]} -km {target[1]}{{fg_reset}}")
+            cli.log.info(f"{{fg_cyan}}qmk compile -kb {target.keyboard} -km {target.keymap}{{fg_reset}}")
     else:
         if clean:
             cli.run([make_cmd, 'clean'], capture_output=False, stdin=DEVNULL)


### PR DESCRIPTION
## Description

As discussed on Discord

Friendly ping @tzarc 

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

```
$ qmk mass-compile -n
Ψ Retrieving list of keyboards with keymap "default"...
Ψ Preparing target list...
Ψ Compilation targets:
<class 'TypeError'>
☒ 'KeyboardKeymapBuildTarget' object is not subscriptable
Traceback (most recent call last):
  File "/home/elpekenin/.local/lib/python3.13/site-packages/milc/milc.py", line 539, in __call__
    return self.__call__()
           ^^^^^^^^^^^^^^^
  File "/home/elpekenin/.local/lib/python3.13/site-packages/milc/milc.py", line 544, in __call__
    return self._subcommand(self)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elpekenin/dev_qmk/lib/python/qmk/cli/mass_compile.py", line 111, in mass_compile
    return mass_compile_targets(targets, cli.args.clean, cli.args.dry_run, cli.args.no_temp, cli.config.mass_compile.parallel, **build_environment(cli.args.env))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elpekenin/dev_qmk/lib/python/qmk/cli/mass_compile.py", line 28, in mass_compile_targets
    cli.log.info(f"{}qmk compile -kb {target[0]} -km {target[1]}{}")
                                               ~~~~~~^^^
TypeError: 'KeyboardKeymapBuildTarget' object is not subscriptable
``` 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
