### PR TITLE
pointing_device ifdef indentation fix

### DIFF
--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -251,14 +251,15 @@ __attribute__((weak)) bool pointing_device_task(void) {
 #    else
     if (readPin(POINTING_DEVICE_MOTION_PIN))
 #    endif
+    {
 #endif
 
 #if defined(SPLIT_POINTING_ENABLE)
 #    if defined(POINTING_DEVICE_COMBINED)
         static uint8_t old_buttons = 0;
-    local_mouse_report.buttons = old_buttons;
-    local_mouse_report         = pointing_device_driver.get_report(local_mouse_report);
-    old_buttons                = local_mouse_report.buttons;
+        local_mouse_report.buttons = old_buttons;
+        local_mouse_report         = pointing_device_driver.get_report(local_mouse_report);
+        old_buttons                = local_mouse_report.buttons;
 #    elif defined(POINTING_DEVICE_LEFT) || defined(POINTING_DEVICE_RIGHT)
         local_mouse_report = POINTING_DEVICE_THIS_SIDE ? pointing_device_driver.get_report(local_mouse_report) : shared_mouse_report;
 #    else
@@ -267,6 +268,10 @@ __attribute__((weak)) bool pointing_device_task(void) {
 #else
     local_mouse_report = pointing_device_driver.get_report(local_mouse_report);
 #endif // defined(SPLIT_POINTING_ENABLE)
+
+#ifdef POINTING_DEVICE_MOTION_PIN
+    }
+#endif
 
     // allow kb to intercept and modify report
 #if defined(SPLIT_POINTING_ENABLE) && defined(POINTING_DEVICE_COMBINED)


### PR DESCRIPTION
the mutual exclusive POINTING_DEVICE_MOTION_PIN and SPLIT_POINTING_ENABLE influence if and how the `pointing_device_driver.get_report` is triggered. now the way the define is wrapping around an "unbraced" if leads clang-format to weirdly indent the first line in the 'SPLIT_POINTING_ENABLE' as the first command after the if.
    
this hints that any code addition in between the two - that possibly should run regardless, would break the if-def enabled code.
    
 this can be solved by adding a pair of curly braces in the POINTING_DEVICE_MOTION_PIN part, to clearly denote which commands are to be skipped if the motion pin shows now activity.



<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x]  Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
