### PR TITLE
LED drivers: switch to i2c_writeReg()

### DIFF
--- a/drivers/led/issi/is31fl3218-mono.c
+++ b/drivers/led/issi/is31fl3218-mono.c
@@ -15,7 +15,6 @@
  */
 
 #include "is31fl3218-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 
 #define IS31FL3218_PWM_REGISTER_COUNT 18
@@ -29,8 +28,6 @@
 #    define IS31FL3218_I2C_PERSISTENCE 0
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // IS31FL3218 has 18 PWM outputs and a fixed I2C address, so no chaining.
 uint8_t g_pwm_buffer[IS31FL3218_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required = false;
@@ -39,27 +36,22 @@ uint8_t g_led_control_registers[IS31FL3218_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required                        = false;
 
 void is31fl3218_write_register(uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 2, IS31FL3218_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 2, IS31FL3218_I2C_TIMEOUT);
+    i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT);
 #endif
 }
 
 void is31fl3218_write_pwm_buffer(uint8_t *pwm_buffer) {
-    i2c_transfer_buffer[0] = IS31FL3218_REG_PWM;
-    memcpy(i2c_transfer_buffer + 1, pwm_buffer, 18);
-
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 19, IS31FL3218_I2C_TIMEOUT);
+        i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);
     }
 #else
-    i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 19, IS31FL3218_I2C_TIMEOUT);
+    i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);
 #endif
 }
 

--- a/drivers/led/issi/is31fl3218-mono.c
+++ b/drivers/led/issi/is31fl3218-mono.c
@@ -38,7 +38,7 @@ bool    g_led_control_registers_update_required                        = false;
 void is31fl3218_write_register(uint8_t reg, uint8_t data) {
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT);
@@ -48,7 +48,7 @@ void is31fl3218_write_register(uint8_t reg, uint8_t data) {
 void is31fl3218_write_pwm_buffer(uint8_t *pwm_buffer) {
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);
+        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3218.c
+++ b/drivers/led/issi/is31fl3218.c
@@ -15,7 +15,6 @@
  */
 
 #include "is31fl3218.h"
-#include <string.h>
 #include "i2c_master.h"
 
 #define IS31FL3218_PWM_REGISTER_COUNT 18
@@ -29,8 +28,6 @@
 #    define IS31FL3218_I2C_PERSISTENCE 0
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // IS31FL3218 has 18 PWM outputs and a fixed I2C address, so no chaining.
 uint8_t g_pwm_buffer[IS31FL3218_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required = false;
@@ -39,27 +36,22 @@ uint8_t g_led_control_registers[IS31FL3218_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required                        = false;
 
 void is31fl3218_write_register(uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 2, IS31FL3218_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 2, IS31FL3218_I2C_TIMEOUT);
+    i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT);
 #endif
 }
 
 void is31fl3218_write_pwm_buffer(uint8_t *pwm_buffer) {
-    i2c_transfer_buffer[0] = IS31FL3218_REG_PWM;
-    memcpy(i2c_transfer_buffer + 1, pwm_buffer, 18);
-
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 19, IS31FL3218_I2C_TIMEOUT);
+        i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);
     }
 #else
-    i2c_transmit(IS31FL3218_I2C_ADDRESS << 1, i2c_transfer_buffer, 19, IS31FL3218_I2C_TIMEOUT);
+    i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);
 #endif
 }
 

