### PR TITLE
Add waffling80 hotswap PCB

### DIFF
--- a/keyboards/4pplet/waffling80/rev_b_ansi/config.h
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/config.h
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 Stefan Sundin "4pplet" <mail@4pplet.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#define WS2812_EXTERNAL_PULLUP

--- a/keyboards/4pplet/waffling80/rev_b_ansi/info.json
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/info.json
@@ -9,6 +9,13 @@
         "brightness_steps": 8,
         "led_count": 2
     },
+    "features": {
+        "bootmagic": true,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true,
+        "rgblight": true
+    }
     "ws2812": {
         "pin": "A8"
     },

--- a/keyboards/4pplet/waffling80/rev_b_ansi/info.json
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/info.json
@@ -1,0 +1,22 @@
+{
+    "keyboard_name": "waffling80 Rev B ANSI HS",
+    "usb": {
+        "pid": "0x0010",
+        "device_version": "0.0.1"
+    },
+    "rgblight": {
+        "saturation_steps": 8,
+        "brightness_steps": 8,
+        "led_count": 2
+    },
+    "ws2812": {
+        "pin": "A8"
+    },
+    "matrix_pins": {
+        "cols": ["B2", "B1", "B0", "A7", "A6", "A3", "B9", "B8"],
+        "rows": ["B13", "B12", "A5", "A4", "A2", "A1", "F0", "C15", "C13", "C14", "F1", "A0"]
+    },
+    "diode_direction": "COL2ROW",
+    "processor": "STM32F072",
+    "bootloader": "stm32-dfu"
+}

--- a/keyboards/4pplet/waffling80/rev_b_ansi/info.json
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/info.json
@@ -1,7 +1,7 @@
 {
     "keyboard_name": "waffling80 Rev B ANSI HS",
     "usb": {
-        "pid": "0x0010",
+        "pid": "0x0017",
         "device_version": "0.0.1"
     },
     "rgblight": {

--- a/keyboards/4pplet/waffling80/rev_b_ansi/readme.md
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/readme.md
@@ -1,20 +1,18 @@
 # waffling80
 
-A TKL PCB attempting a87 compatibility with different switch and layout-options. 
+A TKL PCB attempting a87 and a88 compatibility with different switch and layout-options. 
 
 * Keyboard Maintainer: [4pplet](https://github.com/4pplet)
 * Hardware Supported: [waffling80](https://github.com/4pplet/waffling80)
 
 Make example for this keyboard (after setting up your build environment):
 
-    make 4pplet/waffling80/rev_a:default
-    make 4pplet/waffling80/rev_b:default
     make 4pplet/waffling80/rev_b_ansi:default
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 
 How to enter bootloader (DFU):
-* Tap the physical reset button or short the reset-header (labled RESET) on tha back of the PCB for keyboard to enter DFU. When in DFU, it's ready to flash the firmware.
+* Hold the reset-header for a few seconds on the back of the PCB for keyboard to enter DFU. When in DFU, it's ready to flash the firmware.
 
 Alternative option if the firmware is already pre-flashed:
-* Unplug your keyboard, hold down the Spacebar and B at the same time, plug in your keyboard and wait a second before releasing the keys. The keyboard will enter DFU and is ready to flash the firmware.
+* Unplug your keyboard, hold down the Esc key, plug in your keyboard and wait a second before releasing the keys. The keyboard will enter DFU and is ready to flash the firmware.

--- a/keyboards/4pplet/waffling80/rev_b_ansi/rev_b_ansi.c
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/rev_b_ansi.c
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 Stefan Sundin "4pplet" <mail@4pplet.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "rev_b_ansi.h"
+
+bool led_update_kb(led_t led_state) {
+    bool res = led_update_user(led_state);
+    if (SCROLL_LOCK_ENABLE && res) {
+        if(led_state.scroll_lock) {
+            #ifdef SCROLL_LOCK_COLOR
+                rgblight_sethsv_at(SCROLL_LOCK_COLOR, 0);
+            #else
+                rgblight_sethsv_at(rgblight_get_hue(),rgblight_get_sat(),rgblight_get_val(), 0);
+            #endif
+        }
+        else {
+            rgblight_sethsv_at(HSV_OFF, 0);
+        }
+    }
+    if (CAPS_LOCK_ENABLE && res) {
+        if(led_state.caps_lock) {
+            #ifdef CAPS_LOCK_COLOR
+                rgblight_sethsv_at(CAPS_LOCK_COLOR, 1);
+            #else
+                rgblight_sethsv_at(rgblight_get_hue(),rgblight_get_sat(),rgblight_get_val(), 1);
+            #endif
+        }
+        else{
+            rgblight_sethsv_at(HSV_OFF, 1);
+        }
+    }
+    return res;
+}
+

--- a/keyboards/4pplet/waffling80/rev_b_ansi/rev_b_ansi.h
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/rev_b_ansi.h
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 Stefan Sundin "4pplet" <mail@4pplet.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#define CAPS_LOCK_ENABLE 1
+#define SCROLL_LOCK_ENABLE 1
+
+// If colors are defined, they will be static. If not defined, color for incicators can be set in VIA.
+//#define CAPS_LOCK_COLOR HSV_GREEN
+//#define SCROLL_LOCK_COLOR HSV_GREEN
+
+#include "quantum.h"

--- a/keyboards/4pplet/waffling80/rev_b_ansi/rules.mk
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/rules.mk
@@ -1,0 +1,16 @@
+# Build Options
+#   change yes to no to disable
+#
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = yes        # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = yes            # Enable N-Key Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
+AUDIO_ENABLE = no           # Audio output
+
+# Wildcard to allow APM32 MCU
+DFU_SUFFIX_ARGS = -p FFFF -v FFFF
+

--- a/keyboards/4pplet/waffling80/rev_b_ansi/rules.mk
+++ b/keyboards/4pplet/waffling80/rev_b_ansi/rules.mk
@@ -1,16 +1,2 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = yes            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = yes        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 # Wildcard to allow APM32 MCU
 DFU_SUFFIX_ARGS = -p FFFF -v FFFF
-


### PR DESCRIPTION
## Description

Adding support for waffling80 hotswap, a open source h88/h87 TKL PCB: https://github.com/4pplet/waffling80 (hotswap version not yet added to readme)

## Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
