### PR TITLE
LED drivers: place I2C addresses into an array

### DIFF
--- a/drivers/led/issi/is31fl3731-mono.c
+++ b/drivers/led/issi/is31fl3731-mono.c
@@ -32,6 +32,19 @@
 #    define IS31FL3731_I2C_PERSISTENCE 0
 #endif
 
+const uint8_t i2c_addresses[IS31FL3731_DRIVER_COUNT] = {
+    IS31FL3731_I2C_ADDRESS_1,
+#ifdef IS31FL3731_I2C_ADDRESS_2
+    IS31FL3731_I2C_ADDRESS_2,
+#    ifdef IS31FL3731_I2C_ADDRESS_3
+    IS31FL3731_I2C_ADDRESS_3,
+#        ifdef IS31FL3731_I2C_ADDRESS_4
+    IS31FL3731_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3731 PWM registers 0x24-0xB3.
 // Storing them like this is optimal for I2C transfers to the registers.
 // We could optimize this and take out the unused registers from these
@@ -43,21 +56,21 @@ bool    g_pwm_buffer_update_required[IS31FL3731_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3731_DRIVER_COUNT][IS31FL3731_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3731_DRIVER_COUNT]                        = {false};
 
-void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3731_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3731_select_page(uint8_t addr, uint8_t page) {
-    is31fl3731_write_register(addr, IS31FL3731_REG_COMMAND, page);
+void is31fl3731_select_page(uint8_t index, uint8_t page) {
+    is31fl3731_write_register(index, IS31FL3731_REG_COMMAND, page);
 }
 
-void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3731_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 9 transfers of 16 bytes.
 
@@ -65,10 +78,10 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT);
 #endif
     }
 }
@@ -76,83 +89,69 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3731_init_drivers(void) {
     i2c_init();
 
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_1);
-#if defined(IS31FL3731_I2C_ADDRESS_2)
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_2);
-#    if defined(IS31FL3731_I2C_ADDRESS_3)
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_3);
-#        if defined(IS31FL3731_I2C_ADDRESS_4)
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3731_DRIVER_COUNT; i++) {
+        is31fl3731_init(i);
+    }
 
     for (int i = 0; i < IS31FL3731_LED_COUNT; i++) {
         is31fl3731_set_led_control_register(i, true);
     }
 
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3731_I2C_ADDRESS_2)
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3731_I2C_ADDRESS_3)
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3731_I2C_ADDRESS_4)
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3731_DRIVER_COUNT; i++) {
+        is31fl3731_update_led_control_registers(i);
+    }
 }
 
-void is31fl3731_init(uint8_t addr) {
+void is31fl3731_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, first enable software shutdown,
     // then set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FUNCTION);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FUNCTION);
 
     // enable software shutdown
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x00);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x00);
 #ifdef IS31FL3731_DEGHOST // set to enable de-ghosting of the array
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_GHOST_IMAGE_PREVENTION, IS31FL3731_GHOST_IMAGE_PREVENTION_GEN);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_GHOST_IMAGE_PREVENTION, IS31FL3731_GHOST_IMAGE_PREVENTION_GEN);
 #endif
 
     // this delay was copied from other drivers, might not be needed
     wait_ms(10);
 
     // picture mode
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_CONFIG, IS31FL3731_CONFIG_MODE_PICTURE);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_CONFIG, IS31FL3731_CONFIG_MODE_PICTURE);
     // display frame 0
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_PICTURE_DISPLAY, 0x00);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_PICTURE_DISPLAY, 0x00);
     // audio sync off
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_AUDIO_SYNC, 0x00);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_AUDIO_SYNC, 0x00);
 
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FRAME_1);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FRAME_1);
 
     // turn off all LEDs in the LED control register
     for (uint8_t i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3731_write_register(addr, IS31FL3731_FRAME_REG_LED_CONTROL + i, 0x00);
+        is31fl3731_write_register(index, IS31FL3731_FRAME_REG_LED_CONTROL + i, 0x00);
     }
 
     // turn off all LEDs in the blink control register (not really needed)
     for (uint8_t i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3731_write_register(addr, IS31FL3731_FRAME_REG_BLINK_CONTROL + i, 0x00);
+        is31fl3731_write_register(index, IS31FL3731_FRAME_REG_BLINK_CONTROL + i, 0x00);
     }
 
     // set PWM on all LEDs to 0
     for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i++) {
-        is31fl3731_write_register(addr, IS31FL3731_FRAME_REG_PWM + i, 0x00);
+        is31fl3731_write_register(index, IS31FL3731_FRAME_REG_PWM + i, 0x00);
     }
 
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FUNCTION);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FUNCTION);
 
     // disable software shutdown
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x01);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x01);
 
     // select page 0 and leave it selected.
     // most usage after initialization is just writing PWM buffers in page 0
     // as there's not much point in double-buffering
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FRAME_1);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FRAME_1);
 }
 
 void is31fl3731_set_value(int index, uint8_t value) {
@@ -192,18 +191,18 @@ void is31fl3731_set_led_control_register(uint8_t index, bool value) {
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3731_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3731_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3731_write_pwm_buffer(addr, index);
+        is31fl3731_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3731_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
         for (uint8_t i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3731_write_register(addr, i, g_led_control_registers[index][i]);
+            is31fl3731_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -211,14 +210,7 @@ void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3731_flush(void) {
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3731_I2C_ADDRESS_2)
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3731_I2C_ADDRESS_3)
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3731_I2C_ADDRESS_4)
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3731_DRIVER_COUNT; i++) {
+        is31fl3731_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3731-mono.h
+++ b/drivers/led/issi/is31fl3731-mono.h
@@ -105,9 +105,9 @@ typedef struct is31fl3731_led_t {
 extern const is31fl3731_led_t PROGMEM g_is31fl3731_leds[IS31FL3731_LED_COUNT];
 
 void is31fl3731_init_drivers(void);
-void is31fl3731_init(uint8_t addr);
-void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3731_select_page(uint8_t addr, uint8_t page);
+void is31fl3731_init(uint8_t index);
+void is31fl3731_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3731_select_page(uint8_t index, uint8_t page);
 
 void is31fl3731_set_value(int index, uint8_t value);
 void is31fl3731_set_value_all(uint8_t value);
@@ -118,8 +118,8 @@ void is31fl3731_set_led_control_register(uint8_t index, bool value);
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3731_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3731_update_pwm_buffers(uint8_t index);
+void is31fl3731_update_led_control_registers(uint8_t index);
 
 void is31fl3731_flush(void);
 

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -31,6 +31,19 @@
 #    define IS31FL3731_I2C_PERSISTENCE 0
 #endif
 
+const uint8_t i2c_addresses[IS31FL3731_DRIVER_COUNT] = {
+    IS31FL3731_I2C_ADDRESS_1,
+#ifdef IS31FL3731_I2C_ADDRESS_2
+    IS31FL3731_I2C_ADDRESS_2,
+#    ifdef IS31FL3731_I2C_ADDRESS_3
+    IS31FL3731_I2C_ADDRESS_3,
+#        ifdef IS31FL3731_I2C_ADDRESS_4
+    IS31FL3731_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3731 PWM registers 0x24-0xB3.
 // Storing them like this is optimal for I2C transfers to the registers.
 // We could optimize this and take out the unused registers from these
@@ -42,21 +55,21 @@ bool    g_pwm_buffer_update_required[IS31FL3731_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3731_DRIVER_COUNT][IS31FL3731_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3731_DRIVER_COUNT]                        = {false};
 
-void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3731_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3731_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3731_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3731_select_page(uint8_t addr, uint8_t page) {
-    is31fl3731_write_register(addr, IS31FL3731_REG_COMMAND, page);
+void is31fl3731_select_page(uint8_t index, uint8_t page) {
+    is31fl3731_write_register(index, IS31FL3731_REG_COMMAND, page);
 }
 
-void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3731_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 9 transfers of 16 bytes.
 
@@ -64,10 +77,10 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, g_pwm_buffer[index] + i, 16, IS31FL3731_I2C_TIMEOUT);
 #endif
     }
 }
@@ -75,83 +88,69 @@ void is31fl3731_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3731_init_drivers(void) {
     i2c_init();
 
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_1);
-#if defined(IS31FL3731_I2C_ADDRESS_2)
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_2);
-#    if defined(IS31FL3731_I2C_ADDRESS_3)
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_3);
-#        if defined(IS31FL3731_I2C_ADDRESS_4)
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3731_DRIVER_COUNT; i++) {
+        is31fl3731_init(i);
+    }
 
     for (int i = 0; i < IS31FL3731_LED_COUNT; i++) {
         is31fl3731_set_led_control_register(i, true, true, true);
     }
 
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3731_I2C_ADDRESS_2)
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3731_I2C_ADDRESS_3)
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3731_I2C_ADDRESS_4)
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3731_DRIVER_COUNT; i++) {
+        is31fl3731_update_led_control_registers(i);
+    }
 }
 
-void is31fl3731_init(uint8_t addr) {
+void is31fl3731_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, first enable software shutdown,
     // then set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FUNCTION);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FUNCTION);
 
     // enable software shutdown
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x00);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x00);
 #ifdef IS31FL3731_DEGHOST // set to enable de-ghosting of the array
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_GHOST_IMAGE_PREVENTION, IS31FL3731_GHOST_IMAGE_PREVENTION_GEN);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_GHOST_IMAGE_PREVENTION, IS31FL3731_GHOST_IMAGE_PREVENTION_GEN);
 #endif
 
     // this delay was copied from other drivers, might not be needed
     wait_ms(10);
 
     // picture mode
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_CONFIG, IS31FL3731_CONFIG_MODE_PICTURE);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_CONFIG, IS31FL3731_CONFIG_MODE_PICTURE);
     // display frame 0
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_PICTURE_DISPLAY, 0x00);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_PICTURE_DISPLAY, 0x00);
     // audio sync off
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_AUDIO_SYNC, 0x00);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_AUDIO_SYNC, 0x00);
 
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FRAME_1);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FRAME_1);
 
     // turn off all LEDs in the LED control register
     for (uint8_t i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3731_write_register(addr, IS31FL3731_FRAME_REG_LED_CONTROL + i, 0x00);
+        is31fl3731_write_register(index, IS31FL3731_FRAME_REG_LED_CONTROL + i, 0x00);
     }
 
     // turn off all LEDs in the blink control register (not really needed)
     for (uint8_t i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3731_write_register(addr, IS31FL3731_FRAME_REG_BLINK_CONTROL + i, 0x00);
+        is31fl3731_write_register(index, IS31FL3731_FRAME_REG_BLINK_CONTROL + i, 0x00);
     }
 
     // set PWM on all LEDs to 0
     for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i++) {
-        is31fl3731_write_register(addr, IS31FL3731_FRAME_REG_PWM + i, 0x00);
+        is31fl3731_write_register(index, IS31FL3731_FRAME_REG_PWM + i, 0x00);
     }
 
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FUNCTION);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FUNCTION);
 
     // disable software shutdown
-    is31fl3731_write_register(addr, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x01);
+    is31fl3731_write_register(index, IS31FL3731_FUNCTION_REG_SHUTDOWN, 0x01);
 
     // select page 0 and leave it selected.
     // most usage after initialization is just writing PWM buffers in page 0
     // as there's not much point in double-buffering
-    is31fl3731_select_page(addr, IS31FL3731_COMMAND_FRAME_1);
+    is31fl3731_select_page(index, IS31FL3731_COMMAND_FRAME_1);
 }
 
 void is31fl3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
@@ -207,18 +206,18 @@ void is31fl3731_set_led_control_register(uint8_t index, bool red, bool green, bo
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3731_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3731_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3731_write_pwm_buffer(addr, index);
+        is31fl3731_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3731_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
         for (uint8_t i = 0; i < IS31FL3731_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3731_write_register(addr, i, g_led_control_registers[index][i]);
+            is31fl3731_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -226,14 +225,7 @@ void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3731_flush(void) {
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3731_I2C_ADDRESS_2)
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3731_I2C_ADDRESS_3)
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3731_I2C_ADDRESS_4)
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3731_DRIVER_COUNT; i++) {
+        is31fl3731_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3731.h
+++ b/drivers/led/issi/is31fl3731.h
@@ -106,9 +106,9 @@ typedef struct is31fl3731_led_t {
 extern const is31fl3731_led_t PROGMEM g_is31fl3731_leds[IS31FL3731_LED_COUNT];
 
 void is31fl3731_init_drivers(void);
-void is31fl3731_init(uint8_t addr);
-void is31fl3731_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3731_select_page(uint8_t addr, uint8_t page);
+void is31fl3731_init(uint8_t index);
+void is31fl3731_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3731_select_page(uint8_t index, uint8_t page);
 
 void is31fl3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3731_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
@@ -119,8 +119,8 @@ void is31fl3731_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3731_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3731_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3731_update_pwm_buffers(uint8_t index);
+void is31fl3731_update_led_control_registers(uint8_t index);
 
 void is31fl3731_flush(void);
 

--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -62,6 +62,32 @@
 #    define IS31FL3733_SYNC_4 IS31FL3733_SYNC_NONE
 #endif
 
+const uint8_t i2c_addresses[IS31FL3733_DRIVER_COUNT] = {
+    IS31FL3733_I2C_ADDRESS_1,
+#ifdef IS31FL3733_I2C_ADDRESS_2
+    IS31FL3733_I2C_ADDRESS_2,
+#    ifdef IS31FL3733_I2C_ADDRESS_3
+    IS31FL3733_I2C_ADDRESS_3,
+#        ifdef IS31FL3733_I2C_ADDRESS_4
+    IS31FL3733_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
+const uint8_t driver_sync[IS31FL3733_DRIVER_COUNT] = {
+    IS31FL3733_SYNC_1,
+#ifdef IS31FL3733_I2C_ADDRESS_2
+    IS31FL3733_SYNC_2,
+#    ifdef IS31FL3733_I2C_ADDRESS_3
+    IS31FL3733_SYNC_3,
+#        ifdef IS31FL3733_I2C_ADDRESS_4
+    IS31FL3733_SYNC_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3733 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -74,22 +100,22 @@ bool    g_pwm_buffer_update_required[IS31FL3733_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
-void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3733_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3733_select_page(uint8_t addr, uint8_t page) {
-    is31fl3733_write_register(addr, IS31FL3733_REG_COMMAND_WRITE_LOCK, IS31FL3733_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3733_write_register(addr, IS31FL3733_REG_COMMAND, page);
+void is31fl3733_select_page(uint8_t index, uint8_t page) {
+    is31fl3733_write_register(index, IS31FL3733_REG_COMMAND_WRITE_LOCK, IS31FL3733_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3733_write_register(index, IS31FL3733_REG_COMMAND, page);
 }
 
-void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3733_write_pwm_buffer(uint8_t index) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
@@ -97,10 +123,10 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT);
 #endif
     }
 }
@@ -108,65 +134,52 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3733_init_drivers(void) {
     i2c_init();
 
-    is31fl3733_init(IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_1);
-#if defined(IS31FL3733_I2C_ADDRESS_2)
-    is31fl3733_init(IS31FL3733_I2C_ADDRESS_2, IS31FL3733_SYNC_2);
-#    if defined(IS31FL3733_I2C_ADDRESS_3)
-    is31fl3733_init(IS31FL3733_I2C_ADDRESS_3, IS31FL3733_SYNC_3);
-#        if defined(IS31FL3733_I2C_ADDRESS_4)
-    is31fl3733_init(IS31FL3733_I2C_ADDRESS_4, IS31FL3733_SYNC_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3733_DRIVER_COUNT; i++) {
+        is31fl3733_init(i);
+    }
 
     for (int i = 0; i < IS31FL3733_LED_COUNT; i++) {
         is31fl3733_set_led_control_register(i, true);
     }
 
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3733_I2C_ADDRESS_2)
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3733_I2C_ADDRESS_3)
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3733_I2C_ADDRESS_4)
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3733_DRIVER_COUNT; i++) {
+        is31fl3733_update_led_control_registers(i);
+    }
 }
 
-void is31fl3733_init(uint8_t addr, uint8_t sync) {
+void is31fl3733_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
-    // Sync is passed so set it according to the datasheet.
 
-    is31fl3733_select_page(addr, IS31FL3733_COMMAND_LED_CONTROL);
+    is31fl3733_select_page(index, IS31FL3733_COMMAND_LED_CONTROL);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3733_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3733_write_register(addr, i, 0x00);
+        is31fl3733_write_register(index, i, 0x00);
     }
 
-    is31fl3733_select_page(addr, IS31FL3733_COMMAND_PWM);
+    is31fl3733_select_page(index, IS31FL3733_COMMAND_PWM);
 
     // Set PWM on all LEDs to 0
     // No need to setup Breath registers to PWM as that is the default.
     for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i++) {
-        is31fl3733_write_register(addr, i, 0x00);
+        is31fl3733_write_register(index, i, 0x00);
     }
 
-    is31fl3733_select_page(addr, IS31FL3733_COMMAND_FUNCTION);
+    is31fl3733_select_page(index, IS31FL3733_COMMAND_FUNCTION);
+
+    uint8_t sync = driver_sync[index];
 
     // Set de-ghost pull-up resistors (SWx)
-    is31fl3733_write_register(addr, IS31FL3733_FUNCTION_REG_SW_PULLUP, IS31FL3733_SW_PULLUP);
+    is31fl3733_write_register(index, IS31FL3733_FUNCTION_REG_SW_PULLUP, IS31FL3733_SW_PULLUP);
     // Set de-ghost pull-down resistors (CSx)
-    is31fl3733_write_register(addr, IS31FL3733_FUNCTION_REG_CS_PULLDOWN, IS31FL3733_CS_PULLDOWN);
+    is31fl3733_write_register(index, IS31FL3733_FUNCTION_REG_CS_PULLDOWN, IS31FL3733_CS_PULLDOWN);
     // Set global current to maximum.
-    is31fl3733_write_register(addr, IS31FL3733_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3733_GLOBAL_CURRENT);
+    is31fl3733_write_register(index, IS31FL3733_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3733_GLOBAL_CURRENT);
     // Disable software shutdown.
