### PR TITLE
Fix Issue with RGB Matrix not understanding the split keyboard

### DIFF
--- a/keyboards/aidansmithdotdev/sango/info.json
+++ b/keyboards/aidansmithdotdev/sango/info.json
@@ -20,6 +20,7 @@
     "processor": "RP2040",
     "rgb_matrix": {
         "driver": "ws2812",
+        "split_count": [36, 36],
         "layout": [
             {"matrix": [0, 1], "x": 60, "y": 0, "flags": 4},
             {"matrix": [0, 2], "x": 50, "y": 0, "flags": 4},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As the title states, the merge for the Sango was missing a definition for the RGB split in info.json. This caused the RGBs on the right side of the board to be uncontrollable. Fixed by adding the definition as explained by @fauxpark and @casuanoob in the QMK Discord.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixed Sango LED definition such that the right side is properly lit

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
