### PR TITLE
Assume only 32u4 boards can run 'promicro' converters

### DIFF
--- a/builddefs/converters.mk
+++ b/builddefs/converters.mk
@@ -5,8 +5,10 @@ ifneq ($(findstring yes, $(CTPC)$(CONVERT_TO_PROTON_C)),)
 $(call CATASTROPHIC_ERROR,The `CONVERT_TO_PROTON_C` and `CTPC` options are now deprecated. `CONVERT_TO=proton_c` should be used instead.)
 endif
 
-# TODO: opt in rather than assume everything uses a pro micro
-PIN_COMPATIBLE ?= promicro
+ifneq (,$(filter $(MCU),atmega32u4))
+    # TODO: opt in rather than assume everything uses a pro micro
+    PIN_COMPATIBLE ?= promicro
+endif
 
 # Remove whitespace from any rule.mk provided vars
 #   - env cannot be overwritten but cannot have whitespace anyway
@@ -15,6 +17,10 @@ ifneq ($(CONVERT_TO),)
 
     # stash so we can overwrite env provided vars if needed
     ACTIVE_CONVERTER=$(CONVERT_TO)
+
+    ifeq ($(PIN_COMPATIBLE),)
+        $(call CATASTROPHIC_ERROR,Converting to '$(CONVERT_TO)' not possible!)
+    endif
 
     # glob to search each platfrorm and/or check for valid converter
     CONVERTER := $(wildcard $(PLATFORM_PATH)/*/converters/$(PIN_COMPATIBLE)_to_$(CONVERT_TO)/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Users should not be trying to target "blackpill" based boards with the current available converters.

The following is logically incorrect...
```
qmk compile -kb cantor -km default -e CONVERT_TO=promicro_rp2040
```
However the error should be a bit more human readable than what is produced.

Long term, #20330 will solve the issue but that involves many keyboard upates.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://discord.com/channels/440868230475677696/867530222407778344/1219772124542013543

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
