### PR TITLE
xiudi/xd75 - Fix backlight compilation issues

### DIFF
--- a/keyboards/xiudi/xd75/keyboard.json
+++ b/keyboards/xiudi/xd75/keyboard.json
@@ -23,6 +23,7 @@
     },
     "diode_direction": "COL2ROW",
     "backlight": {
+        "driver": "timer",
         "pin": "F5",
         "levels": 6,
         "on_state": 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
```
Compiling: platforms/avr/drivers/backlight_pwm.c                                                    [OK]
platforms/avr/drivers/backlight_pwm.c: In function 'enable_pwm':
platforms/avr/drivers/backlight_pwm.c:133:5: error: 'TCCRxA' undeclared (first use in this function); did you mean 'TCCR0A'?
  133 |     TCCRxA |= _BV(COMxx1) | _BV(COMxx0);
      |     ^~~~~~
      |     TCCR0A
 [OK]
platforms/avr/drivers/backlight_pwm.c:133:5: note: each undeclared identifier is reported only once for each function it appears in
In file included from /usr/avr/include/avr/io.h:99,
                 from platforms/avr/_pin_defs.h:18,
                 from platforms/pin_defs.h:22,
                 from platforms/gpio.h:18,
                 from platforms/avr/drivers/backlight_pwm.c:2:
platforms/avr/drivers/backlight_pwm.c:133:19: error: 'COMxx1' undeclared (first use in this function); did you mean 'COM1B1'?
  133 |     TCCRxA |= _BV(COMxx1) | _BV(COMxx0);
      |                   ^~~~~~
platforms/avr/drivers/backlight_pwm.c:133:33: error: 'COMxx0' undeclared (first use in this function); did you mean 'COM0A0'?
  133 |     TCCRxA |= _BV(COMxx1) | _BV(COMxx0);
      |                                 ^~~~~~
platforms/avr/drivers/backlight_pwm.c: In function 'disable_pwm':
platforms/avr/drivers/backlight_pwm.c:141:5: error: 'TCCRxA' undeclared (first use in this function); did you mean 'TCCR0A'?
  141 |     TCCRxA &= ~(_BV(COMxx1) | _BV(COMxx0));
      |     ^~~~~~
      |     TCCR0A
Compiling: quantum/led_tables.c                                                                    platforms/avr/drivers/backlight_pwm.c:141:21: error: 'COMxx1' undeclared (first use in this function); did you mean 'COM1B1'?
  141 |     TCCRxA &= ~(_BV(COMxx1) | _BV(COMxx0));
      |                     ^~~~~~
platforms/avr/drivers/backlight_pwm.c:141:35: error: 'COMxx0' undeclared (first use in this function); did you mean 'COM0A0'?
  141 |     TCCRxA &= ~(_BV(COMxx1) | _BV(COMxx0));
      |                                   ^~~~~~
platforms/avr/drivers/backlight_pwm.c: In function 'cie_lightness':
platforms/avr/drivers/backlight_pwm.c:147:24: error: 'ICRx' undeclared (first use in this function); did you mean 'ICR3'?
  147 |     if (v <= (uint32_t)ICRx / 12) // If the value is less than or equal to ~8% of max
      |                        ^~~~
      |                        ICR3
platforms/avr/drivers/backlight_pwm.c: In function 'set_pwm':
platforms/avr/drivers/backlight_pwm.c:170:5: error: 'OCRxx' undeclared (first use in this function)
  170 |     OCRxx = val;
      |     ^~~~~
platforms/avr/drivers/backlight_pwm.c: In function 'backlight_set':
platforms/avr/drivers/backlight_pwm.c:184:45: error: 'ICRx' undeclared (first use in this function); did you mean 'ICR3'?
  184 |     set_pwm(cie_lightness(rescale_limit_val(ICRx * (uint32_t)level / BACKLIGHT_LEVELS)));
      |                                             ^~~~
      |                                             ICR3
platforms/avr/drivers/backlight_pwm.c: In function 'backlight_init_ports':
platforms/avr/drivers/backlight_pwm.c:316:5: error: 'TCCRxA' undeclared (first use in this function); did you mean 'TCCR0A'?
  316 |     TCCRxA = _BV(COMxx1) | _BV(WGM11);            // = 0b00001010;
      |     ^~~~~~
      |     TCCR0A
platforms/avr/drivers/backlight_pwm.c:316:18: error: 'COMxx1' undeclared (first use in this function); did you mean 'COM1B1'?
  316 |     TCCRxA = _BV(COMxx1) | _BV(WGM11);            // = 0b00001010;
      |                  ^~~~~~
platforms/avr/drivers/backlight_pwm.c:317:5: error: 'TCCRxB' undeclared (first use in this function); did you mean 'TCCR0B'?
  317 |     TCCRxB = _BV(WGM13) | _BV(WGM12) | _BV(CS10); // = 0b00011001;
      |     ^~~~~~
      |     TCCR0B
platforms/avr/drivers/backlight_pwm.c:318:5: error: 'ICRx' undeclared (first use in this function); did you mean 'ICR3'?
  318 |     ICRx   = BACKLIGHT_RESOLUTION;
      |     ^~~~
      |     ICR3
 [OK]
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #23654

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
