### PR TITLE
Fix acceleration reset on overlapping mouse keys

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -398,8 +398,8 @@ void mousekey_on(uint8_t code) {
 #        ifdef MK_KINETIC_SPEED
         mouse_timer = timer_read() - (MOUSEKEY_INTERVAL << 2);
 #        else
-        mousekey_repeat       = MOUSEKEY_MOVE_DELTA;
-        mousekey_wheel_repeat = MOUSEKEY_WHEEL_DELTA;
+        mousekey_repeat       = 0;
+        mousekey_wheel_repeat = 0;
 #        endif
     }
 #    endif // ifndef MOUSEKEY_INERTIA


### PR DESCRIPTION
See https://github.com/qmk/qmk_firmware/pull/21494. Prior to this fix, moving the mouse diagonally would skip the first MOUSEKEY_MOVE_DELTA frames of acceleration.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
I'm not entirely sure this is the behavior we want - resetting acceleration when going from eg. moving up to moving up-right doesn't seem quite right. However, I'm pretty confident that this is what the original patch was meant to do.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