-    is31fl3733_write_register(addr, IS31FL3733_FUNCTION_REG_CONFIGURATION, ((sync & 0b11) << 6) | ((IS31FL3733_PWM_FREQUENCY & 0b111) << 3) | 0x01);
+    is31fl3733_write_register(index, IS31FL3733_FUNCTION_REG_CONFIGURATION, ((sync & 0b11) << 6) | ((IS31FL3733_PWM_FREQUENCY & 0b111) << 3) | 0x01);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -209,22 +222,22 @@ void is31fl3733_set_led_control_register(uint8_t index, bool value) {
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3733_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3733_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3733_select_page(addr, IS31FL3733_COMMAND_PWM);
+        is31fl3733_select_page(index, IS31FL3733_COMMAND_PWM);
 
-        is31fl3733_write_pwm_buffer(addr, index);
+        is31fl3733_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3733_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
-        is31fl3733_select_page(addr, IS31FL3733_COMMAND_LED_CONTROL);
+        is31fl3733_select_page(index, IS31FL3733_COMMAND_LED_CONTROL);
 
         for (uint8_t i = 0; i < IS31FL3733_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3733_write_register(addr, i, g_led_control_registers[index][i]);
+            is31fl3733_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -232,14 +245,7 @@ void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3733_flush(void) {
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3733_I2C_ADDRESS_2)
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3733_I2C_ADDRESS_3)
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3733_I2C_ADDRESS_4)
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3733_DRIVER_COUNT; i++) {
+        is31fl3733_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3733-mono.h
+++ b/drivers/led/issi/is31fl3733-mono.h
@@ -115,9 +115,9 @@ typedef struct is31fl3733_led_t {
 extern const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT];
 
 void is31fl3733_init_drivers(void);
-void is31fl3733_init(uint8_t addr, uint8_t sync);
-void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3733_select_page(uint8_t addr, uint8_t page);
+void is31fl3733_init(uint8_t index);
+void is31fl3733_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3733_select_page(uint8_t index, uint8_t page);
 
 void is31fl3733_set_value(int index, uint8_t value);
 void is31fl3733_set_value_all(uint8_t value);
@@ -128,8 +128,8 @@ void is31fl3733_set_led_control_register(uint8_t index, bool value);
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3733_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3733_update_pwm_buffers(uint8_t index);
+void is31fl3733_update_led_control_registers(uint8_t index);
 
 void is31fl3733_flush(void);
 

--- a/drivers/led/issi/is31fl3733.h
+++ b/drivers/led/issi/is31fl3733.h
@@ -140,9 +140,9 @@ typedef struct is31fl3733_led_t {
 extern const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT];
 
 void is31fl3733_init_drivers(void);
-void is31fl3733_init(uint8_t addr, uint8_t sync);
-void is31fl3733_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3733_select_page(uint8_t addr, uint8_t page);
+void is31fl3733_init(uint8_t index);
+void is31fl3733_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3733_select_page(uint8_t index, uint8_t page);
 
 void is31fl3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3733_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
@@ -153,8 +153,8 @@ void is31fl3733_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3733_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3733_update_pwm_buffers(uint8_t index);
+void is31fl3733_update_led_control_registers(uint8_t index);
 
 void is31fl3733_flush(void);
 

--- a/drivers/led/issi/is31fl3736-mono.c
+++ b/drivers/led/issi/is31fl3736-mono.c
@@ -46,6 +46,19 @@
 #    define IS31FL3736_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3736_DRIVER_COUNT] = {
+    IS31FL3736_I2C_ADDRESS_1,
+#ifdef IS31FL3736_I2C_ADDRESS_2
+    IS31FL3736_I2C_ADDRESS_2,
+#    ifdef IS31FL3736_I2C_ADDRESS_3
+    IS31FL3736_I2C_ADDRESS_3,
+#        ifdef IS31FL3736_I2C_ADDRESS_4
+    IS31FL3736_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3736 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -58,22 +71,22 @@ bool    g_pwm_buffer_update_required[IS31FL3736_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3736_DRIVER_COUNT][IS31FL3736_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3736_DRIVER_COUNT]                        = {false};
 
-void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3736_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3736_select_page(uint8_t addr, uint8_t page) {
-    is31fl3736_write_register(addr, IS31FL3736_REG_COMMAND_WRITE_LOCK, IS31FL3736_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3736_write_register(addr, IS31FL3736_REG_COMMAND, page);
+void is31fl3736_select_page(uint8_t index, uint8_t page) {
+    is31fl3736_write_register(index, IS31FL3736_REG_COMMAND_WRITE_LOCK, IS31FL3736_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3736_write_register(index, IS31FL3736_REG_COMMAND, page);
 }
 
-void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3736_write_pwm_buffer(uint8_t index) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
@@ -81,10 +94,10 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT);
 #endif
     }
 }
@@ -92,64 +105,50 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3736_init_drivers(void) {
     i2c_init();
 
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_1);
-#if defined(IS31FL3736_I2C_ADDRESS_2)
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_2);
-#    if defined(IS31FL3736_I2C_ADDRESS_3)
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_3);
-#        if defined(IS31FL3736_I2C_ADDRESS_4)
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3736_DRIVER_COUNT; i++) {
+        is31fl3736_init(i);
+    }
 
     for (int i = 0; i < IS31FL3736_LED_COUNT; i++) {
         is31fl3736_set_led_control_register(i, true);
     }
 
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3736_I2C_ADDRESS_2)
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3736_I2C_ADDRESS_3)
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3736_I2C_ADDRESS_4)
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3736_DRIVER_COUNT; i++) {
+        is31fl3736_update_led_control_registers(i);
+    }
 }
 
-void is31fl3736_init(uint8_t addr) {
+void is31fl3736_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3736_select_page(addr, IS31FL3736_COMMAND_LED_CONTROL);
+    is31fl3736_select_page(index, IS31FL3736_COMMAND_LED_CONTROL);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3736_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3736_write_register(addr, i, 0x00);
+        is31fl3736_write_register(index, i, 0x00);
     }
 
-    is31fl3736_select_page(addr, IS31FL3736_COMMAND_PWM);
+    is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
 
     // Set PWM on all LEDs to 0
     // No need to setup Breath registers to PWM as that is the default.
     for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i++) {
-        is31fl3736_write_register(addr, i, 0x00);
+        is31fl3736_write_register(index, i, 0x00);
     }
 
-    is31fl3736_select_page(addr, IS31FL3736_COMMAND_FUNCTION);
+    is31fl3736_select_page(index, IS31FL3736_COMMAND_FUNCTION);
 
     // Set de-ghost pull-up resistors (SWx)
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_SW_PULLUP, IS31FL3736_SW_PULLUP);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_SW_PULLUP, IS31FL3736_SW_PULLUP);
     // Set de-ghost pull-down resistors (CSx)
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_CS_PULLDOWN, IS31FL3736_CS_PULLDOWN);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_CS_PULLDOWN, IS31FL3736_CS_PULLDOWN);
     // Set global current to maximum.
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3736_GLOBAL_CURRENT);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3736_GLOBAL_CURRENT);
     // Disable software shutdown.
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_CONFIGURATION, ((IS31FL3736_PWM_FREQUENCY & 0b111) << 3) | 0x01);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_CONFIGURATION, ((IS31FL3736_PWM_FREQUENCY & 0b111) << 3) | 0x01);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -198,22 +197,22 @@ void is31fl3736_set_led_control_register(uint8_t index, bool value) {
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3736_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3736_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3736_select_page(addr, IS31FL3736_COMMAND_PWM);
+        is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
 
-        is31fl3736_write_pwm_buffer(addr, index);
+        is31fl3736_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3736_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
-        is31fl3736_select_page(addr, IS31FL3736_COMMAND_LED_CONTROL);
+        is31fl3736_select_page(index, IS31FL3736_COMMAND_LED_CONTROL);
 
         for (uint8_t i = 0; i < IS31FL3736_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3736_write_register(addr, i, g_led_control_registers[index][i]);
+            is31fl3736_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -221,14 +220,7 @@ void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3736_flush(void) {
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3736_I2C_ADDRESS_2)
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3736_I2C_ADDRESS_3)
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3736_I2C_ADDRESS_4)
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3736_DRIVER_COUNT; i++) {
+        is31fl3736_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3736-mono.h
+++ b/drivers/led/issi/is31fl3736-mono.h
@@ -110,9 +110,9 @@ typedef struct is31fl3736_led_t {
 extern const is31fl3736_led_t PROGMEM g_is31fl3736_leds[IS31FL3736_LED_COUNT];
 
 void is31fl3736_init_drivers(void);
-void is31fl3736_init(uint8_t addr);
-void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3736_select_page(uint8_t addr, uint8_t page);
+void is31fl3736_init(uint8_t index);
+void is31fl3736_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3736_select_page(uint8_t index, uint8_t page);
 
 void is31fl3736_set_value(int index, uint8_t value);
 void is31fl3736_set_value_all(uint8_t value);
@@ -123,8 +123,8 @@ void is31fl3736_set_led_control_register(uint8_t index, bool value);
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3736_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3736_update_pwm_buffers(uint8_t index);
+void is31fl3736_update_led_control_registers(uint8_t index);
 
 void is31fl3736_flush(void);
 

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -46,6 +46,19 @@
 #    define IS31FL3736_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3736_DRIVER_COUNT] = {
+    IS31FL3736_I2C_ADDRESS_1,
+#ifdef IS31FL3736_I2C_ADDRESS_2
+    IS31FL3736_I2C_ADDRESS_2,
+#    ifdef IS31FL3736_I2C_ADDRESS_3
+    IS31FL3736_I2C_ADDRESS_3,
+#        ifdef IS31FL3736_I2C_ADDRESS_4
+    IS31FL3736_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3736 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -58,22 +71,22 @@ bool    g_pwm_buffer_update_required[IS31FL3736_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3736_DRIVER_COUNT][IS31FL3736_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3736_DRIVER_COUNT]                        = {false};
 
-void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3736_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3736_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3736_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3736_select_page(uint8_t addr, uint8_t page) {
-    is31fl3736_write_register(addr, IS31FL3736_REG_COMMAND_WRITE_LOCK, IS31FL3736_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3736_write_register(addr, IS31FL3736_REG_COMMAND, page);
+void is31fl3736_select_page(uint8_t index, uint8_t page) {
+    is31fl3736_write_register(index, IS31FL3736_REG_COMMAND_WRITE_LOCK, IS31FL3736_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3736_write_register(index, IS31FL3736_REG_COMMAND, page);
 }
 
-void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3736_write_pwm_buffer(uint8_t index) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
@@ -81,10 +94,10 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3736_I2C_TIMEOUT);
 #endif
     }
 }
@@ -92,64 +105,50 @@ void is31fl3736_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3736_init_drivers(void) {
     i2c_init();
 
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_1);
-#if defined(IS31FL3736_I2C_ADDRESS_2)
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_2);
-#    if defined(IS31FL3736_I2C_ADDRESS_3)
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_3);
-#        if defined(IS31FL3736_I2C_ADDRESS_4)
-    is31fl3736_init(IS31FL3736_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3736_DRIVER_COUNT; i++) {
+        is31fl3736_init(i);
+    }
 
     for (int i = 0; i < IS31FL3736_LED_COUNT; i++) {
         is31fl3736_set_led_control_register(i, true, true, true);
     }
 
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3736_I2C_ADDRESS_2)
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3736_I2C_ADDRESS_3)
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3736_I2C_ADDRESS_4)
-    is31fl3736_update_led_control_registers(IS31FL3736_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3736_DRIVER_COUNT; i++) {
+        is31fl3736_update_led_control_registers(i);
+    }
 }
 
-void is31fl3736_init(uint8_t addr) {
+void is31fl3736_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3736_select_page(addr, IS31FL3736_COMMAND_LED_CONTROL);
+    is31fl3736_select_page(index, IS31FL3736_COMMAND_LED_CONTROL);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3736_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3736_write_register(addr, i, 0x00);
+        is31fl3736_write_register(index, i, 0x00);
     }
 
-    is31fl3736_select_page(addr, IS31FL3736_COMMAND_PWM);
+    is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
 
     // Set PWM on all LEDs to 0
     // No need to setup Breath registers to PWM as that is the default.
     for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i++) {
-        is31fl3736_write_register(addr, i, 0x00);
+        is31fl3736_write_register(index, i, 0x00);
     }
 
-    is31fl3736_select_page(addr, IS31FL3736_COMMAND_FUNCTION);
+    is31fl3736_select_page(index, IS31FL3736_COMMAND_FUNCTION);
 
     // Set de-ghost pull-up resistors (SWx)
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_SW_PULLUP, IS31FL3736_SW_PULLUP);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_SW_PULLUP, IS31FL3736_SW_PULLUP);
     // Set de-ghost pull-down resistors (CSx)
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_CS_PULLDOWN, IS31FL3736_CS_PULLDOWN);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_CS_PULLDOWN, IS31FL3736_CS_PULLDOWN);
     // Set global current to maximum.
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3736_GLOBAL_CURRENT);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3736_GLOBAL_CURRENT);
     // Disable software shutdown.
-    is31fl3736_write_register(addr, IS31FL3736_FUNCTION_REG_CONFIGURATION, ((IS31FL3736_PWM_FREQUENCY & 0b111) << 3) | 0x01);
+    is31fl3736_write_register(index, IS31FL3736_FUNCTION_REG_CONFIGURATION, ((IS31FL3736_PWM_FREQUENCY & 0b111) << 3) | 0x01);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -215,22 +214,22 @@ void is31fl3736_set_led_control_register(uint8_t index, bool red, bool green, bo
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3736_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3736_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3736_select_page(addr, IS31FL3736_COMMAND_PWM);
+        is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
 
-        is31fl3736_write_pwm_buffer(addr, index);
+        is31fl3736_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3736_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
-        is31fl3736_select_page(addr, IS31FL3736_COMMAND_LED_CONTROL);
+        is31fl3736_select_page(index, IS31FL3736_COMMAND_LED_CONTROL);
 
         for (uint8_t i = 0; i < IS31FL3736_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3736_write_register(addr, i, g_led_control_registers[index][i]);
+            is31fl3736_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -238,14 +237,7 @@ void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3736_flush(void) {
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3736_I2C_ADDRESS_2)
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3736_I2C_ADDRESS_3)
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3736_I2C_ADDRESS_4)
-    is31fl3736_update_pwm_buffers(IS31FL3736_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3736_DRIVER_COUNT; i++) {
+        is31fl3736_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3736.h
+++ b/drivers/led/issi/is31fl3736.h
@@ -124,9 +124,9 @@ typedef struct is31fl3736_led_t {
 extern const is31fl3736_led_t PROGMEM g_is31fl3736_leds[IS31FL3736_LED_COUNT];
 
 void is31fl3736_init_drivers(void);
-void is31fl3736_init(uint8_t addr);
-void is31fl3736_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3736_select_page(uint8_t addr, uint8_t page);
+void is31fl3736_init(uint8_t index);
+void is31fl3736_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3736_select_page(uint8_t index, uint8_t page);
 
 void is31fl3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3736_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
@@ -137,8 +137,8 @@ void is31fl3736_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3736_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3736_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3736_update_pwm_buffers(uint8_t index);
+void is31fl3736_update_led_control_registers(uint8_t index);
 
 void is31fl3736_flush(void);
 

--- a/drivers/led/issi/is31fl3737-mono.c
+++ b/drivers/led/issi/is31fl3737-mono.c
@@ -48,6 +48,19 @@
 #    define IS31FL3737_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3737_DRIVER_COUNT] = {
+    IS31FL3737_I2C_ADDRESS_1,
+#ifdef IS31FL3737_I2C_ADDRESS_2
+    IS31FL3737_I2C_ADDRESS_2,
+#    ifdef IS31FL3737_I2C_ADDRESS_3
+    IS31FL3737_I2C_ADDRESS_3,
+#        ifdef IS31FL3737_I2C_ADDRESS_4
+    IS31FL3737_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3737 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -61,22 +74,22 @@ bool    g_pwm_buffer_update_required[IS31FL3737_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3737_DRIVER_COUNT][IS31FL3737_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3737_DRIVER_COUNT]                        = {false};
 
-void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3737_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3737_select_page(uint8_t addr, uint8_t page) {
-    is31fl3737_write_register(addr, IS31FL3737_REG_COMMAND_WRITE_LOCK, IS31FL3737_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3737_write_register(addr, IS31FL3737_REG_COMMAND, page);
+void is31fl3737_select_page(uint8_t index, uint8_t page) {
+    is31fl3737_write_register(index, IS31FL3737_REG_COMMAND_WRITE_LOCK, IS31FL3737_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3737_write_register(index, IS31FL3737_REG_COMMAND, page);
 }
 
-void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3737_write_pwm_buffer(uint8_t index) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
@@ -84,10 +97,10 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT);
 #endif
     }
 }
@@ -95,64 +108,50 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3737_init_drivers(void) {
     i2c_init();
 
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_1);
-#if defined(IS31FL3737_I2C_ADDRESS_2)
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_2);
-#    if defined(IS31FL3737_I2C_ADDRESS_3)
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_3);
-#        if defined(IS31FL3737_I2C_ADDRESS_4)
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3737_DRIVER_COUNT; i++) {
+        is31fl3737_init(i);
+    }
 
     for (int i = 0; i < IS31FL3737_LED_COUNT; i++) {
         is31fl3737_set_led_control_register(i, true);
     }
 
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3737_I2C_ADDRESS_2)
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3737_I2C_ADDRESS_3)
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3737_I2C_ADDRESS_4)
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3737_DRIVER_COUNT; i++) {
+        is31fl3737_update_led_control_registers(i);
+    }
 }
 
-void is31fl3737_init(uint8_t addr) {
+void is31fl3737_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3737_select_page(addr, IS31FL3737_COMMAND_LED_CONTROL);
+    is31fl3737_select_page(index, IS31FL3737_COMMAND_LED_CONTROL);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3737_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3737_write_register(addr, i, 0x00);
+        is31fl3737_write_register(index, i, 0x00);
     }
 
-    is31fl3737_select_page(addr, IS31FL3737_COMMAND_PWM);
+    is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
 
     // Set PWM on all LEDs to 0
     // No need to setup Breath registers to PWM as that is the default.
     for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i++) {
-        is31fl3737_write_register(addr, i, 0x00);
+        is31fl3737_write_register(index, i, 0x00);
     }
 