--- a/drivers/led/issi/is31fl3218.c
+++ b/drivers/led/issi/is31fl3218.c
@@ -38,7 +38,7 @@ bool    g_led_control_registers_update_required                        = false;
 void is31fl3218_write_register(uint8_t reg, uint8_t data) {
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, reg, &data, 1, IS31FL3218_I2C_TIMEOUT);
@@ -48,7 +48,7 @@ void is31fl3218_write_register(uint8_t reg, uint8_t data) {
 void is31fl3218_write_pwm_buffer(uint8_t *pwm_buffer) {
 #if IS31FL3218_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3218_I2C_PERSISTENCE; i++) {
-        i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);
+        if (i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(IS31FL3218_I2C_ADDRESS << 1, IS31FL3218_REG_PWM, pwm_buffer, 18, IS31FL3218_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3731-mono.c
+++ b/drivers/led/issi/is31fl3731-mono.c
@@ -46,7 +46,7 @@ bool    g_led_control_registers_update_required[IS31FL3731_DRIVER_COUNT]        
 void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
@@ -65,7 +65,7 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3731-mono.c
+++ b/drivers/led/issi/is31fl3731-mono.c
@@ -18,7 +18,6 @@
  */
 
 #include "is31fl3731-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -33,8 +32,6 @@
 #    define IS31FL3731_I2C_PERSISTENCE 0
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3731 PWM registers 0x24-0xB3.
 // Storing them like this is optimal for I2C transfers to the registers.
 // We could optimize this and take out the unused registers from these
@@ -47,15 +44,12 @@ uint8_t g_led_control_registers[IS31FL3731_DRIVER_COUNT][IS31FL3731_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3731_DRIVER_COUNT]                        = {false};
 
 void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3731_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3731_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3731_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
 #endif
 }
 
@@ -64,26 +58,17 @@ void is31fl3731_select_page(uint8_t addr, uint8_t page) {
 }
 
 void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
-    // assumes page 0 is already selected
+    // Assumes page 0 is already selected.
+    // Transmit PWM registers in 9 transfers of 16 bytes.
 
-    // transmit PWM registers in 9 transfers of 16 bytes
-    // i2c_transfer_buffer[] is 20 bytes
-
-    // iterate over the pwm_buffer contents at 16 byte intervals
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
-        // set the first register, e.g. 0x24, 0x34, 0x44, etc.
-        i2c_transfer_buffer[0] = 0x24 + i;
-        // copy the data from i to i+15
-        // device will auto-increment register for data after the first byte
-        // thus this sets registers 0x24-0x33, 0x34-0x43, etc. in one transfer
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3731_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3731_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3731-mono.c
+++ b/drivers/led/issi/is31fl3731-mono.c
@@ -62,9 +62,9 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 9 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -17,7 +17,6 @@
  */
 
 #include "is31fl3731.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -32,8 +31,6 @@
 #    define IS31FL3731_I2C_PERSISTENCE 0
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3731 PWM registers 0x24-0xB3.
 // Storing them like this is optimal for I2C transfers to the registers.
 // We could optimize this and take out the unused registers from these
@@ -46,15 +43,12 @@ uint8_t g_led_control_registers[IS31FL3731_DRIVER_COUNT][IS31FL3731_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3731_DRIVER_COUNT]                        = {false};
 
 void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3731_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3731_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3731_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
 #endif
 }
 
@@ -63,26 +57,17 @@ void is31fl3731_select_page(uint8_t addr, uint8_t page) {
 }
 
 void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
-    // assumes page 0 is already selected
+    // Assumes page 0 is already selected.
+    // Transmit PWM registers in 9 transfers of 16 bytes.
 
-    // transmit PWM registers in 9 transfers of 16 bytes
-    // i2c_transfer_buffer[] is 20 bytes
-
-    // iterate over the pwm_buffer contents at 16 byte intervals
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
-        // set the first register, e.g. 0x24, 0x34, 0x44, etc.
-        i2c_transfer_buffer[0] = 0x24 + i;
-        // copy the data from i to i+15
-        // device will auto-increment register for data after the first byte
-        // thus this sets registers 0x24-0x33, 0x34-0x43, etc. in one transfer
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3731_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3731_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -61,9 +61,9 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 9 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -45,7 +45,7 @@ bool    g_led_control_registers_update_required[IS31FL3731_DRIVER_COUNT]        
 void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
@@ -64,7 +64,7 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, 0x24 + i, pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -94,9 +94,9 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3733-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -63,8 +62,6 @@
 #    define IS31FL3733_SYNC_4 IS31FL3733_SYNC_NONE
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3733 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -78,15 +75,12 @@ uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
 void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
 #endif
 }
 
@@ -98,22 +92,15 @@ void is31fl3733_select_page(uint8_t addr, uint8_t page) {
 void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3733_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3733_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -77,7 +77,7 @@ bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]        
 void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
@@ -97,7 +97,7 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -76,7 +76,7 @@ bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]        
 void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
@@ -96,7 +96,7 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -93,9 +93,9 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -18,7 +18,6 @@
  */
 
 #include "is31fl3733.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -62,8 +61,6 @@
 #    define IS31FL3733_SYNC_4 IS31FL3733_SYNC_NONE
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3733 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -77,15 +74,12 @@ uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
 void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
 #endif
 }
 
