### PR TITLE
CLI Speed improvements.

### DIFF
--- a/lib/python/qmk/json_schema.py
+++ b/lib/python/qmk/json_schema.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from functools import lru_cache
 from typing import OrderedDict
 from pathlib import Path
+from copy import deepcopy
 
 from milc import cli
 
@@ -22,7 +23,8 @@ def _dict_raise_on_duplicates(ordered_pairs):
     return d
 
 
-def json_load(json_file, strict=True):
+@lru_cache(maxsize=20)
+def _json_load_impl(json_file, strict=True):
     """Load a json file from disk.
 
     Note: file must be a Path object.
@@ -42,7 +44,11 @@ def json_load(json_file, strict=True):
         exit(1)
 
 
-@lru_cache(maxsize=0)
+def json_load(json_file, strict=True):
+    return deepcopy(_json_load_impl(json_file=json_file, strict=strict))
+
+
+@lru_cache(maxsize=20)
 def load_jsonschema(schema_name):
     """Read a jsonschema file from disk.
     """
@@ -57,7 +63,7 @@ def load_jsonschema(schema_name):
     return json_load(schema_path)
 
 
-@lru_cache(maxsize=0)
+@lru_cache(maxsize=1)
 def compile_schema_store():
     """Compile all our schemas into a schema store.
     """
@@ -73,7 +79,7 @@ def compile_schema_store():
     return schema_store
 
 
-@lru_cache(maxsize=0)
+@lru_cache(maxsize=20)
 def create_validator(schema):
     """Creates a validator for the given schema id.
     """


### PR DESCRIPTION
## Description

We've been trying to work on this for a while:

* Loading JSON files can take a while, so we remember their post-load state
* Concerns were made that the resulting data could be modified, so we deepcopy and return that instead
* lru_cache of 0 was actually doing nothing but logging, so sizes were adapted to be nonzero.

Before:
```
qmk find -f 'exists(split.matrix_pins)'  571.96s user 6.05s system 1137% cpu 50.815 total
```

After:
```
qmk find -f 'exists(split.matrix_pins)'  349.67s user 3.47s system 1119% cpu 31.539 total
```

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
