### PR TITLE
Allow QMK to save a single default layers in the full range of 0-31

### DIFF
--- a/docs/feature_layers.md
+++ b/docs/feature_layers.md
@@ -53,6 +53,8 @@ Layers stack on top of each other in numerical order. When determining what a ke
 
 Sometimes, you might want to switch between layers in a macro or as part of a tap dance routine. `layer_on` activates a layer, and `layer_off` deactivates it. More layer-related functions can be found in [action_layer.h](https://github.com/qmk/qmk_firmware/blob/master/quantum/action_layer.h).
 
+If you want to save multiple persistent default layers, you will want to avoid using the `set_single_persistent_default_layer` function which only supports one default persistent layer at a time. Instead, you can `#define DEFAULT_LAYER_BITMASK_ENABLE` and call the `eeconfig_update_default_layer` function directly, passing it an 8-bit wide bitfield representing the least significant byte of a layer_state_t variable. Note that this approach is limited to storing persistent default layers only between layers 0 and 7.
+
 ## Functions :id=functions
 
 There are a number of functions (and variables) related to how you can use or manipulate the layers.

--- a/keyboards/satt/comet46/keymaps/default-rgbled/keymap.c
+++ b/keyboards/satt/comet46/keymaps/default-rgbled/keymap.c
@@ -174,7 +174,11 @@ void matrix_init_user(void) {
 
 void matrix_scan_user(void) {
   uint8_t layer = get_highest_layer(layer_state);
-  uint8_t default_layer = biton32(eeconfig_read_default_layer());
+#ifdef DEFAULT_LAYER_BITMASK_ENABLE
+  uint8_t default_layer = get_highest_layer(eeconfig_read_default_layer());
+#else
+  uint8_t default_layer = eeconfig_read_default_layer();
+#endif
   switch (layer) {
     case _LOWER:
       set_led_red;

--- a/keyboards/satt/comet46/keymaps/default/keymap.c
+++ b/keyboards/satt/comet46/keymaps/default/keymap.c
@@ -158,7 +158,11 @@ bool oled_task_user(void) {
   char layer_str[22];
   oled_write_P(PSTR("Layer: "), false);
   uint8_t layer = get_highest_layer(layer_state);
+#ifdef DEFAULT_LAYER_BITMASK_ENABLE
   uint8_t default_layer = get_highest_layer(eeconfig_read_default_layer());
+#else
+  uint8_t default_layer = eeconfig_read_default_layer();
+#endif
   switch (layer) {
     case _QWERTY:
       switch (default_layer) {

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -51,7 +51,11 @@ void eeconfig_init_quantum(void) {
 
     eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_NUMBER);
     eeprom_update_byte(EECONFIG_DEBUG, 0);
+#if defined(DEFAULT_LAYER_BITMASK_ENABLE)
     default_layer_state = (layer_state_t)1 << 0;
+#else
+    default_layer_state = 0;
+#endif
     eeprom_update_byte(EECONFIG_DEFAULT_LAYER, default_layer_state);
     // Enable oneshot and autocorrect by default: 0b0001 0100 0000 0000
     eeprom_update_word(EECONFIG_KEYMAP, 0x1400);

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -394,7 +394,13 @@ void quantum_init(void) {
 #endif
 
     /* read here just incase bootmagic process changed its value */
+#if defined(DEFAULT_LAYER_BITMASK_ENABLE)
+    /* stored as 8-bit-wide bitmask, so write the value directly to default_layer */
     layer_state_t default_layer = (layer_state_t)eeconfig_read_default_layer();
+#else
+    /* stored as a layer number, so left shift 1 by the stored value */
+    layer_state_t default_layer = (layer_state_t)(1UL << eeconfig_read_default_layer());
+#endif
     default_layer_set(default_layer);
 
     /* Also initialize layer state to trigger callback functions for layer_state */

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -483,7 +483,11 @@ void set_single_persistent_default_layer(uint8_t default_layer) {
 #if defined(AUDIO_ENABLE) && defined(DEFAULT_LAYER_SONGS)
     PLAY_SONG(default_layer_songs[default_layer]);
 #endif
+#if defined(DEFAULT_LAYER_BITMASK_ENABLE)
     eeconfig_update_default_layer((layer_state_t)1 << default_layer);
+#else
+    eeconfig_update_default_layer(default_layer);
+#endif
     default_layer_set((layer_state_t)1 << default_layer);
 }
 


### PR DESCRIPTION
## Description

Currently QMK saves the default layer persistently through EECONFIG as an 8-bit wide bit field which allows for saving multiple simultaneous default layers, but only for layers 0 through 7. This PR adds the ability to save the default layer as a value instead of a bit field, so that layers 0 through 31 can be the default layer, subject to the constraint that there is only one default layer selected at a time.

Pull request https://github.com/qmk/qmk_firmware/pull/21881 is written to allow default layers in the range from 0 to 31, but that is currently not possible with the existing implementation. Functions like `set_single_persistent_default_layer` indicate that the more common use case is a single default layer. There are no instances of multiple default layers being saved in the QMK repository, but there is awareness of one instance of multiple default layers being used in the recently removed user code.

This PR changes the default/presumed paradigm to a single default layer, and the original bit field method can be the re-enabled with `#define DEFAULT_LAYER_BITMASK_ENABLE`. If desired, I can update the PR to preserve the original implementation by default instead.

Additionally:
- ~~All bespoke implementations that save default layers by calling `eeconfig_update_default_layer` to set a single layer have been replaced with API calls to `set_single_persistent_default_layer`~~ Removed from this PR, was implemented in #23436
- ~~EECONFIG magic number has been decremented~~ No longer decremented as a decrement has already been performed for this breaking chances cycle

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->



<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [X] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
