### PR TITLE
Initial `qmk test-c` functionality

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Install dependencies
       run: pip3 install -r requirements-dev.txt
     - name: Run tests
-      run: make test:all
+      run: qmk test-c

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -791,3 +791,39 @@ This command converts a TTF font to an intermediate format for editing, before c
 
 This command converts an intermediate font image to the QFF File Format. See the [Quantum Painter](quantum_painter.md?id=quantum-painter-cli) documentation for more information on this command.
 
+## `qmk test-c`
+
+This command runs the C unit test suite. If you make changes to C code you should ensure this runs successfully.
+
+**Usage**:
+
+```
+qmk test-c [-h] [-t TEST] [-l] [-c] [-e ENV] [-j PARALLEL]
+
+options:
+  -h, --help            show this help message and exit
+  -t TEST, --test TEST  Test to run from the available list. Supports wildcard globs. May be passed multiple times.
+  -l, --list            List available tests.
+  -c, --clean           Remove object files before compiling.
+  -e ENV, --env ENV     Set a variable to be passed to make. May be passed multiple times.
+  -j PARALLEL, --parallel PARALLEL
+                        Set the number of parallel make jobs; 0 means unlimited.
+```
+
+**Examples**:
+
+Run entire test suite:
+
+    qmk test-c
+
+List available tests:
+
+    qmk test-c --list
+
+Run matching test:
+
+    qmk test-c --test unicode*
+
+Run single test:
+
+    qmk test-c --test basic

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -81,6 +81,7 @@ subcommands = [
     'qmk.cli.new.keymap',
     'qmk.cli.painter',
     'qmk.cli.pytest',
+    'qmk.cli.test.c',
     'qmk.cli.userspace.add',
     'qmk.cli.userspace.compile',
     'qmk.cli.userspace.doctor',

--- a/lib/python/qmk/cli/test/c.py
+++ b/lib/python/qmk/cli/test/c.py
@@ -1,0 +1,47 @@
+import fnmatch
+import re
+from subprocess import DEVNULL
+
+from milc import cli
+
+from qmk.commands import find_make, get_make_parallel_args, build_environment
+
+
+@cli.argument('-j', '--parallel', type=int, default=1, help="Set the number of parallel make jobs; 0 means unlimited.")
+@cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")
+@cli.argument('-c', '--clean', arg_only=True, action='store_true', help="Remove object files before compiling.")
+@cli.argument('-l', '--list', arg_only=True, action='store_true', help='List available tests.')
+@cli.argument('-t', '--test', arg_only=True, action='append', default=[], help="Test to run from the available list. Supports wildcard globs. May be passed multiple times.")
+@cli.subcommand("QMK C Unit Tests.", hidden=False if cli.config.user.developer else True)
+def test_c(cli):
+    """Run native unit tests.
+    """
+    list_tests = cli.run([find_make(), 'list-tests', 'SILENT=true'])
+    available_tests = sorted(list_tests.stdout.strip().split())
+
+    if cli.args.list:
+        return print("\n".join(available_tests))
+
+    # expand any wildcards
+    filtered_tests = set()
+    for test in cli.args.test:
+        regex = re.compile(fnmatch.translate(test))
+        filtered_tests |= set(filter(regex.match, available_tests))
+
+    for invalid in filtered_tests - set(available_tests):
+        cli.log.warning(f'Invalid test provided: {invalid}')
+
+    # convert test names to build targets
+    targets = list(map(lambda x: f'test:{x}', filtered_tests or ['all']))
+
+    if cli.args.clean:
+        targets.insert(0, 'clean')
+
+    # Add in the environment vars
+    for key, value in build_environment(cli.args.env).items():
+        targets.append(f'{key}={value}')
+
+    command = [find_make(), *get_make_parallel_args(cli.config.test_c.parallel), *targets]
+
+    cli.log.info('Compiling tests with {fg_cyan}%s', ' '.join(command))
+    return cli.run(command, capture_output=False, stdin=DEVNULL).returncode


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Adds CLI subcommand that extends the available functionality of normal test execution.

Adds:
* basic test filtering

#### Examples
```bash
# list available tests
qmk test-c --list

# run all tests
qmk test-c

# clean and run a single test
qmk test-c --clean --test basic

# run all tests that start with "unicode"
qmk test-c --test unicode*

# run all tests with unicode somewhere in the name
qmk test-c --test *unicode*

# parallel compilation
qmk test-c -j=2 --test basic

# environment args
qmk test-c --test basic -e DEBUG=1
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
