### PR TITLE
Insert delay between shifted chars in send_string_with_delay for AVR

### DIFF
--- a/quantum/send_string/send_string.c
+++ b/quantum/send_string/send_string.c
@@ -294,7 +294,7 @@ void tap_random_base64(void) {
 
 #if defined(__AVR__)
 void send_string_P(const char *string) {
-    send_string_with_delay_P(string, 0);
+    send_string_with_delay_P(string, TAP_CODE_DELAY);
 }
 
 void send_string_with_delay_P(const char *string, uint8_t interval) {
@@ -303,6 +303,7 @@ void send_string_with_delay_P(const char *string, uint8_t interval) {
         if (!ascii_code) break;
         if (ascii_code == SS_QMK_PREFIX) {
             ascii_code = pgm_read_byte(++string);
+
             if (ascii_code == SS_TAP_CODE) {
                 // tap
                 uint8_t keycode = pgm_read_byte(++string);
@@ -319,24 +320,19 @@ void send_string_with_delay_P(const char *string, uint8_t interval) {
                 // delay
                 int     ms      = 0;
                 uint8_t keycode = pgm_read_byte(++string);
+
                 while (isdigit(keycode)) {
                     ms *= 10;
                     ms += keycode - '0';
                     keycode = pgm_read_byte(++string);
                 }
-                while (ms--)
-                    wait_ms(1);
+                wait_ms(ms);
             }
         } else {
-            send_char(ascii_code);
+            send_char_with_delay(ascii_code, interval);
         }
+
         ++string;
-        // interval
-        {
-            uint8_t ms = interval;
-            while (ms--)
-                wait_ms(1);
-        }
     }
 }
 #endif


### PR DESCRIPTION
This was done for ARM in #19280, but there is another copy of these functions that needed to be fixed too.

## Description

See #19280

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
