### PR TITLE
add Bruce le Clavier

### DIFF
--- a/keyboards/jlw/bruce_le_clavier/info.json
+++ b/keyboards/jlw/bruce_le_clavier/info.json
@@ -1,0 +1,82 @@
+{
+    "keyboard_name": "Bruce the Keyboard",
+    "manufacturer": "jlw",
+    "url": "https://github.com/josh-l-wang/Bruce-the-Keyboard-the-Resources",
+    "maintainer": "jlw",
+    "usb": {
+        "vid": "0x1209",
+        "pid": "0xA459",
+        "device_version": "0.0.1"
+    },
+    "processor": "STM32F072",
+    "bootloader": "stm32-dfu",
+    "diode_direction": "COL2ROW",
+    "matrix_pins": {
+        "cols": ["B1", "B0", "A7", "A4", "A3", "B7", "B6", "B5", "B4", "B3", "B14"],
+        "rows": ["B11", "B9", "A5", "A6", "B15"]
+    },
+    "features": {
+        "bootmagic": true,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true,
+        "encoder": true
+    },
+    "bootmagic": {
+        "matrix": [4, 10]
+    },
+    "encoder": {
+        "rotary": [
+            {"pin_a": "B12", "pin_b": "B13"}
+        ]
+    },
+    "ws2812": {
+        "pin": "B8"
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0, "h":1.75},
+                {"matrix": [0, 1], "x": 1, "y": 0, "h":1.5},
+                {"matrix": [0, 2], "x": 2, "y": 0},
+                {"matrix": [0, 3], "x": 3, "y": 0, "h":1.25},
+                {"matrix": [0, 4], "x": 4, "y": 0, "h":1.25},
+
+                {"matrix": [4, 10], "x": 5.25, "y": 0},
+
+                {"matrix": [0, 5], "x": 6.5, "y": 0, "h":1.25},
+                {"matrix": [0, 6], "x": 7.5, "y": 0, "h":1.25},
+                {"matrix": [0, 7], "x": 8.5, "y": 0},
+                {"matrix": [0, 8], "x": 9.5, "y": 0, "h":1.5},
+                {"matrix": [0, 9], "x": 10.5, "y": 0, "h":1.75},
+
+                {"matrix": [1, 0], "x": 0, "y": 1.75},
+                {"matrix": [1, 1], "x": 1, "y": 1.5},
+                {"matrix": [1, 2], "x": 2, "y": 1},
+                {"matrix": [1, 3], "x": 3, "y": 1.25},
+                {"matrix": [1, 4], "x": 4, "y": 1.25},
+                {"matrix": [1, 5], "x": 6.5, "y": 1.25},
+                {"matrix": [1, 6], "x": 7.5, "y": 1.25},
+                {"matrix": [1, 7], "x": 8.5, "y": 1},
+                {"matrix": [1, 8], "x": 9.5, "y": 1.5},
+                {"matrix": [1, 9], "x": 10.5,"y": 1.75},
+
+                {"matrix": [2, 0], "x": 0, "y": 2.75, "h":1.5},
+                {"matrix": [2, 1], "x": 1, "y": 2.5, "h":1.75},
+                {"matrix": [2, 2], "x": 2, "y": 2, "h":1.25},
+                {"matrix": [2, 3], "x": 3, "y": 2.25},
+                {"matrix": [2, 4], "x": 4, "y": 2.25},
+                {"matrix": [2, 5], "x": 6.5, "y": 2.25},
+                {"matrix": [2, 6], "x": 7.5, "y": 2.25},
+                {"matrix": [2, 7], "x": 8.5, "y": 2, "h":1.25},
+                {"matrix": [2, 8], "x": 9.5, "y": 2.5, "h":1.75},
+                {"matrix": [2, 9], "x": 10.5,"y": 2.75, "h":1.5},
+
+                {"matrix": [3, 2], "x": 2, "y": 3.25},
+                {"matrix": [3, 3], "x": 3, "y": 3.25, "w": 2},
+                {"matrix": [3, 5], "x": 6.5, "y": 3.25, "w": 2},
+                {"matrix": [3, 7], "x": 8.5, "y": 3.25}
+            ]
+        }
+    }
+}

