### PR TITLE
Fix PS/2 Trackpoint mouse clicks (#22265)

### DIFF
--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -88,6 +88,8 @@ void ps2_mouse_task(void) {
 #    endif
     } else {
         if (debug_mouse) print("ps2_mouse: fail to get mouse packet\n");
+        /* return here to avoid updating the mouse button state */
+        return;
     }
 #else
     if (pbuf_has_data()) {

--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -99,6 +99,8 @@ void ps2_mouse_task(void) {
 #    endif
     } else {
         if (debug_mouse) print("ps2_mouse: fail to get mouse packet\n");
+        /* return here to avoid updating the mouse button state */
+        return;
     }
 #endif
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Bug report #22265 and fix by d93921012, I'm just pushing the change. There is a longer description the bug report; shorter summary:

When the main loop calls `ps2_mouse_task()` for the first time after the button down event, it finds no new data in the PS/2 receive buffer. Here it should return, or it tries to detect a button state change anyway and updates the mouse state with the button released before it is actually released. When doing click and drag, it cycles between button down and up.

Tested on ARM ChibiOS (RP2040) with a Trackpoint from a Thinkpad T61. With this change it works perfectly. The keyboard itself is a home-made converter for the Thinkpad keyboard (only in my personal fork at this point).



<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #22265

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
