### PR TITLE
Rename `RGBW` define to `WS2812_RGBW`

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -164,7 +164,6 @@
     "RGBLIGHT_DEFAULT_SAT": {"info_key": "rgblight.default.sat", "value_type": "int"},
     "RGBLIGHT_DEFAULT_VAL": {"info_key": "rgblight.default.val", "value_type": "int"},
     "RGBLIGHT_DEFAULT_SPD": {"info_key": "rgblight.default.speed", "value_type": "int"},
-    "RGBW": {"info_key": "rgblight.rgbw", "value_type": "flag"},
 
     // Secure
     "SECURE_IDLE_TIMEOUT": {"info_key": "secure.idle_timeout", "value_type": "int"},
@@ -215,6 +214,7 @@
     "WS2812_DI_PIN": {"info_key": "ws2812.pin"},
     "WS2812_I2C_ADDRESS": {"info_key": "ws2812.i2c_address", "value_type": "hex"},
     "WS2812_I2C_TIMEOUT": {"info_key": "ws2812.i2c_timeout", "value_type": "int"},
+    "WS2812_RGBW": {"info_key": "ws2812.rgbw", "value_type": "flag"},
 
     "LAYOUTS": {"info_key": "layout_aliases", "value_type": "mapping"},
 
@@ -229,6 +229,7 @@
     "PREVENT_STUCK_MODIFIERS": {"info_key": "_invalid.prevent_stuck_mods", "invalid": true},
     "QMK_KEYS_PER_SCAN": {"info_key": "qmk.keys_per_scan", "value_type": "int", "deprecated": true},
     "RGB_DI_PIN": {"info_key": "rgblight.pin", "invalid": true, "replace_with": "WS2812_DI_PIN or APA102_DI_PIN"},
+    "RGBW": {"info_key": "rgblight.rgbw", "invalid": true, "replace_with": "WS2812_RGBW"},
     "RGB_DISABLE_WHEN_USB_SUSPENDED": {"info_key": "_invalid.rgb_matrix_sleep", "invalid": true, "replace_with": "RGB_MATRIX_SLEEP"},
     "RGBLIGHT_ANIMATIONS": {"info_key": "_invalid.rgblight.animations.all", "value_type": "flag", "invalid": true},
     "TAPPING_FORCE_HOLD": {"info_key": "tapping.force_hold", "value_type": "flag", "deprecated": true},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -648,7 +648,10 @@
                     "$ref": "qmk.definitions.v1#/mcu_pin",
                     "$comment": "Deprecated: use ws2812.pin instead"
                 },
-                "rgbw": {"type": "boolean"},
+                "rgbw": {
+                    "type": "boolean",
+                    "$comment": "Deprecated: use ws2812.rgbw instead"
+                },
                 "saturation_steps": {"$ref": "qmk.definitions.v1#/unsigned_int"},
                 "sleep": {"type": "boolean"},
                 "split": {"type": "boolean"},
@@ -924,6 +927,7 @@
                     "enum": ["bitbang", "custom", "i2c", "pwm", "spi", "vendor"]
                 },
                 "pin": {"$ref": "qmk.definitions.v1#/mcu_pin"},
+                "rgbw": {"type": "boolean"},
                 "i2c_address": {"$ref": "qmk.definitions.v1#/hex_number_2d"},
                 "i2c_timeout": {"$ref": "qmk.definitions.v1#/unsigned_int"}
             }

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -237,7 +237,7 @@ If you define these options you will enable the associated feature, which may in
   * units to step when in/decreasing saturation
 * `#define RGBLIGHT_VAL_STEP 12`
   * units to step when in/decreasing value (brightness)
-* `#define RGBW`
+* `#define WS2812_RGBW`
   * Enables RGBW LED support
 
 ## Mouse Key Options

