### PR TITLE
Add configuration for the DAC peripheral on the STM G4

### DIFF
--- a/docs/audio_driver.md
+++ b/docs/audio_driver.md
@@ -120,6 +120,9 @@ Additionally, in the board config, you'll want to make changes to enable the DAC
 | `AUDIO_MAX_SIMULTANEOUS_TONES`   | __see next table__         | The number of tones that can be played simultaneously.  A value that is too high may freeze the controller or glitch out when too many tones are being played.        |
 | `AUDIO_DAC_SAMPLE_RATE`          | __see next table__         | Effective bit rate of the DAC (in hertz), higher limits simultaneous tones, and lower sacrifices quality.                                                             |
 | `AUDIO_DAC_BUFFER_SIZE`          | __see next table__         | Number of samples generated every refill. Too few may cause excessive CPU load; too many may cause freezes, RAM or flash exhaustion or lags during matrix scanning.   |
+| `AUDIO_DAC_CH1_TRIGGER`          | `0b000`                    | Trigger used in the DAC for channel 1. The default is to select timer 6 this is the correct configuration for the F3 family. The G4 Family uses  0b111 |
+| `AUDIO_DAC_CH2_TRIGGER`          | `0b010`                    | Trigger used in the DAC for channel 1. The default is to select timer 7 this is the correct configuration for the F3 family. The G4 Family also uses  0b010 |
+| `AUDIO_NO_BOFF`                  | undefined                  | If this define is set then the BOFF bit in the CR register is not automatically cleared. The default is for the F3 family where the BOFF bits must be explictly cleared. In the G4 family this behaviour is not needed |
 
 There are a number of predefined quality settings that you can use, with "sane minimum" being the default.  You can use custom values by simply defining the sample rate, number of simultaneous tones and buffer size, instead of using one of the listed presets.
 

--- a/docs/audio_driver.md
+++ b/docs/audio_driver.md
@@ -122,7 +122,6 @@ Additionally, in the board config, you'll want to make changes to enable the DAC
 | `AUDIO_DAC_BUFFER_SIZE`          | __see next table__         | Number of samples generated every refill. Too few may cause excessive CPU load; too many may cause freezes, RAM or flash exhaustion or lags during matrix scanning.   |
 | `AUDIO_DAC_CH1_TRIGGER`          | `0b000`                    | Trigger used in the DAC for channel 1. The default is to select timer 6 this is the correct configuration for the F3 family. The G4 Family uses  0b111 |
 | `AUDIO_DAC_CH2_TRIGGER`          | `0b010`                    | Trigger used in the DAC for channel 1. The default is to select timer 7 this is the correct configuration for the F3 family. The G4 Family also uses  0b010 |
-| `AUDIO_NO_BOFF`                  | undefined                  | If this define is set then the BOFF bit in the CR register is not automatically cleared. The default is for the F3 family where the BOFF bits must be explictly cleared. In the G4 family this behaviour is not needed |
 
 There are a number of predefined quality settings that you can use, with "sane minimum" being the default.  You can use custom values by simply defining the sample rate, number of simultaneous tones and buffer size, instead of using one of the listed presets.
 

--- a/platforms/chibios/drivers/audio_dac.h
+++ b/platforms/chibios/drivers/audio_dac.h
@@ -166,7 +166,7 @@
 #        define AUDIO_DAC_CH1_TRIGGER 0b0111
 #    else
 #        define AUDIO_DAC_CH1_TRIGGER 0b000
