### PR TITLE
LED drivers: misc formatting and typos

### DIFF
--- a/drivers/led/aw20216s.h
+++ b/drivers/led/aw20216s.h
@@ -119,6 +119,7 @@ void aw20216s_flush(void);
 #define CS16_SW1 0x0F
 #define CS17_SW1 0x10
 #define CS18_SW1 0x11
+
 #define CS1_SW2 0x12
 #define CS2_SW2 0x13
 #define CS3_SW2 0x14
@@ -137,6 +138,7 @@ void aw20216s_flush(void);
 #define CS16_SW2 0x21
 #define CS17_SW2 0x22
 #define CS18_SW2 0x23
+
 #define CS1_SW3 0x24
 #define CS2_SW3 0x25
 #define CS3_SW3 0x26
@@ -155,6 +157,7 @@ void aw20216s_flush(void);
 #define CS16_SW3 0x33
 #define CS17_SW3 0x34
 #define CS18_SW3 0x35
+
 #define CS1_SW4 0x36
 #define CS2_SW4 0x37
 #define CS3_SW4 0x38
@@ -173,6 +176,7 @@ void aw20216s_flush(void);
 #define CS16_SW4 0x45
 #define CS17_SW4 0x46
 #define CS18_SW4 0x47
+
 #define CS1_SW5 0x48
 #define CS2_SW5 0x49
 #define CS3_SW5 0x4A
@@ -191,6 +195,7 @@ void aw20216s_flush(void);
 #define CS16_SW5 0x57
 #define CS17_SW5 0x58
 #define CS18_SW5 0x59
+
 #define CS1_SW6 0x5A
 #define CS2_SW6 0x5B
 #define CS3_SW6 0x5C
@@ -209,6 +214,7 @@ void aw20216s_flush(void);
 #define CS16_SW6 0x69
 #define CS17_SW6 0x6A
 #define CS18_SW6 0x6B
+
 #define CS1_SW7 0x6C
 #define CS2_SW7 0x6D
 #define CS3_SW7 0x6E
@@ -227,6 +233,7 @@ void aw20216s_flush(void);
 #define CS16_SW7 0x7B
 #define CS17_SW7 0x7C
 #define CS18_SW7 0x7D
+
 #define CS1_SW8 0x7E
 #define CS2_SW8 0x7F
 #define CS3_SW8 0x80
@@ -245,6 +252,7 @@ void aw20216s_flush(void);
 #define CS16_SW8 0x8D
 #define CS17_SW8 0x8E
 #define CS18_SW8 0x8F
+
 #define CS1_SW9 0x90
 #define CS2_SW9 0x91
 #define CS3_SW9 0x92
@@ -263,6 +271,7 @@ void aw20216s_flush(void);
 #define CS16_SW9 0x9F
 #define CS17_SW9 0xA0
 #define CS18_SW9 0xA1
+
 #define CS1_SW10 0xA2
 #define CS2_SW10 0xA3
 #define CS3_SW10 0xA4
@@ -281,6 +290,7 @@ void aw20216s_flush(void);
 #define CS16_SW10 0xB1
 #define CS17_SW10 0xB2
 #define CS18_SW10 0xB3
+
 #define CS1_SW11 0xB4
 #define CS2_SW11 0xB5
 #define CS3_SW11 0xB6
@@ -299,6 +309,7 @@ void aw20216s_flush(void);
 #define CS16_SW11 0xC3
 #define CS17_SW11 0xC4
 #define CS18_SW11 0xC5
+
 #define CS1_SW12 0xC6
 #define CS2_SW12 0xC7
 #define CS3_SW12 0xC8

--- a/drivers/led/issi/is31fl3218-mono.c
+++ b/drivers/led/issi/is31fl3218-mono.c
@@ -13,6 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "is31fl3218-mono.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -93,14 +94,17 @@ void is31fl3218_init(void) {
 
 void is31fl3218_set_value(int index, uint8_t value) {
     is31fl3218_led_t led;
+
     if (index >= 0 && index < IS31FL3218_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3218_leds[index]), sizeof(led));
+
+        if (g_pwm_buffer[led.v - IS31FL3218_REG_PWM] == value) {
+            return;
+        }
+
+        g_pwm_buffer[led.v - IS31FL3218_REG_PWM] = value;
+        g_pwm_buffer_update_required             = true;
     }
