### PR TITLE
Remove `quantum.h` includes from keyboard custom `matrix.c`s

### DIFF
--- a/keyboards/barleycorn_smd/matrix.c
+++ b/keyboards/barleycorn_smd/matrix.c
@@ -14,10 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
+#include "matrix.h"
 #include "wait.h"
-#include "quantum.h"
 #include "i2c_master.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/bpiphany/ghost_squid/matrix.c
+++ b/keyboards/bpiphany/ghost_squid/matrix.c
@@ -17,7 +17,6 @@
 */
 
 #include "matrix.h"
-#include "quantum.h"
 
 matrix_row_t read_rows(void) {
     return

--- a/keyboards/centromere/matrix.c
+++ b/keyboards/centromere/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/converter/siemens_tastatur/matrix.c
+++ b/keyboards/converter/siemens_tastatur/matrix.c
@@ -14,10 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include <string.h>
-#include "quantum.h"
 #include "timer.h"
 #include "wait.h"
 #include "print.h"

--- a/keyboards/custommk/evo70_r2/matrix.c
+++ b/keyboards/custommk/evo70_r2/matrix.c
@@ -1,6 +1,7 @@
 // Copyright 2023 David Hoelscher (@customMK)
 // SPDX-License-Identifier: GPL-2.0-or-later
-#include "quantum.h"
+#include "matrix.h"
+#include <string.h>
 
 // Pin definitions
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/dc01/right/matrix.c
+++ b/keyboards/dc01/right/matrix.c
@@ -15,8 +15,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #if defined(__AVR__)
 #include <avr/io.h>
 #include <avr/wdt.h>
@@ -31,7 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "timer.h"
 #include "i2c_slave.h"
 #include "lufa.h"
-#include "quantum.h"
 
 #define SLAVE_I2C_ADDRESS 0x32
 

--- a/keyboards/dp60/matrix.c
+++ b/keyboards/dp60/matrix.c
@@ -13,7 +13,10 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "quantum.h"
+#include "matrix.h"
+#include "print.h"
+#include "bitwise.h"
+#include "wait.h"
 
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5

--- a/keyboards/duck/orion/v3/matrix.c
+++ b/keyboards/duck/orion/v3/matrix.c
@@ -14,7 +14,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
+#include "matrix.h"
+#include "debug.h"
+#include "bitwise.h"
+#include "wait.h"
 
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5

--- a/keyboards/evyd13/wasdat/matrix.c
+++ b/keyboards/evyd13/wasdat/matrix.c
@@ -15,10 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "matrix.h"
-#include "quantum.h"
 #include "sn74x138.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/evyd13/wasdat_code/matrix.c
+++ b/keyboards/evyd13/wasdat_code/matrix.c
@@ -15,10 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "matrix.h"
-#include "quantum.h"
 #include "sn74x138.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/geistmaschine/macropod/matrix.c
+++ b/keyboards/geistmaschine/macropod/matrix.c
@@ -14,8 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "matrix.h"
 #include "pca9555.h"
-#include "quantum.h"
+#include "timer.h"
 
 // PCA9555 i2c address, 0x20: A0 = 0, A1 = 0, A2 = 0
 #define IC1 0x20

--- a/keyboards/gl516/a52gl/matrix.c
+++ b/keyboards/gl516/a52gl/matrix.c
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "matrix.h"
-#include "quantum.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/gl516/j73gl/matrix.c
+++ b/keyboards/gl516/j73gl/matrix.c
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "matrix.h"
-#include "quantum.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/gl516/n51gl/matrix.c
+++ b/keyboards/gl516/n51gl/matrix.c
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "matrix.h"
-#include "quantum.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/glenpickle/chimera_ergo/matrix.c
+++ b/keyboards/glenpickle/chimera_ergo/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/glenpickle/chimera_ls/matrix.c
+++ b/keyboards/glenpickle/chimera_ls/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/glenpickle/chimera_ortho/matrix.c
+++ b/keyboards/glenpickle/chimera_ortho/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/glenpickle/chimera_ortho_plus/matrix.c
+++ b/keyboards/glenpickle/chimera_ortho_plus/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/gmmk/numpad/matrix.c
+++ b/keyboards/gmmk/numpad/matrix.c
@@ -4,15 +4,12 @@
 /*
  * scan matrix
  */
-#include <stdint.h>
-#include <stdbool.h>
+#include "matrix.h"
+#include <string.h>
+#include "atomic_util.h"
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
-#include "util.h"
-#include "matrix.h"
-#include "debounce.h"
-#include "quantum.h"
 
 /* matrix state(1:on, 0:off) */
 extern matrix_row_t matrix[MATRIX_ROWS];     // debounced values

--- a/keyboards/halfcliff/matrix.c
+++ b/keyboards/halfcliff/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
-#include "util.h"
 #include "matrix.h"
-#include "debounce.h"
-#include "quantum.h"
+#include "atomic_util.h"
 #include "split_util.h"
-#include "config.h"
 #include "transport.h"
+#include "debounce.h"
+#include "wait.h"
 
 #define ERROR_DISCONNECT_COUNT 5
 

--- a/keyboards/handwired/dqz11n1g/matrix.c
+++ b/keyboards/handwired/dqz11n1g/matrix.c
@@ -15,14 +15,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-
-#include <avr/io.h>
-
 #include "spi_master.h"
-#include "quantum.h"
 #include "matrix.h"
 
 static pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/handwired/dygma/raise/matrix.c
+++ b/keyboards/handwired/dygma/raise/matrix.c
@@ -13,8 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "quantum.h"
+#include "matrix.h"
 #include "i2c_master.h"
+#include "wait.h"
 #include <string.h>
 #include "wire-protocol-constants.h"
 

--- a/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
+++ b/keyboards/handwired/symmetric70_proto/matrix_debug/matrix.c
@@ -14,12 +14,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 #ifndef readPort
 #    include "gpio_extr.h"
 #endif

--- a/keyboards/handwired/symmetric70_proto/matrix_fast/matrix.c
+++ b/keyboards/handwired/symmetric70_proto/matrix_fast/matrix.c
@@ -15,9 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 // clang-format off
-#include <stdint.h>
-#include <stdbool.h>
-#include <gpio.h>
 #ifndef readPort
 #    include "gpio_extr.h"
 #endif
@@ -25,7 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "matrix.h"
 #include "matrix_extr.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #define ALWAYS_INLINE inline __attribute__((always_inline))
 #define NO_INLINE     __attribute__((noinline))

--- a/keyboards/hazel/bad_wings/matrix.c
+++ b/keyboards/hazel/bad_wings/matrix.c
@@ -2,12 +2,11 @@
 // Copyright 2023 @jasonhazel (Jason Hazel)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "quantum.h"
-#include "spi_master.h"
-#include <string.h> /* memset */
-#include <unistd.h> /* close */
-#include "quantum.h"
 #include "matrix.h"
+#include <string.h>
+#include "spi_master.h"
+#include "debug.h"
+#include "wait.h"
 
 #if (!defined(SHIFTREG_MATRIX_COL_CS))
 #    error Missing shift register I/O pin definitions

--- a/keyboards/hhkb/yang/matrix.c
+++ b/keyboards/hhkb/yang/matrix.c
@@ -16,7 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
+#include "matrix.h"
+#include "debug.h"
+#include "timer.h"
+#include "wait.h"
+#include "suspend.h"
+#include <avr/interrupt.h>
 
 #ifdef BLUETOOTH_ENABLE
 #    include "adafruit_ble.h"

--- a/keyboards/hineybush/hbcp/matrix.c
+++ b/keyboards/hineybush/hbcp/matrix.c
@@ -14,12 +14,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 static const pin_t row_pins[] = MATRIX_ROW_PINS;
 static const pin_t col_pins[] = MATRIX_COL_PINS;

--- a/keyboards/ibm/model_m/mschwingen/matrix.c
+++ b/keyboards/ibm/model_m/mschwingen/matrix.c
@@ -14,12 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <stdint.h>
-#include <stdbool.h>
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 #include "spi_master.h"
 #include "print.h"
 #include "mschwingen.h"

--- a/keyboards/jones/v03/matrix.c
+++ b/keyboards/jones/v03/matrix.c
@@ -14,10 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "matrix.h"
-#include "quantum.h"
 
 #define ROW_SHIFTER ((uint16_t)1)
 

--- a/keyboards/jones/v03_1/matrix.c
+++ b/keyboards/jones/v03_1/matrix.c
@@ -14,10 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "matrix.h"
-#include "quantum.h"
 
 #define ROW_SHIFTER ((uint16_t)1)
 

--- a/keyboards/joshajohnson/hub16/matrix.c
+++ b/keyboards/joshajohnson/hub16/matrix.c
@@ -14,12 +14,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "util.h"
 #include "matrix.h"
-#include "quantum.h"
 
 // Encoder things
 #define SWITCH_1 F7

--- a/keyboards/kagizaraya/chidori/matrix.c
+++ b/keyboards/kagizaraya/chidori/matrix.c
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "board.h"
 

--- a/keyboards/kakunpc/angel64/alpha/matrix.c
+++ b/keyboards/kakunpc/angel64/alpha/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")

--- a/keyboards/kakunpc/angel64/rev1/matrix.c
+++ b/keyboards/kakunpc/angel64/rev1/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")

--- a/keyboards/kakunpc/choc_taro/matrix.c
+++ b/keyboards/kakunpc/choc_taro/matrix.c
@@ -14,10 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "matrix.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define ROW_SHIFTER ((uint8_t)1)

--- a/keyboards/kakunpc/thedogkeyboard/matrix.c
+++ b/keyboards/kakunpc/thedogkeyboard/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")

--- a/keyboards/kbdmania/kmac/matrix.c
+++ b/keyboards/kbdmania/kmac/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header() print("\nr/c 01234567\n")

--- a/keyboards/kbdmania/kmac_pad/matrix.c
+++ b/keyboards/kbdmania/kmac_pad/matrix.c
@@ -17,7 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "wait.h"
 #include "matrix.h"
-#include "quantum.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/keyboardio/model01/matrix.c
+++ b/keyboards/keyboardio/model01/matrix.c
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "quantum.h"
+#include "matrix.h"
 #include "i2c_master.h"
 #include <string.h>
 #include "model01.h"

--- a/keyboards/keychron/c2_pro/matrix.c
+++ b/keyboards/keychron/c2_pro/matrix.c
@@ -14,7 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "quantum.h"
+#include "matrix.h"
+#include "atomic_util.h"
+#include <string.h>
 
 #ifndef SHIFT_COL_START
 #    define SHIFT_COL_START 8

--- a/keyboards/keychron/q10/matrix.c
+++ b/keyboards/keychron/q10/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN A7

--- a/keyboards/keychron/q12/matrix.c
+++ b/keyboards/keychron/q12/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN C15

--- a/keyboards/keychron/q1v2/matrix.c
+++ b/keyboards/keychron/q1v2/matrix.c
@@ -14,7 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "quantum.h"
+#include "matrix.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN A7

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -15,6 +15,8 @@
  */
 
 #include "matrix.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN A7

--- a/keyboards/keychron/q3/matrix.c
+++ b/keyboards/keychron/q3/matrix.c
@@ -15,7 +15,6 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN A7

--- a/keyboards/keychron/q5/matrix.c
+++ b/keyboards/keychron/q5/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN C15

--- a/keyboards/keychron/q6/matrix.c
+++ b/keyboards/keychron/q6/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN C15

--- a/keyboards/keychron/q65/matrix.c
+++ b/keyboards/keychron/q65/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN C15

--- a/keyboards/keychron/v1/matrix.c
+++ b/keyboards/keychron/v1/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN A7

--- a/keyboards/keychron/v10/matrix.c
+++ b/keyboards/keychron/v10/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 #ifndef PIN_USED_74HC595
 #    define PIN_USED_74HC595 8

--- a/keyboards/keychron/v3/matrix.c
+++ b/keyboards/keychron/v3/matrix.c
@@ -15,6 +15,8 @@
  */
 
 #include "matrix.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN A7

--- a/keyboards/keychron/v3/matrix.c
+++ b/keyboards/keychron/v3/matrix.c
@@ -15,7 +15,6 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN A7

--- a/keyboards/keychron/v5/matrix.c
+++ b/keyboards/keychron/v5/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 // Pin connected to DS of 74HC595
 #define DATA_PIN C15

--- a/keyboards/keychron/v6/matrix.c
+++ b/keyboards/keychron/v6/matrix.c
@@ -15,7 +15,8 @@
  */
 
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
+#include <string.h>
 
 #ifndef PIN_USED_74HC595
 #    define PIN_USED_74HC595 8

--- a/keyboards/kinesis/nguyenvietyen/matrix.c
+++ b/keyboards/kinesis/nguyenvietyen/matrix.c
@@ -3,8 +3,6 @@
 
 #include "matrix.h"
 
-#include "quantum.h"
-
 static matrix_row_t read_row(uint8_t row) {
     matrix_io_delay();  // without this wait read unstable value.
 

--- a/keyboards/matrix/abelx/matrix.c
+++ b/keyboards/matrix/abelx/matrix.c
@@ -17,10 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "quantum.h"
 #include "matrix.h"
 #include "tca6424.h"
 #include "abelx.h"

--- a/keyboards/matrix/m12og/rev1/matrix.c
+++ b/keyboards/matrix/m12og/rev1/matrix.c
@@ -14,12 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/matrix/m20add/matrix.c
+++ b/keyboards/matrix/m20add/matrix.c
@@ -2,10 +2,6 @@
  * matrix.c
  */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "quantum.h"
 #include "matrix.h"
 #include "tca6424.h"
 #include "m20add.h"

--- a/keyboards/matrix/noah/matrix.c
+++ b/keyboards/matrix/noah/matrix.c
@@ -2,16 +2,10 @@
  * matrix.c
  */
 
-#include <stdint.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <string.h>
-#include <hal.h>
-#include "quantum.h"
+#include "matrix.h"
 #include "timer.h"
 #include "wait.h"
 #include "print.h"
-#include "matrix.h"
 
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5
@@ -167,16 +161,16 @@ matrix_row_t matrix_get_row(uint8_t row) { return matrix[row]; }
 
 void matrix_print(void)
 {
-    printf("\nr/c 01234567\n");
+    xprintf("\nr/c 01234567\n");
     for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-        printf("%X0: ", row);
+        xprintf("%X0: ", row);
         matrix_row_t data = matrix_get_row(row);
         for (int col = 0; col < MATRIX_COLS; col++) {
             if (data & (1<<col))
-                printf("1");
+                xprintf("1");
             else
-                printf("0");
+                xprintf("0");
         }
-        printf("\n");
+        xprintf("\n");
     }
 }

--- a/keyboards/mechlovin/adelais/standard_led/avr/rev1/matrix.c
+++ b/keyboards/mechlovin/adelais/standard_led/avr/rev1/matrix.c
@@ -16,13 +16,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #ifdef DIRECT_PINS
 static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;

--- a/keyboards/mechlovin/infinity87/rev2/matrix.c
+++ b/keyboards/mechlovin/infinity87/rev2/matrix.c
@@ -16,13 +16,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #ifdef DIRECT_PINS
 static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;

--- a/keyboards/mechlovin/infinity875/matrix.c
+++ b/keyboards/mechlovin/infinity875/matrix.c
@@ -16,13 +16,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #ifdef DIRECT_PINS
 static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;

--- a/keyboards/mechlovin/olly/jf/rev1/matrix.c
+++ b/keyboards/mechlovin/olly/jf/rev1/matrix.c
@@ -16,13 +16,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #ifdef DIRECT_PINS
 static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;

--- a/keyboards/mechlovin/serratus/matrix.c
+++ b/keyboards/mechlovin/serratus/matrix.c
@@ -16,13 +16,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #ifdef DIRECT_PINS
 static pin_t direct_pins[MATRIX_ROWS][MATRIX_COLS] = DIRECT_PINS;

--- a/keyboards/mexsistor/ludmila/matrix.c
+++ b/keyboards/mexsistor/ludmila/matrix.c
@@ -14,12 +14,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "util.h"
 #include "matrix.h"
-#include "quantum.h"
 
 // Encoder things
 #define ENC_SW F7

--- a/keyboards/miiiw/blackio83/matrix.c
+++ b/keyboards/miiiw/blackio83/matrix.c
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "quantum.h"
 #include "matrix.h"
+#include "wait.h"
 #include "common/shift_register.h"
 
 static uint8_t read_rows(void);

--- a/keyboards/mitosis/matrix.c
+++ b/keyboards/mitosis/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/moon/matrix.c
+++ b/keyboards/moon/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 #include "pca9555.h"
 
 /*

--- a/keyboards/mt/split75/matrix.c
+++ b/keyboards/mt/split75/matrix.c
@@ -15,9 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <string.h>
-#include <stdio.h>
-#include "quantum.h"
+#include "matrix.h"
 #include "i2c_master.h"
 
 #define RIGHT_HALF

--- a/keyboards/nullbitsco/nibble/matrix.c
+++ b/keyboards/nullbitsco/nibble/matrix.c
@@ -13,7 +13,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "quantum.h"
+#include "matrix.h"
+#include "wait.h"
 
 #define COL_SHIFTER ((uint32_t)1)
 

--- a/keyboards/nullbitsco/snap/matrix.c
+++ b/keyboards/nullbitsco/snap/matrix.c
@@ -13,13 +13,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "util.h"
 #include "matrix.h"
+#include <string.h>
 #include "split_util.h"
-#include "quantum.h"
+#include "wait.h"
 
 #define VIRT_COLS_PER_HAND 1
 #define PHYS_COLS_PER_HAND (MATRIX_COLS - VIRT_COLS_PER_HAND)

--- a/keyboards/oddforge/vea/matrix.c
+++ b/keyboards/oddforge/vea/matrix.c
@@ -15,9 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <string.h>
-#include <stdio.h>
-#include "quantum.h"
+#include "matrix.h"
 #include "i2c_master.h"
 
 #define RIGHT_HALF

--- a/keyboards/om60/matrix.c
+++ b/keyboards/om60/matrix.c
@@ -15,7 +15,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "quantum.h"
+#include "matrix.h"
+#include "wait.h"
 
 #if (MATRIX_COLS <= 8)
 #    define ROW_SHIFTER ((uint8_t)1)

--- a/keyboards/pierce/matrix.c
+++ b/keyboards/pierce/matrix.c
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "quantum.h"
+#include "matrix.h"
 #include "i2c_slave.h"
 
 #define MY_I2C_ADDRESS (0x20U << 1)

--- a/keyboards/planck/rev6_drop/matrix.c
+++ b/keyboards/planck/rev6_drop/matrix.c
@@ -15,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "quantum.h"
+#include "matrix.h"
+#include "wait.h"
 
 /* matrix state(1:on, 0:off) */
 static pin_t matrix_row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/planck/rev7/matrix.c
+++ b/keyboards/planck/rev7/matrix.c
@@ -15,11 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "gpio.h"
-#include "hal_pal.h"
-#include "hal_pal_lld.h"
-#include "quantum.h"
+#include "matrix.h"
+#include <hal_pal.h>
 #include <math.h>
+#include "wait.h"
 
 // STM32-specific watchdog config calculations
 // timeout = 31.25us * PR * (RL + 1)

--- a/keyboards/preonic/rev3_drop/matrix.c
+++ b/keyboards/preonic/rev3_drop/matrix.c
@@ -15,7 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "quantum.h"
+#include "matrix.h"
+#include "debug.h"
+#include "timer.h"
+#include "wait.h"
 
 #ifndef DEBOUNCE
 #    define DEBOUNCE 5

--- a/keyboards/qvex/lynepad2/matrix.c
+++ b/keyboards/qvex/lynepad2/matrix.c
@@ -14,13 +14,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "util.h"
 #include "matrix.h"
-#include "debounce.h"
-#include "quantum.h"
+#include "wait.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/rate/pistachio_pro/matrix.c
+++ b/keyboards/rate/pistachio_pro/matrix.c
@@ -14,10 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "matrix.h"
-#include "quantum.h"
+#include "atomic_util.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/redox/wireless/matrix.c
+++ b/keyboards/redox/wireless/matrix.c
@@ -14,7 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/redscarf_iiplus/verb/matrix.c
+++ b/keyboards/redscarf_iiplus/verb/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")

--- a/keyboards/redscarf_iiplus/verc/matrix.c
+++ b/keyboards/redscarf_iiplus/verc/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")

--- a/keyboards/redscarf_iiplus/verd/matrix.c
+++ b/keyboards/redscarf_iiplus/verd/matrix.c
@@ -14,15 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
 #include "wait.h"
 #include "print.h"
 #include "debug.h"
 #include "util.h"
 #include "matrix.h"
 #include "debounce.h"
-#include "quantum.h"
 
 #if (MATRIX_COLS <= 8)
 #    define print_matrix_header()  print("\nr/c 01234567\n")

--- a/keyboards/ryanskidmore/rskeys100/matrix.c
+++ b/keyboards/ryanskidmore/rskeys100/matrix.c
@@ -17,10 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdbool.h>
 #include "matrix.h"
 #include <util/delay.h>
-#include "quantum.h"
 
 static const uint32_t col_values[24] = SHR_COLS;
 

--- a/keyboards/satt/comet46/matrix.c
+++ b/keyboards/satt/comet46/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/sirius/uni660/rev1/matrix.c
+++ b/keyboards/sirius/uni660/rev1/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/sirius/uni660/rev2/matrix.c
+++ b/keyboards/sirius/uni660/rev2/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/spiderisland/split78/matrix.c
+++ b/keyboards/spiderisland/split78/matrix.c
@@ -15,9 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <string.h>
-#include <stdio.h>
-#include "quantum.h"
+#include "matrix.h"
 #include "i2c_master.h"
 
 #define RIGHT_HALF

--- a/keyboards/sthlmkb/lagom/matrix.c
+++ b/keyboards/sthlmkb/lagom/matrix.c
@@ -13,7 +13,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "quantum.h"
+#include "matrix.h"
+#include "wait.h"
 
 #define COL_SHIFTER ((uint32_t)1)
 

--- a/keyboards/switchplate/southpaw_65/matrix.c
+++ b/keyboards/switchplate/southpaw_65/matrix.c
@@ -13,15 +13,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <stdint.h>
-#include <stdbool.h>
-#include <avr/io.h>
-#include <string.h>
 #include "matrix.h"
 #include "pca9555.h"
-#include "quantum.h"
-
-#include "debug.h"
 
 // PCA9555 slave addresses
 #define IC1 0x20

--- a/keyboards/telophase/matrix.c
+++ b/keyboards/telophase/matrix.c
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "quantum.h"
 #include "matrix.h"
 #include "uart.h"
 

--- a/keyboards/touchpad/matrix.c
+++ b/keyboards/touchpad/matrix.c
@@ -23,7 +23,8 @@ SOFTWARE.
 
 #include "matrix.h"
 #include "i2c_master.h"
-#include "quantum.h"
+#include "print.h"
+#include <string.h>
 
 #define VIBRATE_LENGTH 50 //Defines number of interrupts motor will vibrate for, must be bigger than 8 for correct operation
 volatile uint8_t vibrate = 0; //Trigger vibration in interrupt
@@ -276,16 +277,16 @@ matrix_row_t matrix_get_row(uint8_t row) {
 }
 
 void matrix_print(void) {
-    printf("\nr/c 01234567\n");
+    xprintf("\nr/c 01234567\n");
     for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
-        printf("%X0: ", row);
+        xprintf("%X0: ", row);
         matrix_row_t data = matrix_get_row(row);
         for (int col = 0; col < MATRIX_COLS; col++) {
             if (data & (1<<col))
-                printf("1");
+                xprintf("1");
             else
-                printf("0");
+                xprintf("0");
         }
-        printf("\n");
+        xprintf("\n");
     }
 }

