### PR TITLE
 Swift65 Solder Layout Name Standardization

### DIFF
--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -52,7 +52,8 @@
         "LAYOUT_625u_space": "LAYOUT_ansi_blocker",
         "LAYOUT_625u_space_split_bs": "LAYOUT_ansi_blocker_split_bs",
         "LAYOUT_7u_space": "LAYOUT_ansi_blocker_tsangan",
-        "LAYOUT_7u_space_split_bs": "LAYOUT_ansi_blocker_tsangan_split_bs"
+        "LAYOUT_7u_space_split_bs": "LAYOUT_ansi_blocker_tsangan_split_bs",
+        "LAYOUT_iso_625u_space": "LAYOUT_iso_blocker"
     },
     "layouts": {
         "LAYOUT_ansi_blocker": {
@@ -367,7 +368,7 @@
                 {"matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_iso_625u_space": {
+        "LAYOUT_iso_blocker": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -50,7 +50,8 @@
         "LAYOUT": "LAYOUT_ansi_blocker_split_bs",
         "LAYOUT_all": "LAYOUT_ansi_blocker_split_bs",
         "LAYOUT_625u_space": "LAYOUT_ansi_blocker",
-        "LAYOUT_625u_space_split_bs": "LAYOUT_ansi_blocker_split_bs"
+        "LAYOUT_625u_space_split_bs": "LAYOUT_ansi_blocker_split_bs",
+        "LAYOUT_7u_space": "LAYOUT_ansi_blocker_tsangan"
     },
     "layouts": {
         "LAYOUT_ansi_blocker": {
@@ -210,7 +211,7 @@
                 {"matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_7u_space": {
+        "LAYOUT_ansi_blocker_tsangan": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -47,9 +47,10 @@
     "processor": "atmega32u4",
     "bootloader": "atmel-dfu",
     "layout_aliases": {
-        "LAYOUT": "LAYOUT_625u_space_split_bs",
-        "LAYOUT_all": "LAYOUT_625u_space_split_bs",
-        "LAYOUT_625u_space": "LAYOUT_ansi_blocker"
+        "LAYOUT": "LAYOUT_ansi_blocker_split_bs",
+        "LAYOUT_all": "LAYOUT_ansi_blocker_split_bs",
+        "LAYOUT_625u_space": "LAYOUT_ansi_blocker",
+        "LAYOUT_625u_space_split_bs": "LAYOUT_ansi_blocker_split_bs"
     },
     "layouts": {
         "LAYOUT_ansi_blocker": {
@@ -130,7 +131,7 @@
                 {"matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_625u_space_split_bs": {
+        "LAYOUT_ansi_blocker_split_bs": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -54,7 +54,8 @@
         "LAYOUT_7u_space": "LAYOUT_ansi_blocker_tsangan",
         "LAYOUT_7u_space_split_bs": "LAYOUT_ansi_blocker_tsangan_split_bs",
         "LAYOUT_iso_625u_space": "LAYOUT_iso_blocker",
-        "LAYOUT_iso_625u_space_split_bs": "LAYOUT_iso_blocker_split_bs"
+        "LAYOUT_iso_625u_space_split_bs": "LAYOUT_iso_blocker_split_bs",
+        "LAYOUT_iso_7u_space": "LAYOUT_iso_blocker_tsangan"
     },
     "layouts": {
         "LAYOUT_ansi_blocker": {
@@ -528,7 +529,7 @@
                 {"matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_iso_7u_space": {
+        "LAYOUT_iso_blocker_tsangan": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -51,7 +51,8 @@
         "LAYOUT_all": "LAYOUT_ansi_blocker_split_bs",
         "LAYOUT_625u_space": "LAYOUT_ansi_blocker",
         "LAYOUT_625u_space_split_bs": "LAYOUT_ansi_blocker_split_bs",
-        "LAYOUT_7u_space": "LAYOUT_ansi_blocker_tsangan"
+        "LAYOUT_7u_space": "LAYOUT_ansi_blocker_tsangan",
+        "LAYOUT_7u_space_split_bs": "LAYOUT_ansi_blocker_tsangan_split_bs"
     },
     "layouts": {
         "LAYOUT_ansi_blocker": {
@@ -288,7 +289,7 @@
                 {"matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_7u_space_split_bs": {
+        "LAYOUT_ansi_blocker_tsangan_split_bs": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -53,7 +53,8 @@
         "LAYOUT_625u_space_split_bs": "LAYOUT_ansi_blocker_split_bs",
         "LAYOUT_7u_space": "LAYOUT_ansi_blocker_tsangan",
         "LAYOUT_7u_space_split_bs": "LAYOUT_ansi_blocker_tsangan_split_bs",
-        "LAYOUT_iso_625u_space": "LAYOUT_iso_blocker"
+        "LAYOUT_iso_625u_space": "LAYOUT_iso_blocker",
+        "LAYOUT_iso_625u_space_split_bs": "LAYOUT_iso_blocker_split_bs"
     },
     "layouts": {
         "LAYOUT_ansi_blocker": {
@@ -447,7 +448,7 @@
                 {"matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_iso_625u_space_split_bs": {
+        "LAYOUT_iso_blocker_split_bs": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -55,7 +55,8 @@
         "LAYOUT_7u_space_split_bs": "LAYOUT_ansi_blocker_tsangan_split_bs",
         "LAYOUT_iso_625u_space": "LAYOUT_iso_blocker",
         "LAYOUT_iso_625u_space_split_bs": "LAYOUT_iso_blocker_split_bs",
-        "LAYOUT_iso_7u_space": "LAYOUT_iso_blocker_tsangan"
+        "LAYOUT_iso_7u_space": "LAYOUT_iso_blocker_tsangan",
+        "LAYOUT_iso_7u_space_split_bs": "LAYOUT_iso_blocker_tsangan_split_bs"
     },
     "layouts": {
         "LAYOUT_ansi_blocker": {
@@ -607,7 +608,7 @@
                 {"matrix": [4, 14], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_iso_7u_space_split_bs": {
+        "LAYOUT_iso_blocker_tsangan_split_bs": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keyboard.json
+++ b/keyboards/alfredslab/swift65/solder/keyboard.json
@@ -48,10 +48,11 @@
     "bootloader": "atmel-dfu",
     "layout_aliases": {
         "LAYOUT": "LAYOUT_625u_space_split_bs",
-        "LAYOUT_all": "LAYOUT_625u_space_split_bs"
+        "LAYOUT_all": "LAYOUT_625u_space_split_bs",
+        "LAYOUT_625u_space": "LAYOUT_ansi_blocker"
     },
     "layouts": {
-        "LAYOUT_625u_space": {
+        "LAYOUT_ansi_blocker": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/alfredslab/swift65/solder/keymaps/default/keymap.c
+++ b/keyboards/alfredslab/swift65/solder/keymaps/default/keymap.c
@@ -17,14 +17,14 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_625u_space_split_bs(
+    [0] = LAYOUT_ansi_blocker_split_bs(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSPC,   KC_HOME,
         KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,        KC_DEL,
         KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,                KC_PGUP,
         KC_LSFT,            KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LSFT,        KC_UP,
         KC_LCTL,   KC_LGUI,   KC_LALT,                       KC_SPC,                              KC_LALT,   MO(1),          KC_LEFT, KC_DOWN, KC_RGHT
     ),
-    [1] = LAYOUT_625u_space_split_bs(
+    [1] = LAYOUT_ansi_blocker_split_bs(
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL,    _______,
         _______,     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        _______,
         _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,               KC_PGDN,

--- a/keyboards/alfredslab/swift65/solder/keymaps/default/keymap.c
+++ b/keyboards/alfredslab/swift65/solder/keymaps/default/keymap.c
@@ -18,18 +18,18 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_ansi_blocker_split_bs(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSPC,   KC_HOME,
-        KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,        KC_DEL,
-        KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,                KC_PGUP,
-        KC_LSFT,            KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LSFT,        KC_UP,
-        KC_LCTL,   KC_LGUI,   KC_LALT,                       KC_SPC,                              KC_LALT,   MO(1),          KC_LEFT, KC_DOWN, KC_RGHT
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSPC,    KC_HOME,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,             KC_DEL,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,              KC_PGUP,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LSFT, KC_UP,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                    KC_LALT, MO(1),            KC_LEFT, KC_DOWN, KC_RGHT
     ),
     [1] = LAYOUT_ansi_blocker_split_bs(
-        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL,    _______,
-        _______,     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        _______,
-        _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,               KC_PGDN,
-        QK_BOOT,              _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        KC_PGUP,
-        _______,   _______,   _______,                      _______,                              _______,   _______,        KC_HOME, KC_PGDN, KC_END
+        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL,     _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,             KC_PGDN,
+        QK_BOOT,          _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_PGUP,
+        _______, _______, _______,                            _______,                   _______, _______,          KC_HOME, KC_PGDN, KC_END
     ),
 
 };

--- a/keyboards/alfredslab/swift65/solder/keymaps/via/keymap.c
+++ b/keyboards/alfredslab/swift65/solder/keymaps/via/keymap.c
@@ -17,28 +17,28 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_625u_space_split_bs(
+    [0] = LAYOUT_ansi_blocker_split_bs(
         KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSPC,   KC_HOME,
         KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,        KC_DEL,
         KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,                KC_PGUP,
         KC_LSFT,            KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LSFT,        KC_UP,
         KC_LCTL,   KC_LGUI,   KC_LALT,                       KC_SPC,                              KC_LALT,   MO(1),          KC_LEFT, KC_DOWN, KC_RGHT
     ),
-    [1] = LAYOUT_625u_space_split_bs(
+    [1] = LAYOUT_ansi_blocker_split_bs(
         KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL,    _______,
         _______,     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        _______,
         _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,               KC_PGDN,
         QK_BOOT,              _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        KC_PGUP,
         _______,   _______,   _______,                      _______,                              _______,   _______,        KC_HOME, KC_PGDN, KC_END
     ),
-    [2] = LAYOUT_625u_space_split_bs(
+    [2] = LAYOUT_ansi_blocker_split_bs(
         KC_TRNS,  KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS,
         KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,        KC_TRNS,
         KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS,
         KC_TRNS,              KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,        KC_TRNS,
         KC_TRNS,   KC_TRNS,   KC_TRNS,                      KC_TRNS,                              KC_TRNS,   KC_TRNS,        KC_TRNS, KC_TRNS, KC_TRNS
     ),
-    [3] = LAYOUT_625u_space_split_bs(
+    [3] = LAYOUT_ansi_blocker_split_bs(
         KC_TRNS,  KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS,
         KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,        KC_TRNS,
         KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS,

--- a/keyboards/alfredslab/swift65/solder/keymaps/via/keymap.c
+++ b/keyboards/alfredslab/swift65/solder/keymaps/via/keymap.c
@@ -18,32 +18,32 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_ansi_blocker_split_bs(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSPC,   KC_HOME,
-        KC_TAB,      KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,        KC_DEL,
-        KC_CAPS,       KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,                KC_PGUP,
-        KC_LSFT,            KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LSFT,        KC_UP,
-        KC_LCTL,   KC_LGUI,   KC_LALT,                       KC_SPC,                              KC_LALT,   MO(1),          KC_LEFT, KC_DOWN, KC_RGHT
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSPC,    KC_HOME,
+        KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,             KC_DEL,
+        KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,              KC_PGUP,
+        KC_LSFT,          KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_LSFT, KC_UP,
+        KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                    KC_LALT, MO(1),            KC_LEFT, KC_DOWN, KC_RGHT
     ),
     [1] = LAYOUT_ansi_blocker_split_bs(
-        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL,    _______,
-        _______,     _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        _______,
-        _______,       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,               KC_PGDN,
-        QK_BOOT,              _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,        KC_PGUP,
-        _______,   _______,   _______,                      _______,                              _______,   _______,        KC_HOME, KC_PGDN, KC_END
+        KC_GRV,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, KC_DEL,     _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,             _______,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______,             KC_PGDN,
+        QK_BOOT,          _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_PGUP,
+        _______, _______, _______,                            _______,                   _______, _______,          KC_HOME, KC_PGDN, KC_END
     ),
     [2] = LAYOUT_ansi_blocker_split_bs(
-        KC_TRNS,  KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS,
-        KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,        KC_TRNS,
-        KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS,
-        KC_TRNS,              KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,        KC_TRNS,
-        KC_TRNS,   KC_TRNS,   KC_TRNS,                      KC_TRNS,                              KC_TRNS,   KC_TRNS,        KC_TRNS, KC_TRNS, KC_TRNS
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,    KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,             KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,             KC_TRNS,
+        KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                   KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS
     ),
     [3] = LAYOUT_ansi_blocker_split_bs(
-        KC_TRNS,  KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,   KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS, KC_TRNS,  KC_TRNS,
-        KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,        KC_TRNS,
-        KC_TRNS,       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,               KC_TRNS,
-        KC_TRNS,              KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,        KC_TRNS,
-        KC_TRNS,   KC_TRNS,   KC_TRNS,                      KC_TRNS,                              KC_TRNS,   KC_TRNS,        KC_TRNS, KC_TRNS, KC_TRNS
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,    KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,             KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,          KC_TRNS,             KC_TRNS,
+        KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,                            KC_TRNS,                   KC_TRNS, KC_TRNS,          KC_TRNS, KC_TRNS, KC_TRNS
     ),
 
 };


### PR DESCRIPTION
## Description

- Renames the layout macros to have more standard names
- Refactors the keymaps

cc @spooknik (keyboard maintainer)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