--- a/keyboards/jlw/bruce_le_clavier/info.json
+++ b/keyboards/jlw/bruce_le_clavier/info.json
@@ -5,7 +5,7 @@
     "maintainer": "jlw",
     "usb": {
         "vid": "0x1209",
-        "pid": "0xA459",
+        "pid": "0xA460",
         "device_version": "0.0.1"
     },
     "processor": "STM32F072",

--- a/keyboards/jlw/bruce_le_clavier/keymaps/default/keymap.c
+++ b/keyboards/jlw/bruce_le_clavier/keymaps/default/keymap.c
@@ -1,0 +1,43 @@
+// Copyright 2023 jlw
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+         KC_Q,          KC_W,           KC_F,           KC_P,   KC_B,    QK_BOOT,   KC_J,   KC_L,   KC_U,           KC_Y,           KC_QUOT,
+         LGUI_T(KC_A),  LALT_T(KC_R),   LCTL_T(KC_S),   KC_T,   KC_G,               KC_M,   KC_N,   RCTL_T(KC_E),   LALT_T(KC_I),   LGUI_T(KC_O),
+         KC_Z,          KC_X,           KC_C,           KC_D,   KC_V,               KC_K,   KC_H,   KC_COMM,        KC_DOT,         KC_SLSH,
+                                        LT(3, KC_TAB), SFT_T(KC_BSPC),              LT(1, KC_SPC),  LT(2,KC_ENT)
+    ),
+
+    [1] = LAYOUT(
+         KC_GRAVE, KC_F2,    XXXXXXX,  KC_F4,    KC_F5,    XXXXXXX,  KC_BSLS,  KC_MINUS, KC_EQUAL, KC_LBRC,  KC_RBRC,
+         KC_1,     KC_2,     KC_3,     KC_4,     KC_5,               KC_6,     KC_7,     KC_8,     KC_9,     KC_0,
+         DF(0),    XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,            DF(1),    XXXXXXX,  _______,  _______,  KC_SCLN,
+                                       _______,  _______,            _______,  _______
+    ),
+
+    [2] = LAYOUT(
+         XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  KC_F11,   KC_F12,   XXXXXXX,  XXXXXXX,
+         KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,              KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,
+         DF(0),    XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,            DF(2),    XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,
+                                       _______,  _______,            _______,  _______
+    ),
+    [3] = LAYOUT(
+         XXXXXXX,  XXXXXXX,  LSG(KC_4),LSG(KC_S),XXXXXXX,  XXXXXXX,  KC_HOME,  XXXXXXX,  KC_UP,    XXXXXXX,  KC_PGUP,
+         KC_LGUI,  KC_LALT,  KC_LCTL,  KC_LGUI,  XXXXXXX,            KC_END,   KC_LEFT,  KC_DOWN,  KC_RIGHT, KC_PGDN,
+         DF(0),    XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,            DF(2),    XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,
+                                       _______,  _______,            _______,  _______
+    )
+};
+
+// Encoder Map
+#ifdef ENCODER_MAP_ENABLE
+    const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+        [0] =   { ENCODER_CCW_CW(S(KC_F2), KC_F2) },
+        [1] =   { ENCODER_CCW_CW(KC_VOLU, KC_VOLD) },
+        [2] =   { ENCODER_CCW_CW(_______, _______) },
+        [3] =   { ENCODER_CCW_CW(_______, _______) }
+    };
+#endif

--- a/keyboards/jlw/bruce_le_clavier/keymaps/default/rules.mk
+++ b/keyboards/jlw/bruce_le_clavier/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+# This file intentionally left blank.