-    is31fl3737_select_page(addr, IS31FL3737_COMMAND_FUNCTION);
+    is31fl3737_select_page(index, IS31FL3737_COMMAND_FUNCTION);
 
     // Set de-ghost pull-up resistors (SWx)
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_SW_PULLUP, IS31FL3737_SW_PULLUP);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_SW_PULLUP, IS31FL3737_SW_PULLUP);
     // Set de-ghost pull-down resistors (CSx)
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_CS_PULLDOWN, IS31FL3737_CS_PULLDOWN);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_CS_PULLDOWN, IS31FL3737_CS_PULLDOWN);
     // Set global current to maximum.
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3737_GLOBAL_CURRENT);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3737_GLOBAL_CURRENT);
     // Disable software shutdown.
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_CONFIGURATION, ((IS31FL3737_PWM_FREQUENCY & 0b111) << 3) | 0x01);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_CONFIGURATION, ((IS31FL3737_PWM_FREQUENCY & 0b111) << 3) | 0x01);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -195,22 +194,22 @@ void is31fl3737_set_led_control_register(uint8_t index, bool value) {
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3737_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3737_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3737_select_page(addr, IS31FL3737_COMMAND_PWM);
+        is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
 
-        is31fl3737_write_pwm_buffer(addr, index);
+        is31fl3737_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3737_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
-        is31fl3737_select_page(addr, IS31FL3737_COMMAND_LED_CONTROL);
+        is31fl3737_select_page(index, IS31FL3737_COMMAND_LED_CONTROL);
 
         for (uint8_t i = 0; i < IS31FL3737_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3737_write_register(addr, i, g_led_control_registers[index][i]);
+            is31fl3737_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -218,14 +217,7 @@ void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3737_flush(void) {
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3737_I2C_ADDRESS_2)
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3737_I2C_ADDRESS_3)
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3737_I2C_ADDRESS_4)
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3737_DRIVER_COUNT; i++) {
+        is31fl3737_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3737-mono.h
+++ b/drivers/led/issi/is31fl3737-mono.h
@@ -100,9 +100,9 @@ typedef struct is31fl3737_led_t {
 extern const is31fl3737_led_t PROGMEM g_is31fl3737_leds[IS31FL3737_LED_COUNT];
 
 void is31fl3737_init_drivers(void);
-void is31fl3737_init(uint8_t addr);
-void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3737_select_page(uint8_t addr, uint8_t page);
+void is31fl3737_init(uint8_t index);
+void is31fl3737_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3737_select_page(uint8_t index, uint8_t page);
 
 void is31fl3737_set_value(int index, uint8_t value);
 void is31fl3737_set_value_all(uint8_t value);
@@ -113,8 +113,8 @@ void is31fl3737_set_led_control_register(uint8_t index, bool value);
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3737_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3737_update_pwm_buffers(uint8_t index);
+void is31fl3737_update_led_control_registers(uint8_t index);
 
 void is31fl3737_flush(void);
 

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -48,6 +48,19 @@
 #    define IS31FL3737_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3737_DRIVER_COUNT] = {
+    IS31FL3737_I2C_ADDRESS_1,
+#ifdef IS31FL3737_I2C_ADDRESS_2
+    IS31FL3737_I2C_ADDRESS_2,
+#    ifdef IS31FL3737_I2C_ADDRESS_3
+    IS31FL3737_I2C_ADDRESS_3,
+#        ifdef IS31FL3737_I2C_ADDRESS_4
+    IS31FL3737_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3737 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -61,22 +74,22 @@ bool    g_pwm_buffer_update_required[IS31FL3737_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3737_DRIVER_COUNT][IS31FL3737_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3737_DRIVER_COUNT]                        = {false};
 
-void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3737_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3737_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3737_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3737_select_page(uint8_t addr, uint8_t page) {
-    is31fl3737_write_register(addr, IS31FL3737_REG_COMMAND_WRITE_LOCK, IS31FL3737_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3737_write_register(addr, IS31FL3737_REG_COMMAND, page);
+void is31fl3737_select_page(uint8_t index, uint8_t page) {
+    is31fl3737_write_register(index, IS31FL3737_REG_COMMAND_WRITE_LOCK, IS31FL3737_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3737_write_register(index, IS31FL3737_REG_COMMAND, page);
 }
 
-void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3737_write_pwm_buffer(uint8_t index) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
@@ -84,10 +97,10 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3737_I2C_TIMEOUT);
 #endif
     }
 }
@@ -95,64 +108,50 @@ void is31fl3737_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3737_init_drivers(void) {
     i2c_init();
 
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_1);
-#if defined(IS31FL3737_I2C_ADDRESS_2)
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_2);
-#    if defined(IS31FL3737_I2C_ADDRESS_3)
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_3);
-#        if defined(IS31FL3737_I2C_ADDRESS_4)
-    is31fl3737_init(IS31FL3737_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3737_DRIVER_COUNT; i++) {
+        is31fl3737_init(i);
+    }
 
     for (int i = 0; i < IS31FL3737_LED_COUNT; i++) {
         is31fl3737_set_led_control_register(i, true, true, true);
     }
 
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3737_I2C_ADDRESS_2)
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3737_I2C_ADDRESS_3)
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3737_I2C_ADDRESS_4)
-    is31fl3737_update_led_control_registers(IS31FL3737_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3737_DRIVER_COUNT; i++) {
+        is31fl3737_update_led_control_registers(i);
+    }
 }
 
-void is31fl3737_init(uint8_t addr) {
+void is31fl3737_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3737_select_page(addr, IS31FL3737_COMMAND_LED_CONTROL);
+    is31fl3737_select_page(index, IS31FL3737_COMMAND_LED_CONTROL);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3737_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3737_write_register(addr, i, 0x00);
+        is31fl3737_write_register(index, i, 0x00);
     }
 
-    is31fl3737_select_page(addr, IS31FL3737_COMMAND_PWM);
+    is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
 
     // Set PWM on all LEDs to 0
     // No need to setup Breath registers to PWM as that is the default.
     for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i++) {
-        is31fl3737_write_register(addr, i, 0x00);
+        is31fl3737_write_register(index, i, 0x00);
     }
 
-    is31fl3737_select_page(addr, IS31FL3737_COMMAND_FUNCTION);
+    is31fl3737_select_page(index, IS31FL3737_COMMAND_FUNCTION);
 
     // Set de-ghost pull-up resistors (SWx)
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_SW_PULLUP, IS31FL3737_SW_PULLUP);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_SW_PULLUP, IS31FL3737_SW_PULLUP);
     // Set de-ghost pull-down resistors (CSx)
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_CS_PULLDOWN, IS31FL3737_CS_PULLDOWN);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_CS_PULLDOWN, IS31FL3737_CS_PULLDOWN);
     // Set global current to maximum.
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3737_GLOBAL_CURRENT);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3737_GLOBAL_CURRENT);
     // Disable software shutdown.
-    is31fl3737_write_register(addr, IS31FL3737_FUNCTION_REG_CONFIGURATION, ((IS31FL3737_PWM_FREQUENCY & 0b111) << 3) | 0x01);
+    is31fl3737_write_register(index, IS31FL3737_FUNCTION_REG_CONFIGURATION, ((IS31FL3737_PWM_FREQUENCY & 0b111) << 3) | 0x01);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -211,22 +210,22 @@ void is31fl3737_set_led_control_register(uint8_t index, bool red, bool green, bo
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3737_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3737_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3737_select_page(addr, IS31FL3737_COMMAND_PWM);
+        is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
 
-        is31fl3737_write_pwm_buffer(addr, index);
+        is31fl3737_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3737_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
-        is31fl3737_select_page(addr, IS31FL3737_COMMAND_LED_CONTROL);
+        is31fl3737_select_page(index, IS31FL3737_COMMAND_LED_CONTROL);
 
         for (uint8_t i = 0; i < IS31FL3737_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3737_write_register(addr, i, g_led_control_registers[index][i]);
+            is31fl3737_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -234,14 +233,7 @@ void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3737_flush(void) {
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3737_I2C_ADDRESS_2)
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3737_I2C_ADDRESS_3)
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3737_I2C_ADDRESS_4)
-    is31fl3737_update_pwm_buffers(IS31FL3737_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3737_DRIVER_COUNT; i++) {
+        is31fl3737_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3737.h
+++ b/drivers/led/issi/is31fl3737.h
@@ -117,9 +117,9 @@ typedef struct is31fl3737_led_t {
 extern const is31fl3737_led_t PROGMEM g_is31fl3737_leds[IS31FL3737_LED_COUNT];
 
 void is31fl3737_init_drivers(void);
-void is31fl3737_init(uint8_t addr);
-void is31fl3737_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3737_select_page(uint8_t addr, uint8_t page);
+void is31fl3737_init(uint8_t index);
+void is31fl3737_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3737_select_page(uint8_t index, uint8_t page);
 
 void is31fl3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3737_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
@@ -130,8 +130,8 @@ void is31fl3737_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3737_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3737_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3737_update_pwm_buffers(uint8_t index);
+void is31fl3737_update_led_control_registers(uint8_t index);
 
 void is31fl3737_flush(void);
 

--- a/drivers/led/issi/is31fl3741-mono.c
+++ b/drivers/led/issi/is31fl3741-mono.c
@@ -52,6 +52,19 @@
 #    define IS31FL3741_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3741_DRIVER_COUNT] = {
+    IS31FL3741_I2C_ADDRESS_1,
+#ifdef IS31FL3741_I2C_ADDRESS_2
+    IS31FL3741_I2C_ADDRESS_2,
+#    ifdef IS31FL3741_I2C_ADDRESS_3
+    IS31FL3741_I2C_ADDRESS_3,
+#        ifdef IS31FL3741_I2C_ADDRESS_4
+    IS31FL3741_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the IS31FL3741 and IS31FL3741A PWM registers.
 // The scaling buffers match the page 2 and 3 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -64,98 +77,84 @@ bool    g_scaling_registers_update_required[IS31FL3741_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3741_DRIVER_COUNT][IS31FL3741_SCALING_REGISTER_COUNT];
 
-void is31fl3741_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3741_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3741_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3741_select_page(uint8_t addr, uint8_t page) {
-    is31fl3741_write_register(addr, IS31FL3741_REG_COMMAND_WRITE_LOCK, IS31FL3741_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3741_write_register(addr, IS31FL3741_REG_COMMAND, page);
+void is31fl3741_select_page(uint8_t index, uint8_t page) {
+    is31fl3741_write_register(index, IS31FL3741_REG_COMMAND_WRITE_LOCK, IS31FL3741_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3741_write_register(index, IS31FL3741_REG_COMMAND, page);
 }
 
-void is31fl3741_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3741_write_pwm_buffer(uint8_t index) {
     // Assume page 0 is already selected
 
     for (uint16_t i = 0; i < 342; i += 18) {
         if (i == 180) {
-            is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_1);
+            is31fl3741_select_page(index, IS31FL3741_COMMAND_PWM_1);
         }
 
 #if IS31FL3741_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3741_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i % 180, g_pwm_buffer[index] + i, 18, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i % 180, g_pwm_buffer[index] + i, 18, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i % 180, g_pwm_buffer[index] + i, 18, IS31FL3741_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i % 180, g_pwm_buffer[index] + i, 18, IS31FL3741_I2C_TIMEOUT);
 #endif
     }
 
     // transfer the left cause the total number is 351
 #if IS31FL3741_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, 162, g_pwm_buffer[index] + 342, 9, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, 162, g_pwm_buffer[index] + 342, 9, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, 162, g_pwm_buffer[index] + 342, 9, IS31FL3741_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, 162, g_pwm_buffer[index] + 342, 9, IS31FL3741_I2C_TIMEOUT);
 #endif
 }
 
 void is31fl3741_init_drivers(void) {
     i2c_init();
 
-    is31fl3741_init(IS31FL3741_I2C_ADDRESS_1);
-#if defined(IS31FL3741_I2C_ADDRESS_2)
-    is31fl3741_init(IS31FL3741_I2C_ADDRESS_2);
-#    if defined(IS31FL3741_I2C_ADDRESS_3)
-    is31fl3741_init(IS31FL3741_I2C_ADDRESS_3);
-#        if defined(IS31FL3741_I2C_ADDRESS_4)
-    is31fl3741_init(IS31FL3741_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3741_DRIVER_COUNT; i++) {
+        is31fl3741_init(i);
+    }
 
     for (int i = 0; i < IS31FL3741_LED_COUNT; i++) {
         is31fl3741_set_led_control_register(i, true);
     }
 
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3741_I2C_ADDRESS_2)
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3741_I2C_ADDRESS_3)
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3741_I2C_ADDRESS_4)
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3741_DRIVER_COUNT; i++) {
+        is31fl3741_update_led_control_registers(i);
+    }
 }
 
-void is31fl3741_init(uint8_t addr) {
+void is31fl3741_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
     // Unlock the command register.
 
-    is31fl3741_select_page(addr, IS31FL3741_COMMAND_FUNCTION);
+    is31fl3741_select_page(index, IS31FL3741_COMMAND_FUNCTION);
 
     // Set to Normal operation
-    is31fl3741_write_register(addr, IS31FL3741_FUNCTION_REG_CONFIGURATION, IS31FL3741_CONFIGURATION);
+    is31fl3741_write_register(index, IS31FL3741_FUNCTION_REG_CONFIGURATION, IS31FL3741_CONFIGURATION);
 
     // Set Golbal Current Control Register
-    is31fl3741_write_register(addr, IS31FL3741_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3741_GLOBAL_CURRENT);
+    is31fl3741_write_register(index, IS31FL3741_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3741_GLOBAL_CURRENT);
     // Set Pull up & Down for SWx CSy
-    is31fl3741_write_register(addr, IS31FL3741_FUNCTION_REG_PULLDOWNUP, ((IS31FL3741_CS_PULLDOWN << 4) | IS31FL3741_SW_PULLUP));
+    is31fl3741_write_register(index, IS31FL3741_FUNCTION_REG_PULLDOWNUP, ((IS31FL3741_CS_PULLDOWN << 4) | IS31FL3741_SW_PULLUP));
     // Set PWM frequency
-    is31fl3741_write_register(addr, IS31FL3741_FUNCTION_REG_PWM_FREQUENCY, (IS31FL3741_PWM_FREQUENCY & 0b1111));
+    is31fl3741_write_register(index, IS31FL3741_FUNCTION_REG_PWM_FREQUENCY, (IS31FL3741_PWM_FREQUENCY & 0b1111));
 
-    // is31fl3741_update_led_scaling_registers(addr, 0xFF, 0xFF, 0xFF);
+    // is31fl3741_update_led_scaling_registers(index, 0xFF, 0xFF, 0xFF);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -195,11 +194,11 @@ void is31fl3741_set_led_control_register(uint8_t index, bool value) {
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3741_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3741_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3741_select_page(addr, IS31FL3741_COMMAND_PWM_0);
+        is31fl3741_select_page(index, IS31FL3741_COMMAND_PWM_0);
 
-        is31fl3741_write_pwm_buffer(addr, index);
+        is31fl3741_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
@@ -210,20 +209,20 @@ void is31fl3741_set_pwm_buffer(const is31fl3741_led_t *pled, uint8_t value) {
     g_pwm_buffer_update_required[pled->driver] = true;
 }
 
-void is31fl3741_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3741_update_led_control_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3741_select_page(addr, IS31FL3741_COMMAND_SCALING_0);
+        is31fl3741_select_page(index, IS31FL3741_COMMAND_SCALING_0);
 
         // CS1_SW1 to CS30_SW6 are on page 2
         for (int i = CS1_SW1; i <= CS30_SW6; ++i) {
-            is31fl3741_write_register(addr, i, g_scaling_registers[index][i]);
+            is31fl3741_write_register(index, i, g_scaling_registers[index][i]);
         }
 
-        is31fl3741_select_page(addr, IS31FL3741_COMMAND_SCALING_1);
+        is31fl3741_select_page(index, IS31FL3741_COMMAND_SCALING_1);
 
         // CS1_SW7 to CS39_SW9 are on page 3
         for (int i = CS1_SW7; i <= CS39_SW9; ++i) {
-            is31fl3741_write_register(addr, i - CS1_SW7, g_scaling_registers[index][i]);
+            is31fl3741_write_register(index, i - CS1_SW7, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -236,14 +235,7 @@ void is31fl3741_set_scaling_registers(const is31fl3741_led_t *pled, uint8_t valu
 }
 
 void is31fl3741_flush(void) {
-    is31fl3741_update_pwm_buffers(IS31FL3741_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3741_I2C_ADDRESS_2)
-    is31fl3741_update_pwm_buffers(IS31FL3741_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3741_I2C_ADDRESS_3)
-    is31fl3741_update_pwm_buffers(IS31FL3741_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3741_I2C_ADDRESS_4)
-    is31fl3741_update_pwm_buffers(IS31FL3741_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3741_DRIVER_COUNT; i++) {
+        is31fl3741_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3741-mono.h
+++ b/drivers/led/issi/is31fl3741-mono.h
@@ -102,9 +102,9 @@ typedef struct is31fl3741_led_t {
 extern const is31fl3741_led_t PROGMEM g_is31fl3741_leds[IS31FL3741_LED_COUNT];
 
 void is31fl3741_init_drivers(void);
-void is31fl3741_init(uint8_t addr);
-void is31fl3741_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3741_select_page(uint8_t addr, uint8_t page);
+void is31fl3741_init(uint8_t index);
+void is31fl3741_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3741_select_page(uint8_t index, uint8_t page);
 
 void is31fl3741_set_value(int index, uint8_t value);
 void is31fl3741_set_value_all(uint8_t value);
@@ -115,8 +115,8 @@ void is31fl3741_set_led_control_register(uint8_t index, bool value);
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3741_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3741_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3741_update_pwm_buffers(uint8_t index);
+void is31fl3741_update_led_control_registers(uint8_t index);
 void is31fl3741_set_scaling_registers(const is31fl3741_led_t *pled, uint8_t value);
 
 void is31fl3741_set_pwm_buffer(const is31fl3741_led_t *pled, uint8_t value);

--- a/drivers/led/issi/is31fl3741.h
+++ b/drivers/led/issi/is31fl3741.h
@@ -119,9 +119,9 @@ typedef struct is31fl3741_led_t {
 extern const is31fl3741_led_t PROGMEM g_is31fl3741_leds[IS31FL3741_LED_COUNT];
 
 void is31fl3741_init_drivers(void);
-void is31fl3741_init(uint8_t addr);
-void is31fl3741_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3741_select_page(uint8_t addr, uint8_t page);
+void is31fl3741_init(uint8_t index);
+void is31fl3741_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3741_select_page(uint8_t index, uint8_t page);
 
 void is31fl3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3741_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
@@ -132,8 +132,8 @@ void is31fl3741_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3741_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3741_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3741_update_pwm_buffers(uint8_t index);
+void is31fl3741_update_led_control_registers(uint8_t index);
 void is31fl3741_set_scaling_registers(const is31fl3741_led_t *pled, uint8_t red, uint8_t green, uint8_t blue);
 
 void is31fl3741_set_pwm_buffer(const is31fl3741_led_t *pled, uint8_t red, uint8_t green, uint8_t blue);

--- a/drivers/led/issi/is31fl3742a-mono.c
+++ b/drivers/led/issi/is31fl3742a-mono.c
@@ -53,28 +53,41 @@
 #    define IS31FL3742A_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3742A_DRIVER_COUNT] = {
+    IS31FL3742A_I2C_ADDRESS_1,
+#ifdef IS31FL3742A_I2C_ADDRESS_2
+    IS31FL3742A_I2C_ADDRESS_2,
+#    ifdef IS31FL3742A_I2C_ADDRESS_3
+    IS31FL3742A_I2C_ADDRESS_3,
+#        ifdef IS31FL3742A_I2C_ADDRESS_4
+    IS31FL3742A_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3742A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3742A_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_SCALING_REGISTER_COUNT];
 
-void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3742a_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3742a_select_page(uint8_t addr, uint8_t page) {
-    is31fl3742a_write_register(addr, IS31FL3742A_REG_COMMAND_WRITE_LOCK, IS31FL3742A_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3742a_write_register(addr, IS31FL3742A_REG_COMMAND, page);
+void is31fl3742a_select_page(uint8_t index, uint8_t page) {
+    is31fl3742a_write_register(index, IS31FL3742A_REG_COMMAND_WRITE_LOCK, IS31FL3742A_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3742a_write_register(index, IS31FL3742A_REG_COMMAND, page);
 }
 
-void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3742a_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 6 transfers of 30 bytes.
 
@@ -82,10 +95,10 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -93,58 +106,44 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3742a_init_drivers(void) {
     i2c_init();
 
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_1);
-#if defined(IS31FL3742A_I2C_ADDRESS_2)
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_2);
-#    if defined(IS31FL3742A_I2C_ADDRESS_3)
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_3);
-#        if defined(IS31FL3742A_I2C_ADDRESS_4)
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3742A_DRIVER_COUNT; i++) {
+        is31fl3742a_init(i);
+    }
 
     for (int i = 0; i < IS31FL3742A_LED_COUNT; i++) {
         is31fl3742a_set_scaling_register(i, 0xFF);
     }
 
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3742A_I2C_ADDRESS_2)
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3742A_I2C_ADDRESS_3)
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3742A_I2C_ADDRESS_4)
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3742A_DRIVER_COUNT; i++) {
+        is31fl3742a_update_scaling_registers(i);
+    }
 }
 
-void is31fl3742a_init(uint8_t addr) {
+void is31fl3742a_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_SCALING);
+    is31fl3742a_select_page(index, IS31FL3742A_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3742A_SCALING_REGISTER_COUNT; i++) {
-        is31fl3742a_write_register(addr, i, 0x00);
+        is31fl3742a_write_register(index, i, 0x00);
     }
 
-    is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_PWM);
+    is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i++) {
-        is31fl3742a_write_register(addr, i, 0x00);
+        is31fl3742a_write_register(index, i, 0x00);
     }
 
