### PR TITLE
fix rgb_matrix pixel fractal bug

### DIFF
--- a/quantum/rgb_matrix/animations/pixel_fractal_anim.h
+++ b/quantum/rgb_matrix/animations/pixel_fractal_anim.h
@@ -28,8 +28,14 @@ static bool PIXEL_FRACTAL(effect_params_t* params) {
     if (g_rgb_timer > wait_timer) {
         RGB rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
         for (uint8_t h = 0; h < MATRIX_ROWS; ++h) {
+            if (g_led_config.matrix_co[h][MID_COL - 1] == NO_LED || g_led_config.matrix_co[h][MATRIX_COLS - MID_COL] == NO_LED) {
+                continue;
+            }
             // Light and copy columns outward
             for (uint8_t l = 0; l < MID_COL - 1; ++l) {
+                if (g_led_config.matrix_co[h][l] == NO_LED || g_led_config.matrix_co[h][MATRIX_COLS - 1 - l] == NO_LED) {
+                    continue;
+                }
                 if (led[h][l]) {
                     rgb_matrix_set_color(g_led_config.matrix_co[h][l], rgb.r, rgb.g, rgb.b);
                     rgb_matrix_set_color(g_led_config.matrix_co[h][MATRIX_COLS - 1 - l], rgb.r, rgb.g, rgb.b);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Under the rgb matrix PIXEL_FRACTAL effect , skip the invalid NO_LED to solve the key failure when LTO_ENABLE is turned on and other possible problems after  in some arm keyboards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
