### PR TITLE
split_util: rename `usbIsActive` to `usb_bus_detected`

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -63,7 +63,7 @@ static struct {
 
 #if defined(SPLIT_USB_DETECT)
 _Static_assert((SPLIT_USB_TIMEOUT / SPLIT_USB_TIMEOUT_POLL) <= UINT16_MAX, "Please lower SPLIT_USB_TIMEOUT and/or increase SPLIT_USB_TIMEOUT_POLL.");
-static bool usbIsActive(void) {
+static bool usb_bus_detected(void) {
     for (uint16_t i = 0; i < (SPLIT_USB_TIMEOUT / SPLIT_USB_TIMEOUT_POLL); i++) {
         // This will return true if a USB connection has been established
         if (usb_connected_state()) {
@@ -74,7 +74,7 @@ static bool usbIsActive(void) {
     return false;
 }
 #else
-static inline bool usbIsActive(void) {
+static inline bool usb_bus_detected(void) {
     return usb_vbus_state();
 }
 #endif
@@ -179,7 +179,7 @@ __attribute__((weak)) bool is_keyboard_left_impl(void) {
 }
 
 __attribute__((weak)) bool is_keyboard_master_impl(void) {
-    bool is_master = usbIsActive();
+    bool is_master = usb_bus_detected();
 
     // Avoid NO_USB_STARTUP_CHECK - Disable USB as the previous checks seem to enable it somehow
     if (!is_master) {


### PR DESCRIPTION
## Description

This follows the style rules and better reflects the intent. Prep work for making `SPLIT_WATCHDOG_ENABLE` the new default.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
