### PR TITLE
Remove `DEFAULT_FOLDER` handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ endef
 TRY_TO_MATCH_RULE_FROM_LIST = $(eval $(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER,$1))$(RULE_FOUND)
 
 # As TRY_TO_MATCH_RULE_FROM_LIST_HELPER, but with additional
-# resolution of DEFAULT_FOLDER and keyboard_aliases.hjson for provided rule 
+# resolution of keyboard_aliases.hjson for provided rule 
 define TRY_TO_MATCH_RULE_FROM_LIST_HELPER_KB
     # Split on ":", padding with empty strings to avoid indexing issues
     TOKEN1:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[0])" $$(RULE))
@@ -255,7 +255,7 @@ endef
 # if we are going to compile all keyboards, match the rest of the rule
 # for each of them
 define PARSE_ALL_KEYBOARDS
-    $$(eval $$(call PARSE_ALL_IN_LIST,PARSE_KEYBOARD,$(shell $(QMK_BIN) list-keyboards --no-resolve-defaults)))
+    $$(eval $$(call PARSE_ALL_IN_LIST,PARSE_KEYBOARD,$(shell $(QMK_BIN) list-keyboards)))
 endef
 
 # Prints a list of all known keymaps for the given keyboard
@@ -447,7 +447,7 @@ git-submodules: git-submodule
 
 .PHONY: list-keyboards
 list-keyboards:
-	$(QMK_BIN) list-keyboards --no-resolve-defaults | tr '\n' ' '
+	$(QMK_BIN) list-keyboards | tr '\n' ' '
 
 .PHONY: list-tests
 list-tests:
@@ -455,7 +455,7 @@ list-tests:
 
 .PHONY: generate-keyboards-file
 generate-keyboards-file:
-	$(QMK_BIN) list-keyboards --no-resolve-defaults
+	$(QMK_BIN) list-keyboards
 
 .PHONY: clean
 clean:

--- a/data/mappings/info_rules.hjson
+++ b/data/mappings/info_rules.hjson
@@ -53,8 +53,8 @@
     "WS2812_DRIVER": {"info_key": "ws2812.driver"},
 
     // Items we want flagged in lint
-    "DEFAULT_FOLDER": {"info_key": "_deprecated.default_folder", "deprecated": true},
     "CTPC": {"info_key": "_invalid.ctpc", "invalid": true, "replace_with": "CONVERT_TO=proton_c"},
     "CONVERT_TO_PROTON_C": {"info_key": "_invalid.ctpc", "invalid": true, "replace_with": "CONVERT_TO=proton_c"},
