### PR TITLE
Change default RGB effect for momokai keypads to solid white

### DIFF
--- a/keyboards/momokai/aurora/info.json
+++ b/keyboards/momokai/aurora/info.json
@@ -43,6 +43,12 @@
         "pin": "C7"
     },
     "rgb_matrix": {
+        "default": {
+            "animation": "solid_color",
+            "hue": 0,
+            "sat": 0,
+            "val": 200
+        },
         "animations": {
             "gradient_up_down": true,
             "gradient_left_right": true,

--- a/keyboards/momokai/tap_duo/info.json
+++ b/keyboards/momokai/tap_duo/info.json
@@ -12,6 +12,12 @@
         "pin": "F0"
     },
     "rgb_matrix": {
+        "default": {
+            "animation": "solid_color",
+            "hue": 0,
+            "sat": 0,
+            "val": 200
+        },
         "animations": {
             "gradient_left_right": true,
             "breathing": true,

--- a/keyboards/momokai/tap_trio/info.json
+++ b/keyboards/momokai/tap_trio/info.json
@@ -12,6 +12,12 @@
         "pin": "F0"
     },
     "rgb_matrix": {
+        "default": {
+            "animation": "solid_color",
+            "hue": 0,
+            "sat": 0,
+            "val": 200
+        },
         "animations": {
             "gradient_up_down": true,
             "gradient_left_right": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Changes default RGB effect for momokai keypads to solid white

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
