### PR TITLE
Add ES_GRV to latam keymaps

### DIFF
--- a/data/constants/keycodes/extras/keycodes_spanish_latin_america_0.0.1.hjson
+++ b/data/constants/keycodes/extras/keycodes_spanish_latin_america_0.0.1.hjson
@@ -335,5 +335,9 @@
             "key": "ES_CIRC",
             "label": "^",
         }
+        "ALGR(KC_NUHS)": {
+            "key": "ES_GRV",
+            "label": "`",
+        }
     }
 }

--- a/quantum/keymap_extras/keymap_spanish_latin_america.h
+++ b/quantum/keymap_extras/keymap_spanish_latin_america.h
@@ -102,4 +102,5 @@
 #define ES_AT   ALGR(ES_Q)    // @
 #define ES_TILD ALGR(ES_PLUS) // ~
 #define ES_CIRC ALGR(ES_LCBR) // ^
+#define ES_GRV  ALGR(KC_NUHS) // `
 


### PR DESCRIPTION
I forgot to add it in #22542
It is needed in order to merge https://github.com/qmk/qmk_configurator/pull/1324


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
