### PR TITLE
[Bug] Fix pmw33xx sensor corruption on get-cpi call

### DIFF
--- a/drivers/sensors/pmw3360.c
+++ b/drivers/sensors/pmw3360.c
@@ -15,6 +15,8 @@ uint16_t pmw33xx_get_cpi(uint8_t sensor) {
     }
 
     uint8_t cpival = pmw33xx_read(sensor, REG_Config1);
+    // In some cases (100, 900, 1700, 2500), reading the CPI corrupts the firmware and the sensor stops responding.
+    // To avoid this, we write the value back to the sensor, which seems to prevent the corruption.
     pmw33xx_write(sensor, REG_Config1, cpival);
     return (uint16_t)((cpival + 1) & 0xFF) * PMW33XX_CPI_STEP;
 }

--- a/drivers/sensors/pmw3360.c
+++ b/drivers/sensors/pmw3360.c
@@ -15,6 +15,7 @@ uint16_t pmw33xx_get_cpi(uint8_t sensor) {
     }
 
     uint8_t cpival = pmw33xx_read(sensor, REG_Config1);
+    pmw33xx_write(sensor, REG_Config1, cpival);
     return (uint16_t)((cpival + 1) & 0xFF) * PMW33XX_CPI_STEP;
 }
 


### PR DESCRIPTION

## Description

Initially reported by Wimads and burkfers on the BastardKB discord.


> The bug with PMW3360 I was talking about a week ago or so, with DPI's of 100, 900, 1700, etc not working. We figured out it was caused by pointing_device_get_cpi() Calling that at those DPI settings, causes mouse reports to break (no reports coming in). Setting cpi right after getting it fixes the issue. So something is going wrong with the get_cpi call.

This sounds like a bug with the pmw3360 firmware itself. But for now, this is a quick fix to the issue that is confirmed to work. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

*  Issue reported on BastardKB discord

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