-    is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_FUNCTION);
+    is31fl3742a_select_page(index, IS31FL3742A_COMMAND_FUNCTION);
 
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_PULLDOWNUP, (IS31FL3742A_SW_PULLDOWN << 4) | IS31FL3742A_CS_PULLUP);
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3742A_GLOBAL_CURRENT);
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_PWM_FREQUENCY, (IS31FL3742A_PWM_FREQUENCY & 0b0111));
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_CONFIGURATION, IS31FL3742A_CONFIGURATION);
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_PULLDOWNUP, (IS31FL3742A_SW_PULLDOWN << 4) | IS31FL3742A_CS_PULLUP);
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3742A_GLOBAL_CURRENT);
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_PWM_FREQUENCY, (IS31FL3742A_PWM_FREQUENCY & 0b0111));
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_CONFIGURATION, IS31FL3742A_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -179,22 +178,22 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t value) {
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3742a_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3742a_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_PWM);
+        is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
 
-        is31fl3742a_write_pwm_buffer(addr, index);
+        is31fl3742a_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3742a_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_SCALING);
+        is31fl3742a_select_page(index, IS31FL3742A_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3742A_SCALING_REGISTER_COUNT; i++) {
-            is31fl3742a_write_register(addr, i, g_scaling_registers[index][i]);
+            is31fl3742a_write_register(index, i, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -202,14 +201,7 @@ void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3742a_flush(void) {
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3742A_I2C_ADDRESS_2)
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3742A_I2C_ADDRESS_3)
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3742A_I2C_ADDRESS_4)
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3742A_DRIVER_COUNT; i++) {
+        is31fl3742a_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3742a-mono.h
+++ b/drivers/led/issi/is31fl3742a-mono.h
@@ -72,17 +72,17 @@ typedef struct is31fl3742a_led_t {
 extern const is31fl3742a_led_t PROGMEM g_is31fl3742a_leds[IS31FL3742A_LED_COUNT];
 
 void is31fl3742a_init_drivers(void);
-void is31fl3742a_init(uint8_t addr);
-void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3742a_select_page(uint8_t addr, uint8_t page);
+void is31fl3742a_init(uint8_t index);
+void is31fl3742a_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3742a_select_page(uint8_t index, uint8_t page);
 
 void is31fl3742a_set_value(int index, uint8_t value);
 void is31fl3742a_set_value_all(uint8_t value);
 
 void is31fl3742a_set_scaling_register(uint8_t index, uint8_t value);
 
-void is31fl3742a_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3742a_update_pwm_buffers(uint8_t index);
+void is31fl3742a_update_scaling_registers(uint8_t index);
 
 void is31fl3742a_flush(void);
 

--- a/drivers/led/issi/is31fl3742a.c
+++ b/drivers/led/issi/is31fl3742a.c
@@ -53,28 +53,41 @@
 #    define IS31FL3742A_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3742A_DRIVER_COUNT] = {
+    IS31FL3742A_I2C_ADDRESS_1,
+#ifdef IS31FL3742A_I2C_ADDRESS_2
+    IS31FL3742A_I2C_ADDRESS_2,
+#    ifdef IS31FL3742A_I2C_ADDRESS_3
+    IS31FL3742A_I2C_ADDRESS_3,
+#        ifdef IS31FL3742A_I2C_ADDRESS_4
+    IS31FL3742A_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3742A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3742A_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3742A_DRIVER_COUNT][IS31FL3742A_SCALING_REGISTER_COUNT];
 
-void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3742a_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3742A_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3742A_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3742a_select_page(uint8_t addr, uint8_t page) {
-    is31fl3742a_write_register(addr, IS31FL3742A_REG_COMMAND_WRITE_LOCK, IS31FL3742A_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3742a_write_register(addr, IS31FL3742A_REG_COMMAND, page);
+void is31fl3742a_select_page(uint8_t index, uint8_t page) {
+    is31fl3742a_write_register(index, IS31FL3742A_REG_COMMAND_WRITE_LOCK, IS31FL3742A_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3742a_write_register(index, IS31FL3742A_REG_COMMAND, page);
 }
 
-void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3742a_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 6 transfers of 30 bytes.
 
@@ -82,10 +95,10 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 30, IS31FL3742A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -93,58 +106,44 @@ void is31fl3742a_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3742a_init_drivers(void) {
     i2c_init();
 
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_1);
-#if defined(IS31FL3742A_I2C_ADDRESS_2)
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_2);
-#    if defined(IS31FL3742A_I2C_ADDRESS_3)
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_3);
-#        if defined(IS31FL3742A_I2C_ADDRESS_4)
-    is31fl3742a_init(IS31FL3742A_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3742A_DRIVER_COUNT; i++) {
+        is31fl3742a_init(i);
+    }
 
     for (int i = 0; i < IS31FL3742A_LED_COUNT; i++) {
         is31fl3742a_set_scaling_register(i, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3742A_I2C_ADDRESS_2)
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3742A_I2C_ADDRESS_3)
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3742A_I2C_ADDRESS_4)
-    is31fl3742a_update_scaling_registers(IS31FL3742A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3742A_DRIVER_COUNT; i++) {
+        is31fl3742a_update_scaling_registers(i);
+    }
 }
 
-void is31fl3742a_init(uint8_t addr) {
+void is31fl3742a_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_SCALING);
+    is31fl3742a_select_page(index, IS31FL3742A_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3742A_SCALING_REGISTER_COUNT; i++) {
-        is31fl3742a_write_register(addr, i, 0x00);
+        is31fl3742a_write_register(index, i, 0x00);
     }
 
-    is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_PWM);
+    is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i++) {
-        is31fl3742a_write_register(addr, i, 0x00);
+        is31fl3742a_write_register(index, i, 0x00);
     }
 
-    is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_FUNCTION);
+    is31fl3742a_select_page(index, IS31FL3742A_COMMAND_FUNCTION);
 
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_PULLDOWNUP, (IS31FL3742A_SW_PULLDOWN << 4) | IS31FL3742A_CS_PULLUP);
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3742A_GLOBAL_CURRENT);
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_PWM_FREQUENCY, (IS31FL3742A_PWM_FREQUENCY & 0b0111));
-    is31fl3742a_write_register(addr, IS31FL3742A_FUNCTION_REG_CONFIGURATION, IS31FL3742A_CONFIGURATION);
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_PULLDOWNUP, (IS31FL3742A_SW_PULLDOWN << 4) | IS31FL3742A_CS_PULLUP);
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3742A_GLOBAL_CURRENT);
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_PWM_FREQUENCY, (IS31FL3742A_PWM_FREQUENCY & 0b0111));
+    is31fl3742a_write_register(index, IS31FL3742A_FUNCTION_REG_CONFIGURATION, IS31FL3742A_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -183,22 +182,22 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3742a_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3742a_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_PWM);
+        is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
 
-        is31fl3742a_write_pwm_buffer(addr, index);
+        is31fl3742a_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3742a_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3742a_select_page(addr, IS31FL3742A_COMMAND_SCALING);
+        is31fl3742a_select_page(index, IS31FL3742A_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3742A_SCALING_REGISTER_COUNT; i++) {
-            is31fl3742a_write_register(addr, i, g_scaling_registers[index][i]);
+            is31fl3742a_write_register(index, i, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -206,14 +205,7 @@ void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3742a_flush(void) {
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3742A_I2C_ADDRESS_2)
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3742A_I2C_ADDRESS_3)
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3742A_I2C_ADDRESS_4)
-    is31fl3742a_update_pwm_buffers(IS31FL3742A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3742A_DRIVER_COUNT; i++) {
+        is31fl3742a_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3742a.h
+++ b/drivers/led/issi/is31fl3742a.h
@@ -74,17 +74,17 @@ typedef struct is31fl3742a_led_t {
 extern const is31fl3742a_led_t PROGMEM g_is31fl3742a_leds[IS31FL3742A_LED_COUNT];
 
 void is31fl3742a_init_drivers(void);
-void is31fl3742a_init(uint8_t addr);
-void is31fl3742a_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3742a_select_page(uint8_t addr, uint8_t page);
+void is31fl3742a_init(uint8_t index);
+void is31fl3742a_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3742a_select_page(uint8_t index, uint8_t page);
 
 void is31fl3742a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3742a_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void is31fl3742a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, uint8_t blue);
 
-void is31fl3742a_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3742a_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3742a_update_pwm_buffers(uint8_t index);
+void is31fl3742a_update_scaling_registers(uint8_t index);
 
 void is31fl3742a_flush(void);
 

--- a/drivers/led/issi/is31fl3743a-mono.c
+++ b/drivers/led/issi/is31fl3743a-mono.c
@@ -62,28 +62,54 @@
 #    define IS31FL3743A_SYNC_4 IS31FL3743A_SYNC_NONE
 #endif
 
+const uint8_t i2c_addresses[IS31FL3743A_DRIVER_COUNT] = {
+    IS31FL3743A_I2C_ADDRESS_1,
+#ifdef IS31FL3743A_I2C_ADDRESS_2
+    IS31FL3743A_I2C_ADDRESS_2,
+#    ifdef IS31FL3743A_I2C_ADDRESS_3
+    IS31FL3743A_I2C_ADDRESS_3,
+#        ifdef IS31FL3743A_I2C_ADDRESS_4
+    IS31FL3743A_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
+const uint8_t driver_sync[IS31FL3743A_DRIVER_COUNT] = {
+    IS31FL3743A_SYNC_1,
+#ifdef IS31FL3743A_I2C_ADDRESS_2
+    IS31FL3743A_SYNC_2,
+#    ifdef IS31FL3743A_I2C_ADDRESS_3
+    IS31FL3743A_SYNC_3,
+#        ifdef IS31FL3743A_I2C_ADDRESS_4
+    IS31FL3743A_SYNC_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3743A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3743A_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_SCALING_REGISTER_COUNT];
 
-void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3743a_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3743a_select_page(uint8_t addr, uint8_t page) {
-    is31fl3743a_write_register(addr, IS31FL3743A_REG_COMMAND_WRITE_LOCK, IS31FL3743A_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3743a_write_register(addr, IS31FL3743A_REG_COMMAND, page);
+void is31fl3743a_select_page(uint8_t index, uint8_t page) {
+    is31fl3743a_write_register(index, IS31FL3743A_REG_COMMAND_WRITE_LOCK, IS31FL3743A_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3743a_write_register(index, IS31FL3743A_REG_COMMAND, page);
 }
 
-void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3743a_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 11 transfers of 18 bytes.
 
@@ -91,10 +117,10 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -102,58 +128,46 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3743a_init_drivers(void) {
     i2c_init();
 
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_1, IS31FL3743A_SYNC_1);
-#if defined(IS31FL3743A_I2C_ADDRESS_2)
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_2, IS31FL3743A_SYNC_2);
-#    if defined(IS31FL3743A_I2C_ADDRESS_3)
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_3, IS31FL3743A_SYNC_3);
-#        if defined(IS31FL3743A_I2C_ADDRESS_4)
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_4, IS31FL3743A_SYNC_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3743A_DRIVER_COUNT; i++) {
+        is31fl3743a_init(i);
+    }
 
     for (int i = 0; i < IS31FL3743A_LED_COUNT; i++) {
         is31fl3743a_set_scaling_register(i, 0xFF);
     }
 
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3743A_I2C_ADDRESS_2)
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3743A_I2C_ADDRESS_3)
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3743A_I2C_ADDRESS_4)
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3743A_DRIVER_COUNT; i++) {
+        is31fl3743a_update_scaling_registers(i);
+    }
 }
 
-void is31fl3743a_init(uint8_t addr, uint8_t sync) {
+void is31fl3743a_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_SCALING);
+    is31fl3743a_select_page(index, IS31FL3743A_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3743A_SCALING_REGISTER_COUNT; i++) {
-        is31fl3743a_write_register(addr, i + 1, 0x00);
+        is31fl3743a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_PWM);
+    is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i++) {
-        is31fl3743a_write_register(addr, i + 1, 0x00);
+        is31fl3743a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_FUNCTION);
+    is31fl3743a_select_page(index, IS31FL3743A_COMMAND_FUNCTION);
 
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_PULLDOWNUP, (IS31FL3743A_SW_PULLDOWN << 4) | IS31FL3743A_CS_PULLUP);
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3743A_GLOBAL_CURRENT);
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_CONFIGURATION, IS31FL3743A_CONFIGURATION);
+    uint8_t sync = driver_sync[index];
+
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_PULLDOWNUP, (IS31FL3743A_SW_PULLDOWN << 4) | IS31FL3743A_CS_PULLUP);
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3743A_GLOBAL_CURRENT);
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_CONFIGURATION, IS31FL3743A_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -188,22 +202,22 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t value) {
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3743a_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3743a_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_PWM);
+        is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
 
