### PR TITLE
Fix git-submodule running in wrong location

### DIFF
--- a/lib/python/qmk/cli/git/submodule.py
+++ b/lib/python/qmk/cli/git/submodule.py
@@ -1,8 +1,8 @@
 import shutil
+from pathlib import Path
 
 from milc import cli
 
-from qmk.path import normpath
 from qmk import submodules
 
 REMOVE_DIRS = [
@@ -40,12 +40,12 @@ def git_submodule(cli):
     remove_dirs = REMOVE_DIRS
     if cli.config.git_submodule.force:
         # Also trash everything that isnt marked as "safe"
-        for path in normpath('lib').iterdir():
+        for path in Path('lib').iterdir():
             if not any(ignore in path.as_posix() for ignore in IGNORE_DIRS):
                 remove_dirs.append(path)
 
-    for folder in map(normpath, remove_dirs):
-        if normpath(folder).is_dir():
+    for folder in map(Path, remove_dirs):
+        if folder.is_dir():
             print(f"Removing '{folder}'")
             shutil.rmtree(folder)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When config or environment variable point to an invalid location, `normpath` can return a directory that does not reflect the change of directory performed by the cli. We never want current directory paths, so the code has been updated to just use regular pathlib funcs. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* <https://discord.com/channels/440868230475677696/473506116718952450/1206416039206719508>

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
