### PR TITLE
[Core] Led Double Buffer

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -100,6 +100,7 @@
     "LED_MATRIX_DEFAULT_ON": {"info_key": "led_matrix.default.on", "value_type": "bool"},
     "LED_MATRIX_DEFAULT_VAL": {"info_key": "led_matrix.default.val", "value_type": "int"},
     "LED_MATRIX_DEFAULT_SPD": {"info_key": "led_matrix.default.speed", "value_type": "int"},
+    "LED_MATRIX_DOUBLE_BUFFER": {"info_key": "led_matrix.double_buffer", "value_type": "flag"},
 
     // Locking Switch
     "LOCKING_SUPPORT_ENABLE": {"info_key": "qmk.locking.enabled", "value_type": "flag"},
@@ -152,6 +153,7 @@
     "RGB_MATRIX_DEFAULT_SAT": {"info_key": "rgb_matrix.default.sat", "value_type": "int"},
     "RGB_MATRIX_DEFAULT_VAL": {"info_key": "rgb_matrix.default.val", "value_type": "int"},
     "RGB_MATRIX_DEFAULT_SPD": {"info_key": "rgb_matrix.default.speed", "value_type": "int"},
+    "RGB_MATRIX_DOUBLE_BUFFER": {"info_key": "rgb_matrix.double_buffer", "value_type": "flag"},
 
     // RGBLight
     "RGBLED_SPLIT": {"info_key": "rgblight.split_count", "value_type": "array.int"},
@@ -172,6 +174,7 @@
     "RGBLIGHT_DEFAULT_SAT": {"info_key": "rgblight.default.sat", "value_type": "int"},
     "RGBLIGHT_DEFAULT_VAL": {"info_key": "rgblight.default.val", "value_type": "int"},
     "RGBLIGHT_DEFAULT_SPD": {"info_key": "rgblight.default.speed", "value_type": "int"},
+    "RGBLIGHT_DOUBLE_BUFFER": {"info_key": "rgblight.double_buffer", "value_type": "flag"},
 
     // Secure
     "SECURE_IDLE_TIMEOUT": {"info_key": "secure.idle_timeout", "value_type": "int"},

--- a/docs/features/led_matrix.md
+++ b/docs/features/led_matrix.md
@@ -230,6 +230,7 @@ For inspiration and examples, check out the built-in effects under `quantum/led_
 #define LED_MATRIX_DEFAULT_FLAGS LED_FLAG_ALL // Sets the default LED flags, if none has been set
 #define LED_MATRIX_SPLIT { X, Y }   // (Optional) For split keyboards, the number of LEDs connected on each half. X = left, Y = Right.
                                     // If reactive effects are enabled, you also will want to enable SPLIT_TRANSPORT_MIRROR
+#define LED_MATRIX_DOUBLE_BUFFER    // Use double buffer when rendering
 ```
 
 ## EEPROM storage {#eeprom-storage}