-#        if !defined(QMK_MCU_SERIES_STM32F0XX) && !defined(QMK_MCU_SERIES_STM32F3XX) && !defined(QMK_MCU_SERIES_STM32L0XX) && !defined(QMK_MCU_SERIES_STM32L4XX) && !defined(QMK_MCU_SERIES_GD32VF103)
+#        if !defined(QMK_MCU_SERIES_STM32F0XX) && !defined(QMK_MCU_SERIES_STM32F3XX) && !defined(QMK_MCU_SERIES_STM32F4XX) && !defined(QMK_MCU_SERIES_STM32L0XX) && !defined(QMK_MCU_SERIES_STM32L4XX) && !defined(QMK_MCU_SERIES_GD32VF103)
 #            pragma message "Default trigger value assigned for AUDIO_DAC_CH1_TRIGGER please ensure this is correct for your MCU"
 #        endif
 #    endif
@@ -177,7 +177,7 @@
 #        define AUDIO_DAC_CH2_TRIGGER 0b0010
 #    else
 #        define AUDIO_DAC_CH2_TRIGGER 0b010
-#        if !defined(QMK_MCU_SERIES_STM32F0XX) && !defined(QMK_MCU_SERIES_STM32F3XX) && !defined(QMK_MCU_SERIES_STM32L0XX) && !defined(QMK_MCU_SERIES_STM32L4XX) && !defined(QMK_MCU_SERIES_GD32VF103)
+#        if !defined(QMK_MCU_SERIES_STM32F0XX) && !defined(QMK_MCU_SERIES_STM32F3XX) && !defined(QMK_MCU_SERIES_STM32F4XX) && !defined(QMK_MCU_SERIES_STM32L0XX) && !defined(QMK_MCU_SERIES_STM32L4XX) && !defined(QMK_MCU_SERIES_GD32VF103)
 #            pragma message "Default trigger value assigned for AUDIO_DAC_CH2_TRIGGER please ensure this is correct for your MCU"
 #        endif
 #    endif

--- a/platforms/chibios/drivers/audio_dac.h
+++ b/platforms/chibios/drivers/audio_dac.h
@@ -145,6 +145,45 @@
 #endif
 
 /**
+ * Check to see if the DAC triggers are set.
+ * If not set them to the defaults for based on the detected MCU family.
+ * If no family is set issue a info message to aid potential debug and default
+ * to the Setting for a STM32F303.
+ *
+ * Here are all the values for DAC_TRG (TSEL in the ref manual) for the STM32F303
+ * TIM15_TRGO 0b011
+ * TIM2_TRGO  0b100
+ * TIM3_TRGO  0b001
+ * TIM6_TRGO  0b000
+ * TIM7_TRGO  0b010
+ * EXTI9      0b110
+ * SWTRIG     0b111
+ *
+ * Other MCUs may vary and the relevant values can be found in there ref manuals
+ */
+#if !defined(AUDIO_DAC_CH1_TRIGGER)
+#    if defined(QMK_MCU_SERIES_STM32G4XX)
+#        define AUDIO_DAC_CH1_TRIGGER 0b0111
+#    else
+#        define AUDIO_DAC_CH1_TRIGGER 0b000
+#        if !defined(QMK_MCU_SERIES_STM32F0XX) && !defined(QMK_MCU_SERIES_STM32F3XX) && !defined(QMK_MCU_SERIES_STM32L0XX) && !defined(QMK_MCU_SERIES_STM32L4XX) && !defined(QMK_MCU_SERIES_GD32VF103)
+#            pragma message "Default trigger value assigned for AUDIO_DAC_CH1_TRIGGER please ensure this is correct for your MCU"
+#        endif
+#    endif
+#endif
+
+#if !defined(AUDIO_DAC_CH2_TRIGGER)
+#    if defined(QMK_MCU_SERIES_STM32G4XX)
+#        define AUDIO_DAC_CH2_TRIGGER 0b0010
+#    else
+#        define AUDIO_DAC_CH2_TRIGGER 0b010
+#        if !defined(QMK_MCU_SERIES_STM32F0XX) && !defined(QMK_MCU_SERIES_STM32F3XX) && !defined(QMK_MCU_SERIES_STM32L0XX) && !defined(QMK_MCU_SERIES_STM32L4XX) && !defined(QMK_MCU_SERIES_GD32VF103)
+#            pragma message "Default trigger value assigned for AUDIO_DAC_CH2_TRIGGER please ensure this is correct for your MCU"
+#        endif
+#    endif
+#endif
+
+/**
  *user overridable sample generation/processing
  */
 uint16_t dac_value_generate(void);

