### PR TITLE
Remove RGBLight `led[]` references

### DIFF
--- a/keyboards/handwired/lovelive9/keymaps/default/keymap.c
+++ b/keyboards/handwired/lovelive9/keymaps/default/keymap.c
@@ -154,26 +154,22 @@ int aqours_color_v[] = {255, 255, 255, 255, 255, 255, 200, 255, 255};
 
 void LED_default_set(void) {
 
-  sethsv(aqours_color_h[2], aqours_color_s[2], aqours_color_v[2], (rgb_led_t *)&led[0]);
-  sethsv(aqours_color_h[7], aqours_color_s[7], aqours_color_v[7], (rgb_led_t *)&led[1]);
-  sethsv(aqours_color_h[1], aqours_color_s[1], aqours_color_v[1], (rgb_led_t *)&led[2]);
-  sethsv(aqours_color_h[5], aqours_color_s[5], aqours_color_v[5], (rgb_led_t *)&led[3]);
-  sethsv(aqours_color_h[8], aqours_color_s[8], aqours_color_v[8], (rgb_led_t *)&led[4]);
-  sethsv(aqours_color_h[6], aqours_color_s[6], aqours_color_v[6], (rgb_led_t *)&led[5]);
-  sethsv(aqours_color_h[0], aqours_color_s[0], aqours_color_v[0], (rgb_led_t *)&led[6]);
-  sethsv(aqours_color_h[4], aqours_color_s[4], aqours_color_v[4], (rgb_led_t *)&led[7]);
-  sethsv(aqours_color_h[3], aqours_color_s[3], aqours_color_v[3], (rgb_led_t *)&led[8]);
-
-  rgblight_set();
-
+  rgblight_sethsv_at(aqours_color_h[2], aqours_color_s[2], aqours_color_v[2], 0);
+  rgblight_sethsv_at(aqours_color_h[7], aqours_color_s[7], aqours_color_v[7], 1);
+  rgblight_sethsv_at(aqours_color_h[1], aqours_color_s[1], aqours_color_v[1], 2);
+  rgblight_sethsv_at(aqours_color_h[5], aqours_color_s[5], aqours_color_v[5], 3);
+  rgblight_sethsv_at(aqours_color_h[8], aqours_color_s[8], aqours_color_v[8], 4);
+  rgblight_sethsv_at(aqours_color_h[6], aqours_color_s[6], aqours_color_v[6], 5);
+  rgblight_sethsv_at(aqours_color_h[0], aqours_color_s[0], aqours_color_v[0], 6);
+  rgblight_sethsv_at(aqours_color_h[4], aqours_color_s[4], aqours_color_v[4], 7);
+  rgblight_sethsv_at(aqours_color_h[3], aqours_color_s[3], aqours_color_v[3], 8);
 }
 
 
 void LED_layer_set(int aqours_index) {
   for (int c = 0; c < 9; c++) {
-    sethsv(aqours_color_h[aqours_index], aqours_color_s[aqours_index], aqours_color_v[aqours_index], (rgb_led_t *)&led[c]);
+    rgblight_sethsv_at(aqours_color_h[aqours_index], aqours_color_s[aqours_index], aqours_color_v[aqours_index], c);
   }
-  rgblight_set();
 }
 
 

--- a/keyboards/hineybush/hbcp/hbcp.c
+++ b/keyboards/hineybush/hbcp/hbcp.c
@@ -49,21 +49,20 @@ bool led_update_kb(led_t led_state) {
     bool res = led_update_user(led_state);
     if (res) {
         if (led_state.caps_lock) {
-            sethsv_raw(HSV_CAPS, (rgb_led_t *)&led[0]);
+            rgblight_sethsv_at(HSV_CAPS, 0);
         } else {
-            sethsv(HSV_BLACK, (rgb_led_t *)&led[0]);
+            rgblight_sethsv_at(HSV_BLACK, 0);
         }
         if (led_state.num_lock) {
-            sethsv_raw(HSV_NLCK, (rgb_led_t *)&led[1]);
+            rgblight_sethsv_at(HSV_NLCK, 1);
         } else {
-            sethsv(HSV_BLACK, (rgb_led_t *)&led[1]);
+            rgblight_sethsv_at(HSV_BLACK, 1);
         }
         if (led_state.scroll_lock) {
-            sethsv_raw(HSV_SCRL, (rgb_led_t *)&led[2]);
+            rgblight_sethsv_at(HSV_SCRL, 2);
         } else {
-            sethsv(HSV_BLACK, (rgb_led_t *)&led[2]);
+            rgblight_sethsv_at(HSV_BLACK, 2);
         }
-        rgblight_set();
     }
     return false;
 }

