### PR TITLE
Enhance overlapping mouse keys control

### DIFF
--- a/docs/features/mouse_keys.md
+++ b/docs/features/mouse_keys.md
@@ -203,6 +203,19 @@ Tips:
 * Keep `MOUSEKEY_MOVE_DELTA` at 1.  This allows precise movements before the gliding effect starts.
 * Mouse wheel options are the same as the default accelerated mode, and do not use inertia.
 
+### Overlapping mouse key control
+
+When additional overlapping mouse key is pressed, the mouse cursor will continue in a new direction with the same acceleration. The following settings can be used to reset the acceleration with new overlapping keys for more precise control if desired:
+
+|Define                        |Default               |Description                                                            |
+|------------------------------|----------------------|-----------------------------------------------------------------------|
+|`MOUSEKEY_OVERLAP_RESET`      |undefined             |Enables overlapping mouse key control                                  |
+|`MOUSEKEY_OVERLAP_MOVE_DELTA` |`MOUSEKEY_MOVE_DELTA` |Step size of reset movement acceleration                               |
+|`MOUSEKEY_OVERLAP_WHEEL_DELTA`|`MOUSEKEY_WHEEL_DELTA`|Step size of reset mouse wheel acceleration                            |
+|`MOUSEKEY_OVERLAP_INTERVAL`   |`MOUSEKEY_INTERVAL`   |Reset time between cursor movements in milliseconds (Kinetic mode only)|
+
+?> This feature will not be applied on Inertial mode
+
 ## Use with PS/2 Mouse and Pointing Device
 
 Mouse keys button state is shared with [PS/2 mouse](ps2_mouse) and [pointing device](pointing_device) so mouse keys button presses can be used for clicks and drags.

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -391,18 +391,18 @@ void mousekey_on(uint8_t code) {
     }
 #    endif
 
-#    ifndef MOUSEKEY_INERTIA
+#    if defined(MOUSEKEY_OVERLAP_RESET) && !defined(MOUSEKEY_INERTIA)
     // If mouse report is not zero, the current mousekey press is overlapping
     // with another. Restart acceleration for smoother directional transition.
     if (mouse_report.x || mouse_report.y || mouse_report.h || mouse_report.v) {
 #        ifdef MK_KINETIC_SPEED
-        mouse_timer = timer_read() - (MOUSEKEY_INTERVAL << 2);
+        mouse_timer = timer_read() - MOUSEKEY_OVERLAP_INTERVAL;
 #        else
-        mousekey_repeat       = MOUSEKEY_MOVE_DELTA;
-        mousekey_wheel_repeat = MOUSEKEY_WHEEL_DELTA;
+        mousekey_repeat       = MOUSEKEY_OVERLAP_MOVE_DELTA;
+        mousekey_wheel_repeat = MOUSEKEY_OVERLAP_WHEEL_DELTA;
 #        endif
     }
-#    endif // ifndef MOUSEKEY_INERTIA
+#    endif // defined(MOUSEKEY_OVERLAP_RESET) && !defined(MOUSEKEY_INERTIA)
 
 #    ifdef MOUSEKEY_INERTIA
 

--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -174,6 +174,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #endif /* #ifndef MK_3_SPEED */
 
+#ifndef MOUSEKEY_OVERLAP_MOVE_DELTA
+#    define MOUSEKEY_OVERLAP_MOVE_DELTA MOUSEKEY_MOVE_DELTA
+#endif
+#ifndef MOUSEKEY_OVERLAP_WHEEL_DELTA
+#    define MOUSEKEY_OVERLAP_WHEEL_DELTA MOUSEKEY_WHEEL_DELTA
+#endif
+#ifndef MOUSEKEY_OVERLAP_INTERVAL
+#    define MOUSEKEY_OVERLAP_INTERVAL MOUSEKEY_INTERVAL
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION

## Description

Enhance the overlapping mouse key press acceleration (introduced in #21494) with user preprocessor controls.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