--- a/keyboards/viktus/sp111/matrix.c
+++ b/keyboards/viktus/sp111/matrix.c
@@ -13,8 +13,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "matrix.h"
 #include "mcp23018.h"
-#include "quantum.h"
+#include "print.h"
+#include "wait.h"
 
 // Optimize scanning code for speed as a slight mitigation for the port expander
 #pragma GCC push_options

--- a/keyboards/xiudi/xd84/matrix.c
+++ b/keyboards/xiudi/xd84/matrix.c
@@ -13,15 +13,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <stdint.h>
-#include <stdbool.h>
-#include <avr/io.h>
-#include <string.h>
 #include "matrix.h"
 #include "pca9555.h"
-#include "quantum.h"
-
-#include "debug.h"
 
 // PCA9555 slave addresses
 #define IC1 0x20

--- a/keyboards/xiudi/xd96/matrix.c
+++ b/keyboards/xiudi/xd96/matrix.c
@@ -13,15 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <stdint.h>
-#include <stdbool.h>
-#include <avr/io.h>
-#include <string.h>
 #include "matrix.h"
 #include "pca9555.h"
-#include "quantum.h"
-
-#include "debug.h"
+#include "wait.h"
 
 // PCA9555 slave addresses
 #define IC1 0x20

--- a/keyboards/ydkb/grape/matrix.c
+++ b/keyboards/ydkb/grape/matrix.c
@@ -15,10 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdint.h>
-#include <stdbool.h>
 #include "matrix.h"
-#include "quantum.h"
 #include "sn74x138.h"
 
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;

--- a/keyboards/yiancardesigns/barleycorn/matrix.c
+++ b/keyboards/yiancardesigns/barleycorn/matrix.c
@@ -14,10 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
+#include "matrix.h"
 #include "wait.h"
-#include "quantum.h"
 #include "i2c_master.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/yiancardesigns/gingham/matrix.c
+++ b/keyboards/yiancardesigns/gingham/matrix.c
@@ -14,10 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
+#include "matrix.h"
 #include "wait.h"
-#include "quantum.h"
 #include "i2c_master.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;

--- a/keyboards/yiancardesigns/seigaiha/matrix.c
+++ b/keyboards/yiancardesigns/seigaiha/matrix.c
@@ -14,10 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdint.h>
-#include <stdbool.h>
+#include "matrix.h"
 #include "wait.h"
-#include "quantum.h"
 #include "i2c_master.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

More elimination of `quantum.h` include laziness.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
