### PR TITLE
Fix the Moonlander from going into a deadlock

### DIFF
--- a/keyboards/zsa/moonlander/moonlander.c
+++ b/keyboards/zsa/moonlander/moonlander.c
@@ -18,6 +18,10 @@
 
 #include "moonlander.h"
 
+#ifndef MOONLANDER_THREAD_INTERVAL_MS
+#    define MOONLANDER_THREAD_INTERVAL_MS 100
+#endif // MOONLANDER_THREAD_INTERVAL_MS
+
 keyboard_config_t keyboard_config;
 
 bool mcp23018_leds[3] = {0, 0, 0};
@@ -82,7 +86,7 @@ void moonlander_led_task(void) {
     else {
         static layer_state_t state = 0;
         if (layer_state != state) {
-            layer_state_set_kb(layer_state);
+            state = layer_state_set_kb(layer_state);
         }
     }
 #endif
@@ -94,7 +98,7 @@ static THD_FUNCTION(LEDThread, arg) {
     chRegSetThreadName("LEDThread");
     while (true) {
         moonlander_led_task();
-        wait_ms(100);
+        wait_ms(MOONLANDER_THREAD_INTERVAL_MS);
     }
 }
 

--- a/keyboards/zsa/moonlander/moonlander.c
+++ b/keyboards/zsa/moonlander/moonlander.c
@@ -80,7 +80,10 @@ void moonlander_led_task(void) {
 #endif
 #if !defined(MOONLANDER_USER_LEDS)
     else {
-        layer_state_set_kb(layer_state);
+        static layer_state_t state = 0;
+        if (layer_state != state) {
+            layer_state_set_kb(layer_state);
+        }
     }
 #endif
 }
@@ -91,6 +94,7 @@ static THD_FUNCTION(LEDThread, arg) {
     chRegSetThreadName("LEDThread");
     while (true) {
         moonlander_led_task();
+        wait_ms(100);
     }
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

It looks like on the Moonlander, there's a separate thread that is constantly running without any sleep, and it calls the layer state set function even when there's no change in layers. Because of this, if there happens to be too much code in the layer state set function, the board will go into a deadlock/stuck state.

Fix this by implementing the change suggested by drashna in #16313. Also, add a 100ms sleep in the thread to allow CPU time for the main thread.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #16313

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
