### PR TITLE
Data-Driven Keyboard Conversions: BastardKB

### DIFF
--- a/keyboards/bastardkb/charybdis/3x5/blackpill/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/blackpill/info.json
@@ -1,7 +1,17 @@
 {
     "keyboard_name": "Charybdis Nano (3x5) Blackpill",
     "usb": {
-        "device_version": "1.0.0"
+        "device_version": "1.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     },
     "eeprom": {
         "driver": "spi"

--- a/keyboards/bastardkb/charybdis/3x5/blackpill/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/blackpill/rules.mk
@@ -1,22 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
-
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/charybdis/3x5/v1/elitec/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/v1/elitec/info.json
@@ -3,6 +3,16 @@
     "usb": {
         "device_version": "1.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
+    "build": {
+        "lto": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/charybdis/3x5/v1/elitec/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/v1/elitec/rules.mk
@@ -1,23 +1,4 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-
-# Enable link-time optimization by default.  The Charybdis packs a lot of
-# features (RGB, Via, trackball) in a small atmega32u4 package.
-LTO_ENABLE = yes

--- a/keyboards/bastardkb/charybdis/3x5/v2/elitec/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/v2/elitec/info.json
@@ -3,6 +3,16 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
+    "build": {
+        "lto": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/charybdis/3x5/v2/elitec/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/v2/elitec/rules.mk
@@ -1,23 +1,4 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-
-# Enable link-time optimization by default.  The Charybdis packs a lot of
-# features (RGB, Via, trackball) in a small atmega32u4 package.
-LTO_ENABLE = yes

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky_2/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky_2/info.json
@@ -3,6 +3,13 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky_2/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky_2/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky_3/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky_3/info.json
@@ -3,6 +3,13 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/charybdis/3x5/v2/splinky_3/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/v2/splinky_3/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/3x5/v2/stemcell/info.json
+++ b/keyboards/bastardkb/charybdis/3x5/v2/stemcell/info.json
@@ -1,7 +1,17 @@
 {
     "keyboard_name": "Charybdis Nano (3x5) STeMCell",
     "usb": {
-        "device_version": "2.0.0"
+        "device_version": "2.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     },
     "rgb_matrix": {
         "driver": "ws2812"

--- a/keyboards/bastardkb/charybdis/3x5/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x5/v2/stemcell/rules.mk
@@ -1,22 +1,6 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/charybdis/3x6/blackpill/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/blackpill/info.json
@@ -1,7 +1,17 @@
 {
     "keyboard_name": "Charybdis Mini (3x6) Blackpill",
     "usb": {
-        "device_version": "1.0.0"
+        "device_version": "1.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     },
     "eeprom": {
         "driver": "spi"

--- a/keyboards/bastardkb/charybdis/3x6/blackpill/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/blackpill/rules.mk
@@ -1,22 +1,6 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/charybdis/3x6/v1/elitec/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/v1/elitec/info.json
@@ -3,6 +3,16 @@
     "usb": {
         "device_version": "1.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
+    "build": {
+        "lto": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/charybdis/3x6/v1/elitec/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/v1/elitec/rules.mk
@@ -1,23 +1,4 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-
-# Enable link-time optimization by default.  The Charybdis packs a lot of
-# features (RGB, Via, trackball) in a small atmega32u4 package.
-LTO_ENABLE = yes

--- a/keyboards/bastardkb/charybdis/3x6/v2/elitec/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/v2/elitec/info.json
@@ -3,6 +3,16 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
+    "build": {
+        "lto": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/charybdis/3x6/v2/elitec/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/v2/elitec/rules.mk
@@ -1,23 +1,4 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-
-# Enable link-time optimization by default.  The Charybdis packs a lot of
-# features (RGB, Via, trackball) in a small atmega32u4 package.
-LTO_ENABLE = yes

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky_2/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky_2/info.json
@@ -3,6 +3,13 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky_2/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky_2/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky_3/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky_3/info.json
@@ -3,6 +3,13 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/charybdis/3x6/v2/splinky_3/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/v2/splinky_3/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/3x6/v2/stemcell/info.json
+++ b/keyboards/bastardkb/charybdis/3x6/v2/stemcell/info.json
@@ -1,7 +1,17 @@
 {
     "keyboard_name": "Charybdis Mini (3x6) STeMCell",
     "usb": {
-        "device_version": "2.0.0"
+        "device_version": "2.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     },
     "rgb_matrix": {
         "driver": "ws2812"

--- a/keyboards/bastardkb/charybdis/3x6/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/charybdis/3x6/v2/stemcell/rules.mk
@@ -1,22 +1,6 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/charybdis/4x6/blackpill/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/blackpill/info.json
@@ -1,7 +1,17 @@
 {
     "keyboard_name": "Charybdis (4x6) Blackpill",
     "usb": {
-        "device_version": "1.0.0"
+        "device_version": "1.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     },
     "eeprom": {
         "driver": "spi"

--- a/keyboards/bastardkb/charybdis/4x6/blackpill/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/blackpill/rules.mk
@@ -1,22 +1,6 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported.
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/charybdis/4x6/v1/elitec/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/v1/elitec/info.json
@@ -3,6 +3,16 @@
     "usb": {
         "device_version": "1.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
+    "build": {
+        "lto": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/charybdis/4x6/v1/elitec/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/v1/elitec/rules.mk
@@ -1,23 +1,4 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported.
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-
-# Enable link-time optimization by default.  The Charybdis packs a lot of
-# features (RGB, Via, trackball) in a small atmega32u4 package.
-LTO_ENABLE = yes

--- a/keyboards/bastardkb/charybdis/4x6/v2/elitec/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/v2/elitec/info.json
@@ -3,6 +3,16 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
+    "build": {
+        "lto": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/charybdis/4x6/v2/elitec/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/v2/elitec/rules.mk
@@ -1,23 +1,4 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported.
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-
-# Enable link-time optimization by default.  The Charybdis packs a lot of
-# features (RGB, Via, trackball) in a small atmega32u4 package.
-LTO_ENABLE = yes

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky_2/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky_2/info.json
@@ -3,6 +3,13 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky_2/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky_2/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky_3/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky_3/info.json
@@ -3,6 +3,13 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/charybdis/4x6/v2/splinky_3/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/v2/splinky_3/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/charybdis/4x6/v2/stemcell/info.json
+++ b/keyboards/bastardkb/charybdis/4x6/v2/stemcell/info.json
@@ -1,7 +1,17 @@
 {
     "keyboard_name": "Charybdis (4x6) STeMCell",
     "usb": {
-        "device_version": "2.0.0"
+        "device_version": "2.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true,
+        "pointing_device": true
     },
     "rgb_matrix": {
         "driver": "ws2812"

--- a/keyboards/bastardkb/charybdis/4x6/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/charybdis/4x6/v2/stemcell/rules.mk
@@ -1,22 +1,6 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
-POINTING_DEVICE_ENABLE = yes # Enable trackball
 POINTING_DEVICE_DRIVER = pmw3360
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/dilemma/3x5_2/assembled/info.json
+++ b/keyboards/bastardkb/dilemma/3x5_2/assembled/info.json
@@ -1,5 +1,11 @@
 {
     "keyboard_name": "Dilemma (3x5+2) Assembled",
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "pointing_device": true
+    },
     "matrix_pins": {
         "cols": ["GP8", "GP9", "GP7", "GP6", "GP27"],
         "rows": ["GP4", "GP5", "GP28", "GP26"]

--- a/keyboards/bastardkb/dilemma/3x5_2/assembled/rules.mk
+++ b/keyboards/bastardkb/dilemma/3x5_2/assembled/rules.mk
@@ -1,22 +1,7 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = no   # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = no     # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = no      # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor
 
-POINTING_DEVICE_ENABLE = yes
 POINTING_DEVICE_DRIVER = cirque_pinnacle_spi # Assembled version uses SPI.

--- a/keyboards/bastardkb/dilemma/3x5_2/splinky/info.json
+++ b/keyboards/bastardkb/dilemma/3x5_2/splinky/info.json
@@ -1,5 +1,11 @@
 {
     "keyboard_name": "Dilemma (3x5+2) Splinky",
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "pointing_device": true
+    },
     "matrix_pins": {
         "cols": ["GP8", "GP9", "GP7", "GP6", "GP27"],
         "rows": ["GP4", "GP5", "GP28", "GP26"]

--- a/keyboards/bastardkb/dilemma/3x5_2/splinky/rules.mk
+++ b/keyboards/bastardkb/dilemma/3x5_2/splinky/rules.mk
@@ -1,22 +1,7 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
 RGB_MATRIX_SUPPORTED = no   # RGB matrix is supported and enabled by default
 RGBLIGHT_SUPPORTED = no     # RGB underglow is supported, but not enabled by default
-RGB_MATRIX_ENABLE = no      # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor
 
-POINTING_DEVICE_ENABLE = yes
 POINTING_DEVICE_DRIVER = cirque_pinnacle_i2c # DIY version uses I2C.

--- a/keyboards/bastardkb/dilemma/3x5_3/info.json
+++ b/keyboards/bastardkb/dilemma/3x5_3/info.json
@@ -38,6 +38,7 @@
         "mousekey": true,
         "nkro": true,
         "rgb_matrix": true,
+        "pointing_device": true,
         "caps_word": true,
         "tri_layer": true
     },

--- a/keyboards/bastardkb/dilemma/3x5_3/rules.mk
+++ b/keyboards/bastardkb/dilemma/3x5_3/rules.mk
@@ -1,4 +1,3 @@
 SERIAL_DRIVER = vendor
 
-POINTING_DEVICE_ENABLE = yes
 POINTING_DEVICE_DRIVER = cirque_pinnacle_spi

--- a/keyboards/bastardkb/dilemma/4x6_4/info.json
+++ b/keyboards/bastardkb/dilemma/4x6_4/info.json
@@ -38,6 +38,7 @@
         "mousekey": true,
         "nkro": true,
         "rgb_matrix": true,
+        "pointing_device": true,
         "caps_word": true,
         "tri_layer": true
     },

--- a/keyboards/bastardkb/dilemma/4x6_4/rules.mk
+++ b/keyboards/bastardkb/dilemma/4x6_4/rules.mk
@@ -1,4 +1,3 @@
 SERIAL_DRIVER = vendor
 
-POINTING_DEVICE_ENABLE = yes
 POINTING_DEVICE_DRIVER = cirque_pinnacle_spi

--- a/keyboards/bastardkb/scylla/blackpill/info.json
+++ b/keyboards/bastardkb/scylla/blackpill/info.json
@@ -1,7 +1,16 @@
 {
     "keyboard_name": "Scylla Blackpill",
     "usb": {
-        "device_version": "1.0.0"
+        "device_version": "1.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
     },
     "eeprom": {
         "driver": "spi"

--- a/keyboards/bastardkb/scylla/blackpill/rules.mk
+++ b/keyboards/bastardkb/scylla/blackpill/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/scylla/v1/elitec/info.json
+++ b/keyboards/bastardkb/scylla/v1/elitec/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "1.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "ws2812": {
         "pin": "D2"
     },

--- a/keyboards/bastardkb/scylla/v1/elitec/rules.mk
+++ b/keyboards/bastardkb/scylla/v1/elitec/rules.mk
@@ -1,15 +1,1 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)

--- a/keyboards/bastardkb/scylla/v2/elitec/info.json
+++ b/keyboards/bastardkb/scylla/v2/elitec/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/scylla/v2/elitec/rules.mk
+++ b/keyboards/bastardkb/scylla/v2/elitec/rules.mk
@@ -1,15 +1,1 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)

--- a/keyboards/bastardkb/scylla/v2/splinky_2/info.json
+++ b/keyboards/bastardkb/scylla/v2/splinky_2/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/scylla/v2/splinky_2/rules.mk
+++ b/keyboards/bastardkb/scylla/v2/splinky_2/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/scylla/v2/splinky_3/info.json
+++ b/keyboards/bastardkb/scylla/v2/splinky_3/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/scylla/v2/splinky_3/rules.mk
+++ b/keyboards/bastardkb/scylla/v2/splinky_3/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/scylla/v2/stemcell/info.json
+++ b/keyboards/bastardkb/scylla/v2/stemcell/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/scylla/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/scylla/v2/stemcell/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/skeletyl/blackpill/info.json
+++ b/keyboards/bastardkb/skeletyl/blackpill/info.json
@@ -1,7 +1,16 @@
 {
     "keyboard_name": "Skeletyl Blackpill",
     "usb": {
-        "device_version": "1.0.0"
+        "device_version": "1.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
     },
     "eeprom": {
         "driver": "spi"

--- a/keyboards/bastardkb/skeletyl/blackpill/rules.mk
+++ b/keyboards/bastardkb/skeletyl/blackpill/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/skeletyl/v1/elitec/info.json
+++ b/keyboards/bastardkb/skeletyl/v1/elitec/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "1.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "ws2812": {
         "pin": "D2"
     },

--- a/keyboards/bastardkb/skeletyl/v1/elitec/rules.mk
+++ b/keyboards/bastardkb/skeletyl/v1/elitec/rules.mk
@@ -1,15 +1,1 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)

--- a/keyboards/bastardkb/skeletyl/v2/elitec/info.json
+++ b/keyboards/bastardkb/skeletyl/v2/elitec/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/skeletyl/v2/elitec/rules.mk
+++ b/keyboards/bastardkb/skeletyl/v2/elitec/rules.mk
@@ -1,15 +1,1 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)

--- a/keyboards/bastardkb/skeletyl/v2/splinky_2/info.json
+++ b/keyboards/bastardkb/skeletyl/v2/splinky_2/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/skeletyl/v2/splinky_2/rules.mk
+++ b/keyboards/bastardkb/skeletyl/v2/splinky_2/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/skeletyl/v2/splinky_3/info.json
+++ b/keyboards/bastardkb/skeletyl/v2/splinky_3/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/skeletyl/v2/splinky_3/rules.mk
+++ b/keyboards/bastardkb/skeletyl/v2/splinky_3/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/skeletyl/v2/stemcell/info.json
+++ b/keyboards/bastardkb/skeletyl/v2/stemcell/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/skeletyl/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/skeletyl/v2/stemcell/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/tbkmini/blackpill/info.json
+++ b/keyboards/bastardkb/tbkmini/blackpill/info.json
@@ -1,7 +1,16 @@
 {
     "keyboard_name": "TBK Mini Blackpill",
     "usb": {
-        "device_version": "1.0.0"
+        "device_version": "1.0.0",
+        "shared_endpoint": {
+            "keyboard": true
+        }
+    },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
     },
     "eeprom": {
         "driver": "spi"

--- a/keyboards/bastardkb/tbkmini/blackpill/rules.mk
+++ b/keyboards/bastardkb/tbkmini/blackpill/rules.mk
@@ -1,20 +1,5 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 MOUSE_SHARED_EP = no # Unify multiple HID interfaces into a single Endpoint
-KEYBOARD_SHARED_EP = yes
 
 SERIAL_DRIVER = usart

--- a/keyboards/bastardkb/tbkmini/v1/elitec/info.json
+++ b/keyboards/bastardkb/tbkmini/v1/elitec/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "1.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "ws2812": {
         "pin": "D2"
     },

--- a/keyboards/bastardkb/tbkmini/v1/elitec/rules.mk
+++ b/keyboards/bastardkb/tbkmini/v1/elitec/rules.mk
@@ -1,15 +1,1 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)

--- a/keyboards/bastardkb/tbkmini/v2/elitec/info.json
+++ b/keyboards/bastardkb/tbkmini/v2/elitec/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "ws2812": {
         "pin": "D3"
     },

--- a/keyboards/bastardkb/tbkmini/v2/elitec/rules.mk
+++ b/keyboards/bastardkb/tbkmini/v2/elitec/rules.mk
@@ -1,15 +1,1 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix (do not use together with RGBLIGHT_ENABLE)

--- a/keyboards/bastardkb/tbkmini/v2/splinky_2/info.json
+++ b/keyboards/bastardkb/tbkmini/v2/splinky_2/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/tbkmini/v2/splinky_2/rules.mk
+++ b/keyboards/bastardkb/tbkmini/v2/splinky_2/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/tbkmini/v2/splinky_3/info.json
+++ b/keyboards/bastardkb/tbkmini/v2/splinky_3/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": false,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/tbkmini/v2/splinky_3/rules.mk
+++ b/keyboards/bastardkb/tbkmini/v2/splinky_3/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = no        # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = vendor

--- a/keyboards/bastardkb/tbkmini/v2/stemcell/info.json
+++ b/keyboards/bastardkb/tbkmini/v2/stemcell/info.json
@@ -3,6 +3,12 @@
     "usb": {
         "device_version": "2.0.0"
     },
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "rgb_matrix": true
+    },
     "rgb_matrix": {
         "driver": "ws2812"
     },

--- a/keyboards/bastardkb/tbkmini/v2/stemcell/rules.mk
+++ b/keyboards/bastardkb/tbkmini/v2/stemcell/rules.mk
@@ -1,17 +1,3 @@
-# Build Options
-#   change yes to no to disable
-#
-BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
-MOUSEKEY_ENABLE = yes       # Mouse keys
-EXTRAKEY_ENABLE = yes       # Audio control and System control
-CONSOLE_ENABLE = no         # Console for debug
-COMMAND_ENABLE = no         # Commands for debug and configuration
-NKRO_ENABLE = no            # Enable N-Key Rollover
-BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
-RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
-AUDIO_ENABLE = no           # Audio output
-
 AUDIO_SUPPORTED = no        # Audio is not supported
-RGB_MATRIX_ENABLE = yes     # Enable keyboard RGB matrix functionality
 
 SERIAL_DRIVER = usart


### PR DESCRIPTION
## Description

Converts `rules.mk` entries to data-driven where applicable.

- keyboards with names beginning with `bastardkb/`

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
