### PR TITLE
Implement HOLD_TAP.

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -173,6 +173,9 @@ If you define these options you will enable the associated feature, which may in
   * See "[hold on other key press](tap_hold.md#hold-on-other-key-press)" for details
 * `#define HOLD_ON_OTHER_KEY_PRESS_PER_KEY`
   * enables handling for per key `HOLD_ON_OTHER_KEY_PRESS` settings
+* `#define HOLD_TAP`
+  * alters the behavior of tap and hold so that the mod hold is immediate.
+  * See "[hold tap](tap_hold.md#hold-tap)" for details
 * `#define LEADER_TIMEOUT 300`
   * how long before the leader key times out
     * If you're having issues finishing the sequence before it times out, you may need to increase the timeout setting. Or you may want to enable the `LEADER_PER_KEY_TIMING` option, which resets the timeout after each key is tapped.

--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -4,6 +4,14 @@ While Tap-Hold options are fantastic, they are not without their issues.  We hav
 
 These options let you modify the behavior of the Tap-Hold keys.
 
+## Hold Tap :id=hold-tap
+
+By default, Tap-Hold only sends the record indicating the modifier hold after the logic has determined that we do not have a tap.
+
+?> `HOLD_TAP` changes this behavior, so that the modifier is set immediately, and if we later decide that we have a tap, we release the modifier and then send the tap records.
+
+This is very helpful when the modifier alters the behavior of some other device, such as what mouse clicks do.
+
 ## Tapping Term
 
 The crux of all of the following features is the tapping term setting.  This determines what is a tap and what is a hold.  The exact timing for this to feel natural can vary from keyboard to keyboard, from switch to switch, and from key to key.

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -510,6 +510,11 @@ void process_action(keyrecord_t *record, action_t action) {
                             } else
 #    endif
                             {
+#    ifdef HOLD_TAP
+                                ac_dprintf("HOLD_TOP: Unregister mods.\n");
+                                unregister_mods(mods);
+#    endif
+
                                 ac_dprintf("MODS_TAP: Tap: register_code\n");
                                 register_code(action.key.code);
                             }
@@ -694,6 +699,9 @@ void process_action(keyrecord_t *record, action_t action) {
                     if (event.pressed) {
                         if (tap_count > 0) {
                             ac_dprintf("KEYMAP_TAP_KEY: Tap: register_code\n");
+#        ifdef HOLD_TAP
+                            layer_off(action.layer_tap.val);
+#        endif
                             register_code(action.layer_tap.code);
                         } else {
                             ac_dprintf("KEYMAP_TAP_KEY: No tap: On on press\n");

--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -179,6 +179,11 @@ bool process_tapping(keyrecord_t *keyp) {
             process_record_tap_hint(&tapping_key);
             waiting_buffer_scan_tap();
             debug_tapping_key();
+
+#    ifdef HOLD_TAP
+            // Hold and tap, process the key immediately.
+            process_record(keyp);
+#    endif
         } else {
             // the current key is just a regular key, pass it on for regular
             // processing
@@ -336,7 +341,9 @@ bool process_tapping(keyrecord_t *keyp) {
                 ac_dprintf("Tapping: End. Timeout. Not tap(0): ");
                 debug_event(event);
                 ac_dprintf("\n");
+#    ifndef HOLD_TAP
                 process_record(&tapping_key);
+#    endif
                 tapping_key = (keyrecord_t){0};
                 debug_tapping_key();
                 return false;


### PR DESCRIPTION
## Description

This changes the behavior of tap and hold so that the hold action happens immediately, and if we later decide that we actually have a tap, we release the hold action just before sending the tap.

This is very helpful when the hold action changes the behavior of some external device, such as altering the behavior of mouse button clicks.

As an aside, this is my first time poking at the guts of QMK, so I would not be entirely shocked if changes needed to be made before this can be merged.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
