### PR TITLE
Fix missing joystick.h include

### DIFF
--- a/keyboards/handwired/battleship_gamepad/config.h
+++ b/keyboards/handwired/battleship_gamepad/config.h
@@ -18,7 +18,6 @@
 
 /* joystick configuration */
 #define JOYSTICK_BUTTON_COUNT 25
-#define JOYSTICK_AXIS_COUNT 2
 #define JOYSTICK_AXIS_RESOLUTION 10
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */

--- a/keyboards/handwired/onekey/keymaps/joystick/config.h
+++ b/keyboards/handwired/onekey/keymaps/joystick/config.h
@@ -1,4 +1,3 @@
 #pragma once
 
-#define JOYSTICK_AXIS_COUNT 2
 #define JOYSTICK_BUTTON_COUNT 1

--- a/keyboards/lime/rev1/config.h
+++ b/keyboards/lime/rev1/config.h
@@ -16,11 +16,6 @@
 
 #pragma once
 
-/* joystick support */
-#ifdef JOYSTICK_ENABLE
-#   define JOYSTICK_AXIS_COUNT 2
-#   define JOYSTICK_BUTTON_COUNT 1
-#   define JOYSTICK_AXIS_RESOLUTION 8
-#endif
+#define JOYSTICK_BUTTON_COUNT 1
 
 #define SPLIT_USB_DETECT

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -22,6 +22,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keycode.h"
 #include "util.h"
 
+#ifdef JOYSTICK_ENABLE
+#    include "joystick.h"
+#endif
+
 // clang-format off
 
 /* HID report IDs */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

If the number of axes/buttons are not explicitly specified in `config.h`, the default values of 2 and 8 respectively are defined by `joystick.h`.

However, `report.h` did not include this header and so the `report_joystick_t` struct ended up missing their respective members, and the compile failed when other code assumed they were present.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
