### PR TITLE
Fail if migrated entities aren't migrated.

### DIFF
--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -22,9 +22,11 @@ def generate_define(define, value=None):
 #undef {define}
 #define {define}{value}"""
     return f"""
-#ifndef {define}
-#    define {define}{value}
-#endif // {define}"""
+#ifdef {define}
+#    error {define} is set in config.h
+#endif // {define}
+#define {define}{value}
+"""
 
 
 def direct_pins(direct_pins, postfix):


### PR DESCRIPTION
## Description

Now that the `config.h` ordering has been somewhat sorted (#23448, keyboard before generated `info_config.h` before keymap), this will ensure that if there are keyboard-level items in `config.h` cause failures during build, prompting migration.

Additionally, a large chunk of documentation will need to be migrated away from promoting the use of `config.h` before we could consider merging this.

This is raised early for visibility purposes and is not expected to be merged any time soon; almost all migrations will need to occur first, otherwise there will be hundreds of build failures.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