--- a/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/ortho/keymaps/default/keymap.c
@@ -217,23 +217,23 @@ void keyboard_post_init_user(void) {
         rgblight_sethsv_noeeprom(50, 255, 100);
         rgblight_mode_noeeprom(RGBLIGHT_EFFECT_BREATHING + 2);
 // Init the second LED to a static color:
-        setrgb(225, 185, 0, (rgb_led_t *)&led[1]);
-    rgblight_set();
+        rgblight_setrgb_at(225, 185, 0, 1);
   #endif // RGBLIGHT_ENABLE
 }
 
 // RGB Indicator Customization: (cont.)
 layer_state_t layer_state_set_user(layer_state_t state){
     #ifdef RGBLIGHT_ENABLE
-        uint8_t led1r = 0; uint8_t led1g = 0; uint8_t led1b = 0;
-            if (layer_state_cmp(state, 1)) {
-                led1b = 255;
-            }
-            if (layer_state_cmp(state, 3)) {
-                led1r = 200;
-            }
-            setrgb(led1r, led1g, led1b, (rgb_led_t *)&led[1]);
-        rgblight_set();
+        uint8_t led1r = 0;
+        uint8_t led1g = 0;
+        uint8_t led1b = 0;
+        if (layer_state_cmp(state, 1)) {
+            led1b = 255;
+        }
+        if (layer_state_cmp(state, 3)) {
+            led1r = 200;
+        }
+        rgblight_setrgb_at(led1r, led1g, led1b, 1);
     #endif //RGBLIGHT_ENABLE
   return state;
 }

--- a/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
+++ b/keyboards/kingly_keys/ave/staggered/keymaps/default/keymap.c
@@ -217,23 +217,24 @@ void keyboard_post_init_user(void) {
         rgblight_sethsv_noeeprom(50, 255, 100);
         rgblight_mode_noeeprom(RGBLIGHT_EFFECT_BREATHING + 2);
 // Init the second LED to a static color:
-        setrgb(225, 185, 0, (rgb_led_t *)&led[1]);
-    rgblight_set();
+        rgblight_setrgb_at(225, 185, 0, 1);
   #endif // RGBLIGHT_ENABLE
 }
 
 // RGB Indicator Customization: (cont.)
 layer_state_t layer_state_set_user(layer_state_t state){
     #ifdef RGBLIGHT_ENABLE
-        uint8_t led1r = 0; uint8_t led1g = 0; uint8_t led1b = 0;
-            if (layer_state_cmp(state, 1)) {
-                led1b = 255;
-            }
-            if (layer_state_cmp(state, 3)) {
-                led1r = 200;
-            }
-            setrgb(led1r, led1g, led1b, (rgb_led_t *)&led[1]);
-        rgblight_set();
+        uint8_t led1r = 0;
+        uint8_t led1g = 0;
+        uint8_t led1b = 0;
+
+        if (layer_state_cmp(state, 1)) {
+            led1b = 255;
+        }
+        if (layer_state_cmp(state, 3)) {
+            led1r = 200;
+        }
+        rgblight_setrgb_at(led1r, led1g, led1b, 1);
     #endif //RGBLIGHT_ENABLE
   return state;
 }

