### PR TITLE
Ensure LED config is extracted when feature is disabled

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -684,12 +684,10 @@ def _extract_led_config(info_data, keyboard):
     rows = info_data['matrix_size']['rows']
 
     # Determine what feature owns g_led_config
-    features = info_data.get("features", {})
     feature = None
-    if features.get("rgb_matrix", False):
-        feature = "rgb_matrix"
-    elif features.get("led_matrix", False):
-        feature = "led_matrix"
+    for feat in ["rgb_matrix", "led_matrix"]:
+        if info_data.get("features", {}).get(feat, False) or feat in info_data:
+            feature = feat
 
     if feature:
         # Process

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -685,23 +685,25 @@ def _extract_led_config(info_data, keyboard):
 
     # Determine what feature owns g_led_config
     feature = None
-    for feat in ["rgb_matrix", "led_matrix"]:
-        if info_data.get("features", {}).get(feat, False) or feat in info_data:
+    for feat in ['rgb_matrix', 'led_matrix']:
+        if info_data.get('features', {}).get(feat, False) or feat in info_data:
             feature = feat
 
     if feature:
-        # Process
-        for file in find_keyboard_c(keyboard):
-            try:
-                ret = find_led_config(file, cols, rows)
-                if ret:
-                    info_data[feature] = info_data.get(feature, {})
-                    info_data[feature]["layout"] = ret
-            except Exception as e:
-                _log_warning(info_data, f'led_config: {file.name}: {e}')
+        # Only attempt search if dd led config is missing
+        if 'layout' not in info_data.get(feature, {}):
+            # Process
+            for file in find_keyboard_c(keyboard):
+                try:
+                    ret = find_led_config(file, cols, rows)
+                    if ret:
+                        info_data[feature] = info_data.get(feature, {})
+                        info_data[feature]['layout'] = ret
+                except Exception as e:
+                    _log_warning(info_data, f'led_config: {file.name}: {e}')
 
-        if info_data[feature].get("layout", None) and not info_data[feature].get("led_count", None):
-            info_data[feature]["led_count"] = len(info_data[feature]["layout"])
+        if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
+            info_data[feature]['led_count'] = len(info_data[feature]['layout'])
 
     return info_data
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Some of the dd conversions, 22806 22807 22808, are failing due to the led config not being parsed (or led count being added) when the lighting feature is disabled by default.

If we have _some_ dd config for a lighting feature, then we probably should still try and search for led config.
Likewise, if we already have position data, there is no point in trying to search for it.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
