### PR TITLE
Clearer text about double tapping reset only working for boot after already having QMK running in board

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -464,4 +464,4 @@ CLI Flashing sequence:
 3. Flash via QMK CLI eg. `qmk flash --keyboard handwired/onekey/rpi_pico --keymap default`
 4. Wait for the keyboard to become available
 
-<sup>1</sup>: This works only if QMK was compiled with `RP2040_BOOTLOADER_DOUBLE_TAP_RESET` defined.
+<sup>1</sup>: This works only if running a QMK compiled with `RP2040_BOOTLOADER_DOUBLE_TAP_RESET` defined.

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -464,4 +464,4 @@ CLI Flashing sequence:
 3. Flash via QMK CLI eg. `qmk flash --keyboard handwired/onekey/rpi_pico --keymap default`
 4. Wait for the keyboard to become available
 
-<sup>1</sup>: This works only if running a QMK compiled with `RP2040_BOOTLOADER_DOUBLE_TAP_RESET` defined.
+<sup>1</sup>: This works only if the controller has been flashed with QMK Firmware with `RP2040_BOOTLOADER_DOUBLE_TAP_RESET` defined.


### PR DESCRIPTION
Clearer text about double tapping reset only working for boot after already having QMK running in board.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Simple change that makes it clearer. It can prevent confusion with I had. As simple as it is, as it sounds like it has something to do with having the program compiled but does not make it clear that it should already be running on the board.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