-        is31fl3743a_write_pwm_buffer(addr, index);
+        is31fl3743a_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3743a_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_SCALING);
+        is31fl3743a_select_page(index, IS31FL3743A_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3743A_SCALING_REGISTER_COUNT; i++) {
-            is31fl3743a_write_register(addr, i + 1, g_scaling_registers[index][i]);
+            is31fl3743a_write_register(index, i + 1, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -211,14 +225,7 @@ void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3743a_flush(void) {
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3743A_I2C_ADDRESS_2)
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3743A_I2C_ADDRESS_3)
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3743A_I2C_ADDRESS_4)
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3743A_DRIVER_COUNT; i++) {
+        is31fl3743a_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3743a-mono.h
+++ b/drivers/led/issi/is31fl3743a-mono.h
@@ -82,17 +82,17 @@ typedef struct is31fl3743a_led_t {
 extern const is31fl3743a_led_t PROGMEM g_is31fl3743a_leds[IS31FL3743A_LED_COUNT];
 
 void is31fl3743a_init_drivers(void);
-void is31fl3743a_init(uint8_t addr, uint8_t sync);
-void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3743a_select_page(uint8_t addr, uint8_t page);
+void is31fl3743a_init(uint8_t index);
+void is31fl3743a_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3743a_select_page(uint8_t index, uint8_t page);
 
 void is31fl3743a_set_value(int index, uint8_t value);
 void is31fl3743a_set_value_all(uint8_t value);
 
 void is31fl3743a_set_scaling_register(uint8_t index, uint8_t value);
 
-void is31fl3743a_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3743a_update_pwm_buffers(uint8_t index);
+void is31fl3743a_update_scaling_registers(uint8_t index);
 
 void is31fl3743a_flush(void);
 

--- a/drivers/led/issi/is31fl3743a.c
+++ b/drivers/led/issi/is31fl3743a.c
@@ -62,28 +62,54 @@
 #    define IS31FL3743A_SYNC_4 IS31FL3743A_SYNC_NONE
 #endif
 
+const uint8_t i2c_addresses[IS31FL3743A_DRIVER_COUNT] = {
+    IS31FL3743A_I2C_ADDRESS_1,
+#ifdef IS31FL3743A_I2C_ADDRESS_2
+    IS31FL3743A_I2C_ADDRESS_2,
+#    ifdef IS31FL3743A_I2C_ADDRESS_3
+    IS31FL3743A_I2C_ADDRESS_3,
+#        ifdef IS31FL3743A_I2C_ADDRESS_4
+    IS31FL3743A_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
+const uint8_t driver_sync[IS31FL3743A_DRIVER_COUNT] = {
+    IS31FL3743A_SYNC_1,
+#ifdef IS31FL3743A_I2C_ADDRESS_2
+    IS31FL3743A_SYNC_2,
+#    ifdef IS31FL3743A_I2C_ADDRESS_3
+    IS31FL3743A_SYNC_3,
+#        ifdef IS31FL3743A_I2C_ADDRESS_4
+    IS31FL3743A_SYNC_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3743A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3743A_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3743A_DRIVER_COUNT][IS31FL3743A_SCALING_REGISTER_COUNT];
 
-void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3743a_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3743A_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3743A_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3743a_select_page(uint8_t addr, uint8_t page) {
-    is31fl3743a_write_register(addr, IS31FL3743A_REG_COMMAND_WRITE_LOCK, IS31FL3743A_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3743a_write_register(addr, IS31FL3743A_REG_COMMAND, page);
+void is31fl3743a_select_page(uint8_t index, uint8_t page) {
+    is31fl3743a_write_register(index, IS31FL3743A_REG_COMMAND_WRITE_LOCK, IS31FL3743A_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3743a_write_register(index, IS31FL3743A_REG_COMMAND, page);
 }
 
-void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3743a_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 11 transfers of 18 bytes.
 
@@ -91,10 +117,10 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3743A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -102,58 +128,46 @@ void is31fl3743a_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3743a_init_drivers(void) {
     i2c_init();
 
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_1, IS31FL3743A_SYNC_1);
-#if defined(IS31FL3743A_I2C_ADDRESS_2)
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_2, IS31FL3743A_SYNC_2);
-#    if defined(IS31FL3743A_I2C_ADDRESS_3)
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_3, IS31FL3743A_SYNC_3);
-#        if defined(IS31FL3743A_I2C_ADDRESS_4)
-    is31fl3743a_init(IS31FL3743A_I2C_ADDRESS_4, IS31FL3743A_SYNC_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3743A_DRIVER_COUNT; i++) {
+        is31fl3743a_init(i);
+    }
 
     for (int i = 0; i < IS31FL3743A_LED_COUNT; i++) {
         is31fl3743a_set_scaling_register(i, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3743A_I2C_ADDRESS_2)
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3743A_I2C_ADDRESS_3)
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3743A_I2C_ADDRESS_4)
-    is31fl3743a_update_scaling_registers(IS31FL3743A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3743A_DRIVER_COUNT; i++) {
+        is31fl3743a_update_scaling_registers(i);
+    }
 }
 
-void is31fl3743a_init(uint8_t addr, uint8_t sync) {
+void is31fl3743a_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_SCALING);
+    is31fl3743a_select_page(index, IS31FL3743A_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3743A_SCALING_REGISTER_COUNT; i++) {
-        is31fl3743a_write_register(addr, i + 1, 0x00);
+        is31fl3743a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_PWM);
+    is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i++) {
-        is31fl3743a_write_register(addr, i + 1, 0x00);
+        is31fl3743a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_FUNCTION);
+    is31fl3743a_select_page(index, IS31FL3743A_COMMAND_FUNCTION);
 
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_PULLDOWNUP, (IS31FL3743A_SW_PULLDOWN << 4) | IS31FL3743A_CS_PULLUP);
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3743A_GLOBAL_CURRENT);
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
-    is31fl3743a_write_register(addr, IS31FL3743A_FUNCTION_REG_CONFIGURATION, IS31FL3743A_CONFIGURATION);
+    uint8_t sync = driver_sync[index];
+
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_PULLDOWNUP, (IS31FL3743A_SW_PULLDOWN << 4) | IS31FL3743A_CS_PULLUP);
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3743A_GLOBAL_CURRENT);
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
+    is31fl3743a_write_register(index, IS31FL3743A_FUNCTION_REG_CONFIGURATION, IS31FL3743A_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -192,22 +206,22 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3743a_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3743a_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_PWM);
+        is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
 
-        is31fl3743a_write_pwm_buffer(addr, index);
+        is31fl3743a_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3743a_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3743a_select_page(addr, IS31FL3743A_COMMAND_SCALING);
+        is31fl3743a_select_page(index, IS31FL3743A_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3743A_SCALING_REGISTER_COUNT; i++) {
-            is31fl3743a_write_register(addr, i + 1, g_scaling_registers[index][i]);
+            is31fl3743a_write_register(index, i + 1, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -215,14 +229,7 @@ void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3743a_flush(void) {
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3743A_I2C_ADDRESS_2)
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3743A_I2C_ADDRESS_3)
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3743A_I2C_ADDRESS_4)
-    is31fl3743a_update_pwm_buffers(IS31FL3743A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3743A_DRIVER_COUNT; i++) {
+        is31fl3743a_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3743a.h
+++ b/drivers/led/issi/is31fl3743a.h
@@ -84,17 +84,17 @@ typedef struct is31fl3743a_led_t {
 extern const is31fl3743a_led_t PROGMEM g_is31fl3743a_leds[IS31FL3743A_LED_COUNT];
 
 void is31fl3743a_init_drivers(void);
-void is31fl3743a_init(uint8_t addr, uint8_t sync);
-void is31fl3743a_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3743a_select_page(uint8_t addr, uint8_t page);
+void is31fl3743a_init(uint8_t index);
+void is31fl3743a_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3743a_select_page(uint8_t index, uint8_t page);
 
 void is31fl3743a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3743a_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void is31fl3743a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, uint8_t blue);
 
-void is31fl3743a_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3743a_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3743a_update_pwm_buffers(uint8_t index);
+void is31fl3743a_update_scaling_registers(uint8_t index);
 
 void is31fl3743a_flush(void);
 

--- a/drivers/led/issi/is31fl3745-mono.c
+++ b/drivers/led/issi/is31fl3745-mono.c
@@ -62,28 +62,54 @@
 #    define IS31FL3745_SYNC_4 IS31FL3745_SYNC_NONE
 #endif
 
+const uint8_t i2c_addresses[IS31FL3745_DRIVER_COUNT] = {
+    IS31FL3745_I2C_ADDRESS_1,
+#ifdef IS31FL3745_I2C_ADDRESS_2
+    IS31FL3745_I2C_ADDRESS_2,
+#    ifdef IS31FL3745_I2C_ADDRESS_3
+    IS31FL3745_I2C_ADDRESS_3,
+#        ifdef IS31FL3745_I2C_ADDRESS_4
+    IS31FL3745_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
+const uint8_t driver_sync[IS31FL3745_DRIVER_COUNT] = {
+    IS31FL3745_SYNC_1,
+#ifdef IS31FL3745_I2C_ADDRESS_2
+    IS31FL3745_SYNC_2,
+#    ifdef IS31FL3745_I2C_ADDRESS_3
+    IS31FL3745_SYNC_3,
+#        ifdef IS31FL3745_I2C_ADDRESS_4
+    IS31FL3745_SYNC_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3745_DRIVER_COUNT][IS31FL3745_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3745_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3745_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3745_DRIVER_COUNT][IS31FL3745_SCALING_REGISTER_COUNT];
 
-void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3745_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3745_select_page(uint8_t addr, uint8_t page) {
-    is31fl3745_write_register(addr, IS31FL3745_REG_COMMAND_WRITE_LOCK, IS31FL3745_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3745_write_register(addr, IS31FL3745_REG_COMMAND, page);
+void is31fl3745_select_page(uint8_t index, uint8_t page) {
+    is31fl3745_write_register(index, IS31FL3745_REG_COMMAND_WRITE_LOCK, IS31FL3745_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3745_write_register(index, IS31FL3745_REG_COMMAND, page);
 }
 
-void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3745_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 8 transfers of 18 bytes.
 
@@ -91,10 +117,10 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT);
 #endif
     }
 }
@@ -102,58 +128,46 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3745_init_drivers(void) {
     i2c_init();
 
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_1, IS31FL3745_SYNC_1);
-#if defined(IS31FL3745_I2C_ADDRESS_2)
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_2, IS31FL3745_SYNC_2);
-#    if defined(IS31FL3745_I2C_ADDRESS_3)
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_3, IS31FL3745_SYNC_3);
-#        if defined(IS31FL3745_I2C_ADDRESS_4)
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_4, IS31FL3745_SYNC_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3745_DRIVER_COUNT; i++) {
+        is31fl3745_init(i);
+    }
 
     for (int i = 0; i < IS31FL3745_LED_COUNT; i++) {
         is31fl3745_set_scaling_register(i, 0xFF);
     }
 
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3745_I2C_ADDRESS_2)
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3745_I2C_ADDRESS_3)
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3745_I2C_ADDRESS_4)
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3745_DRIVER_COUNT; i++) {
+        is31fl3745_update_scaling_registers(i);
+    }
 }
 
-void is31fl3745_init(uint8_t addr, uint8_t sync) {
+void is31fl3745_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3745_select_page(addr, IS31FL3745_COMMAND_SCALING);
+    is31fl3745_select_page(index, IS31FL3745_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3745_SCALING_REGISTER_COUNT; i++) {
-        is31fl3745_write_register(addr, i + 1, 0x00);
+        is31fl3745_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3745_select_page(addr, IS31FL3745_COMMAND_PWM);
+    is31fl3745_select_page(index, IS31FL3745_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i++) {
-        is31fl3745_write_register(addr, i + 1, 0x00);
+        is31fl3745_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3745_select_page(addr, IS31FL3745_COMMAND_FUNCTION);
+    is31fl3745_select_page(index, IS31FL3745_COMMAND_FUNCTION);
 
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_PULLDOWNUP, (IS31FL3745_SW_PULLDOWN << 4) | IS31FL3745_CS_PULLUP);
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3745_GLOBAL_CURRENT);
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_CONFIGURATION, IS31FL3745_CONFIGURATION);
+    uint8_t sync = driver_sync[index];
+
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_PULLDOWNUP, (IS31FL3745_SW_PULLDOWN << 4) | IS31FL3745_CS_PULLUP);
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3745_GLOBAL_CURRENT);
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_CONFIGURATION, IS31FL3745_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -188,22 +202,22 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t value) {
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3745_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3745_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3745_select_page(addr, IS31FL3745_COMMAND_PWM);
+        is31fl3745_select_page(index, IS31FL3745_COMMAND_PWM);
 
-        is31fl3745_write_pwm_buffer(addr, index);
+        is31fl3745_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3745_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3745_select_page(addr, IS31FL3745_COMMAND_SCALING);
+        is31fl3745_select_page(index, IS31FL3745_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3745_SCALING_REGISTER_COUNT; i++) {
-            is31fl3745_write_register(addr, i + 1, g_scaling_registers[index][i]);
+            is31fl3745_write_register(index, i + 1, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -211,14 +225,7 @@ void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3745_flush(void) {
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3745_I2C_ADDRESS_2)
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3745_I2C_ADDRESS_3)
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3745_I2C_ADDRESS_4)
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3745_DRIVER_COUNT; i++) {
+        is31fl3745_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3745-mono.h
+++ b/drivers/led/issi/is31fl3745-mono.h
@@ -82,17 +82,17 @@ typedef struct is31fl3745_led_t {
 extern const is31fl3745_led_t PROGMEM g_is31fl3745_leds[IS31FL3745_LED_COUNT];
 
 void is31fl3745_init_drivers(void);
-void is31fl3745_init(uint8_t addr, uint8_t sync);
-void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3745_select_page(uint8_t addr, uint8_t page);
+void is31fl3745_init(uint8_t index);
+void is31fl3745_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3745_select_page(uint8_t index, uint8_t page);
 
 void is31fl3745_set_value(int index, uint8_t value);
 void is31fl3745_set_value_all(uint8_t value);
 
 void is31fl3745_set_scaling_register(uint8_t index, uint8_t value);
 
-void is31fl3745_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3745_update_pwm_buffers(uint8_t index);
+void is31fl3745_update_scaling_registers(uint8_t index);
 
 void is31fl3745_flush(void);
 

--- a/drivers/led/issi/is31fl3745.c
+++ b/drivers/led/issi/is31fl3745.c
@@ -62,28 +62,54 @@
 #    define IS31FL3745_SYNC_4 IS31FL3745_SYNC_NONE
 #endif
 
+const uint8_t i2c_addresses[IS31FL3745_DRIVER_COUNT] = {
+    IS31FL3745_I2C_ADDRESS_1,
+#ifdef IS31FL3745_I2C_ADDRESS_2
+    IS31FL3745_I2C_ADDRESS_2,
+#    ifdef IS31FL3745_I2C_ADDRESS_3
+    IS31FL3745_I2C_ADDRESS_3,
+#        ifdef IS31FL3745_I2C_ADDRESS_4
+    IS31FL3745_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
+const uint8_t driver_sync[IS31FL3745_DRIVER_COUNT] = {
+    IS31FL3745_SYNC_1,
+#ifdef IS31FL3745_I2C_ADDRESS_2
+    IS31FL3745_SYNC_2,
+#    ifdef IS31FL3745_I2C_ADDRESS_3
+    IS31FL3745_SYNC_3,
+#        ifdef IS31FL3745_I2C_ADDRESS_4
+    IS31FL3745_SYNC_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3745_DRIVER_COUNT][IS31FL3745_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3745_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3745_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3745_DRIVER_COUNT][IS31FL3745_SCALING_REGISTER_COUNT];
 
-void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3745_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3745_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3745_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3745_select_page(uint8_t addr, uint8_t page) {
-    is31fl3745_write_register(addr, IS31FL3745_REG_COMMAND_WRITE_LOCK, IS31FL3745_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3745_write_register(addr, IS31FL3745_REG_COMMAND, page);
+void is31fl3745_select_page(uint8_t index, uint8_t page) {
+    is31fl3745_write_register(index, IS31FL3745_REG_COMMAND_WRITE_LOCK, IS31FL3745_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3745_write_register(index, IS31FL3745_REG_COMMAND, page);
 }
 
-void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3745_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 8 transfers of 18 bytes.
 
@@ -91,10 +117,10 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3745_I2C_TIMEOUT);
 #endif
     }
 }
@@ -102,58 +128,46 @@ void is31fl3745_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3745_init_drivers(void) {
     i2c_init();
 
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_1, IS31FL3745_SYNC_1);
-#if defined(IS31FL3745_I2C_ADDRESS_2)
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_2, IS31FL3745_SYNC_2);
-#    if defined(IS31FL3745_I2C_ADDRESS_3)
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_3, IS31FL3745_SYNC_3);
-#        if defined(IS31FL3745_I2C_ADDRESS_4)
-    is31fl3745_init(IS31FL3745_I2C_ADDRESS_4, IS31FL3745_SYNC_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3745_DRIVER_COUNT; i++) {
+        is31fl3745_init(i);
+    }
 
     for (int i = 0; i < IS31FL3745_LED_COUNT; i++) {
         is31fl3745_set_scaling_register(i, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3745_I2C_ADDRESS_2)
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3745_I2C_ADDRESS_3)
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3745_I2C_ADDRESS_4)
-    is31fl3745_update_scaling_registers(IS31FL3745_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3745_DRIVER_COUNT; i++) {
+        is31fl3745_update_scaling_registers(i);
+    }
 }
 
-void is31fl3745_init(uint8_t addr, uint8_t sync) {
+void is31fl3745_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3745_select_page(addr, IS31FL3745_COMMAND_SCALING);
+    is31fl3745_select_page(index, IS31FL3745_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3745_SCALING_REGISTER_COUNT; i++) {
-        is31fl3745_write_register(addr, i + 1, 0x00);
+        is31fl3745_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3745_select_page(addr, IS31FL3745_COMMAND_PWM);
+    is31fl3745_select_page(index, IS31FL3745_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i++) {
-        is31fl3745_write_register(addr, i + 1, 0x00);
+        is31fl3745_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3745_select_page(addr, IS31FL3745_COMMAND_FUNCTION);
+    is31fl3745_select_page(index, IS31FL3745_COMMAND_FUNCTION);
 
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_PULLDOWNUP, (IS31FL3745_SW_PULLDOWN << 4) | IS31FL3745_CS_PULLUP);
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3745_GLOBAL_CURRENT);
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
-    is31fl3745_write_register(addr, IS31FL3745_FUNCTION_REG_CONFIGURATION, IS31FL3745_CONFIGURATION);
+    uint8_t sync = driver_sync[index];
+
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_PULLDOWNUP, (IS31FL3745_SW_PULLDOWN << 4) | IS31FL3745_CS_PULLUP);
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3745_GLOBAL_CURRENT);
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_SPREAD_SPECTRUM, (sync & 0b11) << 6);
+    is31fl3745_write_register(index, IS31FL3745_FUNCTION_REG_CONFIGURATION, IS31FL3745_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -192,22 +206,22 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, 
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3745_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3745_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3745_select_page(addr, IS31FL3745_COMMAND_PWM);
+        is31fl3745_select_page(index, IS31FL3745_COMMAND_PWM);
 
-        is31fl3745_write_pwm_buffer(addr, index);
+        is31fl3745_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3745_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3745_select_page(addr, IS31FL3745_COMMAND_SCALING);
+        is31fl3745_select_page(index, IS31FL3745_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3745_SCALING_REGISTER_COUNT; i++) {
-            is31fl3745_write_register(addr, i + 1, g_scaling_registers[index][i]);
+            is31fl3745_write_register(index, i + 1, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -215,14 +229,7 @@ void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3745_flush(void) {
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3745_I2C_ADDRESS_2)
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3745_I2C_ADDRESS_3)
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3745_I2C_ADDRESS_4)
-    is31fl3745_update_pwm_buffers(IS31FL3745_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3745_DRIVER_COUNT; i++) {
+        is31fl3745_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3745.h
+++ b/drivers/led/issi/is31fl3745.h
@@ -84,17 +84,17 @@ typedef struct is31fl3745_led_t {
 extern const is31fl3745_led_t PROGMEM g_is31fl3745_leds[IS31FL3745_LED_COUNT];
 
 void is31fl3745_init_drivers(void);
-void is31fl3745_init(uint8_t addr, uint8_t sync);
-void is31fl3745_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3745_select_page(uint8_t addr, uint8_t page);
+void is31fl3745_init(uint8_t index);
+void is31fl3745_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3745_select_page(uint8_t index, uint8_t page);
 
 void is31fl3745_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3745_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void is31fl3745_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, uint8_t blue);
 
-void is31fl3745_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3745_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3745_update_pwm_buffers(uint8_t index);
+void is31fl3745_update_scaling_registers(uint8_t index);
 
 void is31fl3745_flush(void);
 

--- a/drivers/led/issi/is31fl3746a-mono.c
+++ b/drivers/led/issi/is31fl3746a-mono.c
@@ -53,28 +53,41 @@
 #    define IS31FL3746A_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3746A_DRIVER_COUNT] = {
+    IS31FL3746A_I2C_ADDRESS_1,
+#ifdef IS31FL3746A_I2C_ADDRESS_2
+    IS31FL3746A_I2C_ADDRESS_2,
+#    ifdef IS31FL3746A_I2C_ADDRESS_3
+    IS31FL3746A_I2C_ADDRESS_3,
+#        ifdef IS31FL3746A_I2C_ADDRESS_4
+    IS31FL3746A_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3746A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3746A_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_SCALING_REGISTER_COUNT];
 
-void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3746a_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3746a_select_page(uint8_t addr, uint8_t page) {
-    is31fl3746a_write_register(addr, IS31FL3746A_REG_COMMAND_WRITE_LOCK, IS31FL3746A_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3746a_write_register(addr, IS31FL3746A_REG_COMMAND, page);
+void is31fl3746a_select_page(uint8_t index, uint8_t page) {
+    is31fl3746a_write_register(index, IS31FL3746A_REG_COMMAND_WRITE_LOCK, IS31FL3746A_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3746a_write_register(index, IS31FL3746A_REG_COMMAND, page);
 }
 
-void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3746a_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 4 transfers of 18 bytes.
 
@@ -82,10 +95,10 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -93,59 +106,45 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3746a_init_drivers(void) {
     i2c_init();
 
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_1);
-#if defined(IS31FL3746A_I2C_ADDRESS_2)
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_2);
-#    if defined(IS31FL3746A_I2C_ADDRESS_3)
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_3);
-#        if defined(IS31FL3746A_I2C_ADDRESS_4)
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3746A_DRIVER_COUNT; i++) {
+        is31fl3746a_init(i);
+    }
 
     for (int i = 0; i < IS31FL3746A_LED_COUNT; i++) {
         is31fl3746a_set_scaling_register(i, 0xFF);
     }
 
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3746A_I2C_ADDRESS_2)
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3746A_I2C_ADDRESS_3)
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3746A_I2C_ADDRESS_4)
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3746A_DRIVER_COUNT; i++) {
+        is31fl3746a_update_scaling_registers(i);
+    }
 }
 