@@ -97,22 +91,15 @@ void is31fl3733_select_page(uint8_t addr, uint8_t page) {
 void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3733_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3733_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3736-mono.c
+++ b/drivers/led/issi/is31fl3736-mono.c
@@ -16,7 +16,6 @@
  */
 
 #include "is31fl3736-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -47,8 +46,6 @@
 #    define IS31FL3736_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3736 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -62,15 +59,12 @@ uint8_t g_led_control_registers[IS31FL3736_DRIVER_COUNT][IS31FL3736_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3736_DRIVER_COUNT]                        = {false};
 
 void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3736_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3736_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3736_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
 #endif
 }
 
@@ -80,25 +74,17 @@ void is31fl3736_select_page(uint8_t addr, uint8_t page) {
 }
 
 void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
-    // assumes page 1 is already selected
+    // Assumes page 1 is already selected.
+    // Transmit PWM registers in 12 transfers of 16 bytes.
 
-    // transmit PWM registers in 12 transfers of 16 bytes
-    // i2c_transfer_buffer[] is 20 bytes
-
-    // iterate over the pwm_buffer contents at 16 byte intervals
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // copy the data from i to i+15
-        // device will auto-increment register for data after the first byte
-        // thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3736_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3736_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3736-mono.c
+++ b/drivers/led/issi/is31fl3736-mono.c
@@ -78,9 +78,9 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3736-mono.c
+++ b/drivers/led/issi/is31fl3736-mono.c
@@ -61,7 +61,7 @@ bool    g_led_control_registers_update_required[IS31FL3736_DRIVER_COUNT]        
 void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
@@ -81,7 +81,7 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -16,7 +16,6 @@
  */
 
 #include "is31fl3736.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -47,8 +46,6 @@
 #    define IS31FL3736_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3736 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -62,15 +59,12 @@ uint8_t g_led_control_registers[IS31FL3736_DRIVER_COUNT][IS31FL3736_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3736_DRIVER_COUNT]                        = {false};
 
 void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3736_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3736_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3736_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
 #endif
 }
 
@@ -80,25 +74,17 @@ void is31fl3736_select_page(uint8_t addr, uint8_t page) {
 }
 
 void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
-    // assumes page 1 is already selected
+    // Assumes page 1 is already selected.
+    // Transmit PWM registers in 12 transfers of 16 bytes.
 
-    // transmit PWM registers in 12 transfers of 16 bytes
-    // i2c_transfer_buffer[] is 20 bytes
-
-    // iterate over the pwm_buffer contents at 16 byte intervals
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // copy the data from i to i+15
-        // device will auto-increment register for data after the first byte
-        // thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3736_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3736_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -78,9 +78,9 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -61,7 +61,7 @@ bool    g_led_control_registers_update_required[IS31FL3736_DRIVER_COUNT]        
 void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
@@ -81,7 +81,7 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3737-mono.c
+++ b/drivers/led/issi/is31fl3737-mono.c
@@ -81,9 +81,9 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3737-mono.c
+++ b/drivers/led/issi/is31fl3737-mono.c
@@ -18,7 +18,6 @@
  */
 
 #include "is31fl3737-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -49,8 +48,6 @@
 #    define IS31FL3737_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3737 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -65,15 +62,12 @@ uint8_t g_led_control_registers[IS31FL3737_DRIVER_COUNT][IS31FL3737_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3737_DRIVER_COUNT]                        = {false};
 
 void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3737_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3737_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3737_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
 #endif
 }
 
@@ -83,25 +77,17 @@ void is31fl3737_select_page(uint8_t addr, uint8_t page) {
 }
 
 void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
-    // assumes page 1 is already selected
+    // Assumes page 1 is already selected.
+    // Transmit PWM registers in 12 transfers of 16 bytes.
 
-    // transmit PWM registers in 12 transfers of 16 bytes
-    // i2c_transfer_buffer[] is 20 bytes
-
-    // iterate over the pwm_buffer contents at 16 byte intervals
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // copy the data from i to i+15
-        // device will auto-increment register for data after the first byte
-        // thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3737_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3737_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3737-mono.c
+++ b/drivers/led/issi/is31fl3737-mono.c
@@ -64,7 +64,7 @@ bool    g_led_control_registers_update_required[IS31FL3737_DRIVER_COUNT]        
 void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
