### PR TITLE
[Keymap Removal] Restore splitkb 'debug' keymaps

### DIFF
--- a/keyboards/splitkb/aurora/corne/keymaps/debug/config.h
+++ b/keyboards/splitkb/aurora/corne/keymaps/debug/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef RGBLIGHT_ENABLE
+#   define RGBLIGHT_EFFECT_BREATHING
+#endif

--- a/keyboards/splitkb/aurora/corne/keymaps/debug/keymap.c
+++ b/keyboards/splitkb/aurora/corne/keymaps/debug/keymap.c
@@ -1,0 +1,73 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum layers {
+    _DEFAULT = 0,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_DEFAULT] = LAYOUT_split_3x6_3(
+        KC_A, KC_B, KC_C, KC_D, KC_E, KC_F,                    S(KC_F), S(KC_E), S(KC_D), S(KC_C), S(KC_B), S(KC_A),
+        KC_G, KC_H, KC_I, KC_J, KC_K, KC_L,                    S(KC_L), S(KC_K), S(KC_J), S(KC_I), S(KC_H), S(KC_G),
+        KC_M, KC_N, KC_O, KC_P, KC_Q, KC_R,                    S(KC_R), S(KC_Q), S(KC_P), S(KC_O), S(KC_N), S(KC_M),
+                                KC_S, KC_T, KC_U,     S(KC_U), S(KC_T), S(KC_S)
+    )
+};
+
+#ifdef RGBLIGHT_ENABLE
+void keyboard_post_init_user(void) {
+  rgblight_enable_noeeprom(); // enables RGB, without saving settings
+  rgblight_sethsv_noeeprom(HSV_RED); // sets the color to red without saving
+  rgblight_mode_noeeprom(RGBLIGHT_MODE_BREATHING + 3); // sets mode to Fast breathing without saving
+}
+#endif
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    // 0 is left-half encoder,
+    // 1 is right-half encoder
+    if (index == 0) {
+        tap_code(KC_0);
+    } else if (index == 1) {
+        tap_code(KC_1);
+    }
+
+    if (clockwise) {
+        tap_code16(KC_PLUS);
+    } else {
+        tap_code(KC_MINUS);
+    }
+
+    return false;
+}
+#endif
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // A 128x32 OLED rotated 90 degrees is 5 characters wide and 16 characters tall
+    // This example string should fill that neatly
+    const char *text = PSTR("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()[]{}-=_+?");
+
+    if (is_keyboard_master()) {
+        oled_write_P(text, false);
+    } else {
+        oled_write_P(text, false);
+    }
+    return false;
+}
+#endif

