### PR TITLE
Produce warning if keyboard is not configured via `keyboard.json`

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -83,6 +83,24 @@ def _find_invalid_encoder_index(info_data):
     return ret
 
 
+def _validate_info_json_list(keyboard, info_data):
+    """Non schema checks
+    """
+    config_files = find_info_json(keyboard)
+
+    # keyboard.json can only exist at the deepest part of the tree
+    keyboard_json_count = 0
+    for index, info_file in enumerate(config_files):
+        if Path(info_file).name == 'keyboard.json':
+            keyboard_json_count += 1
+            if index != 0 or keyboard_json_count > 1:
+                _log_error(info_data, f'Invalid keyboard.json location detected: {info_file}.')
+
+    # Moving forward keyboard.json should be used as a build target
+    if keyboard_json_count == 0:
+        _log_warning(info_data, 'Build marker "keyboard.json" not found.')
+
+
 def _validate_layouts(keyboard, info_data):  # noqa C901
     """Non schema checks
     """
@@ -181,6 +199,7 @@ def _validate(keyboard, info_data):
         validate(info_data, 'qmk.api.keyboard.v1')
 
         # Additional validation
+        _validate_info_json_list(keyboard, info_data)
         _validate_layouts(keyboard, info_data)
         _validate_keycodes(keyboard, info_data)
         _validate_encoders(keyboard, info_data)
@@ -889,14 +908,6 @@ def merge_info_jsons(keyboard, info_data):
     """Return a merged copy of all the info.json files for a keyboard.
     """
     config_files = find_info_json(keyboard)
-
-    # keyboard.json can only exist at the deepest part of the tree
-    keyboard_json_count = 0
-    for index, info_file in enumerate(config_files):
-        if Path(info_file).name == 'keyboard.json':
-            keyboard_json_count += 1
-            if index != 0 or keyboard_json_count > 1:
-                _log_error(info_data, f'Invalid keyboard.json location detected: {info_file}.')
 
     for info_file in config_files:
         # Load and validate the JSON data

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -83,7 +83,7 @@ def _find_invalid_encoder_index(info_data):
     return ret
 
 
-def _validate_info_json_list(keyboard, info_data):
+def _validate_build_target(keyboard, info_data):
     """Non schema checks
     """
     keyboard_json_path = Path('keyboards') / keyboard / 'keyboard.json'
@@ -200,7 +200,7 @@ def _validate(keyboard, info_data):
         validate(info_data, 'qmk.api.keyboard.v1')
 
         # Additional validation
-        _validate_info_json_list(keyboard, info_data)
+        _validate_build_target(keyboard, info_data)
         _validate_layouts(keyboard, info_data)
         _validate_keycodes(keyboard, info_data)
         _validate_encoders(keyboard, info_data)

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -86,14 +86,15 @@ def _find_invalid_encoder_index(info_data):
 def _validate_info_json_list(keyboard, info_data):
     """Non schema checks
     """
+    keyboard_json_path = Path('keyboards') / keyboard / 'keyboard.json'
     config_files = find_info_json(keyboard)
 
     # keyboard.json can only exist at the deepest part of the tree
     keyboard_json_count = 0
-    for index, info_file in enumerate(config_files):
-        if Path(info_file).name == 'keyboard.json':
+    for info_file in config_files:
+        if info_file.name == 'keyboard.json':
             keyboard_json_count += 1
-            if index != 0 or keyboard_json_count > 1:
+            if info_file != keyboard_json_path:
                 _log_error(info_data, f'Invalid keyboard.json location detected: {info_file}.')
 
     # Moving forward keyboard.json should be used as a build target


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
With the many keyboard level migrations to use `keyboard.json`, there is currently nothing user facing to show that a keyboard is still using the legacy method of `rules.mk`.

This PR adds a lint/build warning when a keyboard has fallen back to backwards compatibility. Which after backwards compatibility is removed, can easily be promoted to a build error.
 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
