### PR TITLE
CLI: Allow generation of both LED and RGB Matrix config

### DIFF
--- a/lib/python/qmk/cli/generate/keyboard_c.py
+++ b/lib/python/qmk/cli/generate/keyboard_c.py
@@ -9,21 +9,25 @@ from qmk.path import normpath
 from qmk.constants import GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE
 
 
-def _gen_led_config(info_data):
+def _gen_led_configs(info_data):
+    lines = []
+
+    if 'layout' in info_data.get('rgb_matrix', {}):
+        lines.extend(_gen_led_config(info_data, 'rgb_matrix'))
+
+    if 'layout' in info_data.get('led_matrix', {}):
+        lines.extend(_gen_led_config(info_data, 'led_matrix'))
+
+    return lines
+
+
+def _gen_led_config(info_data, config_type):
     """Convert info.json content to g_led_config
     """
     cols = info_data['matrix_size']['cols']
     rows = info_data['matrix_size']['rows']
 
-    config_type = None
-    if 'layout' in info_data.get('rgb_matrix', {}):
-        config_type = 'rgb_matrix'
-    elif 'layout' in info_data.get('led_matrix', {}):
-        config_type = 'led_matrix'
-
     lines = []
-    if not config_type:
-        return lines
 
     matrix = [['NO_LED'] * cols for _ in range(rows)]
     pos = []
@@ -53,6 +57,7 @@ def _gen_led_config(info_data):
     lines.append(f'  {{ {", ".join(flags)} }},')
     lines.append('};')
     lines.append('#endif')
+    lines.append('')
 
     return lines
 
@@ -98,7 +103,7 @@ def generate_keyboard_c(cli):
     # Build the layouts.h file.
     keyboard_h_lines = [GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE, '#include QMK_KEYBOARD_H', '']
 
-    keyboard_h_lines.extend(_gen_led_config(kb_info_json))
+    keyboard_h_lines.extend(_gen_led_configs(kb_info_json))
     keyboard_h_lines.extend(_gen_matrix_mask(kb_info_json))
 
     # Show the results

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -691,21 +691,20 @@ def _extract_led_config(info_data, keyboard):
         if info_data.get('features', {}).get(feat, False) or feat in info_data:
             feature = feat
 
-            if feature:
-                # Only attempt search if dd led config is missing
-                if 'layout' not in info_data.get(feature, {}):
-                    # Process
-                    for file in find_keyboard_c(keyboard):
-                        try:
-                            ret = find_led_config(file, cols, rows)
-                            if ret:
-                                info_data[feature] = info_data.get(feature, {})
-                                info_data[feature]['layout'] = ret
-                        except Exception as e:
-                            _log_warning(info_data, f'led_config: {file.name}: {e}')
+            # Only attempt search if dd led config is missing
+            if 'layout' not in info_data.get(feature, {}):
+                # Process
+                for file in find_keyboard_c(keyboard):
+                    try:
+                        ret = find_led_config(file, cols, rows)
+                        if ret:
+                            info_data[feature] = info_data.get(feature, {})
+                            info_data[feature]['layout'] = ret
+                    except Exception as e:
+                        _log_warning(info_data, f'led_config: {file.name}: {e}')
 
-                if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
-                    info_data[feature]['led_count'] = len(info_data[feature]['layout'])
+            if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
+                info_data[feature]['led_count'] = len(info_data[feature]['layout'])
 
     return info_data
 

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -686,27 +686,26 @@ def _extract_led_config(info_data, keyboard):
     cols = info_data['matrix_size']['cols']
     rows = info_data['matrix_size']['rows']
 
-    # Determine what feature owns g_led_config
     feature = None
     for feat in ['rgb_matrix', 'led_matrix']:
         if info_data.get('features', {}).get(feat, False) or feat in info_data:
             feature = feat
 
-    if feature:
-        # Only attempt search if dd led config is missing
-        if 'layout' not in info_data.get(feature, {}):
-            # Process
-            for file in find_keyboard_c(keyboard):
-                try:
-                    ret = find_led_config(file, cols, rows)
-                    if ret:
-                        info_data[feature] = info_data.get(feature, {})
-                        info_data[feature]['layout'] = ret
-                except Exception as e:
-                    _log_warning(info_data, f'led_config: {file.name}: {e}')
+            if feature:
+                # Only attempt search if dd led config is missing
+                if 'layout' not in info_data.get(feature, {}):
+                    # Process
+                    for file in find_keyboard_c(keyboard):
+                        try:
+                            ret = find_led_config(file, cols, rows)
+                            if ret:
+                                info_data[feature] = info_data.get(feature, {})
+                                info_data[feature]['layout'] = ret
+                        except Exception as e:
+                            _log_warning(info_data, f'led_config: {file.name}: {e}')
 
-        if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
-            info_data[feature]['led_count'] = len(info_data[feature]['layout'])
+                if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
+                    info_data[feature]['led_count'] = len(info_data[feature]['layout'])
 
     return info_data
 

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -686,10 +686,8 @@ def _extract_led_config(info_data, keyboard):
     cols = info_data['matrix_size']['cols']
     rows = info_data['matrix_size']['rows']
 
-    feature = None
-    for feat in ['rgb_matrix', 'led_matrix']:
-        if info_data.get('features', {}).get(feat, False) or feat in info_data:
-            feature = feat
+    for feature in ['rgb_matrix', 'led_matrix']:
+        if info_data.get('features', {}).get(feature, False) or feature in info_data:
 
             # Only attempt search if dd led config is missing
             if 'layout' not in info_data.get(feature, {}):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

While it is true that LED and RGB Matrix are mutually exclusive (mainly due to sharing of `g_led_config`), I have encountered this issue as a bit of an edge case with my testbed folder - Features are simply enabled in the keymap-level rules.mk, with most of the actual config living in the top-level or "dev-board"-level info.jsons.

Since all of the LED/RGB Matrix config generated by the CLI is protected by feature ifdefs anyway, it should be safe to have both at once.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
