### PR TITLE
[ploopy][adept] Fix bugs in ploopy adept momentary drag scroll

### DIFF
--- a/keyboards/ploopyco/madromys/madromys.c
+++ b/keyboards/ploopyco/madromys/madromys.c
@@ -94,7 +94,7 @@ report_mouse_t pointing_device_task_kb(report_mouse_t mouse_report) {
 
         mouse_report.h = mouse_report_x_calc;
 
-#ifdef PLOOPY_DRAGSCROLL_INVERT
+#if PLOOPY_DRAGSCROLL_INVERT
         // Invert vertical scroll direction
         mouse_report.v = -mouse_report_y_calc;
 #else
@@ -119,13 +119,13 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     }
 
     if (keycode == DRAG_SCROLL) {
-#ifndef PLOOPY_DRAGSCROLL_MOMENTARY
+#if PLOOPY_DRAGSCROLL_MOMENTARY == 0
         if (record->event.pressed)
 #endif
         {
             is_drag_scroll ^= 1;
         }
-#ifdef PLOOPY_DRAGSCROLL_FIXED
+#if PLOOPY_DRAGSCROLL_FIXED
         pointing_device_set_cpi(is_drag_scroll ? PLOOPY_DRAGSCROLL_DPI : dpi_array[keyboard_config.dpi_config]);
 #else
         pointing_device_set_cpi(is_drag_scroll ? (dpi_array[keyboard_config.dpi_config] * PLOOPY_DRAGSCROLL_MULTIPLIER) : dpi_array[keyboard_config.dpi_config]);


### PR DESCRIPTION
## Description
Fix some bugs in the Ploopy Adept firmware, where configuring various `#defines` had no effect, due to checking for definitions, rather than checking for values.

Tested on my own Adept and confirmed the fix had an affect.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
- There was no way to setup 'drag scroll' toggle on the mouse previously, even with modifying config.h
- There was no way to define a non-fixed drag scroll DPI, even if modifying config.h

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