--- a/docs/feature_rgblight.md
+++ b/docs/feature_rgblight.md
@@ -6,7 +6,7 @@ QMK has the ability to control RGB LEDs attached to your keyboard. This is commo
 
 Some keyboards come with RGB LEDs preinstalled. Others must have them installed after the fact. See the [Hardware Modification](#hardware-modification) section for information on adding RGB lighting to your keyboard.
 
-Currently QMK supports the following addressable LEDs (however, the white LED in RGBW variants is not supported):
+Currently QMK supports the following addressable LEDs:
 
  * WS2811, WS2812, WS2812B, WS2812C, etc.
  * SK6812, SK6812MINI, SK6805

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -586,9 +586,6 @@ Configures the [RGB Lighting](feature_rgblight.md) feature.
     * `max_brightness`
         * The maximum value which the HSV "V" component is scaled to, from 0 to 255.
         * Default: `255`
-    * `rgbw`
-        * Enable RGBW LEDs.
-        * Default: `false`
     * `saturation_steps`
         * The number of saturation adjustment steps.
         * Default: `17`
@@ -853,3 +850,6 @@ Configures the [WS2812](ws2812_driver.md) driver.
     * `i2c_timeout`
         * The I²C timeout in milliseconds (`i2c` driver only).
         * Default: `100` (100 ms)
+    * `rgbw`
+        * Enable RGBW LEDs.
+        * Default: `false`

--- a/docs/ws2812_driver.md
+++ b/docs/ws2812_driver.md
@@ -33,6 +33,7 @@ Add the following to your `config.h`:
 |`WS2812_T0H`       |`350`                  |The length of a "0" bit's high phase in nanoseconds                                             |
 |`WS2812_TRST_US`   |`280`                  |The length of the reset phase in microseconds                                                   |
 |`WS2812_BYTE_ORDER`|`WS2812_BYTE_ORDER_GRB`|The byte order of the RGB data                                                                  |
+|`WS2812_RGBW`      |*Not defined*          |Enables RGBW support (except `i2c` driver)                                                      |
 
 ### Timing Adjustment :id=timing-adjustment
 
@@ -57,6 +58,27 @@ Where the byte order may be one of:
 |`GRB`     |Most WS2812s, SK6812, SK6805|
 |`RGB`     |WS2812B-2020                |
 |`BGR`     |TM1812                      |
+
+### RGBW Support :id=rgbw-support
+
+Rendering the color white with RGB LEDs is typically inconsistent due to inherent variations between each individual LED die. However, some WS2812 variants (such as SK6812RGBW) also possess a white LED along with the red, green, and blue channels, which allows for a more accurate white to be displayed.
+
+QMK can automatically convert the RGB data to be sent to the LEDs to mix in the white channel:
+
+```
+w = min(r, g, b)
+r -= w
+g -= w
+b -= w
+```
+
+Thus, an RGB triplet of `255,255,255` will simply turn on the white LED fully (`0,0,0,255`).
+
+To enable RGBW conversion, add the following to your `config.h`:
+
+```c
+#define WS2812_RGBW
+```
 
 ## Driver Configuration :id=driver-configuration
 

--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -73,8 +73,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* fix space cadet rollover issue */
 #define DISABLE_SPACE_CADET_ROLLOVER
 
-#define RGBW
-
 /*
  * The debounce filtering reports a key/switch change directly,
  * without any extra delay. After that the debounce logic will filter

--- a/keyboards/ergodox_ez/info.json
+++ b/keyboards/ergodox_ez/info.json
@@ -27,7 +27,8 @@
         "debounce_type": "sym_eager_pr"
     },
     "ws2812": {
-        "pin": "D7"
+        "pin": "D7",
+        "rgbw": true
     },
     "rgb_matrix": {
         "animations": {

--- a/keyboards/ergodox_ez/shine/rgblight_custom.c
+++ b/keyboards/ergodox_ez/shine/rgblight_custom.c
@@ -25,7 +25,7 @@ void setleds_custom(rgb_led_t *led, uint16_t led_num) {
     uint16_t length = 0;
     int i = 0;
     int j = 0;
-#    ifdef RGBW
+#    ifdef WS2812_RGBW
     int bytes_per_led = 4;
 #    else
     int bytes_per_led = 3;
@@ -52,7 +52,7 @@ void setleds_custom(rgb_led_t *led, uint16_t led_num) {
         data[j++] = data_byte[0];
         data[j++] = data_byte[1];
         data[j++] = data_byte[2];
-#ifdef RGBW
+#ifdef WS2812_RGBW
         data[j++] = data_byte[3];
 #endif
     }

--- a/keyboards/handwired/tennie/config.h
+++ b/keyboards/handwired/tennie/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#define RGBW
-
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/handwired/tennie/keyboard.json
+++ b/keyboards/handwired/tennie/keyboard.json
@@ -26,7 +26,8 @@
         }
     },
     "ws2812": {
-        "pin": "D1"
+        "pin": "D1",
+        "rgbw": true
     },
     "features": {
         "bootmagic": true,

--- a/keyboards/oddforge/vea/ws2812_custom.c
+++ b/keyboards/oddforge/vea/ws2812_custom.c
@@ -1,7 +1,7 @@
 #include "ws2812.h"
 #include "i2c_master.h"
 
-#ifdef RGBW
+#ifdef WS2812_RGBW
 #    error "RGBW not supported"
 #endif
 

--- a/keyboards/rgbkb/pan/pan.c
+++ b/keyboards/rgbkb/pan/pan.c
@@ -42,7 +42,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
         rgb_matrix_ws2812_array[i].g = g;
         rgb_matrix_ws2812_array[i].b = b;
     }
-#        ifdef RGBW
+#        ifdef WS2812_RGBW
     convert_rgb_to_rgbw(&rgb_matrix_ws2812_array[i]);
 #        endif
 }

--- a/keyboards/westfoxtrot/aanzee/config.h
+++ b/keyboards/westfoxtrot/aanzee/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#define RGBW
-
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 #define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/westfoxtrot/aanzee/keyboard.json
+++ b/keyboards/westfoxtrot/aanzee/keyboard.json
@@ -52,7 +52,8 @@
     }
   },
   "ws2812": {
-    "pin": "E6"
+    "pin": "E6",
+    "rgbw": true
   },
   "processor": "atmega32u4",
   "bootloader": "atmel-dfu",

--- a/platforms/avr/drivers/ws2812_i2c.c
+++ b/platforms/avr/drivers/ws2812_i2c.c
@@ -1,7 +1,7 @@
 #include "ws2812.h"
 #include "i2c_master.h"
 
-#ifdef RGBW
+#ifdef WS2812_RGBW
 #    error "RGBW not supported"
 #endif
 

--- a/platforms/chibios/drivers/vendor/RP/RP2040/ws2812_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/ws2812_vendor.c
@@ -161,7 +161,7 @@ static void ws2812_dma_callback(void* p, uint32_t ct) {
     // FIFO is already empty.
     rtcnt_t time_to_completion = (pio_sm_get_tx_fifo_level(pio, STATE_MACHINE) + 1) * MAX(WS2812_T1H + WS2812_T1L, WS2812_T0H + WS2812_T0L);
 
-#if defined(RGBW)
+#if defined(WS2812_RGBW)
     time_to_completion *= 32;
 #else
     time_to_completion *= 24;
@@ -222,7 +222,7 @@ void ws2812_init(void) {
     sm_config_set_sideset(&config, 1, false, false);
 #endif
 
-#if defined(RGBW)
+#if defined(WS2812_RGBW)
     sm_config_set_out_shift(&config, false, true, 32);
 #else
     sm_config_set_out_shift(&config, false, true, 24);
@@ -270,7 +270,7 @@ void ws2812_setleds(rgb_led_t* ledarray, uint16_t leds) {
     sync_ws2812_transfer();
 
     for (int i = 0; i < leds; i++) {
-#if defined(RGBW)
+#if defined(WS2812_RGBW)
         WS2812_BUFFER[i] = rgbw8888_to_u32(ledarray[i].r, ledarray[i].g, ledarray[i].b, ledarray[i].w);
 #else
         WS2812_BUFFER[i] = rgbw8888_to_u32(ledarray[i].r, ledarray[i].g, ledarray[i].b, 0);

--- a/platforms/chibios/drivers/ws2812_bitbang.c
+++ b/platforms/chibios/drivers/ws2812_bitbang.c
@@ -101,7 +101,7 @@ void ws2812_setleds(rgb_led_t *ledarray, uint16_t leds) {
         sendByte(ledarray[i].r);
 #endif
 
-#ifdef RGBW
+#ifdef WS2812_RGBW
         sendByte(ledarray[i].w);
 #endif
     }

--- a/platforms/chibios/drivers/ws2812_pwm.c
+++ b/platforms/chibios/drivers/ws2812_pwm.c
@@ -16,7 +16,7 @@
 
 /* Adapted from https://github.com/joewa/WS2812-LED-Driver_ChibiOS/ */
 
-#ifdef RGBW
+#ifdef WS2812_RGBW
 #    define WS2812_CHANNELS 4
 #else
 #    define WS2812_CHANNELS 3
@@ -262,7 +262,7 @@
 #    define WS2812_BLUE_BIT(led, bit) WS2812_BIT((led), 0, (bit))
 #endif
 
-#ifdef RGBW
+#ifdef WS2812_RGBW
 /**
  * @brief   Determine the index in @ref ws2812_frame_buffer "the frame buffer" of a given white bit
  *
@@ -381,7 +381,7 @@ void ws2812_write_led_rgbw(uint16_t led_number, uint8_t r, uint8_t g, uint8_t b,
         ws2812_frame_buffer[WS2812_RED_BIT(led_number, bit)]   = ((r >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
         ws2812_frame_buffer[WS2812_GREEN_BIT(led_number, bit)] = ((g >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
         ws2812_frame_buffer[WS2812_BLUE_BIT(led_number, bit)]  = ((b >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
-#ifdef RGBW
+#ifdef WS2812_RGBW
         ws2812_frame_buffer[WS2812_WHITE_BIT(led_number, bit)] = ((w >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
 #endif
     }
@@ -390,7 +390,7 @@ void ws2812_write_led_rgbw(uint16_t led_number, uint8_t r, uint8_t g, uint8_t b,
 // Setleds for standard RGB
 void ws2812_setleds(rgb_led_t* ledarray, uint16_t leds) {
     for (uint16_t i = 0; i < leds; i++) {
-#ifdef RGBW
+#ifdef WS2812_RGBW
         ws2812_write_led_rgbw(i, ledarray[i].r, ledarray[i].g, ledarray[i].b, ledarray[i].w);
 #else
         ws2812_write_led(i, ledarray[i].r, ledarray[i].g, ledarray[i].b);

--- a/platforms/chibios/drivers/ws2812_spi.c
+++ b/platforms/chibios/drivers/ws2812_spi.c
@@ -76,7 +76,7 @@
 #endif
 
 #define BYTES_FOR_LED_BYTE 4
-#ifdef RGBW
+#ifdef WS2812_RGBW
 #    define WS2812_CHANNELS 4
 #else
 #    define WS2812_CHANNELS 3
@@ -131,7 +131,7 @@ static void set_led_color_rgb(rgb_led_t color, int pos) {
     for (int j = 0; j < 4; j++)
         tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE * 2 + j] = get_protocol_eq(color.r, j);
 #endif
-#ifdef RGBW
+#ifdef WS2812_RGBW
     for (int j = 0; j < 4; j++)
         tx_start[BYTES_FOR_LED * pos + BYTES_FOR_LED_BYTE * 4 + j] = get_protocol_eq(color.w, j);
 #endif

--- a/quantum/color.c
+++ b/quantum/color.c
@@ -109,7 +109,7 @@ RGB hsv_to_rgb_nocie(HSV hsv) {
     return hsv_to_rgb_impl(hsv, false);
 }
 
-#ifdef RGBW
+#ifdef WS2812_RGBW
 void convert_rgb_to_rgbw(rgb_led_t *led) {
     // Determine lowest value in all three colors, put that into
     // the white channel and then shift all colors by that amount

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -96,7 +96,7 @@ typedef struct PACKED rgb_led_t {
     uint8_t g;
     uint8_t r;
 #endif
-#ifdef RGBW
+#ifdef WS2812_RGBW
     uint8_t w;
 #endif
 } rgb_led_t;
@@ -111,6 +111,6 @@ typedef struct PACKED HSV {
 
 RGB hsv_to_rgb(HSV hsv);
 RGB hsv_to_rgb_nocie(HSV hsv);
-#ifdef RGBW
+#ifdef WS2812_RGBW
 void convert_rgb_to_rgbw(rgb_led_t *led);
 #endif

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -185,7 +185,7 @@ static inline void setled(int i, uint8_t r, uint8_t g, uint8_t b) {
     rgb_matrix_ws2812_array[i].r = r;
     rgb_matrix_ws2812_array[i].g = g;
     rgb_matrix_ws2812_array[i].b = b;
-#    ifdef RGBW
+#    ifdef WS2812_RGBW
     convert_rgb_to_rgbw(&rgb_matrix_ws2812_array[i]);
 #    endif
 }

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -149,7 +149,7 @@ void setrgb(uint8_t r, uint8_t g, uint8_t b, rgb_led_t *led1) {
     led1->r = r;
     led1->g = g;
     led1->b = b;
-#ifdef RGBW
+#ifdef WS2812_RGBW
     led1->w = 0;
 #endif
 }
@@ -652,7 +652,7 @@ void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b) {
         led[i].r = r;
         led[i].g = g;
         led[i].b = b;
-#ifdef RGBW
+#ifdef WS2812_RGBW
         led[i].w = 0;
 #endif
     }
@@ -667,7 +667,7 @@ void rgblight_setrgb_at(uint8_t r, uint8_t g, uint8_t b, uint8_t index) {
     led[index].r = r;
     led[index].g = g;
     led[index].b = b;
-#ifdef RGBW
+#ifdef WS2812_RGBW
     led[index].w = 0;
 #endif
     rgblight_set();
@@ -704,7 +704,7 @@ void rgblight_setrgb_range(uint8_t r, uint8_t g, uint8_t b, uint8_t start, uint8
         led[i].r = r;
         led[i].g = g;
         led[i].b = b;
-#ifdef RGBW
+#ifdef WS2812_RGBW
         led[i].w = 0;
 #endif
     }
@@ -905,7 +905,7 @@ void rgblight_set(void) {
             led[i].r = 0;
             led[i].g = 0;
             led[i].b = 0;
-#ifdef RGBW
+#ifdef WS2812_RGBW
             led[i].w = 0;
 #endif
         }
@@ -933,7 +933,7 @@ void rgblight_set(void) {
     start_led = led + rgblight_ranges.clipping_start_pos;
 #endif
 
-#ifdef RGBW
+#ifdef WS2812_RGBW
     for (uint8_t i = 0; i < num_leds; i++) {
         convert_rgb_to_rgbw(&start_led[i]);
     }
@@ -1263,7 +1263,7 @@ void rgblight_effect_snake(animation_status_t *anim) {
         ledp->r         = 0;
         ledp->g         = 0;
         ledp->b         = 0;
-#    ifdef RGBW
+#    ifdef WS2812_RGBW
         ledp->w = 0;
 #    endif
         for (j = 0; j < RGBLIGHT_EFFECT_SNAKE_LENGTH; j++) {
@@ -1323,7 +1323,7 @@ void rgblight_effect_knight(animation_status_t *anim) {
         led[i].r = 0;
         led[i].g = 0;
         led[i].b = 0;
-#    ifdef RGBW
+#    ifdef WS2812_RGBW
         led[i].w = 0;
 #    endif
     }
@@ -1337,7 +1337,7 @@ void rgblight_effect_knight(animation_status_t *anim) {
             led[cur].r = 0;
             led[cur].g = 0;
             led[cur].b = 0;
-#    ifdef RGBW
+#    ifdef WS2812_RGBW
             led[cur].w = 0;
 #    endif
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This define really only affects the WS2812 driver:

- RGBLight only supports WS2812 and APA102 LEDs. As far as I can ascertain, there is no such thing as an RGBW APA102, and there is no support for RGBW in the current APA102 driver code.
- RGB Matrix supports WS2812 as well as a variety of ISSI LED drivers. These technically *could* do RGBW, as the drivers are simply mapping the RGB values to the PWM buffer indices specified in their LED config structs, but I would argue these should get their own defines (eg. `IS31FL3733_RGBW` etc.), if there exists a board with RGBW LEDs driven by one of these chips.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
