### PR TITLE
Force CPI update using timer when using split pointing.

### DIFF
--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -711,15 +711,16 @@ static bool pointing_handlers_master(matrix_row_t master_matrix[], matrix_row_t 
     }
 #    endif
     static uint32_t last_update = 0;
+    static uint32_t last_cpi_update = 0;
     static uint16_t last_cpi    = 0;
     report_mouse_t  temp_state;
     uint16_t        temp_cpi;
     bool            okay = read_if_checksum_mismatch(GET_POINTING_CHECKSUM, GET_POINTING_DATA, &last_update, &temp_state, &split_shmem->pointing.report, sizeof(temp_state));
     if (okay) pointing_device_set_shared_report(temp_state);
     temp_cpi = pointing_device_get_shared_cpi();
-    if (temp_cpi && last_cpi != temp_cpi) {
+    if (temp_cpi) {
         split_shmem->pointing.cpi = temp_cpi;
-        okay                      = transport_write(PUT_POINTING_CPI, &split_shmem->pointing.cpi, sizeof(split_shmem->pointing.cpi));
+        okay                      = send_if_condition(PUT_POINTING_CPI, &last_cpi_update, last_cpi != temp_cpi, &split_shmem->pointing.cpi, sizeof(split_shmem->pointing.cpi));
         if (okay) {
             last_cpi = temp_cpi;
         }

--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -710,9 +710,9 @@ static bool pointing_handlers_master(matrix_row_t master_matrix[], matrix_row_t 
         return true;
     }
 #    endif
-    static uint32_t last_update = 0;
+    static uint32_t last_update     = 0;
     static uint32_t last_cpi_update = 0;
-    static uint16_t last_cpi    = 0;
+    static uint16_t last_cpi        = 0;
     report_mouse_t  temp_state;
     uint16_t        temp_cpi;
     bool            okay = read_if_checksum_mismatch(GET_POINTING_CHECKSUM, GET_POINTING_DATA, &last_update, &temp_state, &split_shmem->pointing.report, sizeof(temp_state));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This was a bad assumption on my part in thinking a true return meant the slave side had received the transaction.

Forcing an update using the timer ensures the CPI is set correctly if it fails without error albeit with a small delay.

I've targeted master as I think it's more a bug fix and causes no compatibility issues but I'm happy to switch to develop if required. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
