### PR TITLE
Fix invalid use of stemcell converter

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/v2/stemcell/config.h
+++ b/keyboards/bastardkb/charybdis/3x5/v2/stemcell/config.h
@@ -39,15 +39,14 @@
 
 /* SPI config for pmw3360 sensor. */
 #define SPI_DRIVER SPID1
-#define SPI_SCK_PIN B1
+#define SPI_SCK_PIN A5
 #define SPI_SCK_PAL_MODE 5
-#define SPI_MOSI_PIN B2
+#define SPI_MOSI_PIN A7
 #define SPI_MOSI_PAL_MODE 5
-#define SPI_MISO_PIN B3
+#define SPI_MISO_PIN A6
 #define SPI_MISO_PAL_MODE 5
 
 /* PMW3360 settings. */
-#define A1 PAL_LINE(GPIOA, 1)
 #define POINTING_DEVICE_CS_PIN A1
 #define PMW3360_CS_MODE 3
 #define PMW3360_CS_DIVISOR 64

--- a/keyboards/bastardkb/charybdis/3x5/v2/stemcell/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/v2/stemcell/info.json
@@ -7,20 +7,19 @@
         "driver": "ws2812"
     },
     "ws2812": {
-        "pin": "D3",
+        "pin": "A2",
         "driver": "pwm"
     },
     "build": {
         "debounce_type": "asym_eager_defer_pk"
     },
     "matrix_pins": {
-        "cols": ["F5", "B6", "D7", "E6", "B4"],
-        "rows": ["F7", "C6", "D4", "B5"]
+        "cols": ["B2", "A4", "B4", "B5", "B8"],
+        "rows": ["B0", "B3", "A15", "B9"]
     },
     "diode_direction": "ROW2COL",
     "split": {
-        "soft_serial_pin": "D2"
+        "soft_serial_pin": "A3"
     },
-    "processor": "STM32F411",
-    "bootloader": "stm32-dfu"
+    "development_board": "stemcell"
 }

--- a/keyboards/bastardkb/charybdis/3x5/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/v2/stemcell/rules.mk
@@ -1,5 +1,3 @@
-CONVERT_TO = stemcell
-
 # Build Options
 #   change yes to no to disable
 #

--- a/keyboards/bastardkb/charybdis/3x6/v2/stemcell/config.h
+++ b/keyboards/bastardkb/charybdis/3x6/v2/stemcell/config.h
@@ -39,15 +39,14 @@
 
 /* SPI config for pmw3360 sensor. */
 #define SPI_DRIVER SPID1
-#define SPI_SCK_PIN B1
+#define SPI_SCK_PIN A5
 #define SPI_SCK_PAL_MODE 5
-#define SPI_MOSI_PIN B2
+#define SPI_MOSI_PIN A7
 #define SPI_MOSI_PAL_MODE 5
-#define SPI_MISO_PIN B3
+#define SPI_MISO_PIN A6
 #define SPI_MISO_PAL_MODE 5
 
 /* PMW3360 settings. */
-#define A1 PAL_LINE(GPIOA, 1)
 #define POINTING_DEVICE_CS_PIN A1
 #define PMW3360_CS_MODE 3
 #define PMW3360_CS_DIVISOR 64

--- a/keyboards/bastardkb/charybdis/3x6/v2/stemcell/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/v2/stemcell/info.json
@@ -7,20 +7,19 @@
         "driver": "ws2812"
     },
     "ws2812": {
-        "pin": "D3",
+        "pin": "A2",
         "driver": "pwm"
     },
     "build": {
         "debounce_type": "asym_eager_defer_pk"
     },
     "matrix_pins": {
-        "cols": ["F6", "F5", "B6", "D7", "E6", "B4"],
-        "rows": ["F7", "C6", "D4", "B5"]
+        "cols": ["B1", "B2", "A4", "B4", "B5", "B8"],
+        "rows": ["B0", "B3", "A15", "B9"]
     },
     "diode_direction": "ROW2COL",
     "split": {
-        "soft_serial_pin": "D2"
+        "soft_serial_pin": "A3"
     },
-    "processor": "STM32F411",
-    "bootloader": "stm32-dfu"
+    "development_board": "stemcell"
 }

--- a/keyboards/bastardkb/charybdis/3x6/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/v2/stemcell/rules.mk
@@ -1,5 +1,3 @@
-CONVERT_TO = stemcell
-
 # Build Options
 #   change yes to no to disable
 #

--- a/keyboards/bastardkb/charybdis/4x6/v2/stemcell/config.h
+++ b/keyboards/bastardkb/charybdis/4x6/v2/stemcell/config.h
@@ -39,15 +39,14 @@
 
 /* SPI config for pmw3360 sensor. */
 #define SPI_DRIVER SPID1
-#define SPI_SCK_PIN B1
+#define SPI_SCK_PIN A5
 #define SPI_SCK_PAL_MODE 5
-#define SPI_MOSI_PIN B2
+#define SPI_MOSI_PIN A7
 #define SPI_MOSI_PAL_MODE 5
-#define SPI_MISO_PIN B3
+#define SPI_MISO_PIN A6
 #define SPI_MISO_PAL_MODE 5
 
 /* PMW3360 settings. */
-#define A1 PAL_LINE(GPIOA, 1)
 #define POINTING_DEVICE_CS_PIN A1
 #define PMW3360_CS_MODE 3
 #define PMW3360_CS_DIVISOR 64

