### PR TITLE
Retro Tapping Re-Write; Key Roll Fix

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -47,7 +47,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 int tp_buttons;
 
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-int retro_tapping_counter = 0;
+bool     retro_should_tap = false;
+uint16_t retro_last_key   = 0;
+uint8_t  retro_curr_mods  = 0;
+uint8_t  retro_next_mods  = 0;
 #endif
 
 #if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT) && !defined(NO_ACTION_TAPPING)
@@ -77,7 +80,13 @@ void action_exec(keyevent_t event) {
         debug_event(event);
         ac_dprintf("\n");
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-        retro_tapping_counter++;
+        uint16_t event_keycode = get_event_keycode(event, false);
+        if (event.pressed) {
+            retro_should_tap = false;
+            retro_last_key   = event_keycode;
+        } else if (retro_last_key == event_keycode) {
+            retro_should_tap = true;
+        }
 #endif
     }
 
@@ -531,7 +540,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #    if defined(RETRO_TAPPING) && defined(DUMMY_MOD_NEUTRALIZER_KEYCODE)
                             // Send a dummy keycode to neutralize flashing modifiers
                             // if the key was held and then released with no interruptions.
-                            if (retro_tapping_counter == 2) {
+                            if (retro_should_tap && retro_last_key == get_event_keycode(event, false)) {
                                 neutralize_flashing_modifiers(get_mods());
                             }
 #    endif
@@ -827,30 +836,37 @@ void process_action(keyrecord_t *record, action_t action) {
 
 #ifndef NO_ACTION_TAPPING
 #    if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-    if (!is_tap_action(action)) {
-        retro_tapping_counter = 0;
-    } else {
+    uint16_t event_keycode = get_event_keycode(event, false);
+
+    if (is_tap_action(action)) {
         if (event.pressed) {
             if (tap_count > 0) {
-                retro_tapping_counter = 0;
+                retro_should_tap = false;
+            } else {
+                retro_curr_mods = retro_next_mods;
+                retro_next_mods = get_mods();
             }
         } else {
+            uint8_t curr_mods = get_mods();
             if (tap_count > 0) {
-                retro_tapping_counter = 0;
-            } else {
+                retro_should_tap = false;
+            } else if (retro_last_key == event_keycode) {
                 if (
 #        ifdef RETRO_TAPPING_PER_KEY
-                    get_retro_tapping(get_event_keycode(record->event, false), record) &&
+                    get_retro_tapping(event_keycode, record) &&
 #        endif
-                    retro_tapping_counter == 2) {
+                    retro_should_tap) {
 #        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     process_auto_shift(action.layer_tap.code, record);
 #        else
+                    set_mods(retro_curr_mods);
                     tap_code(action.layer_tap.code);
+                    set_mods(curr_mods);
 #        endif
                 }
-                retro_tapping_counter = 0;
+                retro_should_tap = false;
             }
+            retro_next_mods = curr_mods;
         }
     }
 #    endif

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -849,7 +849,7 @@ void process_action(keyrecord_t *record, action_t action) {
             }
         } else {
             uint16_t event_keycode = get_event_keycode(event, false);
-            uint8_t curr_mods      = get_mods();
+            uint8_t  curr_mods     = get_mods();
             if (tap_count > 0) {
                 retro_tap.primed = false;
             } else if (retro_tap.curr_key == event_keycode) {

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -84,7 +84,7 @@ void action_exec(keyevent_t event) {
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
         uint16_t event_keycode = get_event_keycode(event, false);
         if (event.pressed) {
-            retro_tap.primed = false;
+            retro_tap.primed   = false;
             retro_tap.curr_key = event_keycode;
         } else if (retro_tap.curr_key == event_keycode) {
             retro_tap.primed = true;
@@ -849,7 +849,7 @@ void process_action(keyrecord_t *record, action_t action) {
             }
         } else {
             uint16_t event_keycode = get_event_keycode(event, false);
-            uint8_t curr_mods = get_mods();
+            uint8_t curr_mods      = get_mods();
             if (tap_count > 0) {
                 retro_tap.primed = false;
             } else if (retro_tap.curr_key == event_keycode) {

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -47,10 +47,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 int tp_buttons;
 
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-bool     retro_should_tap = false;
-uint16_t retro_last_key   = 0;
-uint8_t  retro_curr_mods  = 0;
-uint8_t  retro_next_mods  = 0;
+static struct {
+    bool     primed : 1;
+    uint16_t curr_key;
+    uint8_t  curr_mods;
+    uint8_t  next_mods;
+} retro_tap = {0, 0, 0, 0};
 #endif
 
 #if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT) && !defined(NO_ACTION_TAPPING)
@@ -82,10 +84,10 @@ void action_exec(keyevent_t event) {
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
         uint16_t event_keycode = get_event_keycode(event, false);
         if (event.pressed) {
-            retro_should_tap = false;
-            retro_last_key   = event_keycode;
-        } else if (retro_last_key == event_keycode) {
-            retro_should_tap = true;
+            retro_tap.primed = false;
+            retro_tap.curr_key = event_keycode;
+        } else if (retro_tap.curr_key == event_keycode) {
+            retro_tap.primed = true;
         }
 #endif
     }
@@ -540,7 +542,8 @@ void process_action(keyrecord_t *record, action_t action) {
 #    if defined(RETRO_TAPPING) && defined(DUMMY_MOD_NEUTRALIZER_KEYCODE)
                             // Send a dummy keycode to neutralize flashing modifiers
                             // if the key was held and then released with no interruptions.
-                            if (retro_should_tap && retro_last_key == get_event_keycode(event, false)) {
+                            uint16_t ev_kc = get_event_keycode(event, false);
+                            if (retro_tap.primed && retro_tap.curr_key == ev_kc) {
                                 neutralize_flashing_modifiers(get_mods());
                             }
 #    endif
@@ -836,37 +839,37 @@ void process_action(keyrecord_t *record, action_t action) {
 
 #ifndef NO_ACTION_TAPPING
 #    if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-    uint16_t event_keycode = get_event_keycode(event, false);
-
     if (is_tap_action(action)) {
         if (event.pressed) {
             if (tap_count > 0) {
-                retro_should_tap = false;
+                retro_tap.primed = false;
             } else {
-                retro_curr_mods = retro_next_mods;
-                retro_next_mods = get_mods();
+                retro_tap.curr_mods = retro_tap.next_mods;
+                retro_tap.next_mods = get_mods();
             }
         } else {
+            uint16_t event_keycode = get_event_keycode(event, false);
             uint8_t curr_mods = get_mods();
             if (tap_count > 0) {
-                retro_should_tap = false;
-            } else if (retro_last_key == event_keycode) {
+                retro_tap.primed = false;
+            } else if (retro_tap.curr_key == event_keycode) {
                 if (
 #        ifdef RETRO_TAPPING_PER_KEY
                     get_retro_tapping(event_keycode, record) &&
 #        endif
-                    retro_should_tap) {
+                    retro_tap.primed) {
+
 #        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     process_auto_shift(action.layer_tap.code, record);
 #        else
-                    set_mods(retro_curr_mods);
+                    set_mods(retro_tap.curr_mods);
                     tap_code(action.layer_tap.code);
                     set_mods(curr_mods);
 #        endif
                 }
-                retro_should_tap = false;
+                retro_tap.primed = false;
             }
-            retro_next_mods = curr_mods;
+            retro_tap.next_mods = curr_mods;
         }
     }
 #    endif

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -540,7 +540,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #    if defined(RETRO_TAPPING) && defined(DUMMY_MOD_NEUTRALIZER_KEYCODE)
                             // Send a dummy keycode to neutralize flashing modifiers
                             // if the key was held and then released with no interruptions.
-                            if (retro_should_tap && retro_last_key == get_event_keycode(event, false)) {
+                            if (retro_should_tap) {
                                 neutralize_flashing_modifiers(get_mods());
                             }
 #    endif

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -540,7 +540,7 @@ void process_action(keyrecord_t *record, action_t action) {
 #    if defined(RETRO_TAPPING) && defined(DUMMY_MOD_NEUTRALIZER_KEYCODE)
                             // Send a dummy keycode to neutralize flashing modifiers
                             // if the key was held and then released with no interruptions.
-                            if (retro_should_tap) {
+                            if (retro_should_tap && retro_last_key == get_event_keycode(event, false)) {
                                 neutralize_flashing_modifiers(get_mods());
                             }
 #    endif

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -49,7 +49,7 @@ int tp_buttons;
 #if defined(RETRO_TAPPING) || defined(RETRO_TAPPING_PER_KEY) || (defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
 bool     retro_tap_primed   = false;
 uint16_t retro_tap_curr_key = 0;
-#    if !defined(NO_ACTION_ONESHOT) && !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#    if !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
 uint8_t retro_tap_curr_mods = 0;
 uint8_t retro_tap_next_mods = 0;
 #    endif

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -844,14 +844,14 @@ void process_action(keyrecord_t *record, action_t action) {
             if (tap_count > 0) {
                 retro_tap_primed = false;
             } else {
-#        if !defined(NO_ACTION_ONESHOT) && !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#        if !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
                 retro_tap_curr_mods = retro_tap_next_mods;
                 retro_tap_next_mods = get_mods();
 #        endif
             }
         } else {
             uint16_t event_keycode = get_event_keycode(event, false);
-#        if !defined(NO_ACTION_ONESHOT) && !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#        if !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
             uint8_t curr_mods = get_mods();
 #        endif
             if (tap_count > 0) {
@@ -862,18 +862,19 @@ void process_action(keyrecord_t *record, action_t action) {
                     get_retro_tapping(event_keycode, record) &&
 #        endif
                     retro_tap_primed) {
-#        if !defined(NO_ACTION_ONESHOT) && !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
-                    set_oneshot_mods(retro_tap_curr_mods);
-#        endif
 #        if defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT)
                     process_auto_shift(action.layer_tap.code, record);
 #        else
+                    register_mods(retro_tap_curr_mods);
+                    wait_ms(TAP_CODE_DELAY);
                     tap_code(action.layer_tap.code);
+                    wait_ms(TAP_CODE_DELAY);
+                    unregister_mods(retro_tap_curr_mods);
 #        endif
                 }
                 retro_tap_primed = false;
             }
-#        if !defined(NO_ACTION_ONESHOT) && !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
+#        if !(defined(AUTO_SHIFT_ENABLE) && defined(RETRO_SHIFT))
             retro_tap_next_mods = curr_mods;
 #        endif
         }

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Vladislav Kucheriavykh
+/* Copyright 2024 John Rigoni
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -102,7 +102,7 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     InSequence s;
     auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
     auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
-    auto       regular_key      = KeymapKey(0, 3, 0, KC_B);
+    auto       regular_key        = KeymapKey(0, 3, 0, KC_B);
 
     set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft, regular_key});
 

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -102,9 +102,8 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     InSequence s;
     auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
     auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
-    auto       regular_key        = KeymapKey(0, 3, 0, KC_B);
 
-    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft, regular_key});
+    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
 
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_lshft.press();
@@ -133,17 +132,8 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     EXPECT_REPORT(driver, (KC_LEFT_GUI));
     EXPECT_EMPTY_REPORT(driver);
     EXPECT_REPORT(driver, (KC_P, KC_LEFT_SHIFT));
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
-    mod_tap_hold_gui.release();
-    run_one_scan_loop();
-    VERIFY_AND_CLEAR(driver);
-
-    // press a regular key so the test ends with an empty report
-    EXPECT_REPORT(driver, (KC_B));
     EXPECT_EMPTY_REPORT(driver);
-    regular_key.press();
-    run_one_scan_loop();
-    regular_key.release();
+    mod_tap_hold_gui.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -97,24 +97,30 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_gui) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
-
 TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     TestDriver driver;
     InSequence s;
     auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
     auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
+    auto       regular_key      = KeymapKey(0, 3, 0, KC_B);
 
-    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
+    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft, regular_key});
 
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_NO_REPORT(driver);
     mod_tap_hold_lshft.press();
     idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_GUI));
+    EXPECT_NO_REPORT(driver);
     mod_tap_hold_gui.press();
     idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_GUI));
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
@@ -129,6 +135,15 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     EXPECT_REPORT(driver, (KC_P, KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     mod_tap_hold_gui.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    // press a regular key so the test ends with an empty report
+    EXPECT_REPORT(driver, (KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.press();
+    run_one_scan_loop();
+    regular_key.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -34,7 +34,6 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_shift) {
 
     set_keymap({mod_tap_hold_key, regular_key});
 
-
     EXPECT_REPORT(driver, (KC_A));
     regular_key.press();
     run_one_scan_loop();
@@ -99,12 +98,11 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_gui) {
     VERIFY_AND_CLEAR(driver);
 }
 
-
 TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     TestDriver driver;
     InSequence s;
-    auto       mod_tap_hold_gui = KeymapKey(0, 1, 0, LGUI_T(KC_P));
-    auto       mod_tap_hold_lshft      = KeymapKey(0, 2, 0, SFT_T(KC_A));
+    auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
 
     set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
 
@@ -113,7 +111,6 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     idle_for(TAPPING_TERM);
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
-
 
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_GUI));
     mod_tap_hold_gui.press();
@@ -135,4 +132,3 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
-

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -1,0 +1,138 @@
+/* Copyright 2023 Vladislav Kucheriavykh
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "keycodes.h"
+#include "test_common.hpp"
+#include "action_tapping.h"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+class RetroTapKeyRoll : public TestFixture {};
+
+TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_shift) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+
+    EXPECT_REPORT(driver, (KC_A));
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A, KC_LEFT_SHIFT));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_gui) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    EXPECT_REPORT(driver, (KC_A));
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A, KC_LEFT_GUI));
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LGUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+
+TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_gui = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       mod_tap_hold_lshft      = KeymapKey(0, 2, 0, SFT_T(KC_A));
+
+    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    mod_tap_hold_lshft.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_GUI));
+    mod_tap_hold_gui.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    mod_tap_hold_lshft.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LGUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_P, KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    mod_tap_hold_gui.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -358,3 +358,51 @@ TEST_F(RetroTapKeyRoll, mod_over_tap_term_to_mod_over_tap_term) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
+
+TEST_F(RetroTapKeyRoll, mod_to_mod_to_mod) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_lalt  = KeymapKey(0, 1, 0, LALT_T(KC_R));
+    auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
+    auto       mod_tap_hold_lctrl = KeymapKey(0, 3, 0, LCTL_T(KC_C));
+
+    set_keymap({mod_tap_hold_lalt, mod_tap_hold_lshft, mod_tap_hold_lctrl});
+
+    EXPECT_REPORT(driver, (KC_LEFT_ALT));
+    mod_tap_hold_lalt.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_ALT));
+    mod_tap_hold_lshft.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    mod_tap_hold_lalt.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL, KC_LEFT_SHIFT));
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_lctrl.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL));
+    mod_tap_hold_lshft.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_C, KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_lctrl.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -26,50 +26,15 @@ using testing::InSequence;
 
 class RetroTapKeyRoll : public TestFixture {};
 
-TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_shift) {
-    TestDriver driver;
-    InSequence s;
-    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_P));
-    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
-
-    set_keymap({mod_tap_hold_key, regular_key});
-
-    EXPECT_REPORT(driver, (KC_A));
-    regular_key.press();
-    run_one_scan_loop();
-    VERIFY_AND_CLEAR(driver);
-
-    EXPECT_NO_REPORT(driver);
-    mod_tap_hold_key.press();
-    idle_for(TAPPING_TERM);
-    VERIFY_AND_CLEAR(driver);
-
-    EXPECT_REPORT(driver, (KC_A, KC_LEFT_SHIFT));
-    run_one_scan_loop();
-    VERIFY_AND_CLEAR(driver);
-
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
-    regular_key.release();
-    run_one_scan_loop();
-    VERIFY_AND_CLEAR(driver);
-
-    EXPECT_EMPTY_REPORT(driver);
-    EXPECT_REPORT(driver, (KC_P));
-    EXPECT_EMPTY_REPORT(driver);
-    mod_tap_hold_key.release();
-    run_one_scan_loop();
-    VERIFY_AND_CLEAR(driver);
-}
-
-TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_gui) {
+TEST_F(RetroTapKeyRoll, regular_to_left_gui_mod_over_tap_term) {
     TestDriver driver;
     InSequence s;
     auto       mod_tap_hold_key = KeymapKey(0, 1, 0, LGUI_T(KC_P));
-    auto       regular_key      = KeymapKey(0, 2, 0, KC_A);
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_B);
 
     set_keymap({mod_tap_hold_key, regular_key});
 
-    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_REPORT(driver, (KC_B));
     regular_key.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
@@ -79,7 +44,7 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_gui) {
     idle_for(TAPPING_TERM);
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_A, KC_LEFT_GUI));
+    EXPECT_REPORT(driver, (KC_B, KC_LEFT_GUI));
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
@@ -97,7 +62,131 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_normal_to_left_gui) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
-TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
+
+TEST_F(RetroTapKeyRoll, regular_to_mod_over_tap_term) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_A));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_B);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    EXPECT_REPORT(driver, (KC_B));
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_B, KC_LEFT_SHIFT));
+    mod_tap_hold_key.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, regular_to_mod_under_tap_term) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_A));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_B);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    EXPECT_REPORT(driver, (KC_B));
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, mod_under_tap_term_to_regular) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_B);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_REPORT(driver, (KC_B, KC_P));
+    EXPECT_REPORT(driver, (KC_B));
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, mod_over_tap_term_to_regular) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_key = KeymapKey(0, 1, 0, SFT_T(KC_A));
+    auto       regular_key      = KeymapKey(0, 2, 0, KC_B);
+
+    set_keymap({mod_tap_hold_key, regular_key});
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    mod_tap_hold_key.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_B));
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_B));
+    mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, mod_under_tap_term_to_mod_under_tap_term) {
     TestDriver driver;
     InSequence s;
     auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
@@ -107,19 +196,111 @@ TEST_F(RetroTapKeyRoll, retro_tap_key_roll_left_shift_to_left_gui) {
 
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_lshft.press();
-    idle_for(TAPPING_TERM);
-    VERIFY_AND_CLEAR(driver);
-
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     EXPECT_NO_REPORT(driver);
     mod_tap_hold_gui.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_lshft.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_gui.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, mod_over_tap_term_to_mod_under_tap_term) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
+
+    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    mod_tap_hold_lshft.press();
     idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_gui.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_lshft.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_P));
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_gui.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, mod_under_tap_term_to_mod_over_tap_term) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
+
+    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_lshft.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_GUI));
+    mod_tap_hold_gui.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    mod_tap_hold_lshft.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LGUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_P, KC_LEFT_SHIFT));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_gui.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(RetroTapKeyRoll, mod_over_tap_term_to_mod_over_tap_term) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
+
+    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    mod_tap_hold_lshft.press();
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_GUI));
+    mod_tap_hold_gui.press();
+    idle_for(TAPPING_TERM);
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -286,6 +286,42 @@ TEST_F(RetroTapKeyRoll, mod_under_tap_term_to_mod_over_tap_term) {
     VERIFY_AND_CLEAR(driver);
 }
 
+TEST_F(RetroTapKeyRoll, mod_under_tap_term_to_mod_over_tap_term_offset) {
+    TestDriver driver;
+    InSequence s;
+    auto       mod_tap_hold_gui   = KeymapKey(0, 1, 0, LGUI_T(KC_P));
+    auto       mod_tap_hold_lshft = KeymapKey(0, 2, 0, SFT_T(KC_A));
+
+    set_keymap({mod_tap_hold_gui, mod_tap_hold_lshft});
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_lshft.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    mod_tap_hold_gui.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_hold_lshft.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI));
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_P));
+    EXPECT_EMPTY_REPORT(driver);
+    idle_for(TAPPING_TERM);
+    mod_tap_hold_gui.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
 TEST_F(RetroTapKeyRoll, mod_over_tap_term_to_mod_over_tap_term) {
     TestDriver driver;
     InSequence s;

--- a/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
+++ b/tests/tap_hold_configurations/retro_tapping/test_key_roll.cpp
@@ -53,7 +53,7 @@ TEST_F(RetroTapKeyRoll, regular_to_left_gui_mod_over_tap_term) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_LGUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
     EXPECT_REPORT(driver, (KC_LEFT_GUI));
     EXPECT_EMPTY_REPORT(driver);
     EXPECT_REPORT(driver, (KC_P));
@@ -274,10 +274,12 @@ TEST_F(RetroTapKeyRoll, mod_under_tap_term_to_mod_over_tap_term) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_LGUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
     EXPECT_REPORT(driver, (KC_LEFT_GUI));
     EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_P, KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_gui.release();
     run_one_scan_loop();
@@ -309,10 +311,12 @@ TEST_F(RetroTapKeyRoll, mod_over_tap_term_to_mod_over_tap_term) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_LGUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
+    EXPECT_REPORT(driver, (KC_LEFT_GUI, DUMMY_MOD_NEUTRALIZER_KEYCODE));
     EXPECT_REPORT(driver, (KC_LEFT_GUI));
     EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_P, KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_gui.release();
     run_one_scan_loop();


### PR DESCRIPTION
## Description

The purpose of this PR is to fix the condition found with RETRO_TAPPING enabled when key rolling. The issue is that the dual function keys's retro tap keycode is not fired when a different key has been released between the dual function keys's down and up events. I am not sure if this is intended behavior or not, but does not seem to be given that retro tapping is supposed to apply if another key is not pressed. Also, none of the existing tests failed after the re-write.

I had to rewrite the logic, though the original idea is still intact. When considering key rolling from a dual function key to a dual function key, it was necessary to capture the previous modifier state and temporarily apply it to the tap code. There is a unit test for this.

This is still an early draft. I am brand new to QMK and am running the ZSA fork so I do not have the experience/ability to see this through without some assistance. I would be happy to hand this off to someone more qualified if appropriate.

⚠️ This change in current form does not consider RETRO_SHIFT nor AUTO_SHIFT_ENABLE. The ZSA fork does not seem to support RETRO_SHIFT so I am not able to test this. I also have not tested RETRO_TAPPING_PER_KEY, though that looks like it will function with no issue. It is not configured in Oryx and I have sparsely looked at keymap.c.

I ensured these changes work on my ZSA Voyager and that I could make all defaults. Thanks.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

#22916

## Checklist


- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Media

### Before Key Roll Fix: Single to Dual Function
![single-dual_before](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/c35d61b2-b747-4631-99ab-3824578c59c2)

### After Key Roll Fix: Single to Dual Function
![sigle-dual_after](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/632795aa-3f7f-4114-b10e-ecd8a44eb565)

### Before Key Roll Fix: Dual to Dual Function
![dual-dual_before](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/378f80b2-175e-40a4-b5ef-55ac031cd5bc)

### After Key Roll Fix: Dual to Dual Function
![dual-dual_after](https://github.com/JohnRigoni/qmk_firmware/assets/38547951/2c4dfd69-8b80-4f70-9ba4-a7c580634c7d)
