### PR TITLE
[Keyboard] Add marshkeys flowerpad

### DIFF
--- a/keyboards/marshkeys/flowerpad/config.h
+++ b/keyboards/marshkeys/flowerpad/config.h
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 Benjamin Božič
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once

--- a/keyboards/marshkeys/flowerpad/flowerpad.c
+++ b/keyboards/marshkeys/flowerpad/flowerpad.c
@@ -1,0 +1,16 @@
+/*
+Copyright 2024 Benjamin Božič
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/

--- a/keyboards/marshkeys/flowerpad/info.json
+++ b/keyboards/marshkeys/flowerpad/info.json
@@ -1,0 +1,37 @@
+{
+    "keyboard_name": "Flowerpad",
+    "maintainer": "Ethirallan",
+    "manufacturer": "marshkeys.com",
+    "url": "marshkeys.com",
+    "development_board": "promicro",
+    "bootmagic": {
+        "enabled": true,
+        "matrix": [0, 1]
+    },
+    "features": {
+        "bootmagic": true,
+        "extrakey": true
+    },
+    "diode_direction": "COL2ROW",
+    "matrix_pins": {
+        "cols": ["F7", "F6", "F5"],
+        "rows": ["C6", "D4", "D0"]
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                { "matrix": [0, 1], "x": 0, "y": 1 },
+                { "matrix": [1, 0], "x": 1, "y": 0 },
+                { "matrix": [1, 1], "x": 1, "y": 1 },
+                { "matrix": [1, 2], "x": 1, "y": 2 },
+                { "matrix": [2, 0], "x": 2, "y": 0 },
+                { "matrix": [2, 2], "x": 2, "y": 2 }
+            ]
+        }
+    },
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x466C",
+        "vid": "0x4D61"
+    }
+}

--- a/keyboards/marshkeys/flowerpad/keymaps/default/keymap.c
+++ b/keyboards/marshkeys/flowerpad/keymaps/default/keymap.c
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 Benjamin Božič
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /*
+   *        --------
+   *        | MUTE |
+   * |------+------+------|
+   * | PREV | PLAY | NEXT |
+   * |------+------+------|
+   *   | VOL- |  | VOL+ |
+   *   --------  --------
+   */
+  LAYOUT(
+               KC_MUTE,
+      KC_MPRV, KC_MPLY, KC_MNXT,
+          KC_VOLD,  KC_VOLU
+  ),
+};

--- a/keyboards/marshkeys/flowerpad/keymaps/default/readme.md
+++ b/keyboards/marshkeys/flowerpad/keymaps/default/readme.md
@@ -1,0 +1,3 @@
+# Default Flowerpad Layout
+
+This is the default layout that comes flashed on every Flowerpad. It has only one layer with multimedia keys.

--- a/keyboards/marshkeys/flowerpad/keymaps/via/keymap.c
+++ b/keyboards/marshkeys/flowerpad/keymaps/via/keymap.c
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 Benjamin Božič
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  /*
+   *        --------
+   *        | MUTE |
+   * |------+------+------|
+   * | PREV | PLAY | NEXT |
+   * |------+------+------|
+   *   | VOL- |  | VOL+ |
+   *   --------  --------
+   */
+  LAYOUT(
+               KC_MUTE,
+      KC_MPRV, KC_MPLY, KC_MNXT,
+          KC_VOLD,  KC_VOLU
+  ),
+};

--- a/keyboards/marshkeys/flowerpad/keymaps/via/rules.mk
+++ b/keyboards/marshkeys/flowerpad/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/marshkeys/flowerpad/readme.md
+++ b/keyboards/marshkeys/flowerpad/readme.md
@@ -1,0 +1,21 @@
+# Flowerpad
+
+A flourishing 6-key macropad that will catch your eye.
+
+* Keyboard Maintainer: [Benjamin Božič](https://github.com/Ethirallan)
+* Hardware Supported: Onboard ATmega32u4, Flowerpad PCB v1, hotswap v1
+* Hardware Availability: marshkeys.com
+
+Make example for this keyboard (after setting up your build environment):
+
+    make marshkeys/flowerpad:default
+
+Flashing example for this keyboard:
+
+    make marshkeys/flowerpad:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader by holding down the top key (where the usb connects) and plug in the keyboard

--- a/keyboards/marshkeys/flowerpad/rules.mk
+++ b/keyboards/marshkeys/flowerpad/rules.mk
@@ -1,0 +1,1 @@
+# This file intentionally left blank


### PR DESCRIPTION
## Description

Add support for marshkeys flowerpad with default and via keymaps.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