@@ -84,7 +84,7 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -81,9 +81,9 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -18,7 +18,6 @@
  */
 
 #include "is31fl3737.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -49,8 +48,6 @@
 #    define IS31FL3737_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3737 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -65,15 +62,12 @@ uint8_t g_led_control_registers[IS31FL3737_DRIVER_COUNT][IS31FL3737_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3737_DRIVER_COUNT]                        = {false};
 
 void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3737_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3737_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3737_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
 #endif
 }
 
@@ -83,25 +77,17 @@ void is31fl3737_select_page(uint8_t addr, uint8_t page) {
 }
 
 void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
-    // assumes page 1 is already selected
+    // Assumes page 1 is already selected.
+    // Transmit PWM registers in 12 transfers of 16 bytes.
 
-    // transmit PWM registers in 12 transfers of 16 bytes
-    // i2c_transfer_buffer[] is 20 bytes
-
-    // iterate over the pwm_buffer contents at 16 byte intervals
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // copy the data from i to i+15
-        // device will auto-increment register for data after the first byte
-        // thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3737_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3737_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -64,7 +64,7 @@ bool    g_led_control_registers_update_required[IS31FL3737_DRIVER_COUNT]        
 void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
@@ -84,7 +84,7 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3741-mono.c
+++ b/drivers/led/issi/is31fl3741-mono.c
@@ -18,7 +18,6 @@
  */
 
 #include "is31fl3741-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -53,8 +52,6 @@
 #    define IS31FL3741_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 // These buffers match the IS31FL3741 and IS31FL3741A PWM registers.
 // The scaling buffers match the page 2 and 3 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -68,15 +65,12 @@ bool    g_scaling_registers_update_required[IS31FL3741_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3741_DRIVER_COUNT][IS31FL3741_SCALING_REGISTER_COUNT];
 
 void is31fl3741_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3741_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT);
 #endif
 }
 
@@ -93,28 +87,22 @@ void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
             is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_1);
         }
 
-        i2c_transfer_buffer[0] = i % 180;
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 18);
-
 #if IS31FL3741_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 19, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        for (uint8_t j = 0; j < IS31FL3741_I2C_PERSISTENCE; j++) {
+            if (i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 19, IS31FL3741_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT);
 #endif
     }
 
     // transfer the left cause the total number is 351
-    i2c_transfer_buffer[0] = 162;
-    memcpy(i2c_transfer_buffer + 1, pwm_buffer + 342, 9);
-
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 10, IS31FL3741_I2C_TIMEOUT) != 0) break;
+        if (i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 10, IS31FL3741_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT);
 #endif
 }
 

--- a/drivers/led/issi/is31fl3741-mono.c
+++ b/drivers/led/issi/is31fl3741-mono.c
@@ -67,7 +67,7 @@ uint8_t g_scaling_registers[IS31FL3741_DRIVER_COUNT][IS31FL3741_SCALING_REGISTER
 void is31fl3741_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT);
@@ -89,7 +89,7 @@ void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 
 #if IS31FL3741_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3741_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT);
@@ -99,7 +99,7 @@ void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // transfer the left cause the total number is 351
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3741-mono.c
+++ b/drivers/led/issi/is31fl3741-mono.c
@@ -82,7 +82,7 @@ void is31fl3741_select_page(uint8_t addr, uint8_t page) {
 void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assume page 0 is already selected
 
-    for (int i = 0; i < 342; i += 18) {
+    for (uint16_t i = 0; i < 342; i += 18) {
         if (i == 180) {
             is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_1);
         }

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -18,7 +18,6 @@
  */
 
 #include "is31fl3741.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -53,8 +52,6 @@
 #    define IS31FL3741_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 // These buffers match the IS31FL3741 and IS31FL3741A PWM registers.
 // The scaling buffers match the page 2 and 3 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -68,15 +65,12 @@ bool    g_scaling_registers_update_required[IS31FL3741_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3741_DRIVER_COUNT][IS31FL3741_SCALING_REGISTER_COUNT];
 
 void is31fl3741_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3741_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT);
 #endif
 }
 
@@ -93,28 +87,22 @@ void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
             is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_1);
         }
 
-        i2c_transfer_buffer[0] = i % 180;
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 18);
-
 #if IS31FL3741_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 19, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        for (uint8_t j = 0; j < IS31FL3741_I2C_PERSISTENCE; j++) {
+            if (i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 19, IS31FL3741_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT);
 #endif
     }
 
     // transfer the left cause the total number is 351