--- a/keyboards/splitkb/aurora/corne/keymaps/debug/readme.md
+++ b/keyboards/splitkb/aurora/corne/keymaps/debug/readme.md
@@ -1,0 +1,24 @@
+# Aurora Corne's Debug Keymap
+
+To make debugging your build as easy as possible, we have provided a special debugging keymap. It is not intended to actually type on, it is just here to make sure that your hardware is working correctly.
+
+## Keys
+
+![Keys](https://i.imgur.com/y5zWjsZh.png)
+
+The left side uses lowercase letters, the right side uses uppercase ones.
+
+## Encoders
+
+Encoders output a number of 0 or 1, depending on the installed position.
+These correspond to the index used for custom encoder code.
+
+The number is followed by either a `+` or a `-`, depending on the direction turned.
+
+## LEDs
+
+Both underglow and per-key RGB should be fading between red and off.
+
+## OLEDs
+
+Both the primary and secondary side should be filled with characters.

--- a/keyboards/splitkb/aurora/corne/keymaps/debug/rules.mk
+++ b/keyboards/splitkb/aurora/corne/keymaps/debug/rules.mk
@@ -1,0 +1,23 @@
+# Copyright 2022 splitkb.com <support@splitkb.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# NOTE: These are already enabled by default at the revision level
+#ENCODER_ENABLE = yes
+#OLED_ENABLE = yes
+
+# RGB Matrix is enabled at the revision level,
+# while we use the regular RGB underglow for testing
+RGB_MATRIX_ENABLE = no
+RGBLIGHT_ENABLE = yes

--- a/keyboards/splitkb/aurora/helix/keymaps/debug/config.h
+++ b/keyboards/splitkb/aurora/helix/keymaps/debug/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2023 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define RGBLIGHT_EFFECT_BREATHING

--- a/keyboards/splitkb/aurora/helix/keymaps/debug/keymap.c
+++ b/keyboards/splitkb/aurora/helix/keymaps/debug/keymap.c
@@ -1,0 +1,68 @@
+/* Copyright 2023 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum layers {
+    _DEFAULT = 0,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_DEFAULT] = LAYOUT(
+        KC_A, KC_B, KC_C, KC_D, KC_E, KC_F,                    S(KC_F), S(KC_E), S(KC_D), S(KC_C), S(KC_B), S(KC_A),
+        KC_G, KC_H, KC_I, KC_J, KC_K, KC_L,                    S(KC_L), S(KC_K), S(KC_J), S(KC_I), S(KC_H), S(KC_G),
+        KC_M, KC_N, KC_O, KC_P, KC_Q, KC_R,                    S(KC_R), S(KC_Q), S(KC_P), S(KC_O), S(KC_N), S(KC_M),
+        KC_S, KC_T, KC_U, KC_V, KC_W, KC_X, KC_Y,     S(KC_Y), S(KC_X), S(KC_W), S(KC_V), S(KC_U), S(KC_T), S(KC_S),
+        KC_Z, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6,     S(KC_6), S(KC_5), S(KC_4), S(KC_3), S(KC_2), S(KC_1), S(KC_Z)
+    )
+};
+
+#ifdef RGBLIGHT_ENABLE
+void keyboard_post_init_user(void) {
+  rgblight_enable_noeeprom(); // enables RGB, without saving settings
+  rgblight_sethsv_noeeprom(HSV_RED); // sets the color to red without saving
+  rgblight_mode_noeeprom(RGBLIGHT_MODE_BREATHING + 3); // sets mode to Fast breathing without saving
+}
+#endif
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    // 0 is left-half encoder
+    // 1 is right-half encoder
+    if (index == 0) {
+        tap_code(KC_0);
+    } else if (index == 1) {
+        tap_code(KC_1);
+    }
+
+    if (clockwise) {
+        tap_code16(KC_PLUS);
+    } else {
+        tap_code(KC_MINUS);
+    }
+
+    return false;
+}
+#endif
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // A 128x32 OLED rotated 90 degrees is 5 characters wide and 16 characters tall
+    // This example string should fill that neatly
+    oled_write_P(PSTR("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()[]{}-=_+?"), false);
+    return false;
+}
+#endif

--- a/keyboards/splitkb/aurora/helix/keymaps/debug/readme.md
+++ b/keyboards/splitkb/aurora/helix/keymaps/debug/readme.md
@@ -1,0 +1,24 @@
+# Aurora Helix's Debug Keymap
+
+To make debugging your build as easy as possible, we have provided a special debugging keymap. It is not intended to actually type on, it is just here to make sure that your hardware is working correctly.
+
+## Keys
+
+![Keys](https://raw.githubusercontent.com/splitkb/qmk_firmware/assets/aurora/keymaps/debug/keys.png)
+
+The left side uses lowercase letters, the right side uses uppercase ones.
+
+## Encoders
+
+Encoders output a number of 0 or 1, depending on the installed position.
+These correspond to the index used for custom encoder code: the left half uses index 0, the right half uses index 1.
+
+The number is followed by either a `+` or a `-`, depending on the direction turned.
+
+## LEDs
+
+Both underglow and per-key RGB should be fading between red and off.
+
+## OLEDs
+
+Both the primary and secondary side should be filled with characters.

--- a/keyboards/splitkb/aurora/helix/keymaps/debug/rules.mk
+++ b/keyboards/splitkb/aurora/helix/keymaps/debug/rules.mk
@@ -1,0 +1,8 @@
+# NOTE: These are already enabled by default at the revision level
+#ENCODER_ENABLE = yes
+#OLED_ENABLE = yes
+
+# RGB Matrix is enabled at the revision level,
+# while we use the regular RGB underglow for testing
+RGB_MATRIX_ENABLE = no
+RGBLIGHT_ENABLE = yes

--- a/keyboards/splitkb/aurora/lily58/keymaps/debug/config.h
+++ b/keyboards/splitkb/aurora/lily58/keymaps/debug/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef RGBLIGHT_ENABLE
+#   define RGBLIGHT_EFFECT_BREATHING
+#endif

--- a/keyboards/splitkb/aurora/lily58/keymaps/debug/keymap.c
+++ b/keyboards/splitkb/aurora/lily58/keymaps/debug/keymap.c
@@ -1,0 +1,75 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum layers {
+    _DEFAULT = 0,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_DEFAULT] = LAYOUT(
+        KC_A, KC_B, KC_C, KC_D, KC_E, KC_F,                    S(KC_F), S(KC_E), S(KC_D), S(KC_C), S(KC_B), S(KC_A),
+        KC_G, KC_H, KC_I, KC_J, KC_K, KC_L,                    S(KC_L), S(KC_K), S(KC_J), S(KC_I), S(KC_H), S(KC_G),
+        KC_M, KC_N, KC_O, KC_P, KC_Q, KC_R,                    S(KC_R), S(KC_Q), S(KC_P), S(KC_O), S(KC_N), S(KC_M),
+        KC_S, KC_T, KC_U, KC_V, KC_W, KC_X, KC_Y,     S(KC_Y), S(KC_X), S(KC_W), S(KC_V), S(KC_U), S(KC_T), S(KC_S),
+                          KC_Z, KC_1, KC_2, KC_3,     S(KC_3), S(KC_2), S(KC_1), S(KC_Z)
+
+    )
+};
+
+#ifdef RGBLIGHT_ENABLE
+void keyboard_post_init_user(void) {
+  rgblight_enable_noeeprom(); // enables RGB, without saving settings
+  rgblight_sethsv_noeeprom(HSV_RED); // sets the color to red without saving
+  rgblight_mode_noeeprom(RGBLIGHT_MODE_BREATHING + 3); // sets mode to Fast breathing without saving
+}
+#endif
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    // 0 is left-half encoder
+    // 1 is right-half encoder
+    if (index == 0) {
+        tap_code(KC_0);
+    } else if (index == 1) {
+        tap_code(KC_1);
+    }
+
+    if (clockwise) {
+        tap_code16(KC_PLUS);
+    } else {
+        tap_code(KC_MINUS);
+    }
+
+    return false;
+}
+#endif
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // A 128x32 OLED rotated 90 degrees is 5 characters wide and 16 characters tall
+    // This example string should fill that neatly
+    const char *text = PSTR("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()[]{}-=_+?");
+
+    if (is_keyboard_master()) {
+        oled_write_P(text, false);
+    } else {
+        oled_write_P(text, false);
+    }
+    return false;
+}
+#endif

--- a/keyboards/splitkb/aurora/lily58/keymaps/debug/readme.md
+++ b/keyboards/splitkb/aurora/lily58/keymaps/debug/readme.md
@@ -1,0 +1,24 @@
+# Aurora Lily58's Debug Keymap
+
+To make debugging your build as easy as possible, we have provided a special debugging keymap. It is not intended to actually type on, it is just here to make sure that your hardware is working correctly.
+
+## Keys
+
+![Keys](https://i.imgur.com/CF0PYu5h.png)
+
+The left side uses lowercase letters, the right side uses uppercase ones.
+
+## Encoders
+
+Encoders output a number of 0 or 1, depending on the installed position.
+These correspond to the index used for custom encoder code: the left half uses index 0, the right half uses index 1.
+
+The number is followed by either a `+` or a `-`, depending on the direction turned.
+
+## LEDs
+
+Both underglow and per-key RGB should be fading between red and off.
+
+## OLEDs
+
+Both the primary and secondary side should be filled with characters.

--- a/keyboards/splitkb/aurora/lily58/keymaps/debug/rules.mk
+++ b/keyboards/splitkb/aurora/lily58/keymaps/debug/rules.mk
@@ -1,0 +1,23 @@
+# Copyright 2022 splitkb.com <support@splitkb.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# NOTE: These are already enabled by default at the revision level
+#ENCODER_ENABLE = yes
+#OLED_ENABLE = yes
+
+# RGB Matrix is enabled at the revision level,
+# while we use the regular RGB underglow for testing
+RGB_MATRIX_ENABLE = no
+RGBLIGHT_ENABLE = yes

--- a/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/config.h
+++ b/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/config.h
@@ -1,0 +1,19 @@
+/* Copyright 2023 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define RGBLIGHT_EFFECT_BREATHING

--- a/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/keymap.c
+++ b/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/keymap.c
@@ -1,0 +1,69 @@
+/* Copyright 2023 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum layers {
+    _DEFAULT = 0,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_DEFAULT] = LAYOUT(
+        KC_A, KC_B, KC_C, KC_D, KC_E, KC_F,                    S(KC_F), S(KC_E), S(KC_D), S(KC_C), S(KC_B), S(KC_A),
+        KC_G, KC_H, KC_I, KC_J, KC_K, KC_L,                    S(KC_L), S(KC_K), S(KC_J), S(KC_I), S(KC_H), S(KC_G),
+        KC_M, KC_N, KC_O, KC_P, KC_Q, KC_R,                    S(KC_R), S(KC_Q), S(KC_P), S(KC_O), S(KC_N), S(KC_M),
+        KC_S, KC_T, KC_U, KC_V, KC_W, KC_X, KC_Y,     S(KC_Y), S(KC_X), S(KC_W), S(KC_V), S(KC_U), S(KC_T), S(KC_S),
+                    KC_Z, KC_1, KC_2, KC_3, KC_4,     S(KC_4), S(KC_3), S(KC_2), S(KC_1), S(KC_Z)
+
+    )
+};
+
+#ifdef RGBLIGHT_ENABLE
+void keyboard_post_init_user(void) {
+  rgblight_enable_noeeprom(); // enables RGB, without saving settings
+  rgblight_sethsv_noeeprom(HSV_RED); // sets the color to red without saving
+  rgblight_mode_noeeprom(RGBLIGHT_MODE_BREATHING + 3); // sets mode to Fast breathing without saving
+}
+#endif
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    // 0 is left-half encoder
+    // 1 is right-half encoder
+    if (index == 0) {
+        tap_code(KC_0);
+    } else if (index == 1) {
+        tap_code(KC_1);
+    }
+
+    if (clockwise) {
+        tap_code16(KC_PLUS);
+    } else {
+        tap_code(KC_MINUS);
+    }
+
+    return false;
+}
+#endif
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // A 128x32 OLED rotated 90 degrees is 5 characters wide and 16 characters tall
+    // This example string should fill that neatly
+    oled_write_P(PSTR("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()[]{}-=_+?"), false);
+    return false;
+}
+#endif

--- a/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/readme.md
+++ b/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/readme.md
@@ -1,0 +1,24 @@
+# Aurora Sofle's Debug Keymap
+
+To make debugging your build as easy as possible, we have provided a special debugging keymap. It is not intended to actually type on, it is just here to make sure that your hardware is working correctly.
+
+## Keys
+
+![Keys](https://i.imgur.com/1qRAV6sh.png)
+
+The left side uses lowercase letters, the right side uses uppercase ones.
+
+## Encoders
+
+Encoders output a number of 0 or 1, depending on the installed position.
+These correspond to the index used for custom encoder code: the left half uses index 0, the right half uses index 1.
+
+The number is followed by either a `+` or a `-`, depending on the direction turned.
+
+## LEDs
+
+Both underglow and per-key RGB should be fading between red and off.
+
+## OLEDs
+
+Both the primary and secondary side should be filled with characters.

--- a/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/rules.mk
+++ b/keyboards/splitkb/aurora/sofle_v2/keymaps/debug/rules.mk
@@ -1,0 +1,8 @@
+# NOTE: These are already enabled by default at the revision level
+#ENCODER_ENABLE = yes
+#OLED_ENABLE = yes
+
+# RGB Matrix is enabled at the revision level,
+# while we use the regular RGB underglow for testing
+RGB_MATRIX_ENABLE = no
+RGBLIGHT_ENABLE = yes

--- a/keyboards/splitkb/aurora/sweep/keymaps/debug/config.h
+++ b/keyboards/splitkb/aurora/sweep/keymaps/debug/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef RGBLIGHT_ENABLE
+#   define RGBLIGHT_EFFECT_BREATHING
+#endif

--- a/keyboards/splitkb/aurora/sweep/keymaps/debug/keymap.c
+++ b/keyboards/splitkb/aurora/sweep/keymaps/debug/keymap.c
@@ -1,0 +1,77 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum layers {
+    _DEFAULT = 0,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_DEFAULT] = LAYOUT(
+        KC_A, KC_B, KC_C, KC_D, KC_E,     S(KC_E), S(KC_D), S(KC_C), S(KC_B), S(KC_A),
+        KC_F, KC_G, KC_H, KC_I, KC_J,     S(KC_J), S(KC_I), S(KC_H), S(KC_G), S(KC_F),
+        KC_K, KC_L, KC_M, KC_N, KC_O,     S(KC_O), S(KC_N), S(KC_M), S(KC_L), S(KC_K),
+                          KC_P, KC_Q,     S(KC_Q), S(KC_P)
+    )
+};
+
+#ifdef RGBLIGHT_ENABLE
+void keyboard_post_init_user(void) {
+  rgblight_enable_noeeprom(); // enables RGB, without saving settings
+  rgblight_sethsv_noeeprom(HSV_RED); // sets the color to red without saving
+  rgblight_mode_noeeprom(RGBLIGHT_MODE_BREATHING + 3); // sets mode to Fast breathing without saving
+}
+#endif
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    // 0 and 1 are left-half encoders
+    // 2 and 3 are right-half encoders
+    if (index == 0) {
+        tap_code(KC_0);
+    } else if (index == 1) {
+        tap_code(KC_1);
+    } else if (index == 2) {
+        tap_code(KC_2);
+    } else if (index == 3) {
+        tap_code(KC_3);
+    }
+
+    if (clockwise) {
+        tap_code16(KC_PLUS);
+    } else {
+        tap_code(KC_MINUS);
+    }
+
+    return false;
+}
+#endif
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // A 128x32 OLED rotated 90 degrees is 5 characters wide and 16 characters tall
+    // This example string should fill that neatly
+    const char *text = PSTR("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()[]{}-=_+?");
+
+    if (is_keyboard_master()) {
+        oled_write_P(text, false);
+    } else {
+        oled_write_P(text, false);
+    }
+    return false;
+}
+#endif

--- a/keyboards/splitkb/aurora/sweep/keymaps/debug/readme.md
+++ b/keyboards/splitkb/aurora/sweep/keymaps/debug/readme.md
@@ -1,0 +1,25 @@
+# Aurora Sweep's Debug Keymap
+
+Due to the complex layer setup, the default keymap for the Aurora Sweep is relatively hard to debug.
+This debug keymap should make that a lot easier.
+
+## Keys
+
+![Keys](https://raw.githubusercontent.com/splitkb/qmk_firmware/assets/aurora/sweep/keymaps/debug/keys.png)
+
+The left side uses lowercase letters, the right side uses uppercase ones.
+
+## Encoders
+
+Encoders output a number of 0 to 3, depending on the installed position.
+These correspond to the index used for custom encoder code.
+
+The number is followed by either a `+` or a `-`, depending on the direction turned.
+
+## LEDs
+
+Both underglow and per-key RGB should be fading between red and off.
+
+## OLEDs
+
+Both the primary and secondary side should be filled with characters.

--- a/keyboards/splitkb/aurora/sweep/keymaps/debug/rules.mk
+++ b/keyboards/splitkb/aurora/sweep/keymaps/debug/rules.mk
@@ -1,0 +1,23 @@
+# Copyright 2022 splitkb.com <support@splitkb.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# NOTE: These are already enabled by default at the revision level
+#ENCODER_ENABLE = yes
+#OLED_ENABLE = yes
+
+# RGB Matrix is enabled at the revision level,
+# while we use the regular RGB underglow for testing
+RGB_MATRIX_ENABLE = no
+RGBLIGHT_ENABLE = yes

--- a/keyboards/splitkb/kyria/keymaps/debug/config.h
+++ b/keyboards/splitkb/kyria/keymaps/debug/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef RGBLIGHT_ENABLE
+#   define RGBLIGHT_EFFECT_BREATHING
+#endif

--- a/keyboards/splitkb/kyria/keymaps/debug/keymap.c
+++ b/keyboards/splitkb/kyria/keymaps/debug/keymap.c
@@ -1,0 +1,73 @@
+/* Copyright 2022 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+enum layers {
+    _DEFAULT = 0,
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_DEFAULT] = LAYOUT(
+        KC_A, KC_B, KC_C, KC_D, KC_E, KC_F,                                   S(KC_F), S(KC_E), S(KC_D), S(KC_C), S(KC_B), S(KC_A),
+        KC_G, KC_H, KC_I, KC_J, KC_K, KC_L,                                   S(KC_L), S(KC_K), S(KC_J), S(KC_I), S(KC_H), S(KC_G),
+        KC_M, KC_N, KC_O, KC_P, KC_Q, KC_R, KC_S, KC_T,     S(KC_T), S(KC_S), S(KC_R), S(KC_Q), S(KC_P), S(KC_O), S(KC_N), S(KC_M),
+                          KC_U, KC_V, KC_W, KC_X, KC_Y,     S(KC_Y), S(KC_X), S(KC_W), S(KC_V), S(KC_U)
+    )
+};
+
+#ifdef RGBLIGHT_ENABLE
+void keyboard_post_init_user(void) {
+  rgblight_enable_noeeprom(); // enables RGB, without saving settings
+  rgblight_sethsv_noeeprom(HSV_RED); // sets the color to red without saving
+  rgblight_mode_noeeprom(RGBLIGHT_MODE_BREATHING + 3); // sets mode to Fast breathing without saving
+}
+#endif
+
+#ifdef ENCODER_ENABLE
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    // 0 is left-half encoder,
+    // 1 is right-half encoder
+    if (index == 0) {
+        tap_code(KC_0);
+    } else if (index == 1) {
+        tap_code(KC_1);
+    }
+
+    if (clockwise) {
+        tap_code16(KC_PLUS);
+    } else {
+        tap_code(KC_MINUS);
+    }
+
+    return false;
+}
+#endif
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // A 128x64 OLED rotated 180 degrees is 21 characters wide and 8 characters tall
+    // This example string should fill that neatly
+    const char *text = PSTR("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()[]{}-=_+?/,.|abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()[]{}-=_+?/,.|");
+
+    if (is_keyboard_master()) {
+        oled_write_P(text, false);
+    } else {
+        oled_write_P(text, false);
+    }
+    return false;
+}
+#endif

--- a/keyboards/splitkb/kyria/keymaps/debug/readme.md
+++ b/keyboards/splitkb/kyria/keymaps/debug/readme.md
@@ -1,0 +1,24 @@
+# Kyria's Debug Keymap
+
+To make debugging your build as easy as possible, we have provided a special debugging keymap. It is not intended to actually type on, it is just here to make sure that your hardware is working correctly.
+
+## Keys
+
+![Keys](https://i.imgur.com/pmPBYlkh.png)
+
+The left side uses lowercase letters, the right side uses uppercase ones.
+
+## Encoders
+
+Encoders output a number of 0 or 1, depending on the installed position.
+These correspond to the index used for custom encoder code.
+
+The number is followed by either a `+` or a `-`, depending on the direction turned.
+
+## LEDs
+
+Both underglow and per-key RGB should be fading between red and off.
+
+## OLEDs
+
+Both the primary and secondary side should be filled with characters.

--- a/keyboards/splitkb/kyria/keymaps/debug/rules.mk
+++ b/keyboards/splitkb/kyria/keymaps/debug/rules.mk
@@ -1,0 +1,8 @@
+# NOTE: These are already enabled by default at the revision level
+#ENCODER_ENABLE = yes
+#OLED_ENABLE = yes
+
+# RGB Matrix is enabled at the revision level,
+# while we use the regular RGB underglow for testing
+RGB_MATRIX_ENABLE = no
+RGBLIGHT_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
22693 removed the splitkb debug keymaps, however we have the following request https://github.com/qmk/qmk_firmware/pull/22485#issuecomment-1820891011

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
