### PR TITLE
Draft: Enhance Viktus OSAv2 Topre Firmware with Customizable Key Actuation Sensitivity

### DIFF
--- a/keyboards/viktus/osav2_topre/ec.c
+++ b/keyboards/viktus/osav2_topre/ec.c
@@ -141,14 +141,6 @@ bool ec_update_key(matrix_row_t* current_row, matrix_row_t col, uint16_t sw_valu
 }
 
 const KeyConfig key_level_configs[] = {
-    {&KEY_00_KC_DEL, {55, 65}}, // Default levels for (DEL)
-    {&KEY_01_KC_ESC, {55, 65}}, // Default levels for (ESC)
-    {&KEY_02_KC_1, {55, 65}},   // Default levels for (1)
-    // ...
-    {&KEY_12_KC_Q, {48, 53}}, // Custom levels for (Q)
-    {&KEY_22_KC_A, {48, 53}}, // Custom levels for (A)
-    {&KEY_32_KC_Z, {48, 53}}, // Custom levels for (Z)
-    // ...
     {&KEY_014_KC_BSLS, {48, 53}}, // Custom levels for (SPLIT_BACKSPACE_LEFT_1U)
     {&KEY_015_KC_GRV, {48, 53}},  // Custom levels for (BACKSPACE_2U)
     {&KEY_314_KC_RSFT, {48, 53}}, // Custom levels for (RIGHT_SHIFT_1_75U)
@@ -156,6 +148,9 @@ const KeyConfig key_level_configs[] = {
     {&KEY_46_MO_1_2, {48, 58}},   // Custom levels for (LEFT_SPACE_COL6)
     {&KEY_49_KC_SPC_2, {50, 60}}, // Custom levels for (LEFT_SPACE_COL3)
     {&KEY_411_KC_RALT, {48, 53}}  // Custom levels for (RIGHT_SHIFT_2_75U)
+
+    // ...
+    // Add additional configurations here!
 };
 
 bool ec_matrix_scan(matrix_row_t current_matrix[]) {

--- a/keyboards/viktus/osav2_topre/ec.c
+++ b/keyboards/viktus/osav2_topre/ec.c
@@ -17,8 +17,7 @@
 #include "quantum.h"
 #include "ec.h"
 #include "analog.h"
-//#include "debug.h"  // needed for debugging
-#include "ec.h"
+// #include "debug.h"  // needed for debugging
 #include "key_positions.h"
 
 // sensing channel definitions

--- a/keyboards/viktus/osav2_topre/ec.h
+++ b/keyboards/viktus/osav2_topre/ec.h
@@ -23,8 +23,8 @@
 #include "matrix.h"
 #include "ec_types.h"
 
-#define DEFAULT_RESET_PT 50
-#define DEFAULT_ACTUATION_PT 60
+#define DEFAULT_RESET_PT 55
+#define DEFAULT_ACTUATION_PT 65
 
 void ec_init(ec_config_t const* const ec_config);
 bool ec_matrix_scan(matrix_row_t current_matrix[]);

--- a/keyboards/viktus/osav2_topre/ec.h
+++ b/keyboards/viktus/osav2_topre/ec.h
@@ -14,23 +14,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// ec.h
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
 
 #include "matrix.h"
+#include "ec_types.h"
 
-#define DEFAULT_RESET_PT 45
-#define DEFAULT_ACTUATION_PT 52
+#define DEFAULT_RESET_PT 50
+#define DEFAULT_ACTUATION_PT 60
 
-typedef struct {
-    uint16_t reset_pt;
-    uint16_t actuation_pt;
-} ec_config_t;
-
-void     ec_init(ec_config_t const* const ec_config);
-bool     ec_matrix_scan(matrix_row_t current_matrix[]);
-//void     ec_dprint_matrix(void);  // needed for debugging
+void ec_init(ec_config_t const* const ec_config);
+bool ec_matrix_scan(matrix_row_t current_matrix[]);
+// void ec_dprint_matrix(void);  // needed for debugging
 uint16_t ec_readkey_raw(uint8_t col, uint8_t row);
 bool     ec_update_key(matrix_row_t* current_row, matrix_row_t col, uint16_t sw_value, uint16_t reset_pt, uint16_t actuation_pt);

--- a/keyboards/viktus/osav2_topre/ec.h
+++ b/keyboards/viktus/osav2_topre/ec.h
@@ -14,10 +14,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
 
 #include "matrix.h"
+
+#define DEFAULT_RESET_PT 45
+#define DEFAULT_ACTUATION_PT 52
 
 typedef struct {
     uint16_t reset_pt;

--- a/keyboards/viktus/osav2_topre/ec_types.h
+++ b/keyboards/viktus/osav2_topre/ec_types.h
@@ -1,0 +1,22 @@
+// ec_types.h
+#ifndef EC_TYPES_H
+#define EC_TYPES_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint16_t reset_pt;
+    uint16_t actuation_pt;
+} ec_config_t;
+
+typedef struct {
+    uint8_t row;
+    uint8_t col;
+} KeyPosition;
+
+typedef struct {
+    const KeyPosition* key_position;
+    ec_config_t        key_level;
+} KeyConfig;
+
+#endif // EC_TYPES_H

--- a/keyboards/viktus/osav2_topre/key_positions.c
+++ b/keyboards/viktus/osav2_topre/key_positions.c
@@ -1,0 +1,74 @@
+// key_positions.c
+
+#include "key_positions.h"
+
+const KeyPosition KEY_00_KC_DEL   = {0, 0};
+const KeyPosition KEY_01_KC_ESC   = {0, 1};
+const KeyPosition KEY_02_KC_1     = {0, 2};
+const KeyPosition KEY_03_KC_2     = {0, 3};
+const KeyPosition KEY_04_KC_3     = {0, 4};
+const KeyPosition KEY_05_KC_4     = {0, 5};
+const KeyPosition KEY_06_KC_5     = {0, 6};
+const KeyPosition KEY_07_KC_6     = {0, 7};
+const KeyPosition KEY_08_KC_7     = {0, 8};
+const KeyPosition KEY_09_KC_8     = {0, 9};
+const KeyPosition KEY_010_KC_9    = {0, 10};
+const KeyPosition KEY_011_KC_0    = {0, 11};
+const KeyPosition KEY_012_KC_MINS = {0, 12};
+const KeyPosition KEY_013_KC_EQL  = {0, 13};
+const KeyPosition KEY_014_KC_BSLS = {0, 14};
+const KeyPosition KEY_015_KC_GRV  = {0, 15};
+
+const KeyPosition KEY_10_KC_PGUP  = {1, 0};
+const KeyPosition KEY_11_KC_TAB   = {1, 1};
+const KeyPosition KEY_12_KC_Q     = {1, 2};
+const KeyPosition KEY_13_KC_W     = {1, 3};
+const KeyPosition KEY_14_KC_E     = {1, 4};
+const KeyPosition KEY_15_KC_R     = {1, 5};
+const KeyPosition KEY_16_KC_T     = {1, 6};
+const KeyPosition KEY_18_KC_Y     = {1, 8};
+const KeyPosition KEY_19_KC_U     = {1, 9};
+const KeyPosition KEY_110_KC_I    = {1, 10};
+const KeyPosition KEY_111_KC_O    = {1, 11};
+const KeyPosition KEY_112_KC_P    = {1, 12};
+const KeyPosition KEY_113_KC_LBRC = {1, 13};
+const KeyPosition KEY_114_KC_RBRC = {1, 14};
+const KeyPosition KEY_115_KC_BSPC = {1, 15};
+
+const KeyPosition KEY_20_KC_PGDN  = {2, 0};
+const KeyPosition KEY_21_KC_CAPS  = {2, 1};
+const KeyPosition KEY_22_KC_A     = {2, 2};
+const KeyPosition KEY_23_KC_S     = {2, 3};
+const KeyPosition KEY_24_KC_D     = {2, 4};
+const KeyPosition KEY_25_KC_F     = {2, 5};
+const KeyPosition KEY_26_KC_G     = {2, 6};
+const KeyPosition KEY_28_KC_H     = {2, 8};
+const KeyPosition KEY_29_KC_J     = {2, 9};
+const KeyPosition KEY_210_KC_K    = {2, 10};
+const KeyPosition KEY_211_KC_L    = {2, 11};
+const KeyPosition KEY_212_KC_SCLN = {2, 12};
+const KeyPosition KEY_213_KC_QUOT = {2, 13};
+const KeyPosition KEY_215_KC_ENT  = {2, 15};
+
+const KeyPosition KEY_31_KC_LSFT  = {3, 1};
+const KeyPosition KEY_32_KC_Z     = {3, 2};
+const KeyPosition KEY_33_KC_X     = {3, 3};
+const KeyPosition KEY_34_KC_C     = {3, 4};
+const KeyPosition KEY_35_KC_V     = {3, 5};
+const KeyPosition KEY_36_KC_B     = {3, 6};
+const KeyPosition KEY_38_KC_B_2   = {3, 8};
+const KeyPosition KEY_39_KC_N     = {3, 9};
+const KeyPosition KEY_310_KC_M    = {3, 10};
+const KeyPosition KEY_311_KC_COMM = {3, 11};
+const KeyPosition KEY_312_KC_DOT  = {3, 12};
+const KeyPosition KEY_313_KC_SLSH = {3, 13};
+const KeyPosition KEY_314_KC_RSFT = {3, 14};
+const KeyPosition KEY_315_MO_1    = {3, 15};
+
+const KeyPosition KEY_41_KC_LCTL  = {4, 1};
+const KeyPosition KEY_42_KC_LALT  = {4, 2};
+const KeyPosition KEY_44_KC_SPC   = {4, 4};
+const KeyPosition KEY_46_MO_1_2   = {4, 6};
+const KeyPosition KEY_49_KC_SPC_2 = {4, 9};
+const KeyPosition KEY_411_KC_RALT = {4, 11};
+const KeyPosition KEY_415_KC_RCTL = {4, 15};

--- a/keyboards/viktus/osav2_topre/key_positions.h
+++ b/keyboards/viktus/osav2_topre/key_positions.h
@@ -1,0 +1,79 @@
+// key_positions.h
+#ifndef KEY_POSITIONS_H
+#define KEY_POSITIONS_H
+
+#include "ec_types.h" // Include ec_types.h
+
+// Define KeyPosition objects for all keys in the matrix
+extern const KeyPosition KEY_00_KC_DEL;
+extern const KeyPosition KEY_01_KC_ESC;
+extern const KeyPosition KEY_02_KC_1;
+extern const KeyPosition KEY_03_KC_2;
+extern const KeyPosition KEY_04_KC_3;
+extern const KeyPosition KEY_05_KC_4;
+extern const KeyPosition KEY_06_KC_5;
+extern const KeyPosition KEY_07_KC_6;
+extern const KeyPosition KEY_08_KC_7;
+extern const KeyPosition KEY_09_KC_8;
+extern const KeyPosition KEY_010_KC_9;
+extern const KeyPosition KEY_011_KC_0;
+extern const KeyPosition KEY_012_KC_MINS;
+extern const KeyPosition KEY_013_KC_EQL;
+extern const KeyPosition KEY_014_KC_BSLS;
+extern const KeyPosition KEY_015_KC_GRV;
+
+extern const KeyPosition KEY_10_KC_PGUP;
+extern const KeyPosition KEY_11_KC_TAB;
+extern const KeyPosition KEY_12_KC_Q;
+extern const KeyPosition KEY_13_KC_W;
+extern const KeyPosition KEY_14_KC_E;
+extern const KeyPosition KEY_15_KC_R;
+extern const KeyPosition KEY_16_KC_T;
+extern const KeyPosition KEY_18_KC_Y;
+extern const KeyPosition KEY_19_KC_U;
+extern const KeyPosition KEY_110_KC_I;
+extern const KeyPosition KEY_111_KC_O;
+extern const KeyPosition KEY_112_KC_P;
+extern const KeyPosition KEY_113_KC_LBRC;
+extern const KeyPosition KEY_114_KC_RBRC;
+extern const KeyPosition KEY_115_KC_BSPC;
+
+extern const KeyPosition KEY_20_KC_PGDN;
+extern const KeyPosition KEY_21_KC_CAPS;
+extern const KeyPosition KEY_22_KC_A;
+extern const KeyPosition KEY_23_KC_S;
+extern const KeyPosition KEY_24_KC_D;
+extern const KeyPosition KEY_25_KC_F;
+extern const KeyPosition KEY_26_KC_G;
+extern const KeyPosition KEY_28_KC_H;
+extern const KeyPosition KEY_29_KC_J;
+extern const KeyPosition KEY_210_KC_K;
+extern const KeyPosition KEY_211_KC_L;
+extern const KeyPosition KEY_212_KC_SCLN;
+extern const KeyPosition KEY_213_KC_QUOT;
+extern const KeyPosition KEY_215_KC_ENT;
+
+extern const KeyPosition KEY_31_KC_LSFT;
+extern const KeyPosition KEY_32_KC_Z;
+extern const KeyPosition KEY_33_KC_X;
+extern const KeyPosition KEY_34_KC_C;
+extern const KeyPosition KEY_35_KC_V;
+extern const KeyPosition KEY_36_KC_B;
+extern const KeyPosition KEY_38_KC_B_2;
+extern const KeyPosition KEY_39_KC_N;
+extern const KeyPosition KEY_310_KC_M;
+extern const KeyPosition KEY_311_KC_COMM;
+extern const KeyPosition KEY_312_KC_DOT;
+extern const KeyPosition KEY_313_KC_SLSH;
+extern const KeyPosition KEY_314_KC_RSFT;
+extern const KeyPosition KEY_315_MO_1;
+
+extern const KeyPosition KEY_41_KC_LCTL;
+extern const KeyPosition KEY_42_KC_LALT;
+extern const KeyPosition KEY_44_KC_SPC;
+extern const KeyPosition KEY_46_MO_1_2;
+extern const KeyPosition KEY_49_KC_SPC_2;
+extern const KeyPosition KEY_411_KC_RALT;
+extern const KeyPosition KEY_415_KC_RCTL;
+
+#endif // KEY_POSITIONS_H

--- a/keyboards/viktus/osav2_topre/osav2_topre.c
+++ b/keyboards/viktus/osav2_topre/osav2_topre.c
@@ -19,9 +19,6 @@
 #include "matrix.h"
 //#include "debug.h"  // needed for debugging
 
-#define RESET_PT 55
-#define ACTUATION_PT 65
-
 // console debugging for pad values
 /*void keyboard_post_init_kb() {
     debug_enable = true;
@@ -29,7 +26,7 @@
 }*/
 
 void matrix_init_custom(void) {
-    ec_config_t ec_config = {.reset_pt = RESET_PT, .actuation_pt = ACTUATION_PT};
+    ec_config_t ec_config = {.reset_pt = DEFAULT_RESET_PT, .actuation_pt = DEFAULT_ACTUATION_PT};
 
     ec_init(&ec_config);
 }

--- a/keyboards/viktus/osav2_topre/readme.md
+++ b/keyboards/viktus/osav2_topre/readme.md
@@ -23,3 +23,35 @@ Enter the bootloader in 3 ways:
 * **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
 * **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available
+
+Here are the instructions to add to the README on how users can modify the actuation levels of each key:
+
+## Modifying Key Actuation Levels
+
+The actuation level of each key on the OSAv2 Topre keyboard is determined by two values: `DEFAULT_RESET_PT` and `DEFAULT_ACTUATION_PT`. These values are specified in the `ec.h` file.
+
+By default, all keys use these values. However, you can customize the actuation levels for specific keys by modifying the `key_level_configs` array in the `ec.c` file.
+
+All available key positions on the OSAv2 matrix are defined with friendly names in the `key_positions.c` file. You can refer to these names when specifying the keys you want to customize.
+
+To change the actuation level of a specific key, add an entry to the `key_level_configs` array in the following format:
+
+```c
+const KeyConfig key_level_configs[] = {
+    {&KEY_POSITION_NAME, {reset_pt, actuation_pt}},
+    // ...
+};
+```
+
+Replace `KEY_POSITION_NAME` with the name of the key position you want to customize (e.g., `KEY_014_KC_BSLS`), and set the desired `reset_pt` and `actuation_pt` values.
+
+For example, to customize the actuation levels for the split backspace left 1U key, you would add the following entry:
+
+```c
+const KeyConfig key_level_configs[] = {
+    {&KEY_014_KC_BSLS, {48, 53}}, // Custom levels for (SPLIT_BACKSPACE_LEFT_1U)
+    // ...
+};
+```
+
+You can add multiple entries to the `key_level_configs` array to customize the actuation levels for different keys. By modifying the `key_level_configs` array, you can fine-tune the actuation levels of specific keys to suit your preferences.

--- a/keyboards/viktus/osav2_topre/readme.md
+++ b/keyboards/viktus/osav2_topre/readme.md
@@ -24,8 +24,6 @@ Enter the bootloader in 3 ways:
 * **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available
 
-Here are the instructions to add to the README on how users can modify the actuation levels of each key:
-
 ## Modifying Key Actuation Levels
 
 The actuation level of each key on the OSAv2 Topre keyboard is determined by two values: `DEFAULT_RESET_PT` and `DEFAULT_ACTUATION_PT`. These values are specified in the `ec.h` file.

--- a/keyboards/viktus/osav2_topre/rules.mk
+++ b/keyboards/viktus/osav2_topre/rules.mk
@@ -1,4 +1,5 @@
 CUSTOM_MATRIX = lite
 SRC += ec.c
+SRC += key_positions.c
 
 ANALOG_DRIVER_REQUIRED = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This pull request introduces enhancements to the QMK firmware for the Viktus Design LLC Topre PCB that powers the Viktus OSAv2 keyboard. The changes focus on improving the process of modify the actuation sensitivity for specific keys to provide a more satisfactory user customization experience.

The main modifications include:
- Separating the key position definitions and key level configurations into separate files (`key_positions.h`, `key_positions.c`) for better organization and maintainability.
- Defining KeyPosition objects for all keys in the matrix using a consistent naming convention (`KEY_{ROW}{COL}_{FRIENDLY_NAME}`).
- Allowing users to specify custom actuation levels for specific keys by modifying the `key_level_configs` array in `key_levels.c`.
- Updating the `ec_matrix_scan` function in `ec.c` to apply the configured actuation levels during the matrix scan.
- Implementing a fail-safe mechanism to ensure that the difference between `reset_pt` and `actuation_pt` is at least 5 points for each key.

These changes enhance the firmware by providing a more intuitive and customizable approach to adjusting the actuation sensitivity of individual keys, without modifying the main scanning logic.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).