-void is31fl3746a_init(uint8_t addr) {
+void is31fl3746a_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_SCALING);
+    is31fl3746a_select_page(index, IS31FL3746A_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3746A_SCALING_REGISTER_COUNT; i++) {
-        is31fl3746a_write_register(addr, i + 1, 0x00);
+        is31fl3746a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_PWM);
+    is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i++) {
-        is31fl3746a_write_register(addr, i + 1, 0x00);
+        is31fl3746a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_FUNCTION);
+    is31fl3746a_select_page(index, IS31FL3746A_COMMAND_FUNCTION);
 
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_PULLDOWNUP, (IS31FL3746A_SW_PULLDOWN << 4) | IS31FL3746A_CS_PULLUP);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3746A_GLOBAL_CURRENT);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_PWM_ENABLE, 0x01);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_PWM_FREQUENCY, IS31FL3746A_PWM_FREQUENCY);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_CONFIGURATION, IS31FL3746A_CONFIGURATION);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_PULLDOWNUP, (IS31FL3746A_SW_PULLDOWN << 4) | IS31FL3746A_CS_PULLUP);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3746A_GLOBAL_CURRENT);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_PWM_ENABLE, 0x01);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_PWM_FREQUENCY, IS31FL3746A_PWM_FREQUENCY);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_CONFIGURATION, IS31FL3746A_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -180,22 +179,22 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t value) {
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3746a_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3746a_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_PWM);
+        is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
 
-        is31fl3746a_write_pwm_buffer(addr, index);
+        is31fl3746a_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3746a_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_SCALING);
+        is31fl3746a_select_page(index, IS31FL3746A_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3746A_SCALING_REGISTER_COUNT; i++) {
-            is31fl3746a_write_register(addr, i + 1, g_scaling_registers[index][i]);
+            is31fl3746a_write_register(index, i + 1, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -203,14 +202,7 @@ void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3746a_flush(void) {
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3746A_I2C_ADDRESS_2)
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3746A_I2C_ADDRESS_3)
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3746A_I2C_ADDRESS_4)
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3746A_DRIVER_COUNT; i++) {
+        is31fl3746a_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3746a-mono.h
+++ b/drivers/led/issi/is31fl3746a-mono.h
@@ -84,17 +84,17 @@ typedef struct is31fl3746a_led_t {
 extern const is31fl3746a_led_t PROGMEM g_is31fl3746a_leds[IS31FL3746A_LED_COUNT];
 
 void is31fl3746a_init_drivers(void);
-void is31fl3746a_init(uint8_t addr);
-void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3746a_select_page(uint8_t addr, uint8_t page);
+void is31fl3746a_init(uint8_t index);
+void is31fl3746a_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3746a_select_page(uint8_t index, uint8_t page);
 
 void is31fl3746a_set_value(int index, uint8_t value);
 void is31fl3746a_set_value_all(uint8_t value);
 
 void is31fl3746a_set_scaling_register(uint8_t index, uint8_t value);
 
-void is31fl3746a_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3746a_update_pwm_buffers(uint8_t index);
+void is31fl3746a_update_scaling_registers(uint8_t index);
 
 void is31fl3746a_flush(void);
 

--- a/drivers/led/issi/is31fl3746a.c
+++ b/drivers/led/issi/is31fl3746a.c
@@ -53,28 +53,41 @@
 #    define IS31FL3746A_GLOBAL_CURRENT 0xFF
 #endif
 
+const uint8_t i2c_addresses[IS31FL3746A_DRIVER_COUNT] = {
+    IS31FL3746A_I2C_ADDRESS_1,
+#ifdef IS31FL3746A_I2C_ADDRESS_2
+    IS31FL3746A_I2C_ADDRESS_2,
+#    ifdef IS31FL3746A_I2C_ADDRESS_3
+    IS31FL3746A_I2C_ADDRESS_3,
+#        ifdef IS31FL3746A_I2C_ADDRESS_4
+    IS31FL3746A_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 uint8_t g_pwm_buffer[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_PWM_REGISTER_COUNT];
 bool    g_pwm_buffer_update_required[IS31FL3746A_DRIVER_COUNT]        = {false};
 bool    g_scaling_registers_update_required[IS31FL3746A_DRIVER_COUNT] = {false};
 
 uint8_t g_scaling_registers[IS31FL3746A_DRIVER_COUNT][IS31FL3746A_SCALING_REGISTER_COUNT];
 
-void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3746a_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3746A_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, IS31FL3746A_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3746a_select_page(uint8_t addr, uint8_t page) {
-    is31fl3746a_write_register(addr, IS31FL3746A_REG_COMMAND_WRITE_LOCK, IS31FL3746A_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3746a_write_register(addr, IS31FL3746A_REG_COMMAND, page);
+void is31fl3746a_select_page(uint8_t index, uint8_t page) {
+    is31fl3746a_write_register(index, IS31FL3746A_REG_COMMAND_WRITE_LOCK, IS31FL3746A_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3746a_write_register(index, IS31FL3746A_REG_COMMAND, page);
 }
 
-void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3746a_write_pwm_buffer(uint8_t index) {
     // Assumes page 0 is already selected.
     // Transmit PWM registers in 4 transfers of 18 bytes.
 
@@ -82,10 +95,10 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i + 1, g_pwm_buffer[index] + i, 18, IS31FL3746A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -93,59 +106,45 @@ void is31fl3746a_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3746a_init_drivers(void) {
     i2c_init();
 
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_1);
-#if defined(IS31FL3746A_I2C_ADDRESS_2)
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_2);
-#    if defined(IS31FL3746A_I2C_ADDRESS_3)
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_3);
-#        if defined(IS31FL3746A_I2C_ADDRESS_4)
-    is31fl3746a_init(IS31FL3746A_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3746A_DRIVER_COUNT; i++) {
+        is31fl3746a_init(i);
+    }
 
     for (int i = 0; i < IS31FL3746A_LED_COUNT; i++) {
         is31fl3746a_set_scaling_register(i, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3746A_I2C_ADDRESS_2)
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3746A_I2C_ADDRESS_3)
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3746A_I2C_ADDRESS_4)
-    is31fl3746a_update_scaling_registers(IS31FL3746A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3746A_DRIVER_COUNT; i++) {
+        is31fl3746a_update_scaling_registers(i);
+    }
 }
 
-void is31fl3746a_init(uint8_t addr) {
+void is31fl3746a_init(uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
 
-    is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_SCALING);
+    is31fl3746a_select_page(index, IS31FL3746A_COMMAND_SCALING);
 
     // Turn off all LEDs.
     for (uint8_t i = 0; i < IS31FL3746A_SCALING_REGISTER_COUNT; i++) {
-        is31fl3746a_write_register(addr, i + 1, 0x00);
+        is31fl3746a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_PWM);
+    is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
 
     for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i++) {
-        is31fl3746a_write_register(addr, i + 1, 0x00);
+        is31fl3746a_write_register(index, i + 1, 0x00);
     }
 
-    is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_FUNCTION);
+    is31fl3746a_select_page(index, IS31FL3746A_COMMAND_FUNCTION);
 
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_PULLDOWNUP, (IS31FL3746A_SW_PULLDOWN << 4) | IS31FL3746A_CS_PULLUP);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3746A_GLOBAL_CURRENT);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_PWM_ENABLE, 0x01);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_PWM_FREQUENCY, IS31FL3746A_PWM_FREQUENCY);
-    is31fl3746a_write_register(addr, IS31FL3746A_FUNCTION_REG_CONFIGURATION, IS31FL3746A_CONFIGURATION);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_PULLDOWNUP, (IS31FL3746A_SW_PULLDOWN << 4) | IS31FL3746A_CS_PULLUP);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3746A_GLOBAL_CURRENT);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_PWM_ENABLE, 0x01);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_PWM_FREQUENCY, IS31FL3746A_PWM_FREQUENCY);
+    is31fl3746a_write_register(index, IS31FL3746A_FUNCTION_REG_CONFIGURATION, IS31FL3746A_CONFIGURATION);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -184,22 +183,22 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
     g_scaling_registers_update_required[led.driver] = true;
 }
 
-void is31fl3746a_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3746a_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_PWM);
+        is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
 
-        is31fl3746a_write_pwm_buffer(addr, index);
+        is31fl3746a_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
+void is31fl3746a_update_scaling_registers(uint8_t index) {
     if (g_scaling_registers_update_required[index]) {
-        is31fl3746a_select_page(addr, IS31FL3746A_COMMAND_SCALING);
+        is31fl3746a_select_page(index, IS31FL3746A_COMMAND_SCALING);
 
         for (uint8_t i = 0; i < IS31FL3746A_SCALING_REGISTER_COUNT; i++) {
-            is31fl3746a_write_register(addr, i + 1, g_scaling_registers[index][i]);
+            is31fl3746a_write_register(index, i + 1, g_scaling_registers[index][i]);
         }
 
         g_scaling_registers_update_required[index] = false;
@@ -207,14 +206,7 @@ void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index) {
 }
 
 void is31fl3746a_flush(void) {
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_1, 0);
-#if defined(IS31FL3746A_I2C_ADDRESS_2)
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_2, 1);
-#    if defined(IS31FL3746A_I2C_ADDRESS_3)
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_3, 2);
-#        if defined(IS31FL3746A_I2C_ADDRESS_4)
-    is31fl3746a_update_pwm_buffers(IS31FL3746A_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < IS31FL3746A_DRIVER_COUNT; i++) {
+        is31fl3746a_update_pwm_buffers(i);
+    }
 }

--- a/drivers/led/issi/is31fl3746a.h
+++ b/drivers/led/issi/is31fl3746a.h
@@ -86,17 +86,17 @@ typedef struct is31fl3746a_led_t {
 extern const is31fl3746a_led_t PROGMEM g_is31fl3746a_leds[IS31FL3746A_LED_COUNT];
 
 void is31fl3746a_init_drivers(void);
-void is31fl3746a_init(uint8_t addr);
-void is31fl3746a_write_register(uint8_t addr, uint8_t reg, uint8_t data);
-void is31fl3746a_select_page(uint8_t addr, uint8_t page);
+void is31fl3746a_init(uint8_t index);
+void is31fl3746a_write_register(uint8_t index, uint8_t reg, uint8_t data);
+void is31fl3746a_select_page(uint8_t index, uint8_t page);
 
 void is31fl3746a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void is31fl3746a_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
 
 void is31fl3746a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, uint8_t blue);
 
-void is31fl3746a_update_pwm_buffers(uint8_t addr, uint8_t index);
-void is31fl3746a_update_scaling_registers(uint8_t addr, uint8_t index);
+void is31fl3746a_update_pwm_buffers(uint8_t index);
+void is31fl3746a_update_scaling_registers(uint8_t index);
 
 void is31fl3746a_flush(void);
 

--- a/drivers/led/snled27351-mono.h
+++ b/drivers/led/snled27351-mono.h
@@ -154,9 +154,9 @@ typedef struct snled27351_led_t {
 extern const snled27351_led_t PROGMEM g_snled27351_leds[SNLED27351_LED_COUNT];
 
 void snled27351_init_drivers(void);
-void snled27351_init(uint8_t addr);
-void snled27351_select_page(uint8_t addr, uint8_t page);
-void snled27351_write_register(uint8_t addr, uint8_t reg, uint8_t data);
+void snled27351_init(uint8_t index);
+void snled27351_select_page(uint8_t index, uint8_t page);
+void snled27351_write_register(uint8_t index, uint8_t reg, uint8_t data);
 
 void snled27351_set_value(int index, uint8_t value);
 void snled27351_set_value_all(uint8_t value);
@@ -167,13 +167,13 @@ void snled27351_set_led_control_register(uint8_t index, bool value);
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void snled27351_update_pwm_buffers(uint8_t addr, uint8_t index);
-void snled27351_update_led_control_registers(uint8_t addr, uint8_t index);
+void snled27351_update_pwm_buffers(uint8_t index);
+void snled27351_update_led_control_registers(uint8_t index);
 
 void snled27351_flush(void);
 
-void snled27351_sw_return_normal(uint8_t addr);
-void snled27351_sw_shutdown(uint8_t addr);
+void snled27351_sw_return_normal(uint8_t index);
+void snled27351_sw_shutdown(uint8_t index);
 
 #define A_1 0x00
 #define A_2 0x01

--- a/drivers/led/snled27351.c
+++ b/drivers/led/snled27351.c
@@ -37,6 +37,19 @@
         { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
 #endif
 
+const uint8_t i2c_addresses[SNLED27351_DRIVER_COUNT] = {
+    SNLED27351_I2C_ADDRESS_1,
+#ifdef SNLED27351_I2C_ADDRESS_2
+    SNLED27351_I2C_ADDRESS_2,
+#    ifdef SNLED27351_I2C_ADDRESS_3
+    SNLED27351_I2C_ADDRESS_3,
+#        ifdef SNLED27351_I2C_ADDRESS_4
+    SNLED27351_I2C_ADDRESS_4,
+#        endif
+#    endif
+#endif
+};
+
 // These buffers match the SNLED27351 PWM registers.
 // The control buffers match the PG0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -49,21 +62,21 @@ bool    g_pwm_buffer_update_required[SNLED27351_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[SNLED27351_DRIVER_COUNT][SNLED27351_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[SNLED27351_DRIVER_COUNT]                        = {false};
 
-void snled27351_write_register(uint8_t addr, uint8_t reg, uint8_t data) {
+void snled27351_write_register(uint8_t index, uint8_t reg, uint8_t data) {
 #if SNLED27351_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < SNLED27351_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(addr << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT);
+    i2c_write_register(i2c_addresses[index] << 1, reg, &data, 1, SNLED27351_I2C_TIMEOUT);
 #endif
 }
 
-void snled27351_select_page(uint8_t addr, uint8_t page) {
-    snled27351_write_register(addr, SNLED27351_REG_COMMAND, page);
+void snled27351_select_page(uint8_t index, uint8_t page) {
+    snled27351_write_register(index, SNLED27351_REG_COMMAND, page);
 }
 
-void snled27351_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void snled27351_write_pwm_buffer(uint8_t index) {
     // Assumes PG1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
@@ -71,10 +84,10 @@ void snled27351_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
 #if SNLED27351_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < SNLED27351_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(addr << 1, i, g_pwm_buffer[index] + i, 16, SNLED27351_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, SNLED27351_I2C_TIMEOUT);
 #endif
     }
 }
@@ -82,78 +95,64 @@ void snled27351_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void snled27351_init_drivers(void) {
     i2c_init();
 
-    snled27351_init(SNLED27351_I2C_ADDRESS_1);
-#if defined(SNLED27351_I2C_ADDRESS_2)
-    snled27351_init(SNLED27351_I2C_ADDRESS_2);
-#    if defined(SNLED27351_I2C_ADDRESS_3)
-    snled27351_init(SNLED27351_I2C_ADDRESS_3);
-#        if defined(SNLED27351_I2C_ADDRESS_4)
-    snled27351_init(SNLED27351_I2C_ADDRESS_4);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < SNLED27351_DRIVER_COUNT; i++) {
+        snled27351_init(i);
+    }
 
     for (int i = 0; i < SNLED27351_LED_COUNT; i++) {
         snled27351_set_led_control_register(i, true, true, true);
     }
 
-    snled27351_update_led_control_registers(SNLED27351_I2C_ADDRESS_1, 0);
-#if defined(SNLED27351_I2C_ADDRESS_2)
-    snled27351_update_led_control_registers(SNLED27351_I2C_ADDRESS_2, 1);
-#    if defined(SNLED27351_I2C_ADDRESS_3)
-    snled27351_update_led_control_registers(SNLED27351_I2C_ADDRESS_3, 2);
-#        if defined(SNLED27351_I2C_ADDRESS_4)
-    snled27351_update_led_control_registers(SNLED27351_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < SNLED27351_DRIVER_COUNT; i++) {
+        snled27351_update_led_control_registers(i);
+    }
 }
 
-void snled27351_init(uint8_t addr) {
-    snled27351_select_page(addr, SNLED27351_COMMAND_FUNCTION);
+void snled27351_init(uint8_t index) {
+    snled27351_select_page(index, SNLED27351_COMMAND_FUNCTION);
 
     // Setting LED driver to shutdown mode
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_SHUTDOWN);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_SHUTDOWN);
     // Setting internal channel pulldown/pullup
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_PULLDOWNUP, SNLED27351_PULLDOWNUP_ALL_ENABLED);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_PULLDOWNUP, SNLED27351_PULLDOWNUP_ALL_ENABLED);
     // Select number of scan phase
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SCAN_PHASE, SNLED27351_PHASE_CHANNEL);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SCAN_PHASE, SNLED27351_PHASE_CHANNEL);
     // Setting PWM Delay Phase
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SLEW_RATE_CONTROL_MODE_1, SNLED27351_SLEW_RATE_CONTROL_MODE_1_PDP_ENABLE);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SLEW_RATE_CONTROL_MODE_1, SNLED27351_SLEW_RATE_CONTROL_MODE_1_PDP_ENABLE);
     // Setting Driving/Sinking Channel Slew Rate
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SLEW_RATE_CONTROL_MODE_2, SNLED27351_SLEW_RATE_CONTROL_MODE_2_DSL_ENABLE | SNLED27351_SLEW_RATE_CONTROL_MODE_2_SSL_ENABLE);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SLEW_RATE_CONTROL_MODE_2, SNLED27351_SLEW_RATE_CONTROL_MODE_2_DSL_ENABLE | SNLED27351_SLEW_RATE_CONTROL_MODE_2_SSL_ENABLE);
     // Setting Iref
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SOFTWARE_SLEEP, 0);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SOFTWARE_SLEEP, 0);
 
