### PR TITLE
Double UCIS should cancel or finish previos attempt

### DIFF
--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -10,7 +10,9 @@ bool    active                       = false;
 char    input[UCIS_MAX_INPUT_LENGTH] = {0};
 
 void ucis_start(void) {
-    if (active) ucis_finish(); // Finish action if any!
+    if (active) {
+        ucis_finish(); /* Finish action if any! */
+    }
 
     count  = 0;
     active = true;

--- a/quantum/unicode/ucis.c
+++ b/quantum/unicode/ucis.c
@@ -10,6 +10,8 @@ bool    active                       = false;
 char    input[UCIS_MAX_INPUT_LENGTH] = {0};
 
 void ucis_start(void) {
+    if (active) ucis_finish(); // Finish action if any!
+
     count  = 0;
     active = true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

If you run ucis_start() twice you will get some traces line ⌨ or ⌨foo

Ir argeable if this should be part of the UCIS code or not (I feel it is). Of course you could check in whatever function you are calling but it seems more robust in this way, checking it in the function.

I have chosen to use ucis_finish instead of ucis_cancel. 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Duplicate ⌨ if you call many times ucis_start() (for example if you call tapping a key)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
