### PR TITLE
Remove ee_hands config from ferris/sweep firmware

### DIFF
--- a/keyboards/ferris/sweep/config.h
+++ b/keyboards/ferris/sweep/config.h
@@ -1,9 +1,0 @@
-// Copyright 2018-2020
-// ENDO Katsuhiro <ka2hiro@curlybracket.co.jp>
-// David Philip Barr <@davidphilipbarr>
-// Pierre Chevalier <pierrechevalier83@gmail.com>
-// SPDX-License-Identifier: GPL-2.0+
-
-#pragma once
-
-#define EE_HANDS

--- a/keyboards/ferris/sweep/readme.md
+++ b/keyboards/ferris/sweep/readme.md
@@ -17,27 +17,6 @@ Make example for this keyboard (after setting up your build environment):
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 
-## Setting Handedness
-
-Firmware uses [handedness by EEPROM](https://docs.qmk.fm/#/feature_split_keyboard?id=handedness-by-eeprom) as default and it must be *configured once* on each side. The make commands for Pro micros are:
-
-    make ferris/sweep:default:avrdude-split-left
-    make ferris/sweep:default:avrdude-split-right
-
-For Elite-C or compatible controllers using `DFU` bootloader, add the line `BOOTLOADER = atmel-dfu` into the user keymap `rules.mk` file and use the following make commands:
-
-    make ferris/sweep:default:dfu-split-left
-    make ferris/sweep:default:dfu-split-right
-
-[QMK Toolbox](http://qmk.fm/toolbox) can also be used to set EEPROM handedness. Place the controller in bootloader mode and select menu option Tools -> EEPROM -> Set Left/Right Hand
-
-### RP2040 Controllers
-
-Pro Micro RP2040 controllers are supported with [QMK Converters](https://docs.qmk.fm/#/feature_converters). The make command example with handedness setting for Adafruit's KB2040 are:
-
-    make CONVERT_TO=kb2040 ferris/sweep:default:uf2-split-left
-    make CONVERT_TO=kb2040 ferris/sweep:default:uf2-split-right
-
 ## Bootloader
 
 Enter the bootloader in 3 ways:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For some reason ferris/sweep was configured with EE_hands as its default handedness method. This provides no real benefit, and confuses new users (sweep is one of our most searched for boards according to analytics).

I've deleted the config.h with the ee_hands define meaning it should fall back to MASTER_LEFT by default, and deleted all the extra stuff in readme.md that related to it.

Just aiming to simplify new users experience with this very popular board.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
