### PR TITLE
For kinesis/kint41 keyboard, do not enter lower-power sleep mode when on the ChibiOS idle thread (#23053).

### DIFF
--- a/keyboards/kinesis/kint41/rules.mk
+++ b/keyboards/kinesis/kint41/rules.mk
@@ -10,3 +10,7 @@ ARMV = 7
 BOOTLOADER = halfkay
 
 FIRMWARE_FORMAT = hex
+
+# Do not enter lower-power sleep mode when on the ChibiOS idle thread.
+# See https://github.com/qmk/qmk_firmware/issues/23053.
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=FALSE


### PR DESCRIPTION
For kinesis/kint41 keyboard, do not enter lower-power sleep mode when on the ChibiOS idle thread (#23053).

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

See above.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/23053

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