--- a/keyboards/manyboard/macro/keymaps/default/keymap.c
+++ b/keyboards/manyboard/macro/keymaps/default/keymap.c
@@ -41,16 +41,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 layer_state_t layer_state_set_user(layer_state_t state) {
     switch (get_highest_layer(state)) {
         case 0:
-            sethsv(HSV_WHITE, (rgb_led_t *)&led[0]);
-            rgblight_set();
+            rgblight_sethsv_at(HSV_WHITE, 0);
             break;
         case 1:
-            sethsv(HSV_GREEN, (rgb_led_t *)&led[0]);
-            rgblight_set();
+            rgblight_sethsv_at(HSV_GREEN, 0);
             break;
         case 2:
-            sethsv(HSV_BLUE, (rgb_led_t *)&led[0]);
-            rgblight_set();
+            rgblight_sethsv_at(HSV_BLUE, 0);
             break;
     }
     return state;

--- a/keyboards/manyboard/macro/keymaps/via/keymap.c
+++ b/keyboards/manyboard/macro/keymaps/via/keymap.c
@@ -41,16 +41,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 layer_state_t layer_state_set_user(layer_state_t state) {
     switch (get_highest_layer(state)) {
         case 0:
-            sethsv(HSV_WHITE, (rgb_led_t *)&led[0]);
-            rgblight_set();
+            rgblight_sethsv_at(HSV_WHITE, 0);
             break;
         case 1:
-            sethsv(HSV_GREEN, (rgb_led_t *)&led[0]);
-            rgblight_set();
+            rgblight_sethsv_at(HSV_GREEN, 0);
             break;
         case 2:
-            sethsv(HSV_BLUE, (rgb_led_t *)&led[0]);
-            rgblight_set();
+            rgblight_sethsv_at(HSV_BLUE, 0);
             break;
     }
     return state;

--- a/keyboards/tetris/keymaps/default/keymap.c
+++ b/keyboards/tetris/keymaps/default/keymap.c
@@ -94,44 +94,43 @@ void matrix_scan_user(void) {
         uint16_t kc = keymap_key_to_keycode(layer, (keypos_t) {.row = 0, .col = i
         });
         if (kc == KC_TRNS) {
-          setrgb(5, 5, 5, (rgb_led_t * ) & led[j]); /* TRNS color 0-255*/
+          rgblight_setrgb_at(5, 5, 5, j); /* TRNS color 0-255*/
         } else if (kc == KC_NO) {
-          setrgb(0, 0, 0, (rgb_led_t * ) & led[j]); /* NO color 0-255*/
+          rgblight_setrgb_at(0, 0, 0, j); /* NO color 0-255*/
         } else {
           if (layer == 1) {
-            setrgb(128, 64, 0, (rgb_led_t * ) & led[j]); /* 1 layer 0-255*/
+            rgblight_setrgb_at(128, 64, 0, j); /* 1 layer 0-255*/
           } else if (layer == 2) {
-            setrgb(0, 64, 128, (rgb_led_t * ) & led[j]); /* 2*/
+            rgblight_setrgb_at(0, 64, 128, j); /* 2*/
           } else if (layer == 3) {
-            setrgb(64, 128, 0, (rgb_led_t * ) & led[j]); /* 3*/
+            rgblight_setrgb_at(64, 128, 0, j); /* 3*/
           } else if (layer == 4) {
-            setrgb(0, 128, 64, (rgb_led_t * ) & led[j]); /* 4*/
+            rgblight_setrgb_at(0, 128, 64, j); /* 4*/
           } else if (layer == 5) {
-            setrgb(128, 0, 128, (rgb_led_t * ) & led[j]); /* 5*/
+            rgblight_setrgb_at(128, 0, 128, j); /* 5*/
           } else if (layer == 6) {
-            setrgb(128, 0, 128, (rgb_led_t * ) & led[j]); /* 6*/
+            rgblight_setrgb_at(128, 0, 128, j); /* 6*/
           } else if (layer == 7) {
-            setrgb(128, 128, 0, (rgb_led_t * ) & led[j]); /* 7*/
+            rgblight_setrgb_at(128, 128, 0, j); /* 7*/
           } else if (layer == 8) {
-            setrgb(0, 128, 128, (rgb_led_t * ) & led[j]); /* 8*/
+            rgblight_setrgb_at(0, 128, 128, j); /* 8*/
           } else if (layer == 9) {
-            setrgb(128, 192, 64, (rgb_led_t * ) & led[j]); /* 9*/
+            rgblight_setrgb_at(128, 192, 64, j); /* 9*/
           } else if (layer == 10) {
-            setrgb(64, 192, 128, (rgb_led_t * ) & led[j]); /* 10*/
+            rgblight_setrgb_at(64, 192, 128, j); /* 10*/
           } else if (layer == 11) {
-            setrgb(128, 64, 192, (rgb_led_t * ) & led[j]); /* 11*/
+            rgblight_setrgb_at(128, 64, 192, j); /* 11*/
           } else if (layer == 12) {
-            setrgb(64, 128, 192, (rgb_led_t * ) & led[j]); /* 12*/
+            rgblight_setrgb_at(64, 128, 192, j); /* 12*/
           } else if (layer == 13) {
-            setrgb(128, 192, 0, (rgb_led_t * ) & led[j]); /* 13*/
+            rgblight_setrgb_at(128, 192, 0, j); /* 13*/
           } else if (layer == 14) {
-            setrgb(192, 0, 128, (rgb_led_t * ) & led[j]); /* 14*/
+            rgblight_setrgb_at(192, 0, 128, j); /* 14*/
           } else if (layer == 15) {
-            setrgb(0, 192, 128, (rgb_led_t * ) & led[j]); /* 15*/
+            rgblight_setrgb_at(0, 192, 128, j); /* 15*/
           }
         }
       }
-      rgblight_set();
     }
     has_layer_changed = false;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Part of an effort to move responsibility for the pixel buffer to the LED drivers instead of the RGBLight feature itself. The next part will involve removing the `extern`ed LED array.

These were easy-ish, but there are more which actually read from the array instead of writing to it, and there is no real replacement for this. They may end up having to be removed altogether.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