-    i2c_transfer_buffer[0] = 162;
-    memcpy(i2c_transfer_buffer + 1, pwm_buffer + 342, 9);
-
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 10, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 10, IS31FL3741_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT);
 #endif
 }
 

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -67,7 +67,7 @@ uint8_t g_scaling_registers[IS31FL3741_DRIVER_COUNT][IS31FL3741_SCALING_REGISTER
 void is31fl3741_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT);
@@ -89,7 +89,7 @@ void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
 
 #if IS31FL3741_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3741_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i % 180, pwm_buffer + i, 18, IS31FL3741_I2C_TIMEOUT);
@@ -99,7 +99,7 @@ void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // transfer the left cause the total number is 351
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, 162, pwm_buffer + 342, 9, IS31FL3741_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -82,7 +82,7 @@ void is31fl3741_select_page(uint8_t addr, uint8_t page) {
 void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assume page 0 is already selected
 
-    for (int i = 0; i < 342; i += 18) {
+    for (uint16_t i = 0; i < 342; i += 18) {
         if (i == 180) {
             is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_1);
         }

--- a/drivers/led/issi/is31fl3742a-mono.c
+++ b/drivers/led/issi/is31fl3742a-mono.c
@@ -62,7 +62,7 @@ uint8_t g_scaling_registers[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_SCALING_REGIST
 void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
@@ -82,7 +82,7 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3742a-mono.c
+++ b/drivers/led/issi/is31fl3742a-mono.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3742a-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -54,8 +53,6 @@
 #    define IS31FL3742A_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3742A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3742A_DRIVER_COUNT] = {false};
@@ -63,15 +60,12 @@ bool    g_scaling_registers_update_required[IS31FL3742A_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_SCALING_REGISTER_COUNT];
 
 void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3742A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3742A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3742A_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
 #endif
 }
 
@@ -82,24 +76,16 @@ void is31fl3742a_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 6 transfers of 30 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 30 byte intervals.
+    for (int i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3742A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3742A_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3742a-mono.c
+++ b/drivers/led/issi/is31fl3742a-mono.c
@@ -79,9 +79,9 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 6 transfers of 30 bytes.
 
     // Iterate over the pwm_buffer contents at 30 byte intervals.
-    for (int i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
+    for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3742a.c
+++ b/drivers/led/issi/is31fl3742a.c
@@ -62,7 +62,7 @@ uint8_t g_scaling_registers[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_SCALING_REGIST
 void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
@@ -82,7 +82,7 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3742a.c
+++ b/drivers/led/issi/is31fl3742a.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3742a.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -54,8 +53,6 @@
 #    define IS31FL3742A_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3742A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3742A_DRIVER_COUNT] = {false};
@@ -63,15 +60,12 @@ bool    g_scaling_registers_update_required[IS31FL3742A_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_SCALING_REGISTER_COUNT];
 
 void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3742A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3742A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3742A_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
 #endif
 }
 
@@ -82,24 +76,16 @@ void is31fl3742a_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 6 transfers of 30 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 30 byte intervals.
+    for (int i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3742A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3742A_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3742a.c
+++ b/drivers/led/issi/is31fl3742a.c
@@ -79,9 +79,9 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 6 transfers of 30 bytes.
 
     // Iterate over the pwm_buffer contents at 30 byte intervals.
-    for (int i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
+    for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3743a-mono.c
+++ b/drivers/led/issi/is31fl3743a-mono.c
@@ -88,9 +88,9 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 11 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (int i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3743a-mono.c
+++ b/drivers/led/issi/is31fl3743a-mono.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3743a-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -63,8 +62,6 @@
 #    define IS31FL3743A_SYNC_4 IS31FL3743A_SYNC_NONE
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3743A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3743A_DRIVER_COUNT] = {false};
@@ -72,15 +69,12 @@ bool    g_scaling_registers_update_required[IS31FL3743A_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_SCALING_REGISTER_COUNT];
 
 void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3743A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3743A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3743A_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
 #endif
 }
 
@@ -91,24 +85,16 @@ void is31fl3743a_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 11 transfers of 18 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i + 1;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 18 byte intervals.
+    for (int i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3743A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3743A_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3743a-mono.c
+++ b/drivers/led/issi/is31fl3743a-mono.c
@@ -71,7 +71,7 @@ uint8_t g_scaling_registers[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_SCALING_REGIST
 void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
@@ -91,7 +91,7 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3743a.c
+++ b/drivers/led/issi/is31fl3743a.c
@@ -88,9 +88,9 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 11 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (int i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3743a.c
+++ b/drivers/led/issi/is31fl3743a.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3743a.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -63,8 +62,6 @@
 #    define IS31FL3743A_SYNC_4 IS31FL3743A_SYNC_NONE
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3743A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3743A_DRIVER_COUNT] = {false};
@@ -72,15 +69,12 @@ bool    g_scaling_registers_update_required[IS31FL3743A_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_SCALING_REGISTER_COUNT];
 
 void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3743A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3743A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3743A_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
 #endif
 }
 
@@ -91,24 +85,16 @@ void is31fl3743a_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 11 transfers of 18 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i + 1;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 18 byte intervals.
+    for (int i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3743A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3743A_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3743a.c
+++ b/drivers/led/issi/is31fl3743a.c
@@ -71,7 +71,7 @@ uint8_t g_scaling_registers[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_SCALING_REGIST
 void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
@@ -91,7 +91,7 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3745-mono.c
+++ b/drivers/led/issi/is31fl3745-mono.c
@@ -88,9 +88,9 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 8 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (int i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3745-mono.c
+++ b/drivers/led/issi/is31fl3745-mono.c
@@ -71,7 +71,7 @@ uint8_t g_scaling_registers[IS31FL3745_DRIVER_COUNT][IS31FL3745_SCALING_REGISTER
 void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
@@ -91,7 +91,7 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3745-mono.c
+++ b/drivers/led/issi/is31fl3745-mono.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3745-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -63,8 +62,6 @@
 #    define IS31FL3745_SYNC_4 IS31FL3745_SYNC_NONE
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3745_DRIVER_COUNT][IS31FL3745_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3745_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3745_DRIVER_COUNT] = {false};
@@ -72,15 +69,12 @@ bool    g_scaling_registers_update_required[IS31FL3745_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3745_DRIVER_COUNT][IS31FL3745_SCALING_REGISTER_COUNT];
 
 void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3745_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3745_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3745_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
 #endif
 }
 
@@ -91,24 +85,16 @@ void is31fl3745_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 8 transfers of 18 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i + 1;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 18 byte intervals.
+    for (int i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3745_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3745_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3745.c
+++ b/drivers/led/issi/is31fl3745.c
@@ -88,9 +88,9 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 8 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (int i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3745.c
+++ b/drivers/led/issi/is31fl3745.c
@@ -71,7 +71,7 @@ uint8_t g_scaling_registers[IS31FL3745_DRIVER_COUNT][IS31FL3745_SCALING_REGISTER
 void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
@@ -91,7 +91,7 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3745.c
+++ b/drivers/led/issi/is31fl3745.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3745.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -63,8 +62,6 @@
 #    define IS31FL3745_SYNC_4 IS31FL3745_SYNC_NONE
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3745_DRIVER_COUNT][IS31FL3745_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3745_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3745_DRIVER_COUNT] = {false};
@@ -72,15 +69,12 @@ bool    g_scaling_registers_update_required[IS31FL3745_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3745_DRIVER_COUNT][IS31FL3745_SCALING_REGISTER_COUNT];
 
 void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3745_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3745_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3745_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
 #endif
 }
 
@@ -91,24 +85,16 @@ void is31fl3745_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 8 transfers of 18 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i + 1;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 18 byte intervals.
+    for (int i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3745_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3745_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3746a-mono.c
+++ b/drivers/led/issi/is31fl3746a-mono.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3746a-mono.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -54,8 +53,6 @@
 #    define IS31FL3746A_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3746A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3746A_DRIVER_COUNT] = {false};
@@ -63,15 +60,12 @@ bool    g_scaling_registers_update_required[IS31FL3746A_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_SCALING_REGISTER_COUNT];
 
 void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3746A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3746A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3746A_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
 #endif
 }
 
@@ -82,24 +76,16 @@ void is31fl3746a_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 4 transfers of 18 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i + 1;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 18 byte intervals.
+    for (int i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3746A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3746A_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3746a-mono.c
+++ b/drivers/led/issi/is31fl3746a-mono.c
@@ -62,7 +62,7 @@ uint8_t g_scaling_registers[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_SCALING_REGIST
 void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
@@ -82,7 +82,7 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3746a-mono.c
+++ b/drivers/led/issi/is31fl3746a-mono.c
@@ -79,9 +79,9 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 4 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (int i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/issi/is31fl3746a.c
+++ b/drivers/led/issi/is31fl3746a.c
@@ -19,7 +19,6 @@
  */
 
 #include "is31fl3746a.h"
-#include <string.h>
 #include "i2c_master.h"
 #include "wait.h"
 
@@ -54,8 +53,6 @@
 #    define IS31FL3746A_GLOBAL_CURRENT 0xFF
 #endif
 
-uint8_t i2c_transfer_buffer[20] = {0xFF};
-
 uint8_t g_pwm_buffer[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3746A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3746A_DRIVER_COUNT] = {false};
@@ -63,15 +60,12 @@ bool    g_scaling_registers_update_required[IS31FL3746A_DRIVER_COUNT] = {false};
 uint8_t g_scaling_registers[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_SCALING_REGISTER_COUNT];
 
 void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3746A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3746A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, IS31FL3746A_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
 #endif
 }
 
@@ -82,24 +76,16 @@ void is31fl3746a_select_page(uint8_t addr, uint8_t page) {
 
 void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 0 is already selected.
-    // If any of the transactions fails function returns false.
-    // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
+    // Transmit PWM registers in 4 transfers of 18 bytes.
 
-    // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i + 1;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        memcpy(i2c_transfer_buffer + 1, pwm_buffer + i, 16);
-
+    // Iterate over the pwm_buffer contents at 18 byte intervals.
+    for (int i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3746A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) != 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, IS31FL3746A_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/issi/is31fl3746a.c
+++ b/drivers/led/issi/is31fl3746a.c
@@ -62,7 +62,7 @@ uint8_t g_scaling_registers[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_SCALING_REGIST
 void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
@@ -82,7 +82,7 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) != 0) break;
+            if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3746a.c
+++ b/drivers/led/issi/is31fl3746a.c
@@ -79,9 +79,9 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Transmit PWM registers in 4 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (int i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i + 1, pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) != 0) break;
         }
 #else

--- a/drivers/led/snled27351-mono.c
+++ b/drivers/led/snled27351-mono.c
@@ -37,8 +37,6 @@
         { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the SNLED27351 PWM registers.
 // The control buffers match the PG0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -52,15 +50,12 @@ uint8_t g_led_control_registers[SNLED27351_DRIVER_COUNT][SNLED27351_LED_CONTROL_
 bool    g_led_control_registers_update_required[SNLED27351_DRIVER_COUNT]                        = {false};
 
 void snled27351_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if SNLED27351_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, SNLED27351_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, SNLED27351_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT);
 #endif
 }
 
@@ -71,24 +66,15 @@ void snled27351_select_page(uint8_t addr, uint8_t page) {
 void snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes PG1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (int i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        for (int j = 0; j < 16; j++) {
-            i2c_transfer_buffer[1 + j] = pwm_buffer[i + j];
-        }
-
+    for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
 #if SNLED27351_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 17, SNLED27351_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 17, SNLED27351_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/snled27351-mono.c
+++ b/drivers/led/snled27351-mono.c
@@ -70,7 +70,7 @@ void snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
 #if SNLED27351_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < SNLED27351_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/snled27351-mono.c
+++ b/drivers/led/snled27351-mono.c
@@ -52,7 +52,7 @@ bool    g_led_control_registers_update_required[SNLED27351_DRIVER_COUNT]        
 void snled27351_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if SNLED27351_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT);
@@ -71,7 +71,7 @@ void snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
 #if SNLED27351_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < SNLED27351_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT);

--- a/drivers/led/snled27351.c
+++ b/drivers/led/snled27351.c
@@ -37,8 +37,6 @@
         { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
 #endif
 
-uint8_t i2c_transfer_buffer[65];
-
 // These buffers match the SNLED27351 PWM registers.
 // The control buffers match the PG0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -52,15 +50,12 @@ uint8_t g_led_control_registers[SNLED27351_DRIVER_COUNT][SNLED27351_LED_CONTROL_
 bool    g_led_control_registers_update_required[SNLED27351_DRIVER_COUNT]                        = {false};
 
 void snled27351_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if SNLED27351_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(addr << 1, i2c_transfer_buffer, 2, SNLED27351_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(addr << 1, i2c_transfer_buffer, 2, SNLED27351_I2C_TIMEOUT);
+    i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT);
 #endif
 }
 
@@ -70,24 +65,16 @@ void snled27351_select_page(uint8_t addr, uint8_t page) {
 
 void snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes PG1 is already selected.
-    // Transmit PWM registers in 3 transfers of 64 bytes.
+    // Transmit PWM registers in 12 transfers of 16 bytes.
 
-    // Iterate over the pwm_buffer contents at 64 byte intervals.
-    for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 64) {
-        i2c_transfer_buffer[0] = i;
-        // Copy the data from i to i+63.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        for (uint8_t j = 0; j < 64; j++) {
-            i2c_transfer_buffer[1 + j] = pwm_buffer[i + j];
-        }
-
+    // Iterate over the pwm_buffer contents at 16 byte intervals.
+    for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
 #if SNLED27351_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(addr << 1, i2c_transfer_buffer, 65, SNLED27351_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(addr << 1, i2c_transfer_buffer, 65, SNLED27351_I2C_TIMEOUT);
+        i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT);
 #endif
     }
 }

--- a/drivers/led/snled27351.c
+++ b/drivers/led/snled27351.c
@@ -70,7 +70,7 @@ void snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
 #if SNLED27351_I2C_PERSISTENCE > 0
-        for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
+        for (uint8_t j = 0; j < SNLED27351_I2C_PERSISTENCE; j++) {
             if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == 0) break;
         }
 #else

--- a/drivers/led/snled27351.c
+++ b/drivers/led/snled27351.c
@@ -52,7 +52,7 @@ bool    g_led_control_registers_update_required[SNLED27351_DRIVER_COUNT]        
 void snled27351_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
 #if SNLED27351_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
-        if (i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
     i2c_writeReg(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT);
@@ -71,7 +71,7 @@ void snled27351_write_pwm_buffer(uint8_t addr, uint8_t *pwm_buffer) {
     for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
 #if SNLED27351_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < SNLED27351_I2C_PERSISTENCE; j++) {
-            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_writeReg(addr << 1, i, pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT);

--- a/keyboards/input_club/k_type/is31fl3733-dual.c
+++ b/keyboards/input_club/k_type/is31fl3733-dual.c
@@ -60,8 +60,6 @@
 #    define IS31FL3733_SYNC_4 IS31FL3733_SYNC_NONE
 #endif
 
-uint8_t i2c_transfer_buffer[20];
-
 // These buffers match the IS31FL3733 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -75,15 +73,12 @@ uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
 void is31fl3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data) {
-    i2c_transfer_buffer[0] = reg;
-    i2c_transfer_buffer[1] = data;
-
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_transmit(index, addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT) == 0) break;
+        if (i2c_writeReg(index, addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == 0) break;
     }
 #else
-    i2c_transmit(index, addr << 1, i2c_transfer_buffer, 2, IS31FL3733_I2C_TIMEOUT);
+    i2c_writeReg(index, addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
 #endif
 }
 
@@ -95,24 +90,15 @@ void is31fl3733_select_page(uint8_t index, uint8_t addr, uint8_t page) {
 void is31fl3733_write_pwm_buffer(uint8_t index, uint8_t addr, uint8_t *pwm_buffer) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
-    // i2c_transfer_buffer[] is 20 bytes
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
     for (int i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
-        i2c_transfer_buffer[0] = i;
-        // Copy the data from i to i+15.
-        // Device will auto-increment register for data after the first byte
-        // Thus this sets registers 0x00-0x0F, 0x10-0x1F, etc. in one transfer.
-        for (int j = 0; j < 16; j++) {
-            i2c_transfer_buffer[1 + j] = pwm_buffer[i + j];
-        }
-
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-            if (i2c_transmit(index, addr << 1, i2c_transfer_buffer, 17, IS31FL3733_I2C_TIMEOUT) == 0) break;
+            if (i2c_writeReg(index, addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == 0) break;
         }
 #else
-        i2c_transmit(index, addr << 1, i2c_transfer_buffer, 17, IS31FL3733_I2C_TIMEOUT);
+        i2c_writeReg(index, addr << 1, i, pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT);
 #endif
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It seems to me that this whole memcpy business to transmit the PWM buffers is a relic of the original ISSI driver(s) predating the i2c_master API.

Tested on 3731, appears to work just fine.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
