### PR TITLE
Calculate and print stack size on AVR builds.

### DIFF
--- a/builddefs/message.mk
+++ b/builddefs/message.mk
@@ -90,7 +90,10 @@ endef
 MSG_AVAILABLE_KEYMAPS = $(eval $(call GENERATE_MSG_AVAILABLE_KEYMAPS))$(MSG_AVAILABLE_KEYMAPS_ACTUAL)
 
 MSG_BOOTLOADER_NOT_FOUND_BASE = Bootloader not found. Make sure the board is in bootloader mode. See https://docs.qmk.fm/\#/newbs_flashing\n
+MSG_CHECK_STACKSIZE = Checking stack size of $(TARGET)
 MSG_CHECK_FILESIZE = Checking file size of $(TARGET).$(FIRMWARE_FORMAT)
+MSG_MEMORY_OVERFLOW = $(ERROR_COLOR)RAM usage (not including stack) exceeds available RAM by $(RAM_OVERFLOW_AMOUNT) bytes\n
+MSG_STACK_SIZE = Available stack size: $(STACK_SIZE) bytes\n
 MSG_FILE_TOO_BIG = $(ERROR_COLOR)The firmware is too large!$(NO_COLOR) $(CURRENT_SIZE)/$(MAX_SIZE) ($(OVER_SIZE) bytes over)\n
 MSG_FILE_TOO_SMALL = The firmware is too small! $(CURRENT_SIZE)/$(MAX_SIZE)\n
 MSG_FILE_JUST_RIGHT = The firmware size is fine - $(CURRENT_SIZE)/$(MAX_SIZE) ($(PERCENT_SIZE)%%, $(FREE_SIZE) bytes free)\n

--- a/platforms/avr/platform.mk
+++ b/platforms/avr/platform.mk
@@ -131,6 +131,18 @@ check-size:
 		    fi ; \
 		fi ; \
 	fi
+	$(eval END_POINTER=$(shell printf "%d" $$(( 0xffff & 0x$$( if [ -f $(BUILD_DIR)/$(TARGET).elf ]; then avr-objdump -t $(BUILD_DIR)/$(TARGET).elf | grep -e '\b_end\b' | cut -c -8; else printf 0; fi ) )) ))
+	$(eval STACK_POINTER=$(shell printf "%d" $$(( 0xffff & 0x$$( if [ -f $(BUILD_DIR)/$(TARGET).elf ]; then avr-objdump -t $(BUILD_DIR)/$(TARGET).elf | grep -e '\b__stack\b' | cut -c -8; else printf 0; fi ) )) ))
+	$(eval STACK_SIZE=$(shell expr $(STACK_POINTER) + 1 - $(END_POINTER)))
+	$(eval RAM_OVERFLOW_AMOUNT=$(shell expr 0 - $(STACK_SIZE)))
+	if [ $(STACK_POINTER) -gt 0 ] && [ $(END_POINTER) -gt 0 ]; then \
+		$(SILENT) || printf "$(MSG_CHECK_STACKSIZE)" | $(AWK_CMD); \
+		if [ $(STACK_SIZE) -lt 0 ] ; then \
+			printf "\n * $(MSG_MEMORY_OVERFLOW)"; $(PRINT_ERROR_PLAIN); \
+		else \
+			$(SILENT) || printf "\n * $(MSG_STACK_SIZE)"; \
+		fi ; \
+	fi
 
 # Convert hex to bin.
 bin: $(BUILD_DIR)/$(TARGET).hex


### PR DESCRIPTION
## Description

This is a re-opened pull-request of the original, please see that one for history. It has already received two approvals before the rebase: #20526

AVRs have very limited RAM available. It is nice to have at the end of the build a message showing how much flash space is left, but what is even more important is knowing how we are with regard to RAM usage. Of course linking will fail if so much ram is used up by global variables, that it won't fit even with a 0-sized stack, however what is not detected and cannot be detected at build time is the case when the global variables fit in RAM, but the stack starts overriding them, because not enough stack space has been left. The best thing we can do for this is to calculate and print the stack size, and have the user interpret this.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
