### PR TITLE
Fix pointing_device_set_cpi_on_side() changing CPI on correct side. relevant to #19433.

### DIFF
--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -368,7 +368,7 @@ void pointing_device_set_cpi(uint16_t cpi) {
  * @param[in] cpi uint16_t value.
  */
 void pointing_device_set_cpi_on_side(bool left, uint16_t cpi) {
-    bool local = (is_keyboard_left() & left) ? true : false;
+    bool local = (is_keyboard_left() == left) ? true : false;
     if (local) {
         pointing_device_driver.set_cpi(cpi);
     } else {

--- a/quantum/pointing_device/pointing_device.c
+++ b/quantum/pointing_device/pointing_device.c
@@ -368,7 +368,7 @@ void pointing_device_set_cpi(uint16_t cpi) {
  * @param[in] cpi uint16_t value.
  */
 void pointing_device_set_cpi_on_side(bool left, uint16_t cpi) {
-    bool local = (is_keyboard_left() == left) ? true : false;
+    bool local = (is_keyboard_left() == left);
     if (local) {
         pointing_device_driver.set_cpi(cpi);
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Corrected that when the USB cable was on the right side, the left side was changed when trying to change the CPI on the right side in POINTING_DEVICE_CONBINED.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #19433

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