--- a/keyboards/bastardkb/charybdis/4x6/v2/stemcell/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/v2/stemcell/info.json
@@ -7,20 +7,19 @@
         "driver": "ws2812"
     },
     "ws2812": {
-        "pin": "D3",
+        "pin": "A2",
         "driver": "pwm"
     },
     "build": {
         "debounce_type": "asym_eager_defer_pk"
     },
     "matrix_pins": {
-        "cols": ["F6", "F5", "B6", "D7", "E6", "B4"],
-        "rows": ["F4", "F7", "C6", "D4", "B5"]
+        "cols": ["B1", "B2", "A4", "B4", "B5", "B8"],
+        "rows": ["B10", "B0", "B3", "A15", "B9"]
     },
     "diode_direction": "ROW2COL",
     "split": {
-        "soft_serial_pin": "D2"
+        "soft_serial_pin": "A3"
     },
-    "processor": "STM32F411",
-    "bootloader": "stm32-dfu"
+    "development_board": "stemcell"
 }

--- a/keyboards/bastardkb/charybdis/4x6/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/v2/stemcell/rules.mk
@@ -1,5 +1,3 @@
-CONVERT_TO = stemcell
-
 # Build Options
 #   change yes to no to disable
 #

--- a/keyboards/bastardkb/scylla/v2/stemcell/info.json
+++ b/keyboards/bastardkb/scylla/v2/stemcell/info.json
@@ -7,20 +7,19 @@
         "driver": "ws2812"
     },
     "ws2812": {
-        "pin": "D3",
+        "pin": "A2",
         "driver": "pwm"
     },
     "build": {
         "debounce_type": "asym_eager_defer_pk"
     },
     "matrix_pins": {
-        "cols": ["F6", "F5", "B6", "D7", "E6", "B4"],
-        "rows": ["F4", "F7", "C6", "D4", "B5"]
+        "cols": ["B1", "B2", "A4", "B4", "B5", "B8"],
+        "rows": ["B10", "B0", "B3", "A15", "B9"]
     },
     "diode_direction": "ROW2COL",
     "split": {
-        "soft_serial_pin": "D2"
+        "soft_serial_pin": "A3"
     },
-    "processor": "STM32F411",
-    "bootloader": "stm32-dfu"
+    "development_board": "stemcell"
 }

--- a/keyboards/bastardkb/scylla/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/scylla/v2/stemcell/rules.mk
@@ -1,5 +1,3 @@
-CONVERT_TO = stemcell
-
 # Build Options
 #   change yes to no to disable
 #

--- a/keyboards/bastardkb/skeletyl/v2/stemcell/info.json
+++ b/keyboards/bastardkb/skeletyl/v2/stemcell/info.json
@@ -7,20 +7,19 @@
         "driver": "ws2812"
     },
     "ws2812": {
-        "pin": "D3",
+        "pin": "A2",
         "driver": "pwm"
     },
     "build": {
         "debounce_type": "asym_eager_defer_pk"
     },
     "matrix_pins": {
-        "cols": ["F5", "B6", "D7", "E6", "B4"],
-        "rows": ["F7", "C6", "D4", "B5"]
+        "cols": ["B2", "A4", "B4", "B5", "B8"],
+        "rows": ["B0", "B3", "A15", "B9"]
     },
     "diode_direction": "ROW2COL",
     "split": {
-        "soft_serial_pin": "D2"
+        "soft_serial_pin": "A3"
     },
-    "processor": "STM32F411",
-    "bootloader": "stm32-dfu"
+    "development_board": "stemcell"
 }

--- a/keyboards/bastardkb/skeletyl/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/skeletyl/v2/stemcell/rules.mk
@@ -1,5 +1,3 @@
-CONVERT_TO = stemcell
-
 # Build Options
 #   change yes to no to disable
 #

--- a/keyboards/bastardkb/tbkmini/v2/stemcell/info.json
+++ b/keyboards/bastardkb/tbkmini/v2/stemcell/info.json
@@ -7,20 +7,19 @@
         "driver": "ws2812"
     },
     "ws2812": {
-        "pin": "D3",
+        "pin": "A2",
         "driver": "pwm"
     },
     "build": {
         "debounce_type": "asym_eager_defer_pk"
     },
     "matrix_pins": {
-        "cols": ["F6", "F5", "B6", "D7", "E6", "B4"],
-        "rows": ["F7", "C6", "D4", "B5"]
+        "cols": ["B1", "B2", "A4", "B4", "B5", "B8"],
+        "rows": ["B0", "B3", "A15", "B9"]
     },
     "diode_direction": "ROW2COL",
     "split": {
-        "soft_serial_pin": "D2"
+        "soft_serial_pin": "A3"
     },
-    "processor": "STM32F411",
-    "bootloader": "stm32-dfu"
+    "development_board": "stemcell"
 }

--- a/keyboards/bastardkb/tbkmini/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/tbkmini/v2/stemcell/rules.mk
@@ -1,5 +1,3 @@
-CONVERT_TO = stemcell
-
 # Build Options
 #   change yes to no to disable
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fixes build issues in #23312

Conversion targets **must** adhere to to the given interface.
* Specifying a different MCU/Bootloader while using a converter is incorrect
* Adding in workarounds for missing `elite_c` pins when using a `promicro` a converter is incorrect

Either the keyboard must use conveters correctly, or the keyboard should just specify the native pin config upfront. As the `splinky_v2`/`splinky_v3` keyboard targets specify RP2040 pins directly and do not use a converter, the same has been applied to the `stemcell` targets.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