-    snled27351_select_page(addr, SNLED27351_COMMAND_LED_CONTROL);
+    snled27351_select_page(index, SNLED27351_COMMAND_LED_CONTROL);
 
     for (int i = 0; i < SNLED27351_LED_CONTROL_ON_OFF_LENGTH; i++) {
-        snled27351_write_register(addr, i, 0x00);
+        snled27351_write_register(index, i, 0x00);
     }
 
-    snled27351_select_page(addr, SNLED27351_COMMAND_PWM);
+    snled27351_select_page(index, SNLED27351_COMMAND_PWM);
 
     for (int i = 0; i < SNLED27351_LED_CURRENT_TUNE_LENGTH; i++) {
-        snled27351_write_register(addr, i, 0x00);
+        snled27351_write_register(index, i, 0x00);
     }
 
-    snled27351_select_page(addr, SNLED27351_COMMAND_CURRENT_TUNE);
+    snled27351_select_page(index, SNLED27351_COMMAND_CURRENT_TUNE);
 
     uint8_t current_tune_reg_list[SNLED27351_LED_CURRENT_TUNE_LENGTH] = SNLED27351_CURRENT_TUNE;
     for (int i = 0; i < SNLED27351_LED_CURRENT_TUNE_LENGTH; i++) {
-        snled27351_write_register(addr, i, current_tune_reg_list[i]);
+        snled27351_write_register(index, i, current_tune_reg_list[i]);
     }
 
-    snled27351_select_page(addr, SNLED27351_COMMAND_LED_CONTROL);
+    snled27351_select_page(index, SNLED27351_COMMAND_LED_CONTROL);
 
     for (int i = 0; i < SNLED27351_LED_CONTROL_ON_OFF_LENGTH; i++) {
-        snled27351_write_register(addr, i, 0xFF);
+        snled27351_write_register(index, i, 0xFF);
     }
 
-    snled27351_select_page(addr, SNLED27351_COMMAND_FUNCTION);
+    snled27351_select_page(index, SNLED27351_COMMAND_FUNCTION);
 
     // Setting LED driver to normal mode
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_NORMAL);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_NORMAL);
 }
 
 void snled27351_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
@@ -208,22 +207,22 @@ void snled27351_set_led_control_register(uint8_t index, bool red, bool green, bo
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void snled27351_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void snled27351_update_pwm_buffers(uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        snled27351_select_page(addr, SNLED27351_COMMAND_PWM);
+        snled27351_select_page(index, SNLED27351_COMMAND_PWM);
 
-        snled27351_write_pwm_buffer(addr, index);
+        snled27351_write_pwm_buffer(index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void snled27351_update_led_control_registers(uint8_t addr, uint8_t index) {
+void snled27351_update_led_control_registers(uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
-        snled27351_select_page(addr, SNLED27351_COMMAND_LED_CONTROL);
+        snled27351_select_page(index, SNLED27351_COMMAND_LED_CONTROL);
 
         for (uint8_t i = 0; i < SNLED27351_LED_CONTROL_REGISTER_COUNT; i++) {
-            snled27351_write_register(addr, i, g_led_control_registers[index][i]);
+            snled27351_write_register(index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;
@@ -231,30 +230,23 @@ void snled27351_update_led_control_registers(uint8_t addr, uint8_t index) {
 }
 
 void snled27351_flush(void) {
-    snled27351_update_pwm_buffers(SNLED27351_I2C_ADDRESS_1, 0);
-#if defined(SNLED27351_I2C_ADDRESS_2)
-    snled27351_update_pwm_buffers(SNLED27351_I2C_ADDRESS_2, 1);
-#    if defined(SNLED27351_I2C_ADDRESS_3)
-    snled27351_update_pwm_buffers(SNLED27351_I2C_ADDRESS_3, 2);
-#        if defined(SNLED27351_I2C_ADDRESS_4)
-    snled27351_update_pwm_buffers(SNLED27351_I2C_ADDRESS_4, 3);
-#        endif
-#    endif
-#endif
+    for (uint8_t i = 0; i < SNLED27351_DRIVER_COUNT; i++) {
+        snled27351_update_pwm_buffers(i);
+    }
 }
 
-void snled27351_sw_return_normal(uint8_t addr) {
-    snled27351_select_page(addr, SNLED27351_COMMAND_FUNCTION);
+void snled27351_sw_return_normal(uint8_t index) {
+    snled27351_select_page(index, SNLED27351_COMMAND_FUNCTION);
 
     // Setting LED driver to normal mode
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_NORMAL);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_NORMAL);
 }
 
-void snled27351_sw_shutdown(uint8_t addr) {
-    snled27351_select_page(addr, SNLED27351_COMMAND_FUNCTION);
+void snled27351_sw_shutdown(uint8_t index) {
+    snled27351_select_page(index, SNLED27351_COMMAND_FUNCTION);
 
     // Setting LED driver to shutdown mode
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_SHUTDOWN);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SOFTWARE_SHUTDOWN, SNLED27351_SOFTWARE_SHUTDOWN_SSD_SHUTDOWN);
     // Write SW Sleep Register
-    snled27351_write_register(addr, SNLED27351_FUNCTION_REG_SOFTWARE_SLEEP, SNLED27351_SOFTWARE_SLEEP_ENABLE);
+    snled27351_write_register(index, SNLED27351_FUNCTION_REG_SOFTWARE_SLEEP, SNLED27351_SOFTWARE_SLEEP_ENABLE);
 }

--- a/drivers/led/snled27351.h
+++ b/drivers/led/snled27351.h
@@ -168,9 +168,9 @@ typedef struct snled27351_led_t {
 extern const snled27351_led_t PROGMEM g_snled27351_leds[SNLED27351_LED_COUNT];
 
 void snled27351_init_drivers(void);
-void snled27351_init(uint8_t addr);
-void snled27351_select_page(uint8_t addr, uint8_t page);
-void snled27351_write_register(uint8_t addr, uint8_t reg, uint8_t data);
+void snled27351_init(uint8_t index);
+void snled27351_select_page(uint8_t index, uint8_t page);
+void snled27351_write_register(uint8_t index, uint8_t reg, uint8_t data);
 
 void snled27351_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);
 void snled27351_set_color_all(uint8_t red, uint8_t green, uint8_t blue);
@@ -181,13 +181,13 @@ void snled27351_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void snled27351_update_pwm_buffers(uint8_t addr, uint8_t index);
-void snled27351_update_led_control_registers(uint8_t addr, uint8_t index);
+void snled27351_update_pwm_buffers(uint8_t index);
+void snled27351_update_led_control_registers(uint8_t index);
 
 void snled27351_flush(void);
 
-void snled27351_sw_return_normal(uint8_t addr);
-void snled27351_sw_shutdown(uint8_t addr);
+void snled27351_sw_return_normal(uint8_t index);
+void snled27351_sw_shutdown(uint8_t index);
 
 #define A_1 0x00
 #define A_2 0x01

--- a/keyboards/aeboards/satellite/rev1/rev1.c
+++ b/keyboards/aeboards/satellite/rev1/rev1.c
@@ -146,8 +146,8 @@ led_config_t g_led_config = { {
 static void init(void) {
     i2c_init();
 
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_1);
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_2);
+    is31fl3731_init(0);
+    is31fl3731_init(1);
 
     for (int index = 0; index < IS31FL3731_LED_COUNT; index++) {
         bool enabled = !(   ( index == 18+5) || //B5
@@ -157,8 +157,8 @@ static void init(void) {
         is31fl3731_set_led_control_register(index, enabled, enabled, enabled);
     }
 
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_1, 0);
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_2, 1);
+    is31fl3731_update_led_control_registers(0);
+    is31fl3731_update_led_control_registers(1);
 }
 
 const rgb_matrix_driver_t rgb_matrix_driver = {

--- a/keyboards/input_club/k_type/is31fl3733-dual.c
+++ b/keyboards/input_club/k_type/is31fl3733-dual.c
@@ -250,8 +250,8 @@ void is31fl3733_update_led_control_registers(uint8_t bus, uint8_t index) {
 }
 
 void is31fl3733_flush(void) {
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_pwm_buffers(0, 0);
 #    ifdef USE_I2C2
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_2, 1);
+    is31fl3733_update_pwm_buffers(1, 1);
 #    endif
 }

--- a/keyboards/input_club/k_type/is31fl3733-dual.c
+++ b/keyboards/input_club/k_type/is31fl3733-dual.c
@@ -60,6 +60,20 @@
 #    define IS31FL3733_SYNC_4 IS31FL3733_SYNC_NONE
 #endif
 
+const uint8_t i2c_addresses[IS31FL3733_DRIVER_COUNT] = {
+    IS31FL3733_I2C_ADDRESS_1,
+#ifdef IS31FL3733_I2C_ADDRESS_2
+    IS31FL3733_I2C_ADDRESS_2,
+#endif
+};
+
+const uint8_t driver_sync[IS31FL3733_DRIVER_COUNT] = {
+    IS31FL3733_SYNC_1,
+#ifdef IS31FL3733_I2C_ADDRESS_2
+    IS31FL3733_SYNC_2,
+#endif
+};
+
 // These buffers match the IS31FL3733 PWM registers.
 // The control buffers match the page 0 LED On/Off registers.
 // Storing them like this is optimal for I2C transfers to the registers.
@@ -72,22 +86,22 @@ bool    g_pwm_buffer_update_required[IS31FL3733_DRIVER_COUNT] = {false};
 uint8_t g_led_control_registers[IS31FL3733_DRIVER_COUNT][IS31FL3733_LED_CONTROL_REGISTER_COUNT] = {0};
 bool    g_led_control_registers_update_required[IS31FL3733_DRIVER_COUNT]                        = {false};
 
-void is31fl3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data) {
+void is31fl3733_write_register(uint8_t bus, uint8_t index, uint8_t reg, uint8_t data) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
     for (uint8_t i = 0; i < IS31FL3733_I2C_PERSISTENCE; i++) {
-        if (i2c_write_register(index, addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+        if (i2c_write_register(bus, i2c_addresses[index] << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
     }
 #else
-    i2c_write_register(index, addr << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
+    i2c_write_register(bus, i2c_addresses[index] << 1, reg, &data, 1, IS31FL3733_I2C_TIMEOUT);
 #endif
 }
 
-void is31fl3733_select_page(uint8_t index, uint8_t addr, uint8_t page) {
-    is31fl3733_write_register(index, addr, IS31FL3733_REG_COMMAND_WRITE_LOCK, IS31FL3733_COMMAND_WRITE_LOCK_MAGIC);
-    is31fl3733_write_register(index, addr, IS31FL3733_REG_COMMAND, page);
+void is31fl3733_select_page(uint8_t bus, uint8_t index, uint8_t page) {
+    is31fl3733_write_register(bus, index, IS31FL3733_REG_COMMAND_WRITE_LOCK, IS31FL3733_COMMAND_WRITE_LOCK_MAGIC);
+    is31fl3733_write_register(bus, index, IS31FL3733_REG_COMMAND, page);
 }
 
-void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t index) {
+void is31fl3733_write_pwm_buffer(uint8_t bus, uint8_t index) {
     // Assumes page 1 is already selected.
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
@@ -95,10 +109,10 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t index) {
     for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(index, addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(bus, i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(index, addr << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT);
+        i2c_write_register(bus, i2c_addresses[index] << 1, i, g_pwm_buffer[index] + i, 16, IS31FL3733_I2C_TIMEOUT);
 #endif
     }
 }
@@ -106,54 +120,55 @@ void is31fl3733_write_pwm_buffer(uint8_t addr, uint8_t index) {
 void is31fl3733_init_drivers(void) {
     i2c_init(&I2CD1, I2C1_SCL_PIN, I2C1_SDA_PIN);
 
-    is31fl3733_init(0, IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_1);
+    is31fl3733_init(0, 0);
 #    ifdef USE_I2C2
     i2c_init(&I2CD2, I2C2_SCL_PIN, I2C2_SDA_PIN);
-    is31fl3733_init(1, IS31FL3733_I2C_ADDRESS_2, IS31FL3733_SYNC_2);
+    is31fl3733_init(1, 1);
 #    endif
 
     for (int i = 0; i < IS31FL3733_LED_COUNT; i++) {
         is31fl3733_set_led_control_register(i, true, true, true);
     }
 
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_led_control_registers(0, 0);
 #    ifdef USE_I2C2
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_2, 1);
+    is31fl3733_update_led_control_registers(1, 1);
 #    endif
 }
 
-void is31fl3733_init(uint8_t bus, uint8_t addr, uint8_t sync) {
+void is31fl3733_init(uint8_t bus, uint8_t index) {
     // In order to avoid the LEDs being driven with garbage data
     // in the LED driver's PWM registers, shutdown is enabled last.
     // Set up the mode and other settings, clear the PWM registers,
     // then disable software shutdown.
-    // Sync is passed so set it according to the datasheet.
 
-    is31fl3733_select_page(bus, addr, IS31FL3733_COMMAND_LED_CONTROL);
+    is31fl3733_select_page(bus, index, IS31FL3733_COMMAND_LED_CONTROL);
 
     // Turn off all LEDs.
     for (int i = 0; i < IS31FL3733_LED_CONTROL_REGISTER_COUNT; i++) {
-        is31fl3733_write_register(bus, addr, i, 0x00);
+        is31fl3733_write_register(bus, index, i, 0x00);
     }
 
-    is31fl3733_select_page(bus, addr, IS31FL3733_COMMAND_PWM);
+    is31fl3733_select_page(bus, index, IS31FL3733_COMMAND_PWM);
 
     // Set PWM on all LEDs to 0
     // No need to setup Breath registers to PWM as that is the default.
     for (int i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i++) {
-        is31fl3733_write_register(bus, addr, i, 0x00);
+        is31fl3733_write_register(bus, index, i, 0x00);
     }
 
-    is31fl3733_select_page(bus, addr, IS31FL3733_COMMAND_FUNCTION);
+    is31fl3733_select_page(bus, index, IS31FL3733_COMMAND_FUNCTION);
+
+    uint8_t sync = driver_sync[index];
 
     // Set de-ghost pull-up resistors (SWx)
-    is31fl3733_write_register(bus, addr, IS31FL3733_FUNCTION_REG_SW_PULLUP, IS31FL3733_SW_PULLUP);
+    is31fl3733_write_register(bus, index, IS31FL3733_FUNCTION_REG_SW_PULLUP, IS31FL3733_SW_PULLUP);
     // Set de-ghost pull-down resistors (CSx)
-    is31fl3733_write_register(bus, addr, IS31FL3733_FUNCTION_REG_CS_PULLDOWN, IS31FL3733_CS_PULLDOWN);
+    is31fl3733_write_register(bus, index, IS31FL3733_FUNCTION_REG_CS_PULLDOWN, IS31FL3733_CS_PULLDOWN);
     // Set global current to maximum.
-    is31fl3733_write_register(bus, addr, IS31FL3733_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3733_GLOBAL_CURRENT);
+    is31fl3733_write_register(bus, index, IS31FL3733_FUNCTION_REG_GLOBAL_CURRENT, IS31FL3733_GLOBAL_CURRENT);
     // Disable software shutdown.
-    is31fl3733_write_register(bus, addr, IS31FL3733_FUNCTION_REG_CONFIGURATION, ((sync & 0b11) << 6) | ((IS31FL3733_PWM_FREQUENCY & 0b111) << 3) | 0x01);
+    is31fl3733_write_register(bus, index, IS31FL3733_FUNCTION_REG_CONFIGURATION, ((sync & 0b11) << 6) | ((IS31FL3733_PWM_FREQUENCY & 0b111) << 3) | 0x01);
 
     // Wait 10ms to ensure the device has woken up.
     wait_ms(10);
@@ -212,22 +227,22 @@ void is31fl3733_set_led_control_register(uint8_t index, bool red, bool green, bo
     g_led_control_registers_update_required[led.driver] = true;
 }
 
-void is31fl3733_update_pwm_buffers(uint8_t addr, uint8_t index) {
+void is31fl3733_update_pwm_buffers(uint8_t bus, uint8_t index) {
     if (g_pwm_buffer_update_required[index]) {
-        is31fl3733_select_page(index, addr, IS31FL3733_COMMAND_PWM);
+        is31fl3733_select_page(bus, index, IS31FL3733_COMMAND_PWM);
 
-        is31fl3733_write_pwm_buffer(addr, index);
+        is31fl3733_write_pwm_buffer(bus, index);
 
         g_pwm_buffer_update_required[index] = false;
     }
 }
 
-void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index) {
+void is31fl3733_update_led_control_registers(uint8_t bus, uint8_t index) {
     if (g_led_control_registers_update_required[index]) {
-        is31fl3733_select_page(index, addr, IS31FL3733_COMMAND_LED_CONTROL);
+        is31fl3733_select_page(bus, index, IS31FL3733_COMMAND_LED_CONTROL);
 
         for (int i = 0; i < IS31FL3733_LED_CONTROL_REGISTER_COUNT; i++) {
-            is31fl3733_write_register(index, addr, i, g_led_control_registers[index][i]);
+            is31fl3733_write_register(bus, index, i, g_led_control_registers[index][i]);
         }
 
         g_led_control_registers_update_required[index] = false;

--- a/keyboards/input_club/k_type/is31fl3733-dual.h
+++ b/keyboards/input_club/k_type/is31fl3733-dual.h
@@ -83,7 +83,7 @@ typedef struct is31fl3733_led_t {
 extern const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT];
 
 void is31fl3733_init_drivers(void);
-void is31fl3733_init(uint8_t bus, uint8_t addr, uint8_t sync);
+void is31fl3733_init(uint8_t bus, uint8_t index);
 void is31fl3733_write_register(uint8_t index, uint8_t addr, uint8_t reg, uint8_t data);
 void is31fl3733_select_page(uint8_t index, uint8_t addr, uint8_t page);
 
@@ -96,8 +96,8 @@ void is31fl3733_set_led_control_register(uint8_t index, bool red, bool green, bo
 // (eg. from a timer interrupt).
 // Call this while idle (in between matrix scans).
 // If the buffer is dirty, it will update the driver with the buffer.
-void is31fl3733_update_pwm_buffers(uint8_t addr, uint8_t index); // index is the driver index
-void is31fl3733_update_led_control_registers(uint8_t addr, uint8_t index);
+void is31fl3733_update_pwm_buffers(uint8_t bus, uint8_t index);
+void is31fl3733_update_led_control_registers(uint8_t bus, uint8_t index);
 
 void is31fl3733_flush(void);
 

--- a/keyboards/kprepublic/bm60hsrgb/rev2/rev2.c
+++ b/keyboards/kprepublic/bm60hsrgb/rev2/rev2.c
@@ -153,16 +153,16 @@ rgb_led_t rgb_matrix_ws2812_array[WS2812_LED_TOTAL];
 
 static void rgb_matrix_driver_init(void) {
     i2c_init();
-    is31fl3733_init(IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE);
+    is31fl3733_init(0);
     for (uint8_t index = 0; index < IS31FL3733_LED_COUNT; index++) {
         bool enabled = true;
         is31fl3733_set_led_control_register(index, enabled, enabled, enabled);
     }
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_led_control_registers(0);
 }
 
 static void rgb_matrix_driver_flush(void) {
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_pwm_buffers(0);
 #    if WS2812_LED_TOTAL > 0
     ws2812_setleds(rgb_matrix_ws2812_array, WS2812_LED_TOTAL);
 #    endif

--- a/keyboards/kprepublic/bm60hsrgb_iso/rev2/rev2.c
+++ b/keyboards/kprepublic/bm60hsrgb_iso/rev2/rev2.c
@@ -153,16 +153,16 @@ rgb_led_t rgb_matrix_ws2812_array[WS2812_LED_TOTAL];
 
 static void rgb_matrix_driver_init(void) {
     i2c_init();
-    is31fl3733_init(IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE);
+    is31fl3733_init(0);
     for (uint8_t index = 0; index < IS31FL3733_LED_COUNT; index++) {
         bool enabled = true;
         is31fl3733_set_led_control_register(index, enabled, enabled, enabled);
     }
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_led_control_registers(0);
 }
 
 static void rgb_matrix_driver_flush(void) {
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_pwm_buffers(0);
 #    if WS2812_LED_TOTAL > 0
     ws2812_setleds(rgb_matrix_ws2812_array, WS2812_LED_TOTAL);
 #    endif

--- a/keyboards/kprepublic/bm60hsrgb_poker/rev2/rev2.c
+++ b/keyboards/kprepublic/bm60hsrgb_poker/rev2/rev2.c
@@ -149,16 +149,16 @@ rgb_led_t rgb_matrix_ws2812_array[WS2812_LED_TOTAL];
 
 static void rgb_matrix_driver_init(void) {
     i2c_init();
-    is31fl3733_init(IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE);
+    is31fl3733_init(0);
     for (uint8_t index = 0; index < IS31FL3733_LED_COUNT; index++) {
         bool enabled = true;
         is31fl3733_set_led_control_register(index, enabled, enabled, enabled);
     }
-    is31fl3733_update_led_control_registers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_led_control_registers(0);
 }
 
 static void rgb_matrix_driver_flush(void) {
-    is31fl3733_update_pwm_buffers(IS31FL3733_I2C_ADDRESS_1, 0);
+    is31fl3733_update_pwm_buffers(0);
 #    if WS2812_LED_TOTAL > 0
     ws2812_setleds(rgb_matrix_ws2812_array, WS2812_LED_TOTAL);
 #    endif

--- a/keyboards/melgeek/mach80/rev1/rev1.c
+++ b/keyboards/melgeek/mach80/rev1/rev1.c
@@ -179,7 +179,7 @@ void matrix_init_kb(void) {
         is31fl3741_set_scaling_registers(&led, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_1, 0);
+    is31fl3741_update_led_control_registers(0);
 
     matrix_init_user();
 }

--- a/keyboards/melgeek/mach80/rev2/rev2.c
+++ b/keyboards/melgeek/mach80/rev2/rev2.c
@@ -177,7 +177,7 @@ void matrix_init_kb(void) {
         is31fl3741_set_scaling_registers(&led, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_1, 0);
+    is31fl3741_update_led_control_registers(0);
 
     matrix_init_user();
 }

--- a/keyboards/melgeek/mojo68/rev1/rev1.c
+++ b/keyboards/melgeek/mojo68/rev1/rev1.c
@@ -147,7 +147,7 @@ void matrix_init_kb(void) {
         is31fl3741_set_scaling_registers(&led, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_1, 0);
+    is31fl3741_update_led_control_registers(0);
 
     matrix_init_user();
 }

--- a/keyboards/melgeek/z70ultra/z70ultra.c
+++ b/keyboards/melgeek/z70ultra/z70ultra.c
@@ -161,7 +161,7 @@ void matrix_init_kb(void) {
         is31fl3741_set_scaling_registers(&led, 0xFF, 0xFF, 0xFF);
     }
 
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_1, 0);
+    is31fl3741_update_led_control_registers(0);
 
     matrix_init_user();
 }

--- a/keyboards/wilba_tech/wt_rgb_backlight.c
+++ b/keyboards/wilba_tech/wt_rgb_backlight.c
@@ -980,34 +980,34 @@ void backlight_update_pwm_buffers(void)
 #if defined(RGB_BACKLIGHT_M6_B)
     is31fl3218_update_pwm_buffers();
 #elif defined(RGB_BACKLIGHT_PORTICO75)
-	is31fl3741_update_pwm_buffers( IS31FL3741_I2C_ADDRESS_1, 0 );
-    is31fl3741_update_led_control_registers( IS31FL3741_I2C_ADDRESS_1, 0 );
+	is31fl3741_update_pwm_buffers( 0 );
+    is31fl3741_update_led_control_registers( 0 );
 #elif defined(RGB_BACKLIGHT_M10_C)
-    is31fl3731_update_pwm_buffers( IS31FL3731_I2C_ADDRESS_1, 0 );
-    is31fl3731_update_led_control_registers( IS31FL3731_I2C_ADDRESS_1, 0 );
+    is31fl3731_update_pwm_buffers( 0 );
+    is31fl3731_update_led_control_registers( 0 );
 #elif defined(RGB_BACKLIGHT_HS60)
-    is31fl3733_update_pwm_buffers( IS31FL3733_I2C_ADDRESS_1, 0 );
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_1, 0 );
+    is31fl3733_update_pwm_buffers( 0 );
+    is31fl3733_update_led_control_registers(  0 );
 #elif defined(RGB_BACKLIGHT_NK65) || defined(RGB_BACKLIGHT_NEBULA68) || defined(RGB_BACKLIGHT_NK87) || defined(RGB_BACKLIGHT_KW_MEGA)
-    is31fl3733_update_pwm_buffers( IS31FL3733_I2C_ADDRESS_1, 0 );
-    is31fl3733_update_pwm_buffers( IS31FL3733_I2C_ADDRESS_2, 1 );
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_1, 0 );
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_2, 1 );
+    is31fl3733_update_pwm_buffers( 0 );
+    is31fl3733_update_pwm_buffers( 1 );
+    is31fl3733_update_led_control_registers( 0 );
+    is31fl3733_update_led_control_registers( 1 );
 #elif defined(RGB_BACKLIGHT_NEBULA12)
-    is31fl3731_update_pwm_buffers( IS31FL3731_I2C_ADDRESS_1, 0 );
-    is31fl3731_update_led_control_registers( IS31FL3731_I2C_ADDRESS_1, 0 );
+    is31fl3731_update_pwm_buffers( 0 );
+    is31fl3731_update_led_control_registers( 0 );
 #elif defined(RGB_BACKLIGHT_U80_A)
     static uint8_t driver = 0;
     switch ( driver )
     {
         case 0:
-            is31fl3731_update_pwm_buffers( IS31FL3731_I2C_ADDRESS_1, 0 );
+            is31fl3731_update_pwm_buffers( 0 );
             break;
         case 1:
-            is31fl3731_update_pwm_buffers( IS31FL3731_I2C_ADDRESS_2, 1 );
+            is31fl3731_update_pwm_buffers( 1 );
             break;
         case 2:
-            is31fl3731_update_pwm_buffers( IS31FL3731_I2C_ADDRESS_3, 2 );
+            is31fl3731_update_pwm_buffers( 2 );
             break;
     }
     if ( ++driver > 2 )
@@ -1015,10 +1015,10 @@ void backlight_update_pwm_buffers(void)
         driver = 0;
     }
 #else
-    is31fl3731_update_pwm_buffers( IS31FL3731_I2C_ADDRESS_1, 0 );
-    is31fl3731_update_pwm_buffers( IS31FL3731_I2C_ADDRESS_2, 1 );
-    is31fl3731_update_led_control_registers( IS31FL3731_I2C_ADDRESS_1, 0 );
-    is31fl3731_update_led_control_registers( IS31FL3731_I2C_ADDRESS_2, 1 );
+    is31fl3731_update_pwm_buffers( 0 );
+    is31fl3731_update_pwm_buffers( 1 );
+    is31fl3731_update_led_control_registers( 0 );
+    is31fl3731_update_led_control_registers( 1 );
 #endif
 }
 
@@ -2134,7 +2134,7 @@ void backlight_init_drivers(void)
     // This actually updates the LED drivers
     is31fl3218_update_led_control_registers();
 #elif defined(RGB_BACKLIGHT_HS60)
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE );
+    is31fl3733_init( 0 );
 
     for ( int index = 0; index < IS31FL3733_LED_COUNT; index++ )
     {
@@ -2153,10 +2153,10 @@ void backlight_init_drivers(void)
         is31fl3733_set_led_control_register( index, enabled, enabled, enabled );
     }
     // This actually updates the LED drivers
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_1, 0 );
+    is31fl3733_update_led_control_registers( 0 );
 #elif defined(RGB_BACKLIGHT_NK65)
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE );
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_2, IS31FL3733_SYNC_NONE );
+    is31fl3733_init( 0 );
+    is31fl3733_init( 1 );
 
     for ( int index = 0; index < IS31FL3733_LED_COUNT; index++ )
     {
@@ -2167,11 +2167,11 @@ void backlight_init_drivers(void)
     }
     is31fl3733_set_led_control_register( 7+64-1, 0, 1, 0 ); //Enable LB7 green enable for indicators
     // This actually updates the LED drivers
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_1, 0 );
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_2, 1 );
+    is31fl3733_update_led_control_registers( 0 );
+    is31fl3733_update_led_control_registers( 1 );
 #elif defined(RGB_BACKLIGHT_NK87)
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE );
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_2, IS31FL3733_SYNC_NONE );
+    is31fl3733_init( 0 );
+    is31fl3733_init( 1 );
 
     for ( int index = 0; index < IS31FL3733_LED_COUNT; index++ )
     {
@@ -2197,11 +2197,11 @@ void backlight_init_drivers(void)
     }
     is31fl3733_set_led_control_register( 48+64-1, 0, 0, 1 ); //Enable LB48 blue enable for indicators
     // This actually updates the LED drivers
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_1, 0 );
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_2, 1 );
+    is31fl3733_update_led_control_registers( 0 );
+    is31fl3733_update_led_control_registers( 1 );
 #elif defined(RGB_BACKLIGHT_NEBULA68)
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE );
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_2, IS31FL3733_SYNC_NONE );
+    is31fl3733_init( 0 );
+    is31fl3733_init( 1 );
 
     for ( int index = 0; index < IS31FL3733_LED_COUNT; index++ )
     {
@@ -2211,20 +2211,20 @@ void backlight_init_drivers(void)
         is31fl3733_set_led_control_register( index, enabled, enabled, enabled );
     }
     // This actually updates the LED drivers
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_1, 0 );
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_2, 1 );
+    is31fl3733_update_led_control_registers( 0 );
+    is31fl3733_update_led_control_registers( 1 );
 #elif defined(RGB_BACKLIGHT_PORTICO75)
