### PR TITLE
Fix up license check path.

### DIFF
--- a/lib/python/qmk/cli/license_check.py
+++ b/lib/python/qmk/cli/license_check.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Nick Brassel (@tzarc)
 # SPDX-License-Identifier: GPL-2.0-or-later
 import re
+import os
 from pathlib import Path
 from milc import cli
 from qmk.constants import LICENSE_TEXTS
@@ -79,6 +80,12 @@ def _detect_license_from_file_contents(filename, absolute=False):
 @cli.argument('-e', '--extension', arg_only=True, action='append', default=[], help='Override list of extensions. Can be specified multiple times for multiple extensions.')
 @cli.subcommand('File license check.', hidden=False if cli.config.user.developer else True)
 def license_check(cli):
+    # Fixup inputs if they're not absolute, CLI's working directory is qmk_firmware so relative paths aren't going to be
+    # found unless they're qmk_firmware-local.
+    for i in range(len(cli.args.inputs)):
+        if not cli.args.inputs[i].is_absolute():
+            cli.args.inputs[i] = Path(os.environ.get('ORIG_CWD', os.getcwd())) / cli.args.inputs[i]
+
     def _default_suffix_condition(s):
         return s in SUFFIXES
 


### PR DESCRIPTION
## Description

Running `qmk license-check` against any relative paths _outside_ `qmk_firmware` would result in an inability to actually find the files, as the CLI `cd`s to `qmk_firmware` before executing. This uses `$ORIG_CWD` to make the files absolute.

Had to reorder the file as `qmk pytest` was complaining about complexity.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
