### PR TITLE
Workaround for `make test:all DEBUG=1`

### DIFF
--- a/quantum/logging/debug.h
+++ b/quantum/logging/debug.h
@@ -17,8 +17,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#ifndef PROTOCOL_ARM_ATSAM
+#    include <stdio.h>
+#endif
+
 #include <stdbool.h>
-#include <stdio.h>
 #include "print.h"
 
 #ifdef __cplusplus

--- a/quantum/logging/debug.h
+++ b/quantum/logging/debug.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <stdbool.h>
+#include <stdio.h>
 #include "print.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Should address the keyboard level issues seen in 23041.

```
Compiling: quantum/quantum.c                                                                       In file included from quantum/quantum.h:54,
                 from quantum/quantum.c:17:
quantum/logging/debug.h:58:9: error: expected identifier or ‘(’ before ‘do’
   58 |         do {                                                      \
      |         ^~
quantum/logging/debug.h:60:11: error: expected identifier or ‘(’ before ‘while’
   60 |         } while (0)
      |           ^~~~~
quantum/logging/debug.h:58:9: error: expected identifier or ‘(’ before ‘do’
   58 |         do {                                                      \
      |         ^~
quantum/logging/debug.h:60:11: error: expected identifier or ‘(’ before ‘while’
   60 |         } while (0)
      |           ^~~~~
 [ERRORS]
 | 
 | 
 | 
make[1]: *** [builddefs/common_rules.mk:373: .build/test_obj/basic/quantum/quantum.o] Error 1
```
Longer term the plan is to rework logging to remove `dprintf`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