--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -46,6 +46,11 @@
 #    define AUDIO_PIN_ALT PAL_NOLINE
 #endif
 
+// Check to seee if the dac audio triggers are set. If not set them to the defaults for the f303
+#if !defined(AUDIO_DAC_CH1_TRIGGER)
+#   define AUDIO_DAC_CH1_TRIGGER 0b000
+#endif
+
 #if !defined(AUDIO_DAC_SAMPLE_WAVEFORM_SINE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_TRIANGLE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_SQUARE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_TRAPEZOID)
 #    define AUDIO_DAC_SAMPLE_WAVEFORM_SINE
 #endif
@@ -301,7 +306,7 @@ static const DACConfig dac_conf = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_
  * EXTI9      0b110
  * SWTRIG     0b111
  */
-static const DACConversionGroup dac_conv_cfg = {.num_channels = 1U, .end_cb = dac_end, .error_cb = dac_error, .trigger = DAC_TRG(0b000)};
+static const DACConversionGroup dac_conv_cfg = {.num_channels = 1U, .end_cb = dac_end, .error_cb = dac_error, .trigger = DAC_TRG(AUDIO_DAC_CH1_TRIGGER)};
 
 void audio_driver_initialize(void) {
     if ((AUDIO_PIN == A4) || (AUDIO_PIN_ALT == A4)) {
@@ -321,9 +326,13 @@ void audio_driver_initialize(void) {
      *
      * this is done here, reaching directly into the stm32 registers since chibios has not implemented BOFF handling yet
      * (see: chibios/os/hal/ports/STM32/todo.txt '- BOFF handling in DACv1.'
+     *
+     * This Explict setting to 0 does not seem to be needed for the G4 Series
      */
+#   if !defined(AUDIO_NO_BOFF)
     DACD1.params->dac->CR &= ~DAC_CR_BOFF1;
     DACD2.params->dac->CR &= ~DAC_CR_BOFF2;
+#   endif
 
     /* Start the DAC output with all off values. This buffer will then get fed
      * with samples from dac_end, which will play notes.

--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -46,7 +46,7 @@
 #    define AUDIO_PIN_ALT PAL_NOLINE
 #endif
 
-// Check to seee if the dac audio triggers are set. If not set them to the defaults for the f303
+// Check to see if the DAC triggers are set. If not set them to the defaults for the STM32F303
 #if !defined(AUDIO_DAC_CH1_TRIGGER)
 #    define AUDIO_DAC_CH1_TRIGGER 0b000
 #endif
@@ -285,10 +285,12 @@ static void dac_error(DACDriver *dacp, dacerror_t err) {
     chSysHalt("DAC failure. halp");
 }
 
-static const GPTConfig gpt6cfg1 = {.frequency = AUDIO_DAC_SAMPLE_RATE * 3,
-                                   .callback  = NULL,
-                                   .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.  */
-                                   .dier      = 0U};
+static const GPTConfig gpt6cfg1 = {
+    .frequency = AUDIO_DAC_SAMPLE_RATE * 3,
+    .callback  = NULL,
+    .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.  */
+    .dier      = 0U,
+};
 
 static const DACConfig dac_conf = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};
 

--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -48,7 +48,7 @@
 
 // Check to seee if the dac audio triggers are set. If not set them to the defaults for the f303
 #if !defined(AUDIO_DAC_CH1_TRIGGER)
-#   define AUDIO_DAC_CH1_TRIGGER 0b000
+#    define AUDIO_DAC_CH1_TRIGGER 0b000
 #endif
 
 #if !defined(AUDIO_DAC_SAMPLE_WAVEFORM_SINE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_TRIANGLE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_SQUARE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_TRAPEZOID)
@@ -329,10 +329,10 @@ void audio_driver_initialize(void) {
      *
      * This Explict setting to 0 does not seem to be needed for the G4 Series
      */
-#   if !defined(AUDIO_NO_BOFF)
+#if !defined(AUDIO_NO_BOFF)
     DACD1.params->dac->CR &= ~DAC_CR_BOFF1;
     DACD2.params->dac->CR &= ~DAC_CR_BOFF2;
-#   endif
+#endif
 
     /* Start the DAC output with all off values. This buffer will then get fed
      * with samples from dac_end, which will play notes.

--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -329,9 +329,10 @@ void audio_driver_initialize(void) {
      * this is done here, reaching directly into the stm32 registers since chibios has not implemented BOFF handling yet
      * (see: chibios/os/hal/ports/STM32/todo.txt '- BOFF handling in DACv1.'
      *
-     * This Explict setting to 0 does not seem to be needed for the G4 Series
+     * This Explict setting to 0 does not seem to be needed for the G4 Series and possibly the L4+ serires
+     * to handle this id the BOFF bit defination does not exist then dont include the clearing.
      */
-#if !defined(AUDIO_NO_BOFF)
+#if defined(DAC_CR_BOFF1)
     DACD1.params->dac->CR &= ~DAC_CR_BOFF1;
     DACD2.params->dac->CR &= ~DAC_CR_BOFF2;
 #endif

--- a/platforms/chibios/drivers/audio_dac_additive.c
+++ b/platforms/chibios/drivers/audio_dac_additive.c
@@ -46,11 +46,6 @@
 #    define AUDIO_PIN_ALT PAL_NOLINE
 #endif
 
-// Check to see if the DAC triggers are set. If not set them to the defaults for the STM32F303
-#if !defined(AUDIO_DAC_CH1_TRIGGER)
-#    define AUDIO_DAC_CH1_TRIGGER 0b000
-#endif
-
 #if !defined(AUDIO_DAC_SAMPLE_WAVEFORM_SINE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_TRIANGLE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_SQUARE) && !defined(AUDIO_DAC_SAMPLE_WAVEFORM_TRAPEZOID)
 #    define AUDIO_DAC_SAMPLE_WAVEFORM_SINE
 #endif
@@ -295,18 +290,9 @@ static const GPTConfig gpt6cfg1 = {
 static const DACConfig dac_conf = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};
 
 /**
- * @note The DAC_TRG(0) here selects the Timer 6 TRGO event, which is triggered
+ * @note The DAC_TRG() here selects the Timer 6 TRGO event, which is triggered
  * on the rising edge after 3 APB1 clock cycles, causing our gpt6cfg1.frequency
  * to be a third of what we expect.
- *
- * Here are all the values for DAC_TRG (TSEL in the ref manual)
- * TIM15_TRGO 0b011
- * TIM2_TRGO  0b100
- * TIM3_TRGO  0b001
- * TIM6_TRGO  0b000
- * TIM7_TRGO  0b010
- * EXTI9      0b110
- * SWTRIG     0b111
  */
 static const DACConversionGroup dac_conv_cfg = {.num_channels = 1U, .end_cb = dac_end, .error_cb = dac_error, .trigger = DAC_TRG(AUDIO_DAC_CH1_TRIGGER)};
 

--- a/platforms/chibios/drivers/audio_dac_basic.c
+++ b/platforms/chibios/drivers/audio_dac_basic.c
@@ -48,15 +48,6 @@
 #    define AUDIO_PIN_ALT -1
 #endif
 
-// Check to see if the DAC triggers are set. If not set them to the defaults for the STM32F303
-#if !defined(AUDIO_DAC_CH1_TRIGGER)
-#    define AUDIO_DAC_CH1_TRIGGER 0b000
-#endif
-
-#if !defined(AUDIO_DAC_CH2_TRIGGER)
-#    define AUDIO_DAC_CH2_TRIGGER 0b010
-#endif
-
 #if !defined(AUDIO_STATE_TIMER)
 #    define AUDIO_STATE_TIMER GPTD8
 #endif
@@ -100,18 +91,9 @@ static const DACConfig dac_conf_ch1 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = 
 static const DACConfig dac_conf_ch2 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};
 
 /**
- * @note The DAC_TRG(0) here selects the Timer 6 TRGO event, which is triggered
- * on the rising edge after 3 APB1 clock cycles, causing our gpt6cfg1.frequency
+ * @note The DAC_TRG() here selects the Timer 6/7 TRGO event, which is triggered
+ * on the rising edge after 3 APB1 clock cycles, causing our gpt6/7cfg1.frequency
  * to be a third of what we expect.
- *
- * Here are all the values for DAC_TRG (TSEL in the ref manual)
- * TIM15_TRGO 0b011
- * TIM2_TRGO  0b100
- * TIM3_TRGO  0b001
- * TIM6_TRGO  0b000
- * TIM7_TRGO  0b010
- * EXTI9      0b110
- * SWTRIG     0b111
  */
 static const DACConversionGroup dac_conv_grp_ch1 = {.num_channels = 1U, .trigger = DAC_TRG(AUDIO_DAC_CH1_TRIGGER)};
 static const DACConversionGroup dac_conv_grp_ch2 = {.num_channels = 1U, .trigger = DAC_TRG(AUDIO_DAC_CH2_TRIGGER)};

--- a/platforms/chibios/drivers/audio_dac_basic.c
+++ b/platforms/chibios/drivers/audio_dac_basic.c
@@ -48,7 +48,7 @@
 #    define AUDIO_PIN_ALT -1
 #endif
 
-// Check to seee if the dac audio triggers are set. If not set them to the defaults for the f303
+// Check to see if the DAC triggers are set. If not set them to the defaults for the STM32F303
 #if !defined(AUDIO_DAC_CH1_TRIGGER)
 #    define AUDIO_DAC_CH1_TRIGGER 0b000
 #endif
@@ -75,20 +75,26 @@ static const dacsample_t dac_buffer_2[AUDIO_DAC_BUFFER_SIZE] = {
     [AUDIO_DAC_BUFFER_SIZE / 2 ... AUDIO_DAC_BUFFER_SIZE - 1] = AUDIO_DAC_SAMPLE_MAX,
 };
 
-GPTConfig gpt6cfg1 = {.frequency = AUDIO_DAC_SAMPLE_RATE,
-                      .callback  = NULL,
-                      .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
-                      .dier      = 0U};
-GPTConfig gpt7cfg1 = {.frequency = AUDIO_DAC_SAMPLE_RATE,
-                      .callback  = NULL,
-                      .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
-                      .dier      = 0U};
+GPTConfig gpt6cfg1 = {
+    .frequency = AUDIO_DAC_SAMPLE_RATE,
+    .callback  = NULL,
+    .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
+    .dier      = 0U,
+};
+GPTConfig gpt7cfg1 = {
+    .frequency = AUDIO_DAC_SAMPLE_RATE,
+    .callback  = NULL,
+    .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
+    .dier      = 0U,
+};
 
 static void gpt_audio_state_cb(GPTDriver *gptp);
-GPTConfig   gptStateUpdateCfg = {.frequency = 10,
-                                 .callback  = gpt_audio_state_cb,
-                                 .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
-                                 .dier      = 0U};
+GPTConfig   gptStateUpdateCfg = {
+      .frequency = 10,
+      .callback  = gpt_audio_state_cb,
+      .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
+      .dier      = 0U,
+};
 
 static const DACConfig dac_conf_ch1 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};
 static const DACConfig dac_conf_ch2 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};