-    is31fl3741_init( IS31FL3741_I2C_ADDRESS_1 );
+    is31fl3741_init( 0 );
 	bool enabled = true;
     for ( int index = 0; index < IS31FL3741_LED_COUNT; index++ )
     {
         is31fl3741_set_led_control_register( index, enabled, enabled, enabled );
     }
     // This actually updates the LED drivers
-    is31fl3741_update_led_control_registers( IS31FL3741_I2C_ADDRESS_1, 0 );
+    is31fl3741_update_led_control_registers( 0 );
 #elif defined(RGB_BACKLIGHT_KW_MEGA)
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_1, IS31FL3733_SYNC_NONE );
-    is31fl3733_init( IS31FL3733_I2C_ADDRESS_2, IS31FL3733_SYNC_NONE );
+    is31fl3733_init( 0 );
+    is31fl3733_init( 1 );
 
     for ( int index = 0; index < IS31FL3733_LED_COUNT; index++ )
     {
@@ -2234,18 +2234,18 @@ void backlight_init_drivers(void)
         is31fl3733_set_led_control_register( index, enabled, enabled, enabled );
     }
     // This actually updates the LED drivers
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_1, 0 );
-    is31fl3733_update_led_control_registers( IS31FL3733_I2C_ADDRESS_2, 1 );
+    is31fl3733_update_led_control_registers( 0 );
+    is31fl3733_update_led_control_registers( 1 );
 #else
     // Init the #1 driver
-    is31fl3731_init( IS31FL3731_I2C_ADDRESS_1 );
+    is31fl3731_init( 0 );
     // Init the #2 driver (if used)
 #if !defined(RGB_BACKLIGHT_NEBULA12) && !defined(RGB_BACKLIGHT_M10_C)
-    is31fl3731_init( IS31FL3731_I2C_ADDRESS_2 );
+    is31fl3731_init( 1 );
 #endif
     // Init the #3 driver (if used)
 #if defined(RGB_BACKLIGHT_U80_A)
-    is31fl3731_init( IS31FL3731_I2C_ADDRESS_3 );
+    is31fl3731_init( 2 );
 #endif
 
     // Experimental feature, not in configuration yet
@@ -2378,12 +2378,12 @@ void backlight_init_drivers(void)
     }
     // This actually updates the LED drivers
     // TODO: refactor this to use DRIVER_COUNT
-    is31fl3731_update_led_control_registers( IS31FL3731_I2C_ADDRESS_1, 0 );
+    is31fl3731_update_led_control_registers(  0 );
 #if !defined(RGB_BACKLIGHT_NEBULA12) && !defined(RGB_BACKLIGHT_M10_C)
-    is31fl3731_update_led_control_registers( IS31FL3731_I2C_ADDRESS_2, 1 );
+    is31fl3731_update_led_control_registers( 1 );
 #endif
 #if defined(RGB_BACKLIGHT_U80_A)
-    is31fl3731_update_led_control_registers( IS31FL3731_I2C_ADDRESS_3, 2 );
+    is31fl3731_update_led_control_registers( 2 );
 #endif
 #endif
 

--- a/keyboards/xelus/dawn60/rev1_qmk/rev1_qmk.c
+++ b/keyboards/xelus/dawn60/rev1_qmk/rev1_qmk.c
@@ -145,22 +145,22 @@ led_config_t g_led_config = { {
 //Custom Driver
 static void init(void) {
     i2c_init();
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_1);
-    is31fl3731_init(IS31FL3731_I2C_ADDRESS_2);
+    is31fl3731_init(0);
+    is31fl3731_init(1);
     for (int index = 0; index < IS31FL3731_LED_COUNT; index++) {
         bool enabled = true;
         is31fl3731_set_led_control_register(index, enabled, enabled, enabled);
     }
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_1, 0);
-    is31fl3731_update_led_control_registers(IS31FL3731_I2C_ADDRESS_2, 1);
+    is31fl3731_update_led_control_registers(0);
+    is31fl3731_update_led_control_registers(1);
     
     //RGB Underglow ws2812
     
 }
 
 static void flush(void) {
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_1, 0);
-    is31fl3731_update_pwm_buffers(IS31FL3731_I2C_ADDRESS_2, 1);
+    is31fl3731_update_pwm_buffers(0);
+    is31fl3731_update_pwm_buffers(1);
     ws2812_setleds(rgb_matrix_ws2812_array, WS2812_LED_TOTAL);
 }
 

--- a/keyboards/xelus/pachi/rgb/rev1/rev1.c
+++ b/keyboards/xelus/pachi/rgb/rev1/rev1.c
@@ -188,7 +188,7 @@ led_config_t g_led_config = { {
 
 static void init(void) {
     i2c_init();
-    is31fl3741_init(IS31FL3741_I2C_ADDRESS_1);
+    is31fl3741_init(0);
     for (int index = 0; index < IS31FL3741_LED_COUNT; index++) {
         bool enabled = !(   ( index == -1+0+13) || //A13
                             ( index == -1+13+3) || //B3
@@ -223,7 +223,7 @@ static void init(void) {
                         );
         is31fl3741_set_led_control_register(index, enabled, enabled, enabled);
     }
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_1, 0);
+    is31fl3741_update_led_control_registers(0);
 }
 
 const rgb_matrix_driver_t rgb_matrix_driver = {

--- a/keyboards/xelus/pachi/rgb/rev2/rev2.c
+++ b/keyboards/xelus/pachi/rgb/rev2/rev2.c
@@ -194,7 +194,7 @@ led_config_t g_led_config = { {
 
 static void init(void) {
     i2c_init();
-    is31fl3741_init(IS31FL3741_I2C_ADDRESS_1);
+    is31fl3741_init(0);
     for (int index = 0; index < IS31FL3741_LED_COUNT; index++) {
         bool enabled = !(   ( index == -1+0+13) || //A13
                             ( index == -1+13+3) || //B3
@@ -229,7 +229,7 @@ static void init(void) {
                         );
         is31fl3741_set_led_control_register(index, enabled, enabled, enabled);
     }
-    is31fl3741_update_led_control_registers(IS31FL3741_I2C_ADDRESS_1, 0);
+    is31fl3741_update_led_control_registers(0);
 }
 
 const rgb_matrix_driver_t rgb_matrix_driver = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently in order to use these drivers' API you need to supply both the I2C address and the matching driver index. Instead we can place the defined addresses in an array and use the index to look them up before performing I2C operations.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
