### PR TITLE
Notify about OS detection change on the slave

### DIFF
--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -175,6 +175,7 @@ void slave_update_detected_host_os(os_variant_t os) {
     detected_os = os;
     last_time   = timer_read_fast();
     debouncing  = true;
+    process_detected_host_os_kb(os);
 }
 #endif
 


### PR DESCRIPTION
Make process_detected_os_* work on the slave side of the keyboard in order to be able to customize LED effects based on the OS.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
    No OS detection tests as far as I can see.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