--- a/platforms/chibios/drivers/audio_dac_basic.c
+++ b/platforms/chibios/drivers/audio_dac_basic.c
@@ -50,11 +50,11 @@
 
 // Check to seee if the dac audio triggers are set. If not set them to the defaults for the f303
 #if !defined(AUDIO_DAC_CH1_TRIGGER)
-#   define AUDIO_DAC_CH1_TRIGGER 0b000
+#    define AUDIO_DAC_CH1_TRIGGER 0b000
 #endif
 
 #if !defined(AUDIO_DAC_CH2_TRIGGER)
-#   define AUDIO_DAC_CH2_TRIGGER 0b010
+#    define AUDIO_DAC_CH2_TRIGGER 0b010
 #endif
 
 #if !defined(AUDIO_STATE_TIMER)
@@ -86,9 +86,9 @@ GPTConfig gpt7cfg1 = {.frequency = AUDIO_DAC_SAMPLE_RATE,
 
 static void gpt_audio_state_cb(GPTDriver *gptp);
 GPTConfig   gptStateUpdateCfg = {.frequency = 10,
-                               .callback  = gpt_audio_state_cb,
-                               .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
-                               .dier      = 0U};
+                                 .callback  = gpt_audio_state_cb,
+                                 .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
+                                 .dier      = 0U};
 
 static const DACConfig dac_conf_ch1 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};
 static const DACConfig dac_conf_ch2 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};
