### PR TITLE
Fix for multiple AMUX usage

### DIFF
--- a/keyboards/cipulot/common/ec_switch_matrix.c
+++ b/keyboards/cipulot/common/ec_switch_matrix.c
@@ -153,7 +153,10 @@ void ec_noise_floor(void) {
         for (uint8_t amux = 0; amux < AMUX_COUNT; amux++) {
             disable_unused_amux(amux);
             for (uint8_t col = 0; col < amux_n_col_sizes[amux]; col++) {
-                uint8_t adjusted_col = amux == 0 ? col : col + amux_n_col_sizes[amux - 1];
+                uint8_t sum = 0;
+                for (uint8_t i = 0; i < (amux > 0 ? amux : 0); i++)
+                    sum += amux_n_col_sizes[i];
+                uint8_t adjusted_col = col + sum;
                 for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
                     ec_config.noise_floor[row][adjusted_col] += ec_readkey_raw(amux, row, col);
                 }
@@ -178,7 +181,10 @@ bool ec_matrix_scan(matrix_row_t current_matrix[]) {
         disable_unused_amux(amux);
         for (uint8_t col = 0; col < amux_n_col_sizes[amux]; col++) {
             for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-                uint8_t adjusted_col        = amux == 0 ? col : col + amux_n_col_sizes[amux - 1];
+                uint8_t sum = 0;
+                for (uint8_t i = 0; i < (amux > 0 ? amux : 0); i++)
+                    sum += amux_n_col_sizes[i];
+                uint8_t adjusted_col        = col + sum;
                 sw_value[row][adjusted_col] = ec_readkey_raw(amux, row, col);
 
                 if (ec_config.bottoming_calibration) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
this fix allows PCBs with more than 2 AMUX to correctly index the matrix.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
