### PR TITLE
Cirque reachable calibration aide

### DIFF
--- a/docs/feature_pointing_device.md
+++ b/docs/feature_pointing_device.md
@@ -217,12 +217,13 @@ Also see the `POINTING_DEVICE_TASK_THROTTLE_MS`, which defaults to 10ms when usi
 
 #### Absolute mode settings
 
-| Setting                          | Description                                                | Default            |
-| -------------------------------- | ---------------------------------------------------------- | ------------------ |
-| `CIRQUE_PINNACLE_X_LOWER`        | (Optional) The minimum reachable X value on the sensor.    | `127`              |
-| `CIRQUE_PINNACLE_X_UPPER`        | (Optional) The maximum reachable X value on the sensor.    | `1919`             |
-| `CIRQUE_PINNACLE_Y_LOWER`        | (Optional) The minimum reachable Y value on the sensor.    | `63`               |
-| `CIRQUE_PINNACLE_Y_UPPER`        | (Optional) The maximum reachable Y value on the sensor.    | `1471`             |
+| Setting                                 | Description                                                             | Default     |
+|-----------------------------------------|-------------------------------------------------------------------------|-------------|
+| `CIRQUE_PINNACLE_X_LOWER`               | (Optional) The minimum reachable X value on the sensor.                 | `127`       |
+| `CIRQUE_PINNACLE_X_UPPER`               | (Optional) The maximum reachable X value on the sensor.                 | `1919`      |
+| `CIRQUE_PINNACLE_Y_LOWER`               | (Optional) The minimum reachable Y value on the sensor.                 | `63`        |
+| `CIRQUE_PINNACLE_Y_UPPER`               | (Optional) The maximum reachable Y value on the sensor.                 | `1471`      |
+| `CIRQUE_PINNACLE_REACHABLE_CALIBRATION` | (Optional) Enable console messages to aide in calibrating above values. | not defined |
 
 #### Absolute mode gestures
 

--- a/drivers/sensors/cirque_pinnacle.c
+++ b/drivers/sensors/cirque_pinnacle.c
@@ -332,7 +332,7 @@ pinnacle_data_t cirque_pinnacle_read_data(void) {
 #endif
 
 #ifdef CIRQUE_PINNACLE_REACHABLE_CALIBRATION
-    static uint16_t xMin = 0xffff, yMin = 0xffff, yMax = 0, xMax = 0;
+    static uint16_t xMin = UINT16_MAX, yMin = UINT16_MAX, yMax = 0, xMax = 0;
     if (result.xValue < xMin) xMin = result.xValue;
     if (result.xValue > xMax) xMax = result.xValue;
     if (result.yValue < yMin) yMin = result.yValue;

--- a/drivers/sensors/cirque_pinnacle.c
+++ b/drivers/sensors/cirque_pinnacle.c
@@ -331,6 +331,15 @@ pinnacle_data_t cirque_pinnacle_read_data(void) {
     result.wheelCount = ((int8_t*)data)[3];
 #endif
 
+#ifdef CIRQUE_PINNACLE_REACHABLE_CALIBRATION
+    static uint16_t xMin = 0xffff, yMin = 0xffff, yMax = 0, xMax = 0;
+    if (result.xValue < xMin) xMin = result.xValue;
+    if (result.xValue > xMax) xMax = result.xValue;
+    if (result.yValue < yMin) yMin = result.yValue;
+    if (result.yValue > yMax) yMax = result.yValue;
+    pd_dprintf("%s: xLo=%3d xHi=%3d yLo=%3d yHi=%3d\n", __FUNCTION__, xMin, xMax, yMin, yMax);
+#endif
+
     result.valid = true;
     return result;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

the physical reachable range for the x/y axis can be user defined with `CIRQUE_PINNACLE_X_LOWER` etc, 
to figure out these values the new `CIRQUE_PINNACLE_REACHABLE_CALIBRATION` can be used.

a user can enable the debug console, this feature, dandomly move over the sensor to cover the whole area and then read the last min/max value set printed to the console to set those defines


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
