### PR TITLE
Refactoring successive press() release() calls into tap_key() calls

### DIFF
--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -32,10 +32,7 @@ TEST_F(OneShot, OSMWithoutAdditionalKeypressDoesNothing) {
 
     /* Press and release OSM key*/
     EXPECT_NO_REPORT(driver);
-    osm_key.press();
-    run_one_scan_loop();
-    osm_key.release();
-    run_one_scan_loop();
+    tap_key(osm_key);
     VERIFY_AND_CLEAR(driver);
 
     /* OSM are added when an actual report is send */
@@ -88,10 +85,7 @@ TEST_P(OneShotParametrizedTestFixture, OSMWithAdditionalKeypress) {
 
     /* Press and release OSM */
     EXPECT_NO_REPORT(driver);
-    osm_key.press();
-    run_one_scan_loop();
-    osm_key.release();
-    run_one_scan_loop();
+    tap_key(osm_key);
     VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
@@ -171,18 +165,12 @@ TEST_F(OneShot, OSMChainingTwoOSMs) {
 
     /* Press and release OSM1 */
     EXPECT_NO_REPORT(driver);
-    osm_key1.press();
-    run_one_scan_loop();
-    osm_key1.release();
-    run_one_scan_loop();
+    tap_key(osm_key1);
     VERIFY_AND_CLEAR(driver);
 
     /* Press and relesea OSM2 */
     EXPECT_NO_REPORT(driver);
-    osm_key2.press();
-    run_one_scan_loop();
-    osm_key2.release();
-    run_one_scan_loop();
+    tap_key(osm_key2);
     VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
@@ -209,22 +197,13 @@ TEST_F(OneShot, OSMDoubleTapNotLockingOSMs) {
 
     /* Press and release OSM1 */
     EXPECT_NO_REPORT(driver);
-    osm_key1.press();
-    run_one_scan_loop();
-    osm_key1.release();
-    run_one_scan_loop();
+    tap_key(osm_key1);
     VERIFY_AND_CLEAR(driver);
 
     /* Press and release OSM2 twice */
     EXPECT_NO_REPORT(driver);
-    osm_key2.press();
-    run_one_scan_loop();
-    osm_key2.release();
-    run_one_scan_loop();
-    osm_key2.press();
-    run_one_scan_loop();
-    osm_key2.release();
-    run_one_scan_loop();
+    tap_key(osm_key2);
+    tap_key(osm_key2);
     VERIFY_AND_CLEAR(driver);
 
     /* Press regular key */
@@ -263,10 +242,7 @@ TEST_F(OneShot, OSMHoldNotLockingOSMs) {
 
     /* Press and release OSM1 */
     EXPECT_NO_REPORT(driver);
-    osm_key1.press();
-    run_one_scan_loop();
-    osm_key1.release();
-    run_one_scan_loop();
+    tap_key(osm_key1);
     VERIFY_AND_CLEAR(driver);
 
     /* Press and hold OSM2 */
@@ -279,10 +255,7 @@ TEST_F(OneShot, OSMHoldNotLockingOSMs) {
     /* Press and release regular key */
     EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
     EXPECT_REPORT(driver, (osm_key2.report_code)).Times(1);
-    regular_key.press();
-    run_one_scan_loop();
-    regular_key.release();
-    run_one_scan_loop();
+    tap_key(regular_key);
     VERIFY_AND_CLEAR(driver);
 
     /* Release OSM2 */
@@ -362,10 +335,7 @@ TEST_F(OneShot, OSLWithOsmAndAdditionalKeypress) {
 
     /* Press and release OSM */
     EXPECT_NO_REPORT(driver);
-    osm_key.press();
-    run_one_scan_loop();
-    osm_key.release();
-    run_one_scan_loop();
+    tap_key(osm_key);
     EXPECT_TRUE(layer_state_is(1));
     VERIFY_AND_CLEAR(driver);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
basic unit test refactoring

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
In tests/test_common/test_fixture.cpp there are
```
void TestFixture::run_one_scan_loop() {
    this->idle_for(1);
} 
```
and
```
void TestFixture::tap_key(KeymapKey key, unsigned delay_ms) {
    key.press();
    idle_for(delay_ms);
    key.release();
    run_one_scan_loop();
}

```
So calls like :
```
    key.press();
    run_one_scan_loop();
    key.release();
    run_one_scan_loop();

```
Are the same as :
```
    key.press();
    idle_for(1);
    key.release();
    idle_for(1);
```
or 
`    tap_key(key);`
because 1 is the default value for delay_ms (`void tap_key(KeymapKey key, unsigned delay_ms = 1);` in tests/test_common/test_fixture.hpp)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
