### PR TITLE
Retro Tapping Key Roll Fix

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -47,7 +47,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 int tp_buttons;
 
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-int retro_tapping_counter = 0;
+bool     retro_should_tap = false;
+uint16_t retro_last_key   = 0;
+uint8_t  retro_curr_mods  = 0;
+uint8_t  retro_next_mods  = 0;
 #endif
 
 #if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT) && !defined(NO_ACTION_TAPPING)
@@ -77,7 +80,13 @@ void action_exec(keyevent_t event) {
         debug_event(event);
         ac_dprintf("\n");
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-        retro_tapping_counter++;
+        uint16_t event_keycode = get_event_keycode(event, false);
+        if (event.pressed) {
+            retro_should_tap = false;
+            retro_last_key   = event_keycode;
+        } else if (retro_last_key == event_keycode) {
+            retro_should_tap = true;
+        }
 #endif
     }
 
@@ -531,7 +540,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #    if defined(RETRO_TAPPING) && defined(DUMMY_MOD_NEUTRALIZER_KEYCODE)
                             // Send a dummy keycode to neutralize flashing modifiers
                             // if the key was held and then released with no interruptions.
-                            if (retro_tapping_counter == 2) {
+                            if (retro_should_tap && retro_last_key == get_event_keycode(event, false)) {
                                 neutralize_flashing_modifiers(get_mods());
                             }
 #    endif
@@ -827,30 +836,37 @@ void process_action(keyrecord_t *record, action_t action) {
 
 #ifndef NO_ACTION_TAPPING
 #    if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-    if (!is_tap_action(action)) {
-        retro_tapping_counter = 0;
-    } else {
+    uint16_t event_keycode = get_event_keycode(event, false);
+
+    if (is_tap_action(action)) {
         if (event.pressed) {
             if (tap_count > 0) {
-                retro_tapping_counter = 0;
+                retro_should_tap = false;
+            } else {
+                retro_curr_mods = retro_next_mods;
+                retro_next_mods = get_mods();
             }
         } else {
+            uint8_t curr_mods = get_mods();
             if (tap_count > 0) {
-                retro_tapping_counter = 0;
-            } else {
+                retro_should_tap = false;
+            } else if (retro_last_key == event_keycode) {
                 if (
 #        ifdef RETRO_TAPPING_PER_KEY
-                    get_retro_tapping(get_event_keycode(record->event, false), record) &&
+                    get_retro_tapping(event_keycode, record) &&
 #        endif
-                    retro_tapping_counter == 2) {
+                    retro_should_tap) {
 #        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     process_auto_shift(action.layer_tap.code, record);
 #        else
+                    set_mods(retro_curr_mods);
                     tap_code(action.layer_tap.code);
+                    set_mods(curr_mods);
 #        endif
                 }
-                retro_tapping_counter = 0;
+                retro_should_tap = false;
             }
+            retro_next_mods = curr_mods;
         }
     }
 #    endif


### PR DESCRIPTION
## Description

The purpose of this PR is to fix the condition found with RETRO_TAPPING enabled when key rolling. The issue is that the dual function keys's retro tap keycode is not fired when a different key has been released between the dual function keys's down and up events. I am not sure if this is intended behavior or not, but does not seem to be given that retro tapping is supposed to apply if another key is not *pressed*.

I slightly reworked the logic to fix this. When considering key rolling from a dual function key to a dual function key, it was necessary to capture the previous modifier state and temporarily apply it to the tap code.

This is still an early draft. I am brand new to QMK and am running the ZSA fork so I do not have the experience/ability to see this through without some assistance. I would be happy to hand this off to someone more qualified if appropriate.

⚠️ This change in current form does not consider RETRO_SHIFT nor AUTO_SHIFT_ENABLE. The ZSA fork does not seem to support RETRO_SHIFT so I am not able to test this. I also have not tested RETRO_TAPPING_PER_KEY, though that looks like it will function with no issue. It is not configured in Oryx and I have sparsely looked at keymap.c.

I ensured these changes work on my ZSA Voyager and that I could make all defaults. Thanks.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

#22916 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Media

### Before Key Roll Fix: Single to Dual Function
![single-dual_before](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/c35d61b2-b747-4631-99ab-3824578c59c2)

### After Key Roll Fix: Single to Dual Function
![sigle-dual_after](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/632795aa-3f7f-4114-b10e-ecd8a44eb565)

### Before Key Roll Fix: Dual to Dual Function
![dual-dual_before](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/378f80b2-175e-40a4-b5ef-55ac031cd5bc)

### After Key Roll Fix: Dual to Dual Function
![dual-dual_after](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/2c4dfd69-8b80-4f70-9ba4-a7c580634c7d)