-    if (g_pwm_buffer[led.v - IS31FL3218_REG_PWM] == value) {
-        return;
-    }
-    g_pwm_buffer[led.v - IS31FL3218_REG_PWM] = value;
-    g_pwm_buffer_update_required             = true;
 }
 
 void is31fl3218_set_value_all(uint8_t value) {

--- a/drivers/led/issi/is31fl3218.c
+++ b/drivers/led/issi/is31fl3218.c
@@ -13,6 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "is31fl3218.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -93,16 +94,19 @@ void is31fl3218_init(void) {
 
 void is31fl3218_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3218_led_t led;
+
     if (index >= 0 && index < IS31FL3218_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3218_leds[index]), sizeof(led));
+
+        if (g_pwm_buffer[led.r - IS31FL3218_REG_PWM] == red && g_pwm_buffer[led.g - IS31FL3218_REG_PWM] == green && g_pwm_buffer[led.b - IS31FL3218_REG_PWM] == blue) {
+            return;
+        }
+
+        g_pwm_buffer[led.r - IS31FL3218_REG_PWM] = red;
+        g_pwm_buffer[led.g - IS31FL3218_REG_PWM] = green;
+        g_pwm_buffer[led.b - IS31FL3218_REG_PWM] = blue;
+        g_pwm_buffer_update_required             = true;
     }
-    if (g_pwm_buffer[led.r - IS31FL3218_REG_PWM] == red && g_pwm_buffer[led.g - IS31FL3218_REG_PWM] == green && g_pwm_buffer[led.b - IS31FL3218_REG_PWM] == blue) {
-        return;
-    }
-    g_pwm_buffer[led.r - IS31FL3218_REG_PWM] = red;
-    g_pwm_buffer[led.g - IS31FL3218_REG_PWM] = green;
-    g_pwm_buffer[led.b - IS31FL3218_REG_PWM] = blue;
-    g_pwm_buffer_update_required             = true;
 }
 
 void is31fl3218_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {

--- a/drivers/led/issi/is31fl3731-mono.c
+++ b/drivers/led/issi/is31fl3731-mono.c
@@ -52,9 +52,7 @@ void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 
 #if IS31FL3731_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3731_I2C_TIMEOUT) == 0) {
-            break;
-        }
+        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3731_I2C_TIMEOUT) == 0) break;
     }
 #else
     i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3731_I2C_TIMEOUT);
@@ -174,14 +172,15 @@ void is31fl3731_init(uint8_t addr) {
 
 void is31fl3731_set_value(int index, uint8_t value) {
     is31fl3731_led_t led;
+
     if (index >= 0 && index < IS31FL3731_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3731_leds[index]), sizeof(led));
 
         // Subtract 0x24 to get the second index of g_pwm_buffer
-
         if (g_pwm_buffer[led.driver][led.v - 0x24] == value) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.v - 0x24]   = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }
@@ -212,6 +211,7 @@ void is31fl3731_set_led_control_register(uint8_t index, bool value) {
 void is31fl3731_update_pwm_buffers(uint8_t addr, uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
         is31fl3731_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -221,6 +221,7 @@ void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3731_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
         g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -171,6 +171,7 @@ void is31fl3731_init(uint8_t addr) {
 
 void is31fl3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3731_led_t led;
+
     if (index >= 0 && index < IS31FL3731_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3731_leds[index]), sizeof(led));
 
@@ -178,6 +179,7 @@ void is31fl3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         if (g_pwm_buffer[led.driver][led.r - 0x24] == red && g_pwm_buffer[led.driver][led.g - 0x24] == green && g_pwm_buffer[led.driver][led.b - 0x24] == blue) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.r - 0x24]   = red;
         g_pwm_buffer[led.driver][led.g - 0x24]   = green;
         g_pwm_buffer[led.driver][led.b - 0x24]   = blue;
@@ -224,8 +226,9 @@ void is31fl3731_set_led_control_register(uint8_t index, bool red, bool green, bo
 void is31fl3731_update_pwm_buffers(uint8_t addr, uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
         is31fl3731_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
+        g_pwm_buffer_update_required[index] = false;
     }
-    g_pwm_buffer_update_required[index] = false;
 }
 
 void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index) {
@@ -233,8 +236,9 @@ void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3731_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
+        g_led_control_registers_update_required[index] = false;
     }
