### PR TITLE
Remove redundant backlight eeconfig init

### DIFF
--- a/quantum/backlight/backlight.c
+++ b/quantum/backlight/backlight.c
@@ -42,20 +42,26 @@ backlight_config_t backlight_config;
 static uint8_t breathing_period = BREATHING_PERIOD;
 #endif
 
+static void backlight_check_config(void) {
+    /* Add some out of bound checks for backlight config */
+
+    if (backlight_config.level > BACKLIGHT_LEVELS) {
+        backlight_config.level = BACKLIGHT_LEVELS;
+    }
+}
+
 /** \brief Backlight initialization
  *
  * FIXME: needs doc
  */
 void backlight_init(void) {
-    /* check signature */
-    if (!eeconfig_is_enabled()) {
-        eeconfig_init();
+    backlight_config.raw = eeconfig_read_backlight();
+    if (!backlight_config.valid) {
+        dprintf("backlight_init backlight_config.valid = 0. Write default values to EEPROM.\n");
         eeconfig_update_backlight_default();
     }
-    backlight_config.raw = eeconfig_read_backlight();
-    if (backlight_config.level > BACKLIGHT_LEVELS) {
-        backlight_config.level = BACKLIGHT_LEVELS;
-    }
+    backlight_check_config();
+
     backlight_set(backlight_config.enable ? backlight_config.level : 0);
 }
 
@@ -183,6 +189,7 @@ void eeconfig_update_backlight_current(void) {
 }
 
 void eeconfig_update_backlight_default(void) {
+    backlight_config.valid     = true;
     backlight_config.enable    = BACKLIGHT_DEFAULT_ON;
     backlight_config.breathing = BACKLIGHT_DEFAULT_BREATHING;
     backlight_config.level     = BACKLIGHT_DEFAULT_LEVEL;

--- a/quantum/backlight/backlight.h
+++ b/quantum/backlight/backlight.h
@@ -39,7 +39,7 @@ typedef union {
     struct {
         bool    enable : 1;
         bool    breathing : 1;
-        uint8_t reserved : 1; // Reserved for possible future backlight modes
+        bool    valid : 1;
         uint8_t level : 5;
     };
 } backlight_config_t;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Extracted from #12020, as a more digestible chunk.

With the overall aim to remove all inits,  `magic()` is now called before `backlight_init`. eeprom will always be valid by the time `backlight_init` is called. Because of this, the existing logic to default config is currently broken.

The spare bit in the eeprom config has been used to decide if the backlight eeprom init process has been completed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