+    "DEFAULT_FOLDER": {"info_key": "_invalid.default_folder", "invalid": true},
     "VIAL_ENABLE": {"info_key": "_invalid.vial", "invalid": true}
 }

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -364,8 +364,6 @@ This is a [make](https://www.gnu.org/software/make/manual/make.html) file that i
 
 ## Build Options
 
-* `DEFAULT_FOLDER`
-  * Used to specify a default folder when a keyboard has more than one sub-folder.
 * `FIRMWARE_FORMAT`
   * Defines which format (bin, hex) is copied to the root `qmk_firmware` folder after building.
 * `SRC`

--- a/lib/python/qmk/cli/ci/validate_aliases.py
+++ b/lib/python/qmk/cli/ci/validate_aliases.py
@@ -2,7 +2,7 @@
 """
 from milc import cli
 
-from qmk.keyboard import resolve_keyboard, keyboard_folder, keyboard_alias_definitions
+from qmk.keyboard import keyboard_folder, keyboard_alias_definitions
 
 
 def _safe_keyboard_folder(target):
@@ -15,10 +15,6 @@ def _safe_keyboard_folder(target):
 def _target_keyboard_exists(target):
     # If there's no target, then we can't build it.
     if not target:
-        return False
-
-    # If the target directory existed but there was no rules.mk or rules.mk was incorrectly parsed, then we can't build it.
-    if not resolve_keyboard(target):
         return False
 
     # If the target directory exists but it itself has an invalid alias or invalid rules.mk, then we can't build it either.

--- a/lib/python/qmk/cli/list/keyboards.py
+++ b/lib/python/qmk/cli/list/keyboards.py
@@ -5,10 +5,9 @@ from milc import cli
 import qmk.keyboard
 
 
-@cli.argument('--no-resolve-defaults', arg_only=True, action='store_false', help='Ignore any "DEFAULT_FOLDER" within keyboards rules.mk')
 @cli.subcommand("List the keyboards currently defined within QMK")
 def list_keyboards(cli):
     """List the keyboards currently defined within QMK
     """
-    for keyboard_name in qmk.keyboard.list_keyboards(cli.args.no_resolve_defaults):
+    for keyboard_name in qmk.keyboard.list_keyboards():
         print(keyboard_name)

--- a/lib/python/qmk/cli/migrate.py
+++ b/lib/python/qmk/cli/migrate.py
@@ -6,14 +6,14 @@ from dotty_dict import dotty
 
 from milc import cli
 
-from qmk.keyboard import keyboard_completer, keyboard_folder, resolve_keyboard
+from qmk.keyboard import keyboard_completer, keyboard_folder
 from qmk.info import info_json, find_info_json
 from qmk.json_encoders import InfoJSONEncoder
 from qmk.json_schema import json_load
 
 
 def _candidate_files(keyboard):
-    kb_dir = Path(resolve_keyboard(keyboard))
+    kb_dir = Path(keyboard)
 
     cur_dir = Path('keyboards')
     files = []

--- a/lib/python/qmk/cli/resolve_alias.py
+++ b/lib/python/qmk/cli/resolve_alias.py
@@ -5,7 +5,7 @@ from milc import cli
 
 @cli.argument('--allow-unknown', arg_only=True, action='store_true', help="Return original if rule is not a valid keyboard.")
 @cli.argument('keyboard', arg_only=True, help='The keyboard\'s name')
-@cli.subcommand('Resolve DEFAULT_FOLDER and any keyboard_aliases for provided rule')
+@cli.subcommand('Resolve any keyboard_aliases for provided rule')
 def resolve_alias(cli):
     try:
         print(keyboard_folder(cli.args.keyboard))

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -223,12 +223,6 @@ def _validate(keyboard, info_data):
 def info_json(keyboard, force_layout=None):
     """Generate the info.json data for a specific keyboard.
     """
-    cur_dir = Path('keyboards')
-    root_rules_mk = parse_rules_mk_file(cur_dir / keyboard / 'rules.mk')
-
-    if 'DEFAULT_FOLDER' in root_rules_mk:
-        keyboard = root_rules_mk['DEFAULT_FOLDER']
-
     info_data = {
         'keyboard_name': str(keyboard),
         'keyboard_folder': str(keyboard),
@@ -1004,11 +998,6 @@ def find_info_json(keyboard):
     keyboard_path = base_path / keyboard
     keyboard_parent = keyboard_path.parent
     info_jsons = [keyboard_path / 'info.json', keyboard_path / 'keyboard.json']
-
-    # Add DEFAULT_FOLDER before parents, if present
-    rules = rules_mk(keyboard)
-    if 'DEFAULT_FOLDER' in rules:
-        info_jsons.append(Path(rules['DEFAULT_FOLDER']) / 'info.json')
 
     # Add in parent folders for least specific
     for _ in range(5):

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -21,11 +21,9 @@ def is_keyboard(keyboard_name):
     if Path(keyboard_name).is_absolute():
         return False
 
-    keyboard_path = QMK_FIRMWARE / 'keyboards' / keyboard_name
-    rules_mk = keyboard_path / 'rules.mk'
-    keyboard_json = keyboard_path / 'keyboard.json'
+    keyboard_json = QMK_FIRMWARE / 'keyboards' / keyboard_name  / 'keyboard.json'
 
-    return rules_mk.exists() or keyboard_json.exists()
+    return keyboard_json.exists()
 
 
 def under_qmk_firmware(path=Path(os.environ['ORIG_CWD'])):

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -21,7 +21,7 @@ def is_keyboard(keyboard_name):
     if Path(keyboard_name).is_absolute():
         return False
 
-    keyboard_json = QMK_FIRMWARE / 'keyboards' / keyboard_name  / 'keyboard.json'
+    keyboard_json = QMK_FIRMWARE / 'keyboards' / keyboard_name / 'keyboard.json'
 
     return keyboard_json.exists()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently `DEFAULT_FOLDER` serves 2 main purposes:

1. Maintaining backwards compatibility when new keyboard revision is added
    * The existing `make <vendor>/<product>`  can be mapped to `make <vendor>/<product>/rev1`
2. Parent folders contain common configuration
    * The presence of a `rules.mk` creates a build target that only has partial information and cannot be built 

Unfortunately an additional purpose has been adopted:

3. Providing a shorter form for users to specify in terminal commands

### Issues

While the current solution "works", there are a fair few problems this functionality causes:

1. Many keyboards within the repo put config in incorrect locations and rely on `DEFAULT_FOLDER` to patch up the problems
2. Keyboard updates can change `DEFAULT_FOLDER` to a new revision and not maintain backwards compatibility
3. `DEFAULT_FOLDER` can be set incorrectly (eg on keyboard relocation) and fail to compile
4. `rules.mk` gets parsed multiple times netting slower builds
5. CI can fail to understand the implications of a parent file changing
6. CI can end up building the same build target multiple times

As keyboard updates generally now require going to `develop`, purpose 1 is mostly mitigated.

With the introduction of `keyboard.json` as a build target, `rules.mk` can now become pure config. This solves purpose 2.

Purpose 3 can use the existing framework of keyboard aliases, but could generally target a solution more user focused (eg fuzzy matching, searching, TUI, etc).
 
### Proposal

This PR aims to remove the `DEFAULT_FOLDER` functionality now that everything is worked around, and mitigated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
