### PR TITLE
Remove 'NO_USB_STARTUP_CHECK = no' from keyboards

### DIFF
--- a/keyboards/akegata_denki/device_one/rules.mk
+++ b/keyboards/akegata_denki/device_one/rules.mk
@@ -8,5 +8,3 @@ EXTRAKEY_ENABLE = no				# Audio control and System control
 CONSOLE_ENABLE = no					# Console for debug
 COMMAND_ENABLE = no    			# Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
-NO_USB_STARTUP_CHECK = no   # Disable initialization only when usb is plugged in
-

--- a/keyboards/coarse/ixora/rules.mk
+++ b/keyboards/coarse/ixora/rules.mk
@@ -8,6 +8,3 @@ EXTRAKEY_ENABLE = yes				# Audio control and System control
 CONSOLE_ENABLE = no					# Console for debug
 COMMAND_ENABLE = no    				# Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
-NO_USB_STARTUP_CHECK = no         	# Disable initialization only when usb is plugged in
-
-

--- a/keyboards/coarse/vinta/rules.mk
+++ b/keyboards/coarse/vinta/rules.mk
@@ -8,5 +8,3 @@ EXTRAKEY_ENABLE = yes				# Audio control and System control
 CONSOLE_ENABLE = no					# Console for debug
 COMMAND_ENABLE = no    				# Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
-NO_USB_STARTUP_CHECK = no         	# Disable initialization only when usb is plugged in
-

--- a/keyboards/dztech/dz60rgb/v1/rules.mk
+++ b/keyboards/dztech/dz60rgb/v1/rules.mk
@@ -11,4 +11,3 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/dztech/dz60rgb/v2/rules.mk
+++ b/keyboards/dztech/dz60rgb/v2/rules.mk
@@ -11,4 +11,3 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/dztech/dz60rgb/v2_1/rules.mk
+++ b/keyboards/dztech/dz60rgb/v2_1/rules.mk
@@ -13,7 +13,6 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in
 LTO_ENABLE = yes
 
 SPACE_CADET_ENABLE = no

--- a/keyboards/dztech/dz60rgb_ansi/v1/rules.mk
+++ b/keyboards/dztech/dz60rgb_ansi/v1/rules.mk
@@ -11,4 +11,3 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/dztech/dz60rgb_ansi/v2/rules.mk
+++ b/keyboards/dztech/dz60rgb_ansi/v2/rules.mk
@@ -11,6 +11,5 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in
 
 LTO_ENABLE = yes

--- a/keyboards/dztech/dz60rgb_wkl/v1/rules.mk
+++ b/keyboards/dztech/dz60rgb_wkl/v1/rules.mk
@@ -11,4 +11,3 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/dztech/dz60rgb_wkl/v2/rules.mk
+++ b/keyboards/dztech/dz60rgb_wkl/v2/rules.mk
@@ -11,4 +11,3 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/hand88/rules.mk
+++ b/keyboards/hand88/rules.mk
@@ -11,4 +11,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-NO_USB_STARTUP_CHECK = no   # Disable initialization only when usb is plugged in

--- a/keyboards/hs60/v2/ansi/rules.mk
+++ b/keyboards/hs60/v2/ansi/rules.mk
@@ -14,7 +14,6 @@ CONSOLE_ENABLE = no                # Console for debug
 COMMAND_ENABLE = no                # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 AUDIO_ENABLE = no                  # Audio output
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in
 
 CIE1931_CURVE = yes
 

--- a/keyboards/hs60/v2/hhkb/rules.mk
+++ b/keyboards/hs60/v2/hhkb/rules.mk
@@ -14,7 +14,6 @@ CONSOLE_ENABLE = no                # Console for debug
 COMMAND_ENABLE = no                # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 AUDIO_ENABLE = no                  # Audio output
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in
 
 CIE1931_CURVE = yes
 

--- a/keyboards/hs60/v2/iso/rules.mk
+++ b/keyboards/hs60/v2/iso/rules.mk
@@ -14,7 +14,6 @@ CONSOLE_ENABLE = no                # Console for debug
 COMMAND_ENABLE = no                # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 AUDIO_ENABLE = no                  # Audio output
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in
 
 CIE1931_CURVE = yes
 

--- a/keyboards/kbdfans/bella/rgb/rules.mk
+++ b/keyboards/kbdfans/bella/rgb/rules.mk
@@ -11,6 +11,5 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in
 
 LTO_ENABLE = yes

--- a/keyboards/kbdfans/bella/rgb_iso/rules.mk
+++ b/keyboards/kbdfans/bella/rgb_iso/rules.mk
@@ -11,6 +11,5 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in
 
 LTO_ENABLE = yes

--- a/keyboards/kbdfans/kbd67/mkiirgb/v2/rules.mk
+++ b/keyboards/kbdfans/kbd67/mkiirgb/v2/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no      # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 RGB_MATRIX_ENABLE = yes     # Use RGB matrix
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in

--- a/keyboards/kbdfans/maja/rules.mk
+++ b/keyboards/kbdfans/maja/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 RGB_MATRIX_ENABLE = yes     # Use RGB matrix
-NO_USB_STARTUP_CHECK = no   # Disable initialization only when usb is plugged in

