### PR TITLE
is31fl3733: change `write_register()` return type to `void`

### DIFF
--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -77,23 +77,17 @@ bool    g_pwm_buffer_update_required[IS31FL3733_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
-bool is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    // If the transaction fails function returns false.
+void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
     i2c_transfer_buffer[0] = reg;
     i2c_transfer_buffer[1] = data;
 
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) != 0) {
-            return false;
-        }
+        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) == 0) break;
     }
 #else
-    if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) != 0) {
-        return false;
-    }
+    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT);
 #endif
-    return true;
 }
 
 void is31fl3733_select_page(uint8_t addr, uint8_t page) {

--- a/drivers/led/issi/is31fl3733-mono.h
+++ b/drivers/led/issi/is31fl3733-mono.h
@@ -116,7 +116,7 @@ extern const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT];
 
 void is31fl3733_init_drivers(void);
 void is31fl3733_init(uint8_t addr, uint8_t sync);
-bool is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
+void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void is31fl3733_select_page(uint8_t addr, uint8_t page);
 bool is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -76,23 +76,17 @@ bool    g_pwm_buffer_update_required[IS31FL3733_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
-bool is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    // If the transaction fails function returns false.
+void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
     i2c_transfer_buffer[0] = reg;
     i2c_transfer_buffer[1] = data;
 
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) != 0) {
-            return false;
-        }
+        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) == 0) break;
     }
 #else
-    if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) != 0) {
-        return false;
-    }
+    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT);
 #endif
-    return true;
 }
 
 void is31fl3733_select_page(uint8_t addr, uint8_t page) {

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -141,7 +141,7 @@ extern const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT];
 
 void is31fl3733_init_drivers(void);
 void is31fl3733_init(uint8_t addr, uint8_t sync);
-bool is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
+void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
 void is31fl3733_select_page(uint8_t addr, uint8_t page);
 bool is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer);
 

--- a/keyboards/input_club/k_type/is31fl3733-dual.c
+++ b/keyboards/input_club/k_type/is31fl3733-dual.c
@@ -74,23 +74,17 @@ bool    g_pwm_buffer_update_required[IS31FL3733_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
-bool is31fl3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data) {
-    // If the transaction fails function returns false.
+void is31fl3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data) {
     i2c_transfer_buffer[0] = reg;
     i2c_transfer_buffer[1] = data;
 
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(index, addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) != 0) {
-            return false;
-        }
+        if (i2c_transmit(index, addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) == 0) break;
     }
 #else
-    if (i2c_transmit(index, addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) != 0) {
-        return false;
-    }
+    i2c_transmit(index, addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT);
 #endif
-    return true;
 }
 
 void is31fl3733_select_page(uint8_t index, uint8_t addr, uint8_t page) {

--- a/keyboards/input_club/k_type/is31fl3733-dual.h
+++ b/keyboards/input_club/k_type/is31fl3733-dual.h
@@ -69,7 +69,7 @@ extern const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT];
 
 void is31fl3733_init_drivers(void);
 void is31fl3733_init(uint8_t bus, uint8_t addr, uint8_t sync);
-bool is31fl3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data);
+void is31fl3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data);
 void is31fl3733_select_page(uint8_t index, uint8_t addr, uint8_t page);
 bool is31fl3733_write_pwm_buffer(uint8_t index, uint8_t addr, uint8_t *pwm_buffer);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Never used, and is the only ISSI driver which `write_register()` function does this.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