--- a/keyboards/jlw/bruce_le_clavier/keymaps/default/rules.mk
+++ b/keyboards/jlw/bruce_le_clavier/keymaps/default/rules.mk
@@ -1,1 +1,0 @@
-# This file intentionally left blank.

--- a/keyboards/jlw/bruce_le_clavier/readme.md
+++ b/keyboards/jlw/bruce_le_clavier/readme.md
@@ -1,0 +1,51 @@
+# Bruce le Clavier
+
+Please note that Bruce le Clavier is a keyboard, not a human, and is also not Bruce the Keyboard.
+
+Bruce the Keyboard is a column staggered unibody split 35-key board created by [jlw](github.com/josh-l-wang), with the option to replace the middle key for an EC11 rotary encoder (with or without switch function).
+
+![Bruce le Clavier](https://i.imgur.com/qL9WHW4.jpg)
+
+* Keyboard Maintainer: [jlw](https://github.com/josh-l-wang)
+* Hardware Supported: [Bruce le Clavier and Cases](https://github.com/josh-l-wang/Bruce-the-Keyboard-the-Resources)
+* Hardware Availability: [jlw-kb.com](https://jlw-kb.com)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make jlw/bruce_le_clavier:default
+
+Flashing example for this keyboard:
+
+    make jlw/bruce_le_clavier:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (the top left key) and plug in the keyboard
+* **Physical reset button**: Hold button on the back of the PCB while plugging in the PCB
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available
+
+
+
+
+# Ceci est le micrologiciel pour Bruce le clavier
+
+Notez bien que Bruce le clavier n'est pas un humain.
+
+Bruce le clavier est un clavier de 35 touches colonnaire créé par [jlw](github.com/josh-l-wang). Il y a une option d'utiliser un encodeur rotatif au centre.
+
+* Maintaineur de clavier: [jlw](https://github.com/josh-l-wang)
+* Matériel supporté: [Bruce le Clavier and Cases](https://github.com/josh-l-wang/Bruce-the-Keyboard-the-Resources)
+* Matériel disponibilité: [jlw-kb.com](https://jlw-kb.com)
+
+Exemple de « make » (après avoir installé votre environnement de développement):
+
+    make jlw/bruce_le_clavier:default
+    
+Exemple de flash pour ce clavier:
+
+    make jlw/bruce_le_clavier:flash
+    

--- a/keyboards/jlw/bruce_le_clavier/readme.md
+++ b/keyboards/jlw/bruce_le_clavier/readme.md
@@ -4,6 +4,8 @@ Please note that Bruce le Clavier is a keyboard, not a human, and is also not Br
 
 Bruce the Keyboard is a column staggered unibody split 35-key board created by [jlw](github.com/josh-l-wang), with the option to replace the middle key for an EC11 rotary encoder (with or without switch function).
 
+This keyboard has RGB, 3.3V, and GND pins broken out if you wish to add an LED strip.
+
 ![Bruce le Clavier](https://i.imgur.com/qL9WHW4.jpg)
 
 * Keyboard Maintainer: [jlw](https://github.com/josh-l-wang)

--- a/keyboards/jlw/bruce_le_clavier/rules.mk
+++ b/keyboards/jlw/bruce_le_clavier/rules.mk
@@ -1,0 +1,1 @@
+#This file intentionally left blank


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is a PR to add the keyboard "Bruce le Clavier" to QMK.  There is a PR for its brother, "Bruce the Keyboard"  (#23639). The two boards are very similar, but Bruce the Keyboard is a rectangular 4.25u tall by 10u wide column stagger board, whereas Bruce le Clavier is a unibody split version of Bruce the Keyboard with a center key/encoder option.

This keyboard has broken out pins for an addressable LED strip to be added if the end user so wishes. I defined the WS2812 pin in info.json for users to be able to add their own backlight code, but did not define the RGB Light feature in this PR since it is not a default functionality for the board.

Thank you for taking the time to review this submission (and/or its brother).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