--- a/keyboards/kbdfans/maja_soldered/rules.mk
+++ b/keyboards/kbdfans/maja_soldered/rules.mk
@@ -9,4 +9,3 @@ COMMAND_ENABLE = no         # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = yes      # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
-NO_USB_STARTUP_CHECK = no   # Disable initialization only when usb is plugged in

--- a/keyboards/keebwerk/mega/ansi/rules.mk
+++ b/keyboards/keebwerk/mega/ansi/rules.mk
@@ -15,7 +15,6 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-NO_USB_STARTUP_CHECK = no   # Disable initialization only when usb is plugged in
 
 CIE1931_CURVE = yes
 

--- a/keyboards/kprepublic/bm60hsrgb/rev2/rules.mk
+++ b/keyboards/kprepublic/bm60hsrgb/rev2/rules.mk
@@ -10,7 +10,6 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-NO_USB_STARTUP_CHECK = no
 LTO_ENABLE = yes
 RGB_MATRIX_ENABLE = yes
 WS2812_DRIVER_REQUIRED = yes

--- a/keyboards/latincompass/latin17rgb/rules.mk
+++ b/keyboards/latincompass/latin17rgb/rules.mk
@@ -10,5 +10,4 @@ NKRO_ENABLE = no            # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in
 RGB_MATRIX_ENABLE = yes

--- a/keyboards/latincompass/latin6rgb/rules.mk
+++ b/keyboards/latincompass/latin6rgb/rules.mk
@@ -12,7 +12,6 @@ RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 
 AUDIO_ENABLE = no              # Audio output
 
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in
 RGB_MATRIX_ENABLE = yes
 
 RGB_MATRIX_SUPPORTED = yes

--- a/keyboards/melgeek/mj61/rev1/rules.mk
+++ b/keyboards/melgeek/mj61/rev1/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/melgeek/mj61/rev2/rules.mk
+++ b/keyboards/melgeek/mj61/rev2/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/melgeek/mj63/rev1/rules.mk
+++ b/keyboards/melgeek/mj63/rev1/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/melgeek/mj63/rev2/rules.mk
+++ b/keyboards/melgeek/mj63/rev2/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/melgeek/mj64/rev1/rules.mk
+++ b/keyboards/melgeek/mj64/rev1/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/melgeek/mj64/rev2/rules.mk
+++ b/keyboards/melgeek/mj64/rev2/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/melgeek/mj64/rev3/rules.mk
+++ b/keyboards/melgeek/mj64/rev3/rules.mk
@@ -10,4 +10,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/melgeek/mj65/rev3/rules.mk
+++ b/keyboards/melgeek/mj65/rev3/rules.mk
@@ -10,7 +10,7 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in
+
 RGB_MATRIX_SUPPORTED = yes
 RGBLIGHT_SUPPORTED   = no
 BACKLIGHT_SUPPORTED  = no

--- a/keyboards/miller/gm862/rules.mk
+++ b/keyboards/miller/gm862/rules.mk
@@ -11,4 +11,3 @@ BACKLIGHT_ENABLE = no          # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no           # Enable keyboard RGB underglow
 AUDIO_ENABLE = no              # Audio output
 RGB_MATRIX_ENABLE = yes        # Use RGB matrix
-NO_USB_STARTUP_CHECK = no      # Disable initialization only when usb is plugged in

--- a/keyboards/novelkeys/nk65/rules.mk
+++ b/keyboards/novelkeys/nk65/rules.mk
@@ -14,7 +14,6 @@ CONSOLE_ENABLE = no                # Console for debug
 COMMAND_ENABLE = no                # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 AUDIO_ENABLE = no                  # Audio output
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in
 
 CIE1931_CURVE = yes
 

--- a/keyboards/spaceholdings/nebula12/rules.mk
+++ b/keyboards/spaceholdings/nebula12/rules.mk
@@ -14,7 +14,6 @@ CONSOLE_ENABLE = no                # Console for debug
 COMMAND_ENABLE = no                # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 AUDIO_ENABLE = no                  # Audio output
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in
 RGBLIGHT_ENABLE = yes              # Underglow RGB
 
 CIE1931_CURVE = yes

--- a/keyboards/spaceholdings/nebula68/rules.mk
+++ b/keyboards/spaceholdings/nebula68/rules.mk
@@ -14,7 +14,6 @@ CONSOLE_ENABLE = no                # Console for debug
 COMMAND_ENABLE = no                # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 AUDIO_ENABLE = no                  # Audio output
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in
 RGBLIGHT_ENABLE = yes              # Underglow RGB
 
 CIE1931_CURVE = yes

--- a/keyboards/xbows/woody/rules.mk
+++ b/keyboards/xbows/woody/rules.mk
@@ -10,4 +10,3 @@ COMMAND_ENABLE = no                # Commands for debug and configuration
 NKRO_ENABLE = yes           # Enable N-Key Rollover
 AUDIO_ENABLE = no
 RGB_MATRIX_ENABLE = yes            # Use RGB matrix
-NO_USB_STARTUP_CHECK = no          # Disable initialization only when usb is plugged in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
None of these keyboards enable Bluetooth so is just duplicating the default value of `no`.

Setting does nothing but block automated migrations.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
