### PR TITLE
Remove redundant audio eeconfig init

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -17,6 +17,8 @@
     "APA102_DI_PIN": {"info_key": "apa102.data_pin"},
 
     // Audio
+    "AUDIO_DEFAULT_ON": {"info_key": "audio.default.on", "value_type": "bool"},
+    "AUDIO_DEFAULT_CLICKY_ON": {"info_key": "audio.default.clicky", "value_type": "bool"},
     "AUDIO_VOICES": {"info_key": "audio.voices", "value_type": "bool"},
     "SENDSTRING_BELL": {"info_key": "audio.macro_beep", "value_type": "bool"},
 

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -123,6 +123,14 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "default": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "on": {"type": "boolean"},
+                        "clicky": {"type": "boolean"}
+                    }
+                },
                 "macro_beep": {"type": "boolean"},
                 "pins": {"$ref": "qmk.definitions.v1#/mcu_pin_array"},
                 "voices": {"type": "boolean"}

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -111,6 +111,13 @@ Configures the [APA102](apa102_driver.md) driver.
 Configures the [Audio](feature_audio.md) feature.
 
 * `audio`
+    * `default`
+        * `on`
+            * The default audio enabled state.
+            * Default: `true`
+        * `clicky`
+            * The default audio clicky enabled state.
+            * Default: `true`
     * `macro_beep`
         * Play a short beep for `\a` (ASCII `BEL`) characters in Send String macros.
         * Default: `false`

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -129,6 +129,7 @@ void eeconfig_update_audio_default(void) {
     audio_config.valid         = true;
     audio_config.enable        = AUDIO_DEFAULT_ON;
     audio_config.clicky_enable = AUDIO_DEFAULT_CLICKY_ON;
+    eeconfig_update_audio(audio_config.raw);
 }
 
 void audio_init(void) {

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -62,6 +62,13 @@
  * the internal state of the audio system does its calculations with the later - ms
  */
 
+#ifndef AUDIO_DEFAULT_ON
+#    define AUDIO_DEFAULT_ON true
+#endif
+#ifndef AUDIO_DEFAULT_CLICKY_ON
+#    define AUDIO_DEFAULT_CLICKY_ON true
+#endif
+
 #ifndef AUDIO_TONE_STACKSIZE
 #    define AUDIO_TONE_STACKSIZE 8
 #endif
@@ -117,32 +124,30 @@ void eeconfig_update_audio_current(void) {
     eeconfig_update_audio(audio_config.raw);
 }
 
+void eeconfig_update_audio_default(void) {
+    audio_config.valid         = true;
+    audio_config.enable        = AUDIO_DEFAULT_ON;
+    audio_config.clicky_enable = AUDIO_DEFAULT_CLICKY_ON;
+}
+
 void audio_init(void) {
     if (audio_initialized) {
         return;
     }
 
-    // Check EEPROM
-#ifdef EEPROM_ENABLE
-    if (!eeconfig_is_enabled()) {
-        eeconfig_init();
-    }
     audio_config.raw = eeconfig_read_audio();
-#else // EEPROM settings
-    audio_config.enable        = true;
-#    ifdef AUDIO_CLICKY_ON
-    audio_config.clicky_enable = true;
-#    endif
-#endif // EEPROM settings
+    if (!audio_config.valid) {
+        dprintf("audio_init audio_config.valid = 0. Write default values to EEPROM.\n");
+        eeconfig_update_audio_default();
+    }
 
     for (uint8_t i = 0; i < AUDIO_TONE_STACKSIZE; i++) {
         tones[i] = (musical_tone_t){.time_started = 0, .pitch = -1.0f, .duration = 0};
     }
 
-    if (!audio_initialized) {
-        audio_driver_initialize();
-        audio_initialized = true;
-    }
+    audio_driver_initialize();
+    audio_initialized = true;
+
     stop_all_notes();
 #ifndef AUDIO_INIT_DELAY
     audio_startup();

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -17,6 +17,7 @@
 #include "audio.h"
 #include "eeconfig.h"
 #include "timer.h"
+#include "debug.h"
 #include "wait.h"
 #include "util.h"
 

--- a/quantum/audio/audio.h
+++ b/quantum/audio/audio.h
@@ -33,7 +33,8 @@ typedef union {
     struct {
         bool    enable : 1;
         bool    clicky_enable : 1;
-        uint8_t level : 6;
+        bool    valid : 1;
+        uint8_t reserved : 5;
     };
 } audio_config_t;
 

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -54,7 +54,7 @@ void eeconfig_init_quantum(void) {
     // Enable oneshot and autocorrect by default: 0b0001 0100 0000 0000
     eeprom_update_word(EECONFIG_KEYMAP, 0x1400);
     eeprom_update_byte(EECONFIG_BACKLIGHT, 0);
-    eeprom_update_byte(EECONFIG_AUDIO, 0xFF); // On by default
+    eeprom_update_byte(EECONFIG_AUDIO, 0);
     eeprom_update_dword(EECONFIG_RGBLIGHT, 0);
     eeprom_update_byte(EECONFIG_RGBLIGHT_EXTENDED, 0);
     eeprom_update_byte(EECONFIG_UNUSED, 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Extracted from #12020, as a more digestible chunk.

With the overall aim to remove all inits,  `magic()` is now called before `audio_init`. eeprom will always be valid by the time `audio_init` is called.

A spare bit in the eeprom config has been used to decide if the eeprom init process has been completed. Defaulting of config options has been implemented per other features.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
