### PR TITLE
Mousekeys inertia zero friction improvements

### DIFF
--- a/docs/feature_mouse_keys.md
+++ b/docs/feature_mouse_keys.md
@@ -191,6 +191,7 @@ Recommended settings in your keymap’s `config.h` file:
 |`MOUSEKEY_MAX_SPEED`        |32       |Maximum cursor speed at which acceleration stops           |
 |`MOUSEKEY_TIME_TO_MAX`      |32       |Number of frames until maximum cursor speed is reached     |
 |`MOUSEKEY_FRICTION`         |24       |How quickly the cursor stops after releasing a key         |
+|`MOUSEKEY_STOP_SPEED`       |1        |Lowest possible decelerating velocity before it snaps to 0 |
 |`MOUSEKEY_MOVE_DELTA`       |1        |How much to move on first frame (1 strongly recommended)   |
 
 Tips:
@@ -199,7 +200,8 @@ Tips:
 * Set `MOUSEKEY_INTERVAL` to a value of 1000 / your monitor's FPS.  For 60 FPS, 1000/60 = 16.
 * Set `MOUSEKEY_MAX_SPEED` based on your screen resolution and refresh rate, like Width / FPS.  For example, 1920 pixels / 60 FPS = 32 pixels per frame.
 * Set `MOUSEKEY_TIME_TO_MAX` to a value of approximately FPS / 2, to make it reach full speed in half a second (or so).
-* Set `MOUSEKEY_FRICTION` to something between 1 and 255.  Lower makes the cursor glide longer. Values from 8 to 40 are the most effective.
+* Set `MOUSEKEY_FRICTION` to something between 0 and 255.  Lower makes the cursor glide longer. Values from 8 to 40 are the most effective.
+* Set `MOUSEKEY_STOP_SPEED` to something between 0 and `MOUSEKEY_MAX_SPEED`.  Increase this for easier stopping if you set `MOUSEKEY_FRICTION` to 0.
 * Keep `MOUSEKEY_MOVE_DELTA` at 1.  This allows precise movements before the gliding effect starts.
 * Mouse wheel options are the same as the default accelerated mode, and do not use inertia.
 

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -288,16 +288,18 @@ static int8_t calc_inertia(int8_t direction, int8_t velocity) {
     // simulate acceleration and deceleration
 
     // deceleration
-    if (velocity != 0)
+    if (velocity != 0) {
         velocity = velocity * (256 - MOUSEKEY_FRICTION) / 256;
+    }
 
     // acceleration
-    if ((direction > 0) && (velocity < mk_time_to_max))
+    if ((direction > 0) && (velocity < mk_time_to_max)) {
         velocity++;
-    else if ((direction < 0) && (velocity > -mk_time_to_max))
+    } else if ((direction < 0) && (velocity > -mk_time_to_max)) {
         velocity--;
-    else if (velocity <= MOUSEKEY_STOP_SPEED && velocity >= -MOUSEKEY_STOP_SPEED)
+    } else if (velocity <= MOUSEKEY_STOP_SPEED && velocity >= -MOUSEKEY_STOP_SPEED) {
         velocity = 0;
+    }
 
     return velocity;
 }

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -296,6 +296,8 @@ static int8_t calc_inertia(int8_t direction, int8_t velocity) {
         velocity++;
     else if ((direction < 0) && (velocity > -mk_time_to_max))
         velocity--;
+    else if (velocity <= MOUSEKEY_STOP_SPEED && velocity >= -MOUSEKEY_STOP_SPEED)
+        velocity = 0;
 
     return velocity;
 }

--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -288,9 +288,7 @@ static int8_t calc_inertia(int8_t direction, int8_t velocity) {
     // simulate acceleration and deceleration
 
     // deceleration
-    if ((direction > -1) && (velocity < 0))
-        velocity = (velocity + 1) * (256 - MOUSEKEY_FRICTION) / 256;
-    else if ((direction < 1) && (velocity > 0))
+    if (velocity != 0)
         velocity = velocity * (256 - MOUSEKEY_FRICTION) / 256;
 
     // acceleration

--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -69,6 +69,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #            define MOUSEKEY_MAX_SPEED 10
 #        endif
 #    endif
+#    ifndef MOUSEKEY_STOP_SPEED
+#        define MOUSEKEY_STOP_SPEED 1
+#    endif
 #    ifndef MOUSEKEY_TIME_TO_MAX
 #        if defined(MOUSEKEY_INERTIA)
 #            define MOUSEKEY_TIME_TO_MAX 32


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
I like using Mousekeys in inertia mode with the friction turned off. It's a great way to get analog-like movements when piloted well, though there are some tweaks which I had to make in order to get things to properly behave when `MOUSEKEY_FRICTION` is set to zero.

These changes do _very_ slightly impact the current behavior of the inertia mode, but only imperceptibly so. 

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

There are two changes included in this PR:
1. A fix for a preexisting bug which caused different directions to decelerate differently. The fix is necessary for zero-friction to work correctly, because all directions must decelerate in _exactly_ the same way (i.e.: not at all)
2. A new option called `MOUSE_STOP_SPEED` which allows configuring a threshold below which velocity will snap to zero (if currently decelerating). A value of 0 is identical to the current behavior, though I've chosen a default of 1 instead because it makes stopping through reverse acceleration substantially easier regardless of the friction setting.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes inconsistent deceleration behavior for mousekeys in inertia mode (per above). Not presently tracked on the issue tracker.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).