### PR TITLE
Fix encoder breakage with 4 or more encoders

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -83,7 +83,7 @@ bool encoder_task(void) {
 }
 
 bool encoder_queue_full_advanced(encoder_events_t *events) {
-    return events->head == (events->tail - 1) % MAX_QUEUED_ENCODER_EVENTS;
+    return events->tail == (events->head + 1) % MAX_QUEUED_ENCODER_EVENTS;
 }
 
 bool encoder_queue_full(void) {


### PR DESCRIPTION
## Description

The encoder support was broken in various ways when having 4 or more encoders on any keyboard side (or, more precisely, when `MAX_QUEUED_ENCODER_EVENTS` was not a power of 2, which happened when `NUM_ENCODERS_MAX_PER_SIDE` increased above 3, unless `MAX_QUEUED_ENCODER_EVENTS` was set directly).  In particular, with 4 encoders the encoder rotation did not have any effect.

The problem was caused by `encoder_queue_full_advanced()` always returning `true` even when the queue was not actually full, which caused all encoder events to be dropped.  The underlying reason was that `(events->tail - 1) % MAX_QUEUED_ENCODER_EVENTS` did not calculate what the rest of code expected when `events->tail` was 0, except when `MAX_QUEUED_ENCODER_EVENTS` happened to be a power of 2, so the code seemed to work when the number of encoders was less than 4 (in that case `MAX_QUEUED_ENCODER_EVENTS` was set to 4), but broke when the number of encoders was 4 or more.  With 4 encoders the code ended up calculating `0xffff % 5U` (or `0xffffffff % 5U` on 32-bit platforms), which ended up being 0, so the initial state with an empty queue was mistakenly detected as full.  But with `MAX_QUEUED_ENCODER_EVENTS` = 4 the result of `0xffff % 4U` in the bad case happened to be what was expected, therefore the bug could not be noticed.

Fix the queue full check to avoid negative numbers in calculations, so that the modulo operations would work as expected.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #23531

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
