### PR TITLE
[Keyboard] Add the Osprette

### DIFF
--- a/keyboards/osprette/info.json
+++ b/keyboards/osprette/info.json
@@ -21,9 +21,8 @@
     },
     "diode_direction": "ROW2COL",
     "layouts": {
-        "LAYOUT_pinky_cluster_34": {
+        "LAYOUT": {
             "layout": [
-                {"label": "L01", "matrix": [0, 0], "x": 0, "y": 2.27},
                 {"label": "L02", "matrix": [0, 1], "x": 2, "y": 0.31},
                 {"label": "L03", "matrix": [0, 2], "x": 3, "y": 0},
                 {"label": "L04", "matrix": [0, 3], "x": 4, "y": 0.28},
@@ -33,9 +32,9 @@
                 {"label": "R02", "matrix": [0, 6], "x": 10, "y": 0.28},
                 {"label": "R03", "matrix": [0, 7], "x": 11, "y": 0},
                 {"label": "R04", "matrix": [0, 8], "x": 12, "y": 0.31},
-                {"label": "R05", "matrix": [0, 9], "x": 14, "y": 2.27},
 
-                {"label": "L06", "matrix": [1, 0], "x": 0, "y": 2.27},
+                {"label": "L01", "matrix": [0, 0], "x": 0, "y": 2.47},
+                {"label": "L06", "matrix": [1, 0], "x": 1, "y": 2.27},
                 {"label": "L07", "matrix": [1, 1], "x": 2, "y": 1.31},
                 {"label": "L08", "matrix": [1, 2], "x": 3, "y": 1},
                 {"label": "L09", "matrix": [1, 3], "x": 4, "y": 1.28},
@@ -45,9 +44,10 @@
                 {"label": "R07", "matrix": [1, 6], "x": 10, "y": 1.28},
                 {"label": "R08", "matrix": [1, 7], "x": 11, "y": 1},
                 {"label": "R09", "matrix": [1, 8], "x": 12, "y": 1.31},
-                {"label": "R10", "matrix": [1, 9], "x": 14, "y": 2.27},
+                {"label": "R10", "matrix": [1, 9], "x": 13, "y": 2.27},
+                {"label": "R05", "matrix": [0, 9], "x": 14, "y": 2.47},
 
-                {"label": "L11", "matrix": [2, 0], "x": 0, "y": 3.27},
+                {"label": "L11", "matrix": [2, 0], "x": 1, "y": 3.27},
                 {"label": "L12", "matrix": [2, 1], "x": 2, "y": 2.31},
                 {"label": "L13", "matrix": [2, 2], "x": 3, "y": 2},
                 {"label": "L14", "matrix": [2, 3], "x": 4, "y": 2.28},
@@ -57,7 +57,7 @@
                 {"label": "R12", "matrix": [2, 6], "x": 10, "y": 2.28},
                 {"label": "R13", "matrix": [2, 7], "x": 11, "y": 2},
                 {"label": "R14", "matrix": [2, 8], "x": 12, "y": 2.31},
-                {"label": "R15", "matrix": [2, 9], "x": 14, "y": 3.27},
+                {"label": "R15", "matrix": [2, 9], "x": 13, "y": 3.27},
 
                 {"label": "L16", "matrix": [3, 3], "x": 5, "y": 3.9},
                 {"label": "L17", "matrix": [3, 4], "x": 6, "y": 3.7},

--- a/keyboards/osprette/info.json
+++ b/keyboards/osprette/info.json
@@ -1,0 +1,76 @@
+{
+    "keyboard_name": "The Osprette",
+    "manufacturer": "S'mores",
+    "url": "https://github.com/smores56/osprette",
+    "maintainer": "@smores56",
+    "usb": {
+      "vid": "0xBEEF",
+      "pid": "0x5052",
+      "device_version": "0.0.1"
+    },
+    "development_board": "elite_c",
+    "pin_compatible": "promicro",
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": false
+    },
+    "matrix_pins": {
+        "cols": ["B3", "B1", "F7", "F6", "F5", "D0", "D4", "C6", "D7", "E6"],
+        "rows": ["B2", "B6", "B4", "B5"]
+    },
+    "diode_direction": "ROW2COL",
+    "layout_aliases": {
+        "LAYOUT_split_3x5_2": "LAYOUT_pinky_cluster_34"
+    },
+    "layouts": {
+        "LAYOUT_pinky_cluster_34": {
+            "layout": [
+                {"label": "L01", "matrix": [0, 0], "x": 0, "y": 2.27},
+                {"label": "L02", "matrix": [0, 1], "x": 2, "y": 0.31},
+                {"label": "L03", "matrix": [0, 2], "x": 3, "y": 0},
+                {"label": "L04", "matrix": [0, 3], "x": 4, "y": 0.28},
+                {"label": "L05", "matrix": [0, 4], "x": 5, "y": 0.42},
+
+                {"label": "R01", "matrix": [0, 5], "x": 9, "y": 0.42},
+                {"label": "R02", "matrix": [0, 6], "x": 10, "y": 0.28},
+                {"label": "R03", "matrix": [0, 7], "x": 11, "y": 0},
+                {"label": "R04", "matrix": [0, 8], "x": 12, "y": 0.31},
+                {"label": "R05", "matrix": [0, 9], "x": 14, "y": 2.27},
+
+                {"label": "L06", "matrix": [1, 0], "x": 0, "y": 2.27},
+                {"label": "L07", "matrix": [1, 1], "x": 2, "y": 1.31},
+                {"label": "L08", "matrix": [1, 2], "x": 3, "y": 1},
+                {"label": "L09", "matrix": [1, 3], "x": 4, "y": 1.28},
+                {"label": "L10", "matrix": [1, 4], "x": 5, "y": 1.42},
+
+                {"label": "R06", "matrix": [1, 5], "x": 9, "y": 1.42},
+                {"label": "R07", "matrix": [1, 6], "x": 10, "y": 1.28},
+                {"label": "R08", "matrix": [1, 7], "x": 11, "y": 1},
+                {"label": "R09", "matrix": [1, 8], "x": 12, "y": 1.31},
+                {"label": "R10", "matrix": [1, 9], "x": 14, "y": 2.27},
+
+                {"label": "L11", "matrix": [2, 0], "x": 0, "y": 3.27},
+                {"label": "L12", "matrix": [2, 1], "x": 2, "y": 2.31},
+                {"label": "L13", "matrix": [2, 2], "x": 3, "y": 2},
+                {"label": "L14", "matrix": [2, 3], "x": 4, "y": 2.28},
+                {"label": "L15", "matrix": [2, 4], "x": 5, "y": 2.42},
+
+                {"label": "R11", "matrix": [2, 5], "x": 9, "y": 2.42},
+                {"label": "R12", "matrix": [2, 6], "x": 10, "y": 2.28},
+                {"label": "R13", "matrix": [2, 7], "x": 11, "y": 2},
+                {"label": "R14", "matrix": [2, 8], "x": 12, "y": 2.31},
+                {"label": "R15", "matrix": [2, 9], "x": 14, "y": 3.27},
+
+                {"label": "L16", "matrix": [3, 3], "x": 5, "y": 3.9},
+                {"label": "L17", "matrix": [3, 4], "x": 6, "y": 3.7},
+
+                {"label": "R16", "matrix": [3, 5], "x": 8, "y": 3.7},
+                {"label": "R17", "matrix": [3, 6], "x": 9, "y": 3.9}
+            ]
+        }
+    }
+}

--- a/keyboards/osprette/info.json
+++ b/keyboards/osprette/info.json
@@ -12,11 +12,8 @@
     "pin_compatible": "promicro",
     "features": {
         "bootmagic": true,
-        "command": false,
-        "console": false,
         "extrakey": true,
-        "mousekey": true,
-        "nkro": false
+        "mousekey": true
     },
     "matrix_pins": {
         "cols": ["B3", "B1", "F7", "F6", "F5", "D0", "D4", "C6", "D7", "E6"],

--- a/keyboards/osprette/info.json
+++ b/keyboards/osprette/info.json
@@ -23,9 +23,6 @@
         "rows": ["B2", "B6", "B4", "B5"]
     },
     "diode_direction": "ROW2COL",
-    "layout_aliases": {
-        "LAYOUT_split_3x5_2": "LAYOUT_pinky_cluster_34"
-    },
     "layouts": {
         "LAYOUT_pinky_cluster_34": {
             "layout": [

--- a/keyboards/osprette/info.json
+++ b/keyboards/osprette/info.json
@@ -6,7 +6,7 @@
     "usb": {
       "vid": "0xBEEF",
       "pid": "0x5052",
-      "device_version": "0.0.1"
+      "device_version": "1.0.0"
     },
     "development_board": "elite_c",
     "pin_compatible": "promicro",

--- a/keyboards/osprette/info.json
+++ b/keyboards/osprette/info.json
@@ -8,8 +8,7 @@
       "pid": "0x5052",
       "device_version": "1.0.0"
     },
-    "development_board": "elite_c",
-    "pin_compatible": "promicro",
+    "development_board": "promicro",
     "features": {
         "bootmagic": true,
         "extrakey": true,

--- a/keyboards/osprette/info.json
+++ b/keyboards/osprette/info.json
@@ -18,6 +18,9 @@
         "cols": ["B3", "B1", "F7", "F6", "F5", "D0", "D4", "C6", "D7", "E6"],
         "rows": ["B2", "B6", "B4", "B5"]
     },
+    "tapping": {
+        "term": 250
+    }
     "diode_direction": "ROW2COL",
     "layouts": {
         "LAYOUT": {

--- a/keyboards/osprette/keymaps/default/config.h
+++ b/keyboards/osprette/keymaps/default/config.h
@@ -1,0 +1,7 @@
+// Copyright 2024 Sam Mohr (@smores56)
+// SPDX-License-Identifier: GPL-2.0+
+
+#pragma once
+
+// Defaults for usable home row mods
+#define TAPPING_TERM 250

--- a/keyboards/osprette/keymaps/default/config.h
+++ b/keyboards/osprette/keymaps/default/config.h
@@ -1,7 +1,0 @@
-// Copyright 2024 Sam Mohr (@smores56)
-// SPDX-License-Identifier: GPL-2.0+
-
-#pragma once
-
-// Defaults for usable home row mods
-#define TAPPING_TERM 250

--- a/keyboards/osprette/keymaps/default/keymap.c
+++ b/keyboards/osprette/keymaps/default/keymap.c
@@ -1,0 +1,35 @@
+// Copyright 2024 Sam Mohr (@smores56)
+// SPDX-License-Identifier: GPL-2.0+
+
+#include QMK_KEYBOARD_H
+
+/* Base layer 0 layout uses home row mods. See the following guide for details:
+ * https://precondition.github.io/home-row-mods
+ */
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT_split_3x5_2(
+    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+    CTL_T(KC_A),ALT_T(KC_S),GUI_T(KC_D),SFT_T(KC_F), KC_G,    KC_H, SFT_T(KC_J),GUI_T(KC_K),ALT_T(KC_L),CTL_T(KC_SCLN),
+    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
+                          LT(2,KC_TAB), KC_ENT,      KC_SPC,  LT(1,KC_BSPC)
+    ),
+    [1] = LAYOUT_split_3x5_2(
+    KC_INS,  KC_1,    KC_2,    KC_3,    KC_VOLU,     KC_HOME, KC_PGDN, KC_PGUP, KC_END,  KC_DQUO,
+    KC_DEL,  KC_4,    KC_5,    KC_6,    KC_VOLD,     KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_QUOT,
+    KC_CAPS, KC_7,    KC_8,    KC_9,    KC_0,        _______, _______, _______, _______, _______,
+                               MO(3),   QK_GESC,     _______, _______
+    ),
+    [2] = LAYOUT_split_3x5_2(
+    _______, KC_LBRC, KC_LCBR, KC_RCBR, _______,     KC_CIRC, KC_LPRN, KC_RPRN, KC_RBRC, KC_TILD,
+    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,     KC_AMPR, KC_MINS, KC_EQL,  KC_BSLS, KC_GRV,
+    _______, _______, _______, _______, _______,     KC_ASTR, KC_UNDS, KC_PLUS, KC_PIPE, _______,
+                               _______, _______,     KC_DEL,  MO(3)
+    ),
+    [3] = LAYOUT_split_3x5_2(
+    _______, KC_F1,   KC_F2,   KC_F3,   KC_F10,      _______, KC_WH_U, KC_WH_D, _______, QK_BOOT,
+    _______, KC_F4,   KC_F5,   KC_F6,   KC_F11,      KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R, KC_INS,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F12,      _______, KC_BTN1, KC_BTN2, _______, _______,
+                               _______, _______,     _______, _______
+    )
+};

--- a/keyboards/osprette/keymaps/default/keymap.c
+++ b/keyboards/osprette/keymaps/default/keymap.c
@@ -8,28 +8,28 @@
  */
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_split_3x5_2(
-    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
-    CTL_T(KC_A),ALT_T(KC_S),GUI_T(KC_D),SFT_T(KC_F), KC_G,    KC_H, SFT_T(KC_J),GUI_T(KC_K),ALT_T(KC_L),CTL_T(KC_SCLN),
-    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
-                          LT(2,KC_TAB), KC_ENT,      KC_SPC,  LT(1,KC_BSPC)
+[0] = LAYOUT(
+                           KC_W,        KC_E,         KC_R,        KC_T,     KC_Y,   KC_U,       KC_I,          KC_O,
+        KC_Q, CTL_T(KC_A), ALT_T(KC_S), GUI_T(KC_D),  SFT_T(KC_F), KC_G,     KC_H,  SFT_T(KC_J), GUI_T(KC_K),   ALT_T(KC_L), CTL_T(KC_SCLN), KC_P,
+                           KC_Z,        KC_X,         KC_C,        KC_V,     KC_B,   KC_N,       KC_M, KC_COMM, KC_DOT,      KC_SLSH,
+                                        LT(2,KC_TAB), KC_ENT,                KC_SPC, LT(1,KC_BSPC)
     ),
-    [1] = LAYOUT_split_3x5_2(
-    KC_INS,  KC_1,    KC_2,    KC_3,    KC_VOLU,     KC_HOME, KC_PGDN, KC_PGUP, KC_END,  KC_DQUO,
-    KC_DEL,  KC_4,    KC_5,    KC_6,    KC_VOLD,     KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_QUOT,
-    KC_CAPS, KC_7,    KC_8,    KC_9,    KC_0,        _______, _______, _______, _______, _______,
-                               MO(3),   QK_GESC,     _______, _______
+    [1] = LAYOUT(
+                          KC_1,    KC_2,    KC_3,    KC_VOLU,     KC_HOME, KC_PGDN, KC_PGUP, KC_END,
+        KC_INS, KC_DEL,   KC_4,    KC_5,    KC_6,    KC_VOLD,     KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT, KC_QUOT, KC_DQUO,
+                KC_CAPS,  KC_7,    KC_8,    KC_9,    KC_0,        _______, _______, _______, _______, _______,
+                                            MO(3),   QK_GESC,     _______, _______
     ),
-    [2] = LAYOUT_split_3x5_2(
-    _______, KC_LBRC, KC_LCBR, KC_RCBR, _______,     KC_CIRC, KC_LPRN, KC_RPRN, KC_RBRC, KC_TILD,
-    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,     KC_AMPR, KC_MINS, KC_EQL,  KC_BSLS, KC_GRV,
-    _______, _______, _______, _______, _______,     KC_ASTR, KC_UNDS, KC_PLUS, KC_PIPE, _______,
-                               _______, _______,     KC_DEL,  MO(3)
+    [2] = LAYOUT(
+                 KC_LBRC, KC_LCBR, KC_RCBR, _______,              KC_CIRC, KC_LPRN, KC_RPRN, KC_RBRC,
+        _______, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,     KC_AMPR, KC_MINS, KC_EQL,  KC_BSLS, KC_GRV,  KC_TILD,
+                 _______, _______, _______, _______, _______,     KC_ASTR, KC_UNDS, KC_PLUS, KC_PIPE, _______,
+                                            _______, _______,     KC_DEL,  MO(3)
     ),
-    [3] = LAYOUT_split_3x5_2(
-    _______, KC_F1,   KC_F2,   KC_F3,   KC_F10,      _______, KC_WH_U, KC_WH_D, _______, QK_BOOT,
-    _______, KC_F4,   KC_F5,   KC_F6,   KC_F11,      KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R, KC_INS,
-    _______, KC_F7,   KC_F8,   KC_F9,   KC_F12,      _______, KC_BTN1, KC_BTN2, _______, _______,
-                               _______, _______,     _______, _______
+    [3] = LAYOUT(
+                          KC_F1,   KC_F2,   KC_F3,   KC_F10,      _______, KC_WH_U, KC_WH_D, _______,
+        _______, _______, KC_F4,   KC_F5,   KC_F6,   KC_F11,      KC_MS_L, KC_MS_D, KC_MS_U, KC_MS_R, KC_INS,  QK_BOOT,
+                 _______, KC_F7,   KC_F8,   KC_F9,   KC_F12,      _______, KC_BTN1, KC_BTN2, _______, _______,
+                                            _______, _______,     _______, _______
     )
 };

--- a/keyboards/osprette/readme.md
+++ b/keyboards/osprette/readme.md
@@ -1,0 +1,26 @@
+# The Osprette
+
+This is the official firmware for a family of boards designed by [smores56](https://github.com/smores56),
+the first of which was [the Osprette](https://github.com/smores56/osprette). This firmware works for the following boards:
+
+- [The Osprette](https://github.com/smores56/osprette)
+- [The Osprette V2](https://github.com/smores56/osprette-v2)
+- [The Osprette V3](https://github.com/smores56/osprette-v3)
+- [The Osprette MX](https://github.com/smores56/osprette-mx)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make osprette:default
+
+Flashing example for this keyboard:
+
+    make osprette:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 2 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/osprette/rules.mk
+++ b/keyboards/osprette/rules.mk
@@ -1,0 +1,1 @@
+# This file intentionally left blank


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adds firmware for the [Osprette](https://github.com/smores56/osprette) keyboard (with default layout) to QMK master. The following 4 boards of mine all use the same firmware, meaning this change should continue to be forward-compatible with future boards I design:

- [The Osprette](https://github.com/smores56/osprette)
- [The Osprette V2](https://github.com/smores56/osprette-v2)
- [The Osprette V3](https://github.com/smores56/osprette-v3)
- [The Osprette MX](https://github.com/smores56/osprette-mx)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
