### PR TITLE
Remove 'split.transport.protocol=serial_usart'

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -805,7 +805,7 @@
                     "properties": {
                         "protocol": {
                             "type": "string",
-                            "enum": ["custom", "i2c", "serial", "serial_usart"]
+                            "enum": ["custom", "i2c", "serial"]
                         },
                         "sync": {
                             "type": "object",

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -739,7 +739,7 @@ Configures the [Split Keyboard](feature_split_keyboard.md) feature.
         * Default: `1`
     * `transport`
         * `protocol`
-            * The split transport protocol to use. Must be one of `custom`, `i2c`, `serial`, `serial_usart`.
+            * The split transport protocol to use. Must be one of `custom`, `i2c`, `serial`.
         * `sync`
             * `activity`
                 * Mirror the activity timestamps to the secondary half.

--- a/keyboards/era/sirind/tomak/keyboard.json
+++ b/keyboards/era/sirind/tomak/keyboard.json
@@ -183,7 +183,6 @@
             }
         },
         "transport": {
-            "protocol": "serial_usart",
             "sync": {
                 "indicators": true,
                 "layer_state": true,

--- a/keyboards/keychron/q11/info.json
+++ b/keyboards/keychron/q11/info.json
@@ -54,7 +54,6 @@
             }
         },
         "transport": {
-            "protocol": "serial_usart",
             "sync" :{
                 "matrix_state": true
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Config option does not do anything.

It would have to be manually wired up to produce `SERIAL_DRIVER = usart`, however that scales poorly when we also have other serial drivers available.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
