### PR TITLE
Add a threshold to activate auto mouse layer

### DIFF
--- a/quantum/pointing_device/pointing_device_auto_mouse.c
+++ b/quantum/pointing_device/pointing_device_auto_mouse.c
@@ -217,7 +217,11 @@ void auto_mouse_layer_off(void) {
  * @return bool of pointing_device activation
  */
 __attribute__((weak)) bool auto_mouse_activation(report_mouse_t mouse_report) {
-    return mouse_report.x != 0 || mouse_report.y != 0 || mouse_report.h != 0 || mouse_report.v != 0 || mouse_report.buttons;
+    return mouse_report.x > AUTO_MOUSE_THRESHOLD || mouse_report.x < -AUTO_MOUSE_THRESHOLD
+        || mouse_report.y > AUTO_MOUSE_THRESHOLD || mouse_report.y < -AUTO_MOUSE_THRESHOLD
+        || mouse_report.h > AUTO_MOUSE_THRESHOLD || mouse_report.h < -AUTO_MOUSE_THRESHOLD
+        || mouse_report.v > AUTO_MOUSE_THRESHOLD || mouse_report.v < -AUTO_MOUSE_THRESHOLD
+        || mouse_report.buttons;
 }
 
 /**

--- a/quantum/pointing_device/pointing_device_auto_mouse.h
+++ b/quantum/pointing_device/pointing_device_auto_mouse.h
@@ -42,6 +42,9 @@
 #ifndef AUTO_MOUSE_DEBOUNCE
 #    define AUTO_MOUSE_DEBOUNCE 25
 #endif
+#ifndef AUTO_MOUSE_THRESHOLD
+#    define AUTO_MOUSE_THRESHOLD 0
+#endif
 
 /* data structure */
 typedef struct {


### PR DESCRIPTION
Add a threshold to inhibit unexpected activation of the automatic mouse layer due to keyboard oscillation.

## Description

Define `AUTO_MOUSE_THRESHOLD`.
Check the threshold in `bool auto_mouse_activation(report_mouse_t mouse_report)`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
