### PR TITLE
Fix unit test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,24 +337,23 @@ define BUILD_TEST
     endif
 endef
 
+define LIST_TEST
+    include $(BUILDDEFS_PATH)/testlist.mk
+    FOUND_TESTS := $$(patsubst ./tests/%,%,$$(TEST_LIST))
+    $$(info $$(FOUND_TESTS))
+endef
+
 define PARSE_TEST
     TESTS :=
-    # list of possible targets, colon-delimited, to reassign to MAKE_TARGET and remove
-    TARGETS := :clean:
-    ifneq (,$$(findstring :$$(lastword $$(subst :, ,$$(RULE))):, $$(TARGETS)))
-        MAKE_TARGET := $$(lastword $$(subst :, ,$$(RULE)))
-        TEST_SUBPATH := $$(subst $$(eval) ,/,$$(wordlist 2, $$(words $$(subst :, ,$$(RULE))), _ $$(subst :, ,$$(RULE))))
-    else
-        MAKE_TARGET :=
-        TEST_SUBPATH := $$(subst :,/,$$(RULE))
-    endif
+    TEST_NAME := $$(firstword $$(subst :, ,$$(RULE)))
+    TEST_TARGET := $$(subst $$(TEST_NAME),,$$(subst $$(TEST_NAME):,,$$(RULE)))
     include $(BUILDDEFS_PATH)/testlist.mk
-    ifeq ($$(RULE),all)
+    ifeq ($$(TEST_NAME),all)
         MATCHED_TESTS := $$(TEST_LIST)
     else
-        MATCHED_TESTS := $$(foreach TEST, $$(TEST_LIST),$$(if $$(findstring /$$(TEST_SUBPATH)/, $$(patsubst %,%/,$$(TEST))), $$(TEST),))
+        MATCHED_TESTS := $$(foreach TEST, $$(TEST_LIST),$$(if $$(findstring x$$(TEST_NAME)x, x$$(patsubst ./tests/%,%,$$(TEST)x)), $$(TEST),))
     endif
-    $$(foreach TEST,$$(MATCHED_TESTS),$$(eval $$(call BUILD_TEST,$$(TEST),$$(MAKE_TARGET))))
+    $$(foreach TEST,$$(MATCHED_TESTS),$$(eval $$(call BUILD_TEST,$$(TEST),$$(TEST_TARGET))))
 endef
 
 
@@ -436,6 +435,10 @@ git-submodules: git-submodule
 .PHONY: list-keyboards
 list-keyboards:
 	$(QMK_BIN) list-keyboards --no-resolve-defaults | tr '\n' ' '
+
+.PHONY: list-tests
+list-tests:
+	$(eval $(call LIST_TEST))
 
 .PHONY: generate-keyboards-file
 generate-keyboards-file:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Replaces #23034.

Fixes running unit tests located outside /tests folder. Aligns test names with keyboard compilation, `/` instead of `:`. 

-  Partial revert of #15889
- `Running make test:auto_shift will run all Auto Shift tests`
- 15889 reverted the previous "fix" that was included within #21659
  - `Fixed a small bug with test matching due to how findstring works (eg. make test:unicode builds every test suite starting with unicode instead of just the one named unicode)`
- Partial matches will only be currently supported via future CLI changes

Adds `make list-tests` to make test name discovery a little eaiser.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