-    g_led_control_registers_update_required[index] = false;
 }
 
 void is31fl3731_flush(void) {

--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -199,12 +199,14 @@ void is31fl3733_init(uint8_t addr, uint8_t sync) {
 
 void is31fl3733_set_value(int index, uint8_t value) {
     is31fl3733_led_t led;
+
     if (index >= 0 && index < IS31FL3733_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3733_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }
@@ -241,6 +243,7 @@ void is31fl3733_update_pwm_buffers(uint8_t addr, uint8_t index) {
         if (!is31fl3733_write_pwm_buffer(addr, g_pwm_buffer[index])) {
             g_led_control_registers_update_required[index] = true;
         }
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -252,6 +255,7 @@ void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3733_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3733_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
         g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -198,12 +198,14 @@ void is31fl3733_init(uint8_t addr, uint8_t sync) {
 
 void is31fl3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3733_led_t led;
+
     if (index >= 0 && index < IS31FL3733_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3733_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;
@@ -256,6 +258,7 @@ void is31fl3733_update_pwm_buffers(uint8_t addr, uint8_t index) {
         if (!is31fl3733_write_pwm_buffer(addr, g_pwm_buffer[index])) {
             g_led_control_registers_update_required[index] = true;
         }
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -267,6 +270,7 @@ void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3733_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3733_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
         g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3736-mono.c
+++ b/drivers/led/issi/is31fl3736-mono.c
@@ -171,12 +171,14 @@ void is31fl3736_init(uint8_t addr) {
 
 void is31fl3736_set_value(int index, uint8_t value) {
     is31fl3736_led_t led;
+
     if (index >= 0 && index < IS31FL3736_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3736_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }
@@ -215,6 +217,7 @@ void is31fl3736_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3736_select_page(addr, IS31FL3736_COMMAND_PWM);
 
         is31fl3736_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -226,6 +229,7 @@ void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3736_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3736_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
         g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -171,12 +171,14 @@ void is31fl3736_init(uint8_t addr) {
 
 void is31fl3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3736_led_t led;
+
     if (index >= 0 && index < IS31FL3736_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3736_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;
@@ -232,6 +234,7 @@ void is31fl3736_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3736_select_page(addr, IS31FL3736_COMMAND_PWM);
 
         is31fl3736_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -243,6 +246,7 @@ void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3736_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3736_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
         g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3737-mono.c
+++ b/drivers/led/issi/is31fl3737-mono.c
@@ -174,12 +174,14 @@ void is31fl3737_init(uint8_t addr) {
 
 void is31fl3737_set_value(int index, uint8_t value) {
     is31fl3737_led_t led;
+
     if (index >= 0 && index < IS31FL3737_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3737_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }
@@ -212,6 +214,7 @@ void is31fl3737_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3737_select_page(addr, IS31FL3737_COMMAND_PWM);
 
         is31fl3737_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -223,6 +226,7 @@ void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3737_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3737_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
         g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -41,7 +41,7 @@
 #    define IS31FL3737_SW_PULLUP IS31FL3737_PUR_0_OHM
 #endif
 
-#ifndef IS31FL3737_CS_PULLDONW
+#ifndef IS31FL3737_CS_PULLDOWN
 #    define IS31FL3737_CS_PULLDOWN IS31FL3737_PDR_0_OHM
 #endif
 
@@ -174,12 +174,14 @@ void is31fl3737_init(uint8_t addr) {
 
 void is31fl3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3737_led_t led;
+
     if (index >= 0 && index < IS31FL3737_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3737_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;
@@ -228,6 +230,7 @@ void is31fl3737_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3737_select_page(addr, IS31FL3737_COMMAND_PWM);
 
         is31fl3737_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -239,6 +242,7 @@ void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3737_LED_CONTROL_REGISTER_COUNT; i++) {
             is31fl3737_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
         g_led_control_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3741-mono.c
+++ b/drivers/led/issi/is31fl3741-mono.c
@@ -185,12 +185,14 @@ void is31fl3741_init(uint8_t addr) {
 
 void is31fl3741_set_value(int index, uint8_t value) {
     is31fl3741_led_t led;
+
     if (index >= 0 && index < IS31FL3741_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3741_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.v]          = value;
     }
@@ -220,14 +222,13 @@ void is31fl3741_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_0);
 
         is31fl3741_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3741_set_pwm_buffer(const is31fl3741_led_t *pled, uint8_t value) {
-    g_pwm_buffer[pled->driver][pled->v] = value;
-
+    g_pwm_buffer[pled->driver][pled->v]        = value;
     g_pwm_buffer_update_required[pled->driver] = true;
 }
 
@@ -252,8 +253,7 @@ void is31fl3741_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3741_set_scaling_registers(const is31fl3741_led_t *pled, uint8_t value) {
-    g_scaling_registers[pled->driver][pled->v] = value;
-
+    g_scaling_registers[pled->driver][pled->v]        = value;
     g_scaling_registers_update_required[pled->driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -185,12 +185,14 @@ void is31fl3741_init(uint8_t addr) {
 
 void is31fl3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3741_led_t led;
+
     if (index >= 0 && index < IS31FL3741_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3741_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
@@ -234,16 +236,15 @@ void is31fl3741_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_0);
 
         is31fl3741_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3741_set_pwm_buffer(const is31fl3741_led_t *pled, uint8_t red, uint8_t green, uint8_t blue) {
-    g_pwm_buffer[pled->driver][pled->r] = red;
-    g_pwm_buffer[pled->driver][pled->g] = green;
-    g_pwm_buffer[pled->driver][pled->b] = blue;
-
+    g_pwm_buffer[pled->driver][pled->r]        = red;
+    g_pwm_buffer[pled->driver][pled->g]        = green;
+    g_pwm_buffer[pled->driver][pled->b]        = blue;
     g_pwm_buffer_update_required[pled->driver] = true;
 }
 
@@ -268,10 +269,9 @@ void is31fl3741_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3741_set_scaling_registers(const is31fl3741_led_t *pled, uint8_t red, uint8_t green, uint8_t blue) {
-    g_scaling_registers[pled->driver][pled->r] = red;
-    g_scaling_registers[pled->driver][pled->g] = green;
-    g_scaling_registers[pled->driver][pled->b] = blue;
-
+    g_scaling_registers[pled->driver][pled->r]        = red;
+    g_scaling_registers[pled->driver][pled->g]        = green;
+    g_scaling_registers[pled->driver][pled->b]        = blue;
     g_scaling_registers_update_required[pled->driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3742a-mono.c
+++ b/drivers/led/issi/is31fl3742a-mono.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3742a-mono.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -146,12 +166,14 @@ void is31fl3742a_init(uint8_t addr) {
 
 void is31fl3742a_set_value(int index, uint8_t value) {
     is31fl3742a_led_t led;
+
     if (index >= 0 && index < IS31FL3742A_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3742a_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }
@@ -168,7 +190,6 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t value) {
     memcpy_P(&led, (&g_is31fl3742a_leds[index]), sizeof(led));
 
     g_scaling_registers[led.driver][led.v] = value;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -177,6 +198,7 @@ void is31fl3742a_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_PWM);
 
         is31fl3742a_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -188,6 +210,7 @@ void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3742A_SCALING_REGISTER_COUNT; i++) {
             is31fl3742a_write_register(addr, i, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3742a-mono.c
+++ b/drivers/led/issi/is31fl3742a-mono.c
@@ -189,7 +189,7 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t value) {
     is31fl3742a_led_t led;
     memcpy_P(&led, (&g_is31fl3742a_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.v] = value;
+    g_scaling_registers[led.driver][led.v]          = value;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3742a.c
+++ b/drivers/led/issi/is31fl3742a.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3742a.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -146,12 +166,14 @@ void is31fl3742a_init(uint8_t addr) {
 
 void is31fl3742a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3742a_led_t led;
+
     if (index >= 0 && index < IS31FL3742A_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3742a_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;
@@ -172,7 +194,6 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     g_scaling_registers[led.driver][led.r] = red;
     g_scaling_registers[led.driver][led.g] = green;
     g_scaling_registers[led.driver][led.b] = blue;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -181,6 +202,7 @@ void is31fl3742a_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_PWM);
 
         is31fl3742a_write_pwm_buffer(addr, g_pwm_buffer[index]);
+
         g_pwm_buffer_update_required[index] = false;
     }
 }
@@ -192,6 +214,7 @@ void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3742A_SCALING_REGISTER_COUNT; i++) {
             is31fl3742a_write_register(addr, i, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3742a.c
+++ b/drivers/led/issi/is31fl3742a.c
@@ -191,9 +191,9 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     is31fl3742a_led_t led;
     memcpy_P(&led, (&g_is31fl3742a_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.r] = red;
-    g_scaling_registers[led.driver][led.g] = green;
-    g_scaling_registers[led.driver][led.b] = blue;
+    g_scaling_registers[led.driver][led.r]          = red;
+    g_scaling_registers[led.driver][led.g]          = green;
+    g_scaling_registers[led.driver][led.b]          = blue;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3743a-mono.c
+++ b/drivers/led/issi/is31fl3743a-mono.c
@@ -198,7 +198,7 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t value) {
     is31fl3743a_led_t led;
     memcpy_P(&led, (&g_is31fl3743a_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.v] = value;
+    g_scaling_registers[led.driver][led.v]          = value;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3743a-mono.c
+++ b/drivers/led/issi/is31fl3743a-mono.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3743a-mono.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -155,12 +175,14 @@ void is31fl3743a_init(uint8_t addr, uint8_t sync) {
 
 void is31fl3743a_set_value(int index, uint8_t value) {
     is31fl3743a_led_t led;
+
     if (index >= 0 && index < IS31FL3743A_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3743a_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.v]          = value;
     }
@@ -177,7 +199,6 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t value) {
     memcpy_P(&led, (&g_is31fl3743a_leds[index]), sizeof(led));
 
     g_scaling_registers[led.driver][led.v] = value;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -186,9 +207,9 @@ void is31fl3743a_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_PWM);
 
         is31fl3743a_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
@@ -198,6 +219,7 @@ void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3743A_SCALING_REGISTER_COUNT; i++) {
             is31fl3743a_write_register(addr, i + 1, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3743a.c
+++ b/drivers/led/issi/is31fl3743a.c
@@ -200,9 +200,9 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     is31fl3743a_led_t led;
     memcpy_P(&led, (&g_is31fl3743a_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.r] = red;
-    g_scaling_registers[led.driver][led.g] = green;
-    g_scaling_registers[led.driver][led.b] = blue;
+    g_scaling_registers[led.driver][led.r]          = red;
+    g_scaling_registers[led.driver][led.g]          = green;
+    g_scaling_registers[led.driver][led.b]          = blue;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3743a.c
+++ b/drivers/led/issi/is31fl3743a.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3743a.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -155,12 +175,14 @@ void is31fl3743a_init(uint8_t addr, uint8_t sync) {
 
 void is31fl3743a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3743a_led_t led;
+
     if (index >= 0 && index < IS31FL3743A_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3743a_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
@@ -181,7 +203,6 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     g_scaling_registers[led.driver][led.r] = red;
     g_scaling_registers[led.driver][led.g] = green;
     g_scaling_registers[led.driver][led.b] = blue;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -190,9 +211,9 @@ void is31fl3743a_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_PWM);
 
         is31fl3743a_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
@@ -202,6 +223,7 @@ void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3743A_SCALING_REGISTER_COUNT; i++) {
             is31fl3743a_write_register(addr, i + 1, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3745-mono.c
+++ b/drivers/led/issi/is31fl3745-mono.c
@@ -198,7 +198,7 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t value) {
     is31fl3745_led_t led;
     memcpy_P(&led, (&g_is31fl3745_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.v] = value;
+    g_scaling_registers[led.driver][led.v]          = value;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3745-mono.c
+++ b/drivers/led/issi/is31fl3745-mono.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3745-mono.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -155,12 +175,14 @@ void is31fl3745_init(uint8_t addr, uint8_t sync) {
 
 void is31fl3745_set_value(int index, uint8_t value) {
     is31fl3745_led_t led;
+
     if (index >= 0 && index < IS31FL3745_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3745_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.v]          = value;
     }
@@ -177,7 +199,6 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t value) {
     memcpy_P(&led, (&g_is31fl3745_leds[index]), sizeof(led));
 
     g_scaling_registers[led.driver][led.v] = value;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -186,9 +207,9 @@ void is31fl3745_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3745_select_page(addr, IS31FL3745_COMMAND_PWM);
 
         is31fl3745_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
@@ -198,6 +219,7 @@ void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3745_SCALING_REGISTER_COUNT; i++) {
             is31fl3745_write_register(addr, i + 1, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3745.c
+++ b/drivers/led/issi/is31fl3745.c
@@ -200,9 +200,9 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, 
     is31fl3745_led_t led;
     memcpy_P(&led, (&g_is31fl3745_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.r] = red;
-    g_scaling_registers[led.driver][led.g] = green;
-    g_scaling_registers[led.driver][led.b] = blue;
+    g_scaling_registers[led.driver][led.r]          = red;
+    g_scaling_registers[led.driver][led.g]          = green;
+    g_scaling_registers[led.driver][led.b]          = blue;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3745.c
+++ b/drivers/led/issi/is31fl3745.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3745.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -155,12 +175,14 @@ void is31fl3745_init(uint8_t addr, uint8_t sync) {
 
 void is31fl3745_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3745_led_t led;
+
     if (index >= 0 && index < IS31FL3745_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3745_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
@@ -181,7 +203,6 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, 
     g_scaling_registers[led.driver][led.r] = red;
     g_scaling_registers[led.driver][led.g] = green;
     g_scaling_registers[led.driver][led.b] = blue;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -190,9 +211,9 @@ void is31fl3745_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3745_select_page(addr, IS31FL3745_COMMAND_PWM);
 
         is31fl3745_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
@@ -202,6 +223,7 @@ void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3745_SCALING_REGISTER_COUNT; i++) {
             is31fl3745_write_register(addr, i + 1, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3746a-mono.c
+++ b/drivers/led/issi/is31fl3746a-mono.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3746a-mono.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -147,12 +167,14 @@ void is31fl3746a_init(uint8_t addr) {
 
 void is31fl3746a_set_color(int index, uint8_t value) {
     is31fl3746a_led_t led;
+
     if (index >= 0 && index < IS31FL3746A_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3746a_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.v]          = value;
     }
@@ -169,7 +191,6 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t value) {
     memcpy_P(&led, (&g_is31fl3746a_leds[index]), sizeof(led));
 
     g_scaling_registers[led.driver][led.v] = value;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -178,9 +199,9 @@ void is31fl3746a_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_PWM);
 
         is31fl3746a_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
@@ -190,6 +211,7 @@ void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3746A_SCALING_REGISTER_COUNT; i++) {
             is31fl3746a_write_register(addr, i + 1, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/issi/is31fl3746a-mono.c
+++ b/drivers/led/issi/is31fl3746a-mono.c
@@ -190,7 +190,7 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t value) {
     is31fl3746a_led_t led;
     memcpy_P(&led, (&g_is31fl3746a_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.v] = value;
+    g_scaling_registers[led.driver][led.v]          = value;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3746a.c
+++ b/drivers/led/issi/is31fl3746a.c
@@ -192,9 +192,9 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     is31fl3746a_led_t led;
     memcpy_P(&led, (&g_is31fl3746a_leds[index]), sizeof(led));
 
-    g_scaling_registers[led.driver][led.r] = red;
-    g_scaling_registers[led.driver][led.g] = green;
-    g_scaling_registers[led.driver][led.b] = blue;
+    g_scaling_registers[led.driver][led.r]          = red;
+    g_scaling_registers[led.driver][led.g]          = green;
+    g_scaling_registers[led.driver][led.b]          = blue;
     g_scaling_registers_update_required[led.driver] = true;
 }
 

--- a/drivers/led/issi/is31fl3746a.c
+++ b/drivers/led/issi/is31fl3746a.c
@@ -1,3 +1,23 @@
+/* Copyright 2017 Jason Williams
+ * Copyright 2018 Jack Humbert
+ * Copyright 2018 Yiancar
+ * Copyright 2020 MelGeek
+ * Copyright 2021 MasterSpoon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "is31fl3746a.h"
 #include <string.h>
 #include "i2c_master.h"
@@ -147,12 +167,14 @@ void is31fl3746a_init(uint8_t addr) {
 
 void is31fl3746a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3746a_led_t led;
+
     if (index >= 0 && index < IS31FL3746A_LED_COUNT) {
         memcpy_P(&led, (&g_is31fl3746a_leds[index]), sizeof(led));
 
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer_update_required[led.driver] = true;
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
@@ -173,7 +195,6 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     g_scaling_registers[led.driver][led.r] = red;
     g_scaling_registers[led.driver][led.g] = green;
     g_scaling_registers[led.driver][led.b] = blue;
-
     g_scaling_registers_update_required[led.driver] = true;
 }
 
@@ -182,9 +203,9 @@ void is31fl3746a_update_pwm_buffers(uint8_t addr, uint8_t index) {
         is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_PWM);
 
         is31fl3746a_write_pwm_buffer(addr, g_pwm_buffer[index]);
-    }
 
-    g_pwm_buffer_update_required[index] = false;
+        g_pwm_buffer_update_required[index] = false;
+    }
 }
 
 void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
@@ -194,6 +215,7 @@ void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < IS31FL3746A_SCALING_REGISTER_COUNT; i++) {
             is31fl3746a_write_register(addr, i + 1, g_scaling_registers[index][i]);
         }
+
         g_scaling_registers_update_required[index] = false;
     }
 }

--- a/drivers/led/snled27351-mono.c
+++ b/drivers/led/snled27351-mono.c
@@ -172,7 +172,6 @@ void snled27351_init(uint8_t addr) {
 
     snled27351_select_page(addr, SNLED27351_COMMAND_LED_CONTROL);
 
-    // Enable LEDs ON/OFF
     for (int i = 0; i < SNLED27351_LED_CONTROL_ON_OFF_LENGTH; i++) {
         snled27351_write_register(addr, i, 0xFF);
     }
@@ -191,6 +190,7 @@ void snled27351_set_value(int index, uint8_t value) {
         if (g_pwm_buffer[led.driver][led.v] == value) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.v]          = value;
         g_pwm_buffer_update_required[led.driver] = true;
     }
@@ -225,9 +225,10 @@ void snled27351_update_pwm_buffers(uint8_t addr, uint8_t index) {
         // If any of the transactions fail we risk writing dirty PG0,
         // refresh page 0 just in case.
         if (!snled27351_write_pwm_buffer(addr, g_pwm_buffer[index])) {
-            g_led_control_registers_update_required[index] = true;
+            g_pwm_buffer_update_required[index] = true;
         }
     }
+
     g_pwm_buffer_update_required[index] = false;
 }
 
@@ -238,8 +239,9 @@ void snled27351_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < SNLED27351_LED_CONTROL_REGISTER_COUNT; i++) {
             snled27351_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
+        g_led_control_registers_update_required[index] = false;
     }
-    g_led_control_registers_update_required[index] = false;
 }
 
 void snled27351_flush(void) {

--- a/drivers/led/snled27351.c
+++ b/drivers/led/snled27351.c
@@ -189,6 +189,7 @@ void snled27351_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         if (g_pwm_buffer[led.driver][led.r] == red && g_pwm_buffer[led.driver][led.g] == green && g_pwm_buffer[led.driver][led.b] == blue) {
             return;
         }
+
         g_pwm_buffer[led.driver][led.r]          = red;
         g_pwm_buffer[led.driver][led.g]          = green;
         g_pwm_buffer[led.driver][led.b]          = blue;
@@ -239,9 +240,10 @@ void snled27351_update_pwm_buffers(uint8_t addr, uint8_t index) {
         // If any of the transactions fail we risk writing dirty PG0,
         // refresh page 0 just in case.
         if (!snled27351_write_pwm_buffer(addr, g_pwm_buffer[index])) {
-            g_led_control_registers_update_required[index] = true;
+            g_pwm_buffer_update_required[index] = true;
         }
     }
+
     g_pwm_buffer_update_required[index] = false;
 }
 
@@ -252,8 +254,9 @@ void snled27351_update_led_control_registers(uint8_t addr, uint8_t index) {
         for (int i = 0; i < SNLED27351_LED_CONTROL_REGISTER_COUNT; i++) {
             snled27351_write_register(addr, i, g_led_control_registers[index][i]);
         }
+
+        g_led_control_registers_update_required[index] = false;
     }
-    g_led_control_registers_update_required[index] = false;
 }
 
 void snled27351_flush(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

- Tightened up/normalised formatting
- Added missing license headers
- 3218: tweaked `set_value()`/`set_color()` to match the rest of the drivers - fixes potential out of bounds
- 3737: typo in `IS31FL3737_CS_PULLDOWN`
- snled27351: fixed wrong dirty flag being used in `update_pwm_buffers()`
- Moved some dirty flag assignments inside their checks (as there is no point setting them if it's the same value)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
