### PR TITLE
Fix RGBLIGHT_SLEEP for split keyboards

### DIFF
--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -855,7 +855,8 @@ void protocol_pre_task(void) {
         dprintln("suspending keyboard");
         while (USB_DeviceState == DEVICE_STATE_Suspended) {
             suspend_power_down();
-            if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
+            const bool wakeup = suspend_wakeup_condition();
+            if (USB_Device_RemoteWakeupEnabled && wakeup) {
                 USB_Device_SendRemoteWakeup();
                 clear_keyboard();
 


### PR DESCRIPTION
Make the slave keyboard turn off rgb lights when master is suspended.

## Description

This change fixes an issue I got where the slave half of my keyboard would always stay on when I shutdown my PC. I had this issue when using RGBLIGHT_SLEEP and it was also happening when using RGB_DISABLE_WHEN_USB_SUSPENDED. This change fixes both of them. 

My only concerns with this change, is that I was thinking it could have side effects like maybe draining the battery quicker on wireless keyboards, since now it's doing matrix scan in a loop when suspended. I can't test this since my keyboard is wired. I'd love feedback on this 🙂

For context my keyboard is a corne using pro micro clones

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #22794

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