--- a/docs/features/rgb_matrix.md
+++ b/docs/features/rgb_matrix.md
@@ -382,6 +382,7 @@ These are defined in [`color.h`](https://github.com/qmk/qmk_firmware/blob/master
 #define RGB_MATRIX_SPLIT { X, Y } 	// (Optional) For split keyboards, the number of LEDs connected on each half. X = left, Y = Right.
                               		// If reactive effects are enabled, you also will want to enable SPLIT_TRANSPORT_MIRROR
 #define RGB_TRIGGER_ON_KEYDOWN      // Triggers RGB keypress events on key down. This makes RGB control feel more responsive. This may cause RGB to not function properly on some boards
+#define RGB_MATRIX_DOUBLE_BUFFER    // Use double buffer when rendering
 ```
 
 ## EEPROM storage {#eeprom-storage}

--- a/docs/features/rgblight.md
+++ b/docs/features/rgblight.md
@@ -95,20 +95,22 @@ These keycodes cannot be used with functions like `tap_code16()` as they are not
 
 Your RGB lighting can be configured by placing these `#define`s in your `config.h`:
 
-|Define                     |Default                     |Description                                                                                                                |
-|---------------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------|
-|`RGBLIGHT_HUE_STEP`        |`8`                         |The number of steps to cycle through the hue by                                                                            |
-|`RGBLIGHT_SAT_STEP`        |`17`                        |The number of steps to increment the saturation by                                                                         |
-|`RGBLIGHT_VAL_STEP`        |`17`                        |The number of steps to increment the brightness by                                                                         |
-|`RGBLIGHT_LIMIT_VAL`       |`255`                       |The maximum brightness level                                                                                               |
-|`RGBLIGHT_SLEEP`           |*Not defined*               |If defined, the RGB lighting will be switched off when the host goes to sleep                                              |
-|`RGBLIGHT_SPLIT`           |*Not defined*               |If defined, synchronization functionality for split keyboards is added                                                     |
-|`RGBLIGHT_DEFAULT_MODE`    |`RGBLIGHT_MODE_STATIC_LIGHT`|The default mode to use upon clearing the EEPROM                                                                           |
-|`RGBLIGHT_DEFAULT_HUE`     |`0` (red)                   |The default hue to use upon clearing the EEPROM                                                                            |
-|`RGBLIGHT_DEFAULT_SAT`     |`UINT8_MAX` (255)           |The default saturation to use upon clearing the EEPROM                                                                     |
-|`RGBLIGHT_DEFAULT_VAL`     |`RGBLIGHT_LIMIT_VAL`        |The default value (brightness) to use upon clearing the EEPROM                                                             |
-|`RGBLIGHT_DEFAULT_SPD`     |`0`                         |The default speed to use upon clearing the EEPROM                                                                          |
-|`RGBLIGHT_DEFAULT_ON`      |`true`                      |Enable RGB lighting upon clearing the EEPROM                                                                               |
+|Define                     |Default                     |Description                                                                    |
+|---------------------------|----------------------------|-------------------------------------------------------------------------------|
+|`RGBLIGHT_HUE_STEP`        |`8`                         |The number of steps to cycle through the hue by                                |
+|`RGBLIGHT_SAT_STEP`        |`17`                        |The number of steps to increment the saturation by                             |
+|`RGBLIGHT_VAL_STEP`        |`17`                        |The number of steps to increment the brightness by                             |
+|`RGBLIGHT_LIMIT_VAL`       |`255`                       |The maximum brightness level                                                   |
+|`RGBLIGHT_SLEEP`           |*Not defined*               |If defined, the RGB lighting will be switched off when the host goes to sleep  |
+|`RGBLIGHT_SPLIT`           |*Not defined*               |If defined, synchronization functionality for split keyboards is added         |
+|`RGBLIGHT_DEFAULT_MODE`    |`RGBLIGHT_MODE_STATIC_LIGHT`|The default mode to use upon clearing the EEPROM                               |
+|`RGBLIGHT_DEFAULT_HUE`     |`0` (red)                   |The default hue to use upon clearing the EEPROM                                |
+|`RGBLIGHT_DEFAULT_SAT`     |`UINT8_MAX` (255)           |The default saturation to use upon clearing the EEPROM                         |
+|`RGBLIGHT_DEFAULT_VAL`     |`RGBLIGHT_LIMIT_VAL`        |The default value (brightness) to use upon clearing the EEPROM                 |
+|`RGBLIGHT_DEFAULT_SPD`     |`0`                         |The default speed to use upon clearing the EEPROM                              |
+|`RGBLIGHT_DEFAULT_ON`      |`true`                      |Enable RGB lighting upon clearing the EEPROM                                   |
+|`RGBLIGHT_DOUBLE_BUFFER`   |*Not defined*               |If defined, use double buffer when rendering                                   |
+
 
 ## Effects and Animations
 

--- a/docs/features/rgblight.md
+++ b/docs/features/rgblight.md
@@ -95,22 +95,21 @@ These keycodes cannot be used with functions like `tap_code16()` as they are not
 
 Your RGB lighting can be configured by placing these `#define`s in your `config.h`:
 
-|Define                     |Default                     |Description                                                                    |
-|---------------------------|----------------------------|-------------------------------------------------------------------------------|
-|`RGBLIGHT_HUE_STEP`        |`8`                         |The number of steps to cycle through the hue by                                |
-|`RGBLIGHT_SAT_STEP`        |`17`                        |The number of steps to increment the saturation by                             |
-|`RGBLIGHT_VAL_STEP`        |`17`                        |The number of steps to increment the brightness by                             |
-|`RGBLIGHT_LIMIT_VAL`       |`255`                       |The maximum brightness level                                                   |
-|`RGBLIGHT_SLEEP`           |*Not defined*               |If defined, the RGB lighting will be switched off when the host goes to sleep  |
-|`RGBLIGHT_SPLIT`           |*Not defined*               |If defined, synchronization functionality for split keyboards is added         |
-|`RGBLIGHT_DEFAULT_MODE`    |`RGBLIGHT_MODE_STATIC_LIGHT`|The default mode to use upon clearing the EEPROM                               |
-|`RGBLIGHT_DEFAULT_HUE`     |`0` (red)                   |The default hue to use upon clearing the EEPROM                                |
-|`RGBLIGHT_DEFAULT_SAT`     |`UINT8_MAX` (255)           |The default saturation to use upon clearing the EEPROM                         |
-|`RGBLIGHT_DEFAULT_VAL`     |`RGBLIGHT_LIMIT_VAL`        |The default value (brightness) to use upon clearing the EEPROM                 |
-|`RGBLIGHT_DEFAULT_SPD`     |`0`                         |The default speed to use upon clearing the EEPROM                              |
-|`RGBLIGHT_DEFAULT_ON`      |`true`                      |Enable RGB lighting upon clearing the EEPROM                                   |
-|`RGBLIGHT_DOUBLE_BUFFER`   |*Not defined*               |If defined, use double buffer when rendering                                   |
-
+|Define                  |Default                     |Description                                                                  |
+|------------------------|----------------------------|-----------------------------------------------------------------------------|
+|`RGBLIGHT_HUE_STEP`     |`8`                         |The number of steps to cycle through the hue by                              |
+|`RGBLIGHT_SAT_STEP`     |`17`                        |The number of steps to increment the saturation by                           |
+|`RGBLIGHT_VAL_STEP`     |`17`                        |The number of steps to increment the brightness by                           |
+|`RGBLIGHT_LIMIT_VAL`    |`255`                       |The maximum brightness level                                                 |
+|`RGBLIGHT_SLEEP`        |*Not defined*               |If defined, the RGB lighting will be switched off when the host goes to sleep|
+|`RGBLIGHT_SPLIT`        |*Not defined*               |If defined, synchronization functionality for split keyboards is added       |
+|`RGBLIGHT_DEFAULT_MODE` |`RGBLIGHT_MODE_STATIC_LIGHT`|The default mode to use upon clearing the EEPROM                             |
+|`RGBLIGHT_DEFAULT_HUE`  |`0` (red)                   |The default hue to use upon clearing the EEPROM                              |
+|`RGBLIGHT_DEFAULT_SAT`  |`UINT8_MAX` (255)           |The default saturation to use upon clearing the EEPROM                       |
+|`RGBLIGHT_DEFAULT_VAL`  |`RGBLIGHT_LIMIT_VAL`        |The default value (brightness) to use upon clearing the EEPROM               |
+|`RGBLIGHT_DEFAULT_SPD`  |`0`                         |The default speed to use upon clearing the EEPROM                            |
+|`RGBLIGHT_DEFAULT_ON`   |`true`                      |Enable RGB lighting upon clearing the EEPROM                                 |
+|`RGBLIGHT_DOUBLE_BUFFER`|*Not defined*               |If defined, use double buffer when rendering                                 |
 
 ## Effects and Animations
 

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -31,6 +31,10 @@
 
 #include <lib/lib8tion/lib8tion.h>
 
+#ifdef LED_MATRIX_DOUBLE_BUFFER
+#define led_matrix_driver led_matrix_driver_wrapper
+#endif
+
 #ifndef LED_MATRIX_CENTER
 const led_point_t k_led_matrix_center = {112, 32};
 #else
@@ -631,3 +635,7 @@ void led_matrix_set_flags(led_flags_t flags) {
 void led_matrix_set_flags_noeeprom(led_flags_t flags) {
     led_matrix_set_flags_eeprom_helper(flags, false);
 }
+
+#ifdef LED_MATRIX_DOUBLE_BUFFER
+#undef led_matrix_driver
+#endif

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -635,7 +635,3 @@ void led_matrix_set_flags(led_flags_t flags) {
 void led_matrix_set_flags_noeeprom(led_flags_t flags) {
     led_matrix_set_flags_eeprom_helper(flags, false);
 }
-
-#ifdef LED_MATRIX_DOUBLE_BUFFER
-#    undef led_matrix_driver
-#endif

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -32,7 +32,7 @@
 #include <lib/lib8tion/lib8tion.h>
 
 #ifdef LED_MATRIX_DOUBLE_BUFFER
-#define led_matrix_driver led_matrix_driver_wrapper
+#    define led_matrix_driver led_matrix_driver_wrapper
 #endif
 
 #ifndef LED_MATRIX_CENTER
@@ -637,5 +637,5 @@ void led_matrix_set_flags_noeeprom(led_flags_t flags) {
 }
 
 #ifdef LED_MATRIX_DOUBLE_BUFFER
-#undef led_matrix_driver
+#    undef led_matrix_driver
 #endif

--- a/quantum/led_matrix/led_matrix_drivers.c
+++ b/quantum/led_matrix/led_matrix_drivers.c
@@ -130,3 +130,37 @@ const led_matrix_driver_t led_matrix_driver = {
 };
 
 #endif
+
+#ifdef LED_MATRIX_DOUBLE_BUFFER
+
+static uint8_t led_buffer[LED_MATRIX_LED_COUNT];
+
+void led_matrix_driver_init(void) {
+    led_matrix_driver.init();
+}
+
+void led_matrix_driver_flush(void) {
+    for (uint16_t i = 0; i < led_matrix_LED_COUNT; i++) {
+        led_matrix_driver.set_color(i, led_buffer[i]);
+    }
+    led_matrix_driver.flush();
+}
+
+void led_matrix_driver_set_color(int index, uint8_t value) {
+    led_buffer[index] = value;
+}
+
+void led_matrix_driver_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
+    for (uint16_t i = 0; i < LED_MATRIX_LED_COUNT; i++) {
+        led_matrix_driver_set_color(i, red, green, blue);
+    }
+}
+
+const led_matrix_driver_t led_matrix_driver_wrapper = {
+    .init          = led_matrix_driver_init,
+    .flush         = led_matrix_driver_flush,
+    .set_color     = led_matrix_driver_set_color,
+    .set_color_all = led_matrix_driver_set_color_all,
+};
+
+#endif

--- a/quantum/led_matrix/led_matrix_drivers.h
+++ b/quantum/led_matrix/led_matrix_drivers.h
@@ -45,4 +45,8 @@ typedef struct {
     void (*flush)(void);
 } led_matrix_driver_t;
 
+#ifdef LED_MATRIX_DOUBLE_BUFFER
+extern const led_matrix_driver_t led_matrix_driver_wrapper;
+#endif
+
 extern const led_matrix_driver_t led_matrix_driver;

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -29,6 +29,10 @@
 
 #include <lib/lib8tion/lib8tion.h>
 
+#ifdef RGB_MATRIX_DOUBLE_BUFFER
+#define rgb_matrix_driver rgb_matrix_driver_wrapper
+#endif
+
 #ifndef RGB_MATRIX_CENTER
 const led_point_t k_rgb_matrix_center = {112, 32};
 #else
@@ -717,3 +721,7 @@ void rgb_matrix_set_flags(led_flags_t flags) {
 void rgb_matrix_set_flags_noeeprom(led_flags_t flags) {
     rgb_matrix_set_flags_eeprom_helper(flags, false);
 }
+
+#ifdef RGB_MATRIX_DOUBLE_BUFFER
+#undef rgb_matrix_driver
+#endif

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -30,7 +30,7 @@
 #include <lib/lib8tion/lib8tion.h>
 
 #ifdef RGB_MATRIX_DOUBLE_BUFFER
-#define rgb_matrix_driver rgb_matrix_driver_wrapper
+#    define rgb_matrix_driver rgb_matrix_driver_wrapper
 #endif
 
 #ifndef RGB_MATRIX_CENTER
@@ -723,5 +723,5 @@ void rgb_matrix_set_flags_noeeprom(led_flags_t flags) {
 }
 
 #ifdef RGB_MATRIX_DOUBLE_BUFFER
-#undef rgb_matrix_driver
+#    undef rgb_matrix_driver
 #endif

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -721,7 +721,3 @@ void rgb_matrix_set_flags(led_flags_t flags) {
 void rgb_matrix_set_flags_noeeprom(led_flags_t flags) {
     rgb_matrix_set_flags_eeprom_helper(flags, false);
 }
-
-#ifdef RGB_MATRIX_DOUBLE_BUFFER
-#    undef rgb_matrix_driver
-#endif

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -157,8 +157,6 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 
 #ifdef RGB_MATRIX_DOUBLE_BUFFER
 
-// #undef rgb_matrix_driver
-
 static rgb_t led_buffer[RGB_MATRIX_LED_COUNT];
 
 void rgb_matrix_driver_init(void) {
@@ -181,8 +179,6 @@ void rgb_matrix_driver_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
         rgb_matrix_driver_set_color(i, red, green, blue);
     }
 }
-
-#    undef rgb_matrix_driver
 
 const rgb_matrix_driver_t rgb_matrix_driver_wrapper = {
     .init          = rgb_matrix_driver_init,

--- a/quantum/rgb_matrix/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.c
@@ -154,3 +154,41 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 };
 
 #endif
+
+#ifdef RGB_MATRIX_DOUBLE_BUFFER
+
+// #undef rgb_matrix_driver
+
+static rgb_t led_buffer[RGB_MATRIX_LED_COUNT];
+
+void rgb_matrix_driver_init(void) {
+    rgb_matrix_driver.init();
+}
+
+void rgb_matrix_driver_flush(void) {
+    for (uint16_t i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
+        rgb_matrix_driver.set_color(i, led_buffer[i].r, led_buffer[i].g, led_buffer[i].b);
+    }
+    rgb_matrix_driver.flush();
+}
+
+void rgb_matrix_driver_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
+    led_buffer[index] = (rgb_t){.r = red, .g = green, .b = blue};
+}
+
+void rgb_matrix_driver_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
+    for (uint16_t i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
+        rgb_matrix_driver_set_color(i, red, green, blue);
+    }
+}
+
+#    undef rgb_matrix_driver
+
+const rgb_matrix_driver_t rgb_matrix_driver_wrapper = {
+    .init          = rgb_matrix_driver_init,
+    .flush         = rgb_matrix_driver_flush,
+    .set_color     = rgb_matrix_driver_set_color,
+    .set_color_all = rgb_matrix_driver_set_color_all,
+};
+
+#endif

--- a/quantum/rgb_matrix/rgb_matrix_drivers.h
+++ b/quantum/rgb_matrix/rgb_matrix_drivers.h
@@ -48,4 +48,8 @@ typedef struct {
     void (*flush)(void);
 } rgb_matrix_driver_t;
 
+#ifdef RGB_MATRIX_DOUBLE_BUFFER
+extern const rgb_matrix_driver_t rgb_matrix_driver_wrapper;
+#endif
+
 extern const rgb_matrix_driver_t rgb_matrix_driver;

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -24,6 +24,11 @@
 #include "util.h"
 #include "led_tables.h"
 #include <lib/lib8tion/lib8tion.h>
+
+#ifdef RGBLIGHT_DOUBLE_BUFFER
+#define rgblight_driver rgblight_driver_wrapper
+#endif
+
 #ifdef EEPROM_ENABLE
 #    include "eeprom.h"
 #endif
@@ -1490,4 +1495,8 @@ uint8_t rgblight_velocikey_match_speed(uint8_t minValue, uint8_t maxValue) {
     return MAX(minValue, maxValue - (maxValue - minValue) * ((float)typing_speed / TYPING_SPEED_MAX_VALUE));
 }
 
+#endif
+
+#ifdef RGBLIGHT_DOUBLE_BUFFER
+#undef rgblight_driver
 #endif

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -26,7 +26,7 @@
 #include <lib/lib8tion/lib8tion.h>
 
 #ifdef RGBLIGHT_DOUBLE_BUFFER
-#define rgblight_driver rgblight_driver_wrapper
+#    define rgblight_driver rgblight_driver_wrapper
 #endif
 
 #ifdef EEPROM_ENABLE
@@ -1403,7 +1403,7 @@ void rgblight_effect_twinkle(animation_status_t *anim) {
 
     for (uint8_t i = 0; i < rgblight_ranges.effect_num_leds; i++) {
         TwinkleState *t = &(led_twinkle_state[i]);
-        hsv_t *       c = &(t->hsv);
+        hsv_t        *c = &(t->hsv);
 
         if (!random_color) {
             c->h = rgblight_config.hue;
@@ -1498,5 +1498,5 @@ uint8_t rgblight_velocikey_match_speed(uint8_t minValue, uint8_t maxValue) {
 #endif
 
 #ifdef RGBLIGHT_DOUBLE_BUFFER
-#undef rgblight_driver
+#    undef rgblight_driver
 #endif

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -1403,7 +1403,7 @@ void rgblight_effect_twinkle(animation_status_t *anim) {
 
     for (uint8_t i = 0; i < rgblight_ranges.effect_num_leds; i++) {
         TwinkleState *t = &(led_twinkle_state[i]);
-        hsv_t        *c = &(t->hsv);
+        hsv_t *       c = &(t->hsv);
 
         if (!random_color) {
             c->h = rgblight_config.hue;
@@ -1495,8 +1495,4 @@ uint8_t rgblight_velocikey_match_speed(uint8_t minValue, uint8_t maxValue) {
     return MAX(minValue, maxValue - (maxValue - minValue) * ((float)typing_speed / TYPING_SPEED_MAX_VALUE));
 }
 
-#endif
-
-#ifdef RGBLIGHT_DOUBLE_BUFFER
-#    undef rgblight_driver
 #endif

--- a/quantum/rgblight/rgblight_drivers.c
+++ b/quantum/rgblight/rgblight_drivers.c
@@ -24,3 +24,37 @@ const rgblight_driver_t rgblight_driver = {
 };
 
 #endif
+
+#ifdef RGBLIGHT_DOUBLE_BUFFER
+
+static rgb_t led_buffer[RGBLIGHT_LED_COUNT];
+
+void rgblight_driver_init(void) {
+    rgblight_driver.init();
+}
+
+void rgblight_driver_flush(void) {
+    for (uint16_t i = 0; i < RGBLIGHT_LED_COUNT; i++) {
+        rgblight_driver.set_color(i, led_buffer[i].r, led_buffer[i].g, led_buffer[i].b);
+    }
+    rgblight_driver.flush();
+}
+
+void rgblight_driver_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
+    led_buffer[index] = (rgb_t){.r = red, .g = green, .b = blue};
+}
+
+void rgblight_driver_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
+    for (uint16_t i = 0; i < RGBLIGHT_LED_COUNT; i++) {
+        rgb_matrix_driver_set_color(i, red, green, blue);
+    }
+}
+
+const rgblight_driver_t rgblight_driver_wrapper = {
+    .init          = rgblight_driver_init,
+    .flush         = rgblight_driver_flush,
+    .set_color     = rgblight_driver_set_color,
+    .set_color_all = rgblight_driver_set_color_all,
+};
+
+#endif

--- a/quantum/rgblight/rgblight_drivers.h
+++ b/quantum/rgblight/rgblight_drivers.h
@@ -12,4 +12,8 @@ typedef struct {
     void (*flush)(void);
 } rgblight_driver_t;
 
+#ifdef RGBLIGHT_DOUBLE_BUFFER
+extern const rgblight_driver_t rgblight_driver_wrapper;
+#endif
+
 extern const rgblight_driver_t rgblight_driver;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Takes over from https://github.com/qmk/qmk_firmware/pull/22119

~~Adds double buffer functionality for LED matrix and RGB Matrix since RGB Matrix and LED Matrix both use the underlying drivers to set the values.~~

EDIT: Adds double buffer functionality now for ALL lighting systems.

This feature is disabled by DEFAULT due to the ever present hardware of microcontrollers with very limited RAM. 
It should only be enabled by testing if there is enough RAM.

(tested on Pachi RGB Rev2, with VIA keymap, your numbers may vary) 
![image](https://github.com/user-attachments/assets/2b14814d-8abf-4d8c-8e98-7c427db6003a)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Adds double buffering to all drivers that are supported in RGB/LED Matrix

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
