### PR TITLE
Fixup cipulot eeprom.

### DIFF
--- a/keyboards/cipulot/common/ec_switch_matrix.h
+++ b/keyboards/cipulot/common/ec_switch_matrix.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include "matrix.h"
 #include "eeconfig.h"
+#include "util.h"
 
 typedef struct PACKED {
     uint8_t  actuation_mode;                              // 0: normal board-wide APC, 1: Rapid trigger from specific board-wide actuation point, 2: Rapid trigger from resting point

--- a/keyboards/cipulot/ec_23u/config.h
+++ b/keyboards/cipulot/ec_23u/config.h
@@ -60,7 +60,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 
-#define EECONFIG_KB_DATA_SIZE 58
+#define EECONFIG_KB_DATA_SIZE 57
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/ec_60/config.h
+++ b/keyboards/cipulot/ec_60/config.h
@@ -63,7 +63,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 
-#define EECONFIG_KB_DATA_SIZE 160
+#define EECONFIG_KB_DATA_SIZE 159
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/ec_alveus/1_0_0/config.h
+++ b/keyboards/cipulot/ec_alveus/1_0_0/config.h
@@ -62,7 +62,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 
-#define EECONFIG_KB_DATA_SIZE 170
+#define EECONFIG_KB_DATA_SIZE 169
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/ec_alveus/1_2_0/config.h
+++ b/keyboards/cipulot/ec_alveus/1_2_0/config.h
@@ -62,7 +62,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 
-#define EECONFIG_KB_DATA_SIZE 170
+#define EECONFIG_KB_DATA_SIZE 169
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/ec_pro2/config.h
+++ b/keyboards/cipulot/ec_pro2/config.h
@@ -63,7 +63,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 
-#define EECONFIG_KB_DATA_SIZE 160
+#define EECONFIG_KB_DATA_SIZE 159
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/ec_prox/ansi_iso/config.h
+++ b/keyboards/cipulot/ec_prox/ansi_iso/config.h
@@ -63,7 +63,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 
-#define EECONFIG_KB_DATA_SIZE 160
+#define EECONFIG_KB_DATA_SIZE 159
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/ec_prox/jis/config.h
+++ b/keyboards/cipulot/ec_prox/jis/config.h
@@ -63,7 +63,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 
-#define EECONFIG_KB_DATA_SIZE 150
+#define EECONFIG_KB_DATA_SIZE 149
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/ec_theca/config.h
+++ b/keyboards/cipulot/ec_theca/config.h
@@ -62,7 +62,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 #define DYNAMIC_KEYMAP_LAYER_COUNT 3
-#define EECONFIG_KB_DATA_SIZE 202
+#define EECONFIG_KB_DATA_SIZE 201
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE

--- a/keyboards/cipulot/rf_r1_8_9xu/config.h
+++ b/keyboards/cipulot/rf_r1_8_9xu/config.h
@@ -62,7 +62,7 @@
 
 // #define DEBUG_MATRIX_SCAN_RATE
 #define DYNAMIC_KEYMAP_LAYER_COUNT 3
-#define EECONFIG_KB_DATA_SIZE 202
+#define EECONFIG_KB_DATA_SIZE 201
 
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE


### PR DESCRIPTION
## Description

Noticed that these were all failing on `develop`, but `master` was okay, even without any changes.

See: https://github.com/qmk/qmk_firmware/actions/runs/8279382628

Turns out `util.h` wasn't included, so `PACKED` wasn't defined -- `typedef struct PACKED { ...` was treating `PACKED` as the struct name and continuing without struct packing actually occurring. This fixes things, and updates all the data sizes accordingly (subtract 1).

CC: @Cipulot 

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
