### PR TITLE
Oneshot locked mods split transaction

### DIFF
--- a/docs/feature_split_keyboard.md
+++ b/docs/feature_split_keyboard.md
@@ -266,7 +266,7 @@ This enables syncing of the Host LED status (caps lock, num lock, etc) between b
 #define SPLIT_MODS_ENABLE
 ```
 
-This enables transmitting modifier state (normal, weak and oneshot) to the non primary side of the split keyboard. The purpose of this feature is to support cosmetic use of modifer state (e.g. displaying status on an OLED screen).
+This enables transmitting modifier state (normal, weak, oneshot and oneshot locked) to the non primary side of the split keyboard. The purpose of this feature is to support cosmetic use of modifer state (e.g. displaying status on an OLED screen).
 
 ```c
 #define SPLIT_WPM_ENABLE

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -419,6 +419,10 @@ static bool mods_handlers_master(matrix_row_t master_matrix[], matrix_row_t slav
     if (!mods_need_sync && new_mods.oneshot_mods != split_shmem->mods.oneshot_mods) {
         mods_need_sync = true;
     }
+    new_mods.oneshot_locked_mods = get_oneshot_locked_mods();
+    if (!mods_need_sync && new_mods.oneshot_locked_mods != split_shmem->mods.oneshot_locked_mods) {
+        mods_need_sync = true;
+    }
 #    endif // NO_ACTION_ONESHOT
 
     bool okay = true;
@@ -442,6 +446,7 @@ static void mods_handlers_slave(matrix_row_t master_matrix[], matrix_row_t slave
     set_weak_mods(mods.weak_mods);
 #    ifndef NO_ACTION_ONESHOT
     set_oneshot_mods(mods.oneshot_mods);
+    set_oneshot_locked_mods(mods.oneshot_locked_mods);
 #    endif
 }
 

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -101,6 +101,7 @@ typedef struct _split_mods_sync_t {
     uint8_t weak_mods;
 #    ifndef NO_ACTION_ONESHOT
     uint8_t oneshot_mods;
+    uint8_t oneshot_locked_mods;
 #    endif // NO_ACTION_ONESHOT
 } split_mods_sync_t;
 #endif // SPLIT_MODS_ENABLE


### PR DESCRIPTION
Split transaction mods does not transfer one shot locked mods.

## Description

As noted in the title, split transactions one shot locked mods is not transferred to slave side for oled display, this pull request aims to change that.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
