### PR TITLE
fix clang db generating with qmk userspace as submodule

### DIFF
--- a/lib/python/qmk/cli/generate/compilation_database.py
+++ b/lib/python/qmk/cli/generate/compilation_database.py
@@ -12,7 +12,8 @@ from typing import Dict, Iterator, List, Union
 
 from milc import cli, MILC
 
-from qmk.commands import find_make
+from qmk.commands import find_make,build_environment
+
 from qmk.constants import QMK_FIRMWARE
 from qmk.decorators import automagic_keyboard, automagic_keymap
 from qmk.keyboard import keyboard_completer, keyboard_folder
@@ -117,6 +118,7 @@ def write_compilation_database(keyboard: str = None, keymap: str = None, output_
 
 @cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, help='The keyboard\'s name')
 @cli.argument('-km', '--keymap', completer=keymap_completer, help='The keymap\'s name')
+@cli.argument('-e', '--env', arg_only=True, action='append', default=[], help="Set a variable to be passed to make. May be passed multiple times.")
 @cli.subcommand('Create a compilation database.')
 @automagic_keyboard
 @automagic_keymap
@@ -139,5 +141,6 @@ def generate_compilation_database(cli: MILC) -> Union[bool, int]:
     elif not current_keymap:
         cli.log.error('Could not determine keymap!')
 
+    envs = build_environment(cli.args.env)
     target = KeyboardKeymapBuildTarget(current_keyboard, current_keymap)
-    return target.generate_compilation_database()
+    return target.generate_compilation_database(**envs)


### PR DESCRIPTION
## Description

if qmk userspace in placed under root of qmk firmware
clangd compile  database will fail to generate 


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
