### PR TITLE
Init pins for Analog Joystick sensor

### DIFF
--- a/drivers/sensors/analog_joystick.c
+++ b/drivers/sensors/analog_joystick.c
@@ -128,6 +128,9 @@ report_analog_joystick_t analog_joystick_read(void) {
 }
 
 void analog_joystick_init(void) {
+    setPinInputHigh(ANALOG_JOYSTICK_X_AXIS_PIN);
+    setPinInputHigh(ANALOG_JOYSTICK_Y_AXIS_PIN);
+
 #ifdef ANALOG_JOYSTICK_CLICK_PIN
     setPinInputHigh(ANALOG_JOYSTICK_CLICK_PIN);
 #endif


### PR DESCRIPTION

## Description

Pins for ADC on analog joystick sensor were never initialized.  Would work fine in many cases but causes issues on some controllers. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* [Discord Link](https://discord.com/channels/440868230475677696/867530303261114398/1199605421300797501)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
