### PR TITLE
Fix make clean test:os_detection

### DIFF
--- a/quantum/os_detection/tests/os_detection.cpp
+++ b/quantum/os_detection/tests/os_detection.cpp
@@ -45,6 +45,8 @@ os_variant_t check_sequence(const std::vector<uint16_t> &w_lengths) {
 bool process_detected_host_os_kb(os_variant_t os) {
     reported_count = reported_count + 1;
     reported_os    = os;
+
+    return true;
 }
 
 void assert_not_reported(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
While passing on CI, these fail locally...
```
[ RUN      ] OsDetectionTest.TestDoNotReportIfUsbUnstable
[       OK ] OsDetectionTest.TestDoNotReportIfUsbUnstable (0 ms)
[ RUN      ] OsDetectionTest.TestReportAfterDebounce

Make finished with errors
make: *** [Makefile:417: test:os_detection] Error 1
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