@@ -227,10 +227,10 @@ void audio_driver_initialize(void) {
      *
      * This Explict setting to 0 does not seem to be needed for the G4 Series
      */
-#   if !defined(AUDIO_NO_BOFF)
+#if !defined(AUDIO_NO_BOFF)
     DACD1.params->dac->CR &= ~DAC_CR_BOFF1;
     DACD2.params->dac->CR &= ~DAC_CR_BOFF2;
-#   endif
+#endif
 
     // start state-updater
     gptStart(&AUDIO_STATE_TIMER, &gptStateUpdateCfg);

--- a/platforms/chibios/drivers/audio_dac_basic.c
+++ b/platforms/chibios/drivers/audio_dac_basic.c
@@ -53,7 +53,7 @@
 #   define AUDIO_DAC_CH1_TRIGGER 0b000
 #endif
 
-#if !defined(AUDIO_DAC_CH1_TRIGGER)
+#if !defined(AUDIO_DAC_CH2_TRIGGER)
 #   define AUDIO_DAC_CH2_TRIGGER 0b010
 #endif
 

--- a/platforms/chibios/drivers/audio_dac_basic.c
+++ b/platforms/chibios/drivers/audio_dac_basic.c
@@ -231,9 +231,10 @@ void audio_driver_initialize(void) {
      * this is done here, reaching directly into the stm32 registers since chibios has not implemented BOFF handling yet
      * (see: chibios/os/hal/ports/STM32/todo.txt '- BOFF handling in DACv1.'
      *
-     * This Explict setting to 0 does not seem to be needed for the G4 Series
+     * This Explict setting to 0 does not seem to be needed for the G4 Series and possibly the L4+ serires
+     * to handle this id the BOFF bit defination does not exist then dont include the clearing.
      */
-#if !defined(AUDIO_NO_BOFF)
+#if defined(DAC_CR_BOFF1)
     DACD1.params->dac->CR &= ~DAC_CR_BOFF1;
     DACD2.params->dac->CR &= ~DAC_CR_BOFF2;
 #endif

--- a/platforms/chibios/drivers/audio_dac_basic.c
+++ b/platforms/chibios/drivers/audio_dac_basic.c
@@ -90,10 +90,10 @@ GPTConfig gpt7cfg1 = {
 
 static void gpt_audio_state_cb(GPTDriver *gptp);
 GPTConfig   gptStateUpdateCfg = {
-      .frequency = 10,
-      .callback  = gpt_audio_state_cb,
-      .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
-      .dier      = 0U,
+    .frequency = 10,
+    .callback  = gpt_audio_state_cb,
+    .cr2       = TIM_CR2_MMS_1, /* MMS = 010 = TRGO on Update Event.    */
+    .dier      = 0U,
 };
 
 static const DACConfig dac_conf_ch1 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = DAC_DHRM_12BIT_RIGHT};

--- a/platforms/chibios/drivers/audio_dac_basic.c
+++ b/platforms/chibios/drivers/audio_dac_basic.c
@@ -48,6 +48,15 @@
 #    define AUDIO_PIN_ALT -1
 #endif
 
+// Check to seee if the dac audio triggers are set. If not set them to the defaults for the f303
+#if !defined(AUDIO_DAC_CH1_TRIGGER)
+#   define AUDIO_DAC_CH1_TRIGGER 0b000
+#endif
+
+#if !defined(AUDIO_DAC_CH1_TRIGGER)
+#   define AUDIO_DAC_CH2_TRIGGER 0b010
+#endif
+
 #if !defined(AUDIO_STATE_TIMER)
 #    define AUDIO_STATE_TIMER GPTD8
 #endif
@@ -98,8 +107,8 @@ static const DACConfig dac_conf_ch2 = {.init = AUDIO_DAC_OFF_VALUE, .datamode = 
  * EXTI9      0b110
  * SWTRIG     0b111
  */
-static const DACConversionGroup dac_conv_grp_ch1 = {.num_channels = 1U, .trigger = DAC_TRG(0b000)};
-static const DACConversionGroup dac_conv_grp_ch2 = {.num_channels = 1U, .trigger = DAC_TRG(0b010)};
+static const DACConversionGroup dac_conv_grp_ch1 = {.num_channels = 1U, .trigger = DAC_TRG(AUDIO_DAC_CH1_TRIGGER)};
+static const DACConversionGroup dac_conv_grp_ch2 = {.num_channels = 1U, .trigger = DAC_TRG(AUDIO_DAC_CH2_TRIGGER)};
 
 void channel_1_start(void) {
     gptStart(&GPTD6, &gpt6cfg1);
@@ -215,9 +224,13 @@ void audio_driver_initialize(void) {
      *
      * this is done here, reaching directly into the stm32 registers since chibios has not implemented BOFF handling yet
      * (see: chibios/os/hal/ports/STM32/todo.txt '- BOFF handling in DACv1.'
+     *
+     * This Explict setting to 0 does not seem to be needed for the G4 Series
      */
+#   if !defined(AUDIO_NO_BOFF)
     DACD1.params->dac->CR &= ~DAC_CR_BOFF1;
     DACD2.params->dac->CR &= ~DAC_CR_BOFF2;
+#   endif
 
     // start state-updater
     gptStart(&AUDIO_STATE_TIMER, &gptStateUpdateCfg);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The STM32G4 family has a slightly modified DAC peripheral from the STM32F3. The BOFF no longer exist or need cleared, and the trigger source register has been increased from 3 to 4 bits. At the same time the mapping of the triggers has changed.

I have attempted to manage these changes. To do so i have added 3 new defines. 

The first `AUDIO_NO_BOFF` removes the code that clears the BOFF bits as it is not needed in the G4 Family. 

The 2 other defines `AUDIO_DAC_CH1_TRIGGER` and `AUDIO_DAC_CH2_TRIGGER` allow the triggers to be adjusted. For example to select timer 6 on the G4 you need to select trigger 7 while the F3 wants trigger 0.

I have added documentation for the defines and made the defaults for the defines match the F3 behaviour.

I have a keyboard i am working on that uses these defines to get the DAC working with the G4. From what i can hear it appears to be correct. The code will also builds for:
 * clueboard/66/rev4, F3 audio_dac_basic
 * dac_additive, F3 audio_dac_additive

However i don't own the boards so cannot test them beyond a build

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ x ] Core
- [ ] Bugfix
- [ ] New feature
- [ x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
