### PR TITLE
[CLI] Refactor `open` into `pathlib.Path.open`

### DIFF
--- a/lib/python/qmk/c_parse.py
+++ b/lib/python/qmk/c_parse.py
@@ -5,6 +5,7 @@ from pygments.token import Token
 from pygments import lex
 from itertools import islice
 from pathlib import Path
+from typing import List
 import re
 
 from milc import cli
@@ -44,7 +45,7 @@ def strip_multiline_comment(string):
     return multi_comment_regex.sub('', string)
 
 
-def c_source_files(dir_names):
+def c_source_files(dir_names: List[str]) -> List[Path]:
     """Returns a list of all *.c, *.h, and *.cpp files for a given list of directories
 
     Args:

--- a/lib/python/qmk/cli/chibios/confmigrate.py
+++ b/lib/python/qmk/cli/chibios/confmigrate.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import os
+from pathlib import Path
 
 from qmk.constants import QMK_FIRMWARE
 from qmk.path import normpath
@@ -39,8 +40,8 @@ file_header = """\
 """
 
 
-def collect_defines(filepath):
-    with open(filepath, 'r', encoding='utf-8') as f:
+def collect_defines(filepath: Path):
+    with filepath.open('r', encoding='utf-8') as f:
         content = f.read()
         define_search = re.compile(r'(?m)^#\s*define\s+(?:.*\\\r?\n)*.*$', re.MULTILINE)
         value_search = re.compile(r'^#\s*define\s+(?P<name>[a-zA-Z0-9_]+(\([^\)]*\))?)\s*(?P<value>.*)', re.DOTALL)
@@ -146,17 +147,17 @@ def chibios_confmigrate(cli):
         if cli.args.input.name == "chconf.h" and ("CHCONF_H" in input_defs["dict"] or "_CHCONF_H_" in input_defs["dict"] or cli.args.force):
             migrate_chconf_h(to_override, outfile=sys.stdout)
             if cli.args.overwrite:
-                with open(cli.args.input, "w", encoding='utf-8') as out_file:
+                with cli.args.input.open("w", encoding='utf-8') as out_file:
                     migrate_chconf_h(to_override, outfile=out_file)
 
         elif cli.args.input.name == "halconf.h" and ("HALCONF_H" in input_defs["dict"] or "_HALCONF_H_" in input_defs["dict"] or cli.args.force):
             migrate_halconf_h(to_override, outfile=sys.stdout)
             if cli.args.overwrite:
-                with open(cli.args.input, "w", encoding='utf-8') as out_file:
+                with cli.args.input.open("w", encoding='utf-8') as out_file:
                     migrate_halconf_h(to_override, outfile=out_file)
 
         elif cli.args.input.name == "mcuconf.h" and ("MCUCONF_H" in input_defs["dict"] or "_MCUCONF_H_" in input_defs["dict"] or cli.args.force):
             migrate_mcuconf_h(to_override, outfile=sys.stdout)
             if cli.args.overwrite:
-                with open(cli.args.input, "w", encoding='utf-8') as out_file:
+                with cli.args.input.open("w", encoding='utf-8') as out_file:
                     migrate_mcuconf_h(to_override, outfile=out_file)

--- a/lib/python/qmk/cli/format/json.py
+++ b/lib/python/qmk/cli/format/json.py
@@ -92,7 +92,7 @@ def format_json(cli):
     output = json.dumps(json_data, cls=json_encoder, sort_keys=True)
 
     if cli.args.inplace:
-        with open(cli.args.json_file, 'w+', encoding='utf-8', newline='\n') as outfile:
+        with cli.args.json_file.open('w+', encoding='utf-8', newline='\n') as outfile:
             outfile.write(output + '\n')
 
     # Display the results if print was set

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -1,6 +1,7 @@
 """Command to look over a keyboard/keymap and check for common mistakes.
 """
 from pathlib import Path
+from typing import List
 
 from milc import cli
 
@@ -32,7 +33,7 @@ def _list_defaultish_keymaps(kb):
     return keymaps
 
 
-def _get_code_files(kb, km=None):
+def _get_code_files(kb, km=None) -> List[Path]:
     """Return potential keyboard/keymap code files
     """
     search_path = locate_keymap(kb, km).parent if km else keyboard(kb)
@@ -47,12 +48,12 @@ def _get_code_files(kb, km=None):
     return code_files
 
 
-def _has_license(file):
+def _has_license(file: Path) -> bool:
     """Check file has a license header
     """
     # Crude assumption that first line of license header is a comment
-    fline = open(file).readline().rstrip()
-    return fline.startswith(("/*", "//"))
+    with file.open() as f:
+        return f.readline().rstrip().startswith(("/*", "//"))
 
 
 def _handle_json_errors(kb, info):

--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -31,7 +31,7 @@ def mass_compile_targets(targets: List[BuildTarget], clean: bool, dry_run: bool,
             cli.run([make_cmd, 'clean'], capture_output=False, stdin=DEVNULL)
 
         builddir.mkdir(parents=True, exist_ok=True)
-        with open(makefile, "w") as f:
+        with makefile.open("w") as f:
             for target in sorted(targets, key=lambda t: (t.keyboard, t.keymap)):
                 keyboard_name = target.keyboard
                 keymap_name = target.keymap

--- a/lib/python/qmk/cli/painter/convert_graphics.py
+++ b/lib/python/qmk/cli/painter/convert_graphics.py
@@ -56,7 +56,7 @@ def painter_convert_graphics(cli):
 
     if cli.args.raw:
         raw_file = cli.args.output / (cli.args.input.stem + ".qgf")
-        with open(raw_file, 'wb') as raw:
+        with raw_file.open('wb') as raw:
             raw.write(out_bytes)
         return
 
@@ -79,7 +79,7 @@ def painter_convert_graphics(cli):
     # Render and write the header file
     header_text = render_header(subs)
     header_file = cli.args.output / (cli.args.input.stem + ".qgf.h")
-    with open(header_file, 'w') as header:
+    with header_file.open('w') as header:
         print(f"Writing {header_file}...")
         header.write(header_text)
         header.close()
@@ -87,7 +87,7 @@ def painter_convert_graphics(cli):
     # Render and write the source file
     source_text = render_source(subs)
     source_file = cli.args.output / (cli.args.input.stem + ".qgf.c")
-    with open(source_file, 'w') as source:
+    with source_file.open('w') as source:
         print(f"Writing {source_file}...")
         source.write(source_text)
         source.close()

--- a/lib/python/qmk/cli/painter/make_font.py
+++ b/lib/python/qmk/cli/painter/make_font.py
@@ -58,7 +58,7 @@ def painter_convert_font_image(cli):
 
     if cli.args.raw:
         raw_file = cli.args.output / (cli.args.input.stem + ".qff")
-        with open(raw_file, 'wb') as raw:
+        with raw_file.open('wb') as raw:
             raw.write(out_bytes)
         return
 
@@ -81,7 +81,7 @@ def painter_convert_font_image(cli):
     # Render and write the header file
     header_text = render_header(subs)
     header_file = cli.args.output / (cli.args.input.stem + ".qff.h")
-    with open(header_file, 'w') as header:
+    with header_file.open('w') as header:
         print(f"Writing {header_file}...")
         header.write(header_text)
         header.close()
@@ -89,7 +89,7 @@ def painter_convert_font_image(cli):
     # Render and write the source file
     source_text = render_source(subs)
     source_file = cli.args.output / (cli.args.input.stem + ".qff.c")
-    with open(source_file, 'w') as source:
+    with source_file.open('w') as source:
         print(f"Writing {source_file}...")
         source.write(source_text)
         source.close()


### PR DESCRIPTION
## Description

As per title.
While doing a PR i noticed a few `open(Path, mode)` lines which felt a bit off (non-idiomatic), and after looking for `open` on `lib/python` i've noticed that code does indeed use this method on most places, so refactored the ones that don't for consistency.

Notes:
- I haven't tested any of the changes yet, will try and do later today. Thus, draft
- I was unsure whether a value was `Path` or `str` looking at the code and added a couple type hints on my way to discovery
- On code looking for comments (license headers), shouldn't `strip` be used instead on `rstrip`? ie: remove trailing spaces that would make the `str.startswith` not detect an existing comment

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
