### PR TITLE
Oops, all rotary encoders - new keyboard + demonstrated encoder method

### DIFF
--- a/keyboards/oare/config.h
+++ b/keyboards/oare/config.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Joshua Broekhuijsen (@Snipeye)
+// Copyright 2024 Snipeye (@Snipeye)
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/keyboards/oare/config.h
+++ b/keyboards/oare/config.h
@@ -1,0 +1,20 @@
+// Copyright 2024 Joshua Broekhuijsen (@Snipeye)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+/*
+ * Feature disable options
+ *  These options are also useful to firmware size reduction.
+ */
+
+/* disable debug print */
+//#define NO_DEBUG
+
+/* disable print */
+//#define NO_PRINT
+
+/* disable action features */
+//#define NO_ACTION_LAYER
+//#define NO_ACTION_TAPPING
+//#define NO_ACTION_ONESHOT

--- a/keyboards/oare/info.json
+++ b/keyboards/oare/info.json
@@ -1,0 +1,96 @@
+{
+    "manufacturer": "Joshua Broekhuijsen",
+    "keyboard_name": "oare",
+    "maintainer": "Snipeye",
+    "bootloader": "rp2040",
+    "diode_direction": "ROW2COL",
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true
+    },
+    "matrix_pins": {
+        "cols": ["GP1", "GP0", "GP9", "GP8", "GP7", "GP6", "GP5", "GP4", "GP3", "GP2"],
+        "rows": ["GP25", "GP17", "GP16", "GP18", "GP21", "GP20", "GP22", "GP24", "GP23"]
+    },
+    "encoder": {
+        "rotary": [
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
+            {"pin_a": "NO_PIN", "pin_b": "NO_PIN"}
+        ]
+    },
+    "processor": "RP2040",
+    "url": "",
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x0000",
+        "vid": "0xFEED"
+    },
+    "layouts": {
+        "LAYOUT_ortho_3x10": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0},
+                {"matrix": [0, 1], "x": 1, "y": 0},
+                {"matrix": [0, 2], "x": 2, "y": 0},
+                {"matrix": [0, 3], "x": 3, "y": 0},
+                {"matrix": [0, 4], "x": 4, "y": 0},
+                {"matrix": [0, 5], "x": 5, "y": 0},
+                {"matrix": [0, 6], "x": 6, "y": 0},
+                {"matrix": [0, 7], "x": 7, "y": 0},
+                {"matrix": [0, 8], "x": 8, "y": 0},
+                {"matrix": [0, 9], "x": 9, "y": 0},
+                {"matrix": [3, 0], "x": 0, "y": 1},
+                {"matrix": [3, 1], "x": 1, "y": 1},
+                {"matrix": [3, 2], "x": 2, "y": 1},
+                {"matrix": [3, 3], "x": 3, "y": 1},
+                {"matrix": [3, 4], "x": 4, "y": 1},
+                {"matrix": [3, 5], "x": 5, "y": 1},
+                {"matrix": [3, 6], "x": 6, "y": 1},
+                {"matrix": [3, 7], "x": 7, "y": 1},
+                {"matrix": [3, 8], "x": 8, "y": 1},
+                {"matrix": [3, 9], "x": 9, "y": 1},
+                {"matrix": [6, 0], "x": 0, "y": 2},
+                {"matrix": [6, 1], "x": 1, "y": 2},
+                {"matrix": [6, 2], "x": 2, "y": 2},
+                {"matrix": [6, 3], "x": 3, "y": 2},
+                {"matrix": [6, 4], "x": 4, "y": 2},
+                {"matrix": [6, 5], "x": 5, "y": 2},
+                {"matrix": [6, 6], "x": 6, "y": 2},
+                {"matrix": [6, 7], "x": 7, "y": 2},
+                {"matrix": [6, 8], "x": 8, "y": 2},
+                {"matrix": [6, 9], "x": 9, "y": 2}
+            ]
+        }
+    }
+}

--- a/keyboards/oare/info.json
+++ b/keyboards/oare/info.json
@@ -1,21 +1,9 @@
 {
-    "manufacturer": "Joshua Broekhuijsen",
+    "manufacturer": "Snipeye",
     "keyboard_name": "oare",
     "maintainer": "Snipeye",
     "bootloader": "rp2040",
     "diode_direction": "ROW2COL",
-    "features": {
-        "bootmagic": true,
-        "command": false,
-        "console": false,
-        "extrakey": true,
-        "mousekey": true,
-        "nkro": true
-    },
-    "matrix_pins": {
-        "cols": ["GP1", "GP0", "GP9", "GP8", "GP7", "GP6", "GP5", "GP4", "GP3", "GP2"],
-        "rows": ["GP25", "GP17", "GP16", "GP18", "GP21", "GP20", "GP22", "GP24", "GP23"]
-    },
     "encoder": {
         "rotary": [
             {"pin_a": "NO_PIN", "pin_b": "NO_PIN"},
@@ -50,11 +38,23 @@
             {"pin_a": "NO_PIN", "pin_b": "NO_PIN"}
         ]
     },
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true
+    },
+    "matrix_pins": {
+        "cols": ["GP1", "GP0", "GP9", "GP8", "GP7", "GP6", "GP5", "GP4", "GP3", "GP2"],
+        "rows": ["GP25", "GP17", "GP16", "GP18", "GP21", "GP20", "GP22", "GP24", "GP23"]
+    },
     "processor": "RP2040",
-    "url": "",
+    "url": "https://imgur.com/a/yFKNxBH",
     "usb": {
         "device_version": "1.0.0",
-        "pid": "0x0000",
+        "pid": "0xF000",
         "vid": "0xFEED"
     },
     "layouts": {

--- a/keyboards/oare/keymaps/default/keycode_lookup.c
+++ b/keyboards/oare/keymaps/default/keycode_lookup.c
@@ -3,15 +3,11 @@
 
 #include "keycode_lookup.h"
 #include "keymap_introspection.h"
-#include "print.h"
 
 // Now we implement a custom "semi-transparent" keycode using KC_ENC:
 // We fall through to layer 0 to get the actual keycode, then modify it according to what's in key_offsets
 uint16_t keycode_at_keymap_location(uint8_t layer_num, uint8_t row, uint8_t column) {
     uint16_t code = keycode_at_keymap_location_raw(layer_num, row, column);
-    if (code > 3) {
-        uprintf("got code %d for row %d col %d\n", code, row, column);
-    }
     if (code == KC_ENC) {
         // don't return this, we need to fall through but then modify
         // Could make it more generic to fall to the next active layer instead of straight to 0, but I don't care that much.
@@ -25,9 +21,6 @@ uint16_t keycode_at_keymap_location(uint8_t layer_num, uint8_t row, uint8_t colu
                 code -= KEY_OFFSET_SIZE;
             }
         }
-    }
-    if (code > 3) {
-        uprintf("returning code %d for row %d col %d\n", code, row, column);
     }
     return code;
 }

--- a/keyboards/oare/keymaps/default/keycode_lookup.c
+++ b/keyboards/oare/keymaps/default/keycode_lookup.c
@@ -1,3 +1,6 @@
+// Copyright 2024 Snipeye (@Snipeye)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #include "keycode_lookup.h"
 #include "keymap_introspection.h"
 #include "print.h"

--- a/keyboards/oare/keymaps/default/keycode_lookup.c
+++ b/keyboards/oare/keymaps/default/keycode_lookup.c
@@ -1,0 +1,30 @@
+#include "keycode_lookup.h"
+#include "keymap_introspection.h"
+#include "print.h"
+
+// Now we implement a custom "semi-transparent" keycode using KC_ENC:
+// We fall through to layer 0 to get the actual keycode, then modify it according to what's in key_offsets
+uint16_t keycode_at_keymap_location(uint8_t layer_num, uint8_t row, uint8_t column) {
+    uint16_t code = keycode_at_keymap_location_raw(layer_num, row, column);
+    if (code > 3) {
+        uprintf("got code %d for row %d col %d\n", code, row, column);
+    }
+    if (code == KC_ENC) {
+        // don't return this, we need to fall through but then modify
+        // Could make it more generic to fall to the next active layer instead of straight to 0, but I don't care that much.
+        code = keycode_at_keymap_location_raw(0, row, column);
+        // Only want to mess with it if it's in the alphas, so other functions like delete and such work right
+        if (code >= KC_A && code <= KC_Z) {
+            uint8_t index = key_positions[row][column];
+            code += key_offsets[index];
+            // key_offsets only holds positive numbers, 0-25.  If we go beyond z, need to wrap back to stay in the alphas
+            if (code > KC_Z) {
+                code -= KEY_OFFSET_SIZE;
+            }
+        }
+    }
+    if (code > 3) {
+        uprintf("returning code %d for row %d col %d\n", code, row, column);
+    }
+    return code;
+}

--- a/keyboards/oare/keymaps/default/keycode_lookup.h
+++ b/keyboards/oare/keymaps/default/keycode_lookup.h
@@ -1,5 +1,7 @@
-#ifndef KEYCODE_LOOKUP
-    #define KEYCODE_LOOKUP
+// Copyright 2024 Snipeye (@Snipeye)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
 
 #include "quantum_keycodes.h"
 #include "info_config.h"
@@ -10,5 +12,3 @@ extern uint8_t key_positions[MATRIX_ROWS][MATRIX_COLS];
 enum my_keycodes {
   KC_ENC = SAFE_RANGE
 };
-
-#endif // KEYCODE_LOOKUP

--- a/keyboards/oare/keymaps/default/keycode_lookup.h
+++ b/keyboards/oare/keymaps/default/keycode_lookup.h
@@ -1,0 +1,14 @@
+#ifndef KEYCODE_LOOKUP
+    #define KEYCODE_LOOKUP
+
+#include "quantum_keycodes.h"
+#include "info_config.h"
+#define KEY_OFFSET_SIZE 26
+#define KEY_OFFSET_COUNT 30
+extern uint8_t key_offsets[KEY_OFFSET_COUNT];
+extern uint8_t key_positions[MATRIX_ROWS][MATRIX_COLS];
+enum my_keycodes {
+  KC_ENC = SAFE_RANGE
+};
+
+#endif // KEYCODE_LOOKUP

--- a/keyboards/oare/keymaps/default/keymap.c
+++ b/keyboards/oare/keymaps/default/keymap.c
@@ -4,7 +4,6 @@
 #include QMK_KEYBOARD_H
 #include "keycode_lookup.h"
 #include "matrix.h"
-#include "print.h"
 
 extern matrix_row_t matrix[MATRIX_ROWS];
 
@@ -28,7 +27,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_ortho_3x10(
         KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
         KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_ENT,
-        // KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH
         KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SPC
     ),
     [1] = LAYOUT_ortho_3x10(
@@ -48,10 +46,12 @@ void keyboard_post_init_user(void) {
         key_offsets[i] = 0; // initialize - might not need to, but doesn't hurt
     }
     debug_enable=true;
-    debug_matrix=true;
+    debug_matrix=true; // note that I ran into strange issues where the matrix didn't seem to get populated properly if I wasn't
+    // using the values, such as in this debug - not sure if it's something to do with the compiler optimizing something out?
 }
 
 // We'll need a way to go from row/col to the index in that above array - fortunately we have a pretty convenient macro.
+// This is clever, give me some credit.
 uint8_t key_positions[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_ortho_3x10(
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  
     10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 
@@ -61,12 +61,10 @@ uint8_t key_positions[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_ortho_3x10(
 // Whenever an encoder is turned, we need to update the key_offset array so we know how much to modify the alphas
 bool encoder_update_user(uint8_t index, bool clockwise) {
     uint8_t newVal = key_offsets[index];
-    uint8_t oldVal = newVal;
     newVal += (clockwise ? 1 : -1);
     newVal += KEY_OFFSET_SIZE;
     newVal %= KEY_OFFSET_SIZE;
     key_offsets[index] = newVal;
-    uprintf("Changing index %d from %d to %d\n", index, oldVal, newVal);
     if (index < 29) {
         return false;
     }

--- a/keyboards/oare/keymaps/default/keymap.c
+++ b/keyboards/oare/keymaps/default/keymap.c
@@ -1,0 +1,74 @@
+// Copyright 2023 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+#include "keycode_lookup.h"
+#include "matrix.h"
+#include "print.h"
+
+extern matrix_row_t matrix[MATRIX_ROWS];
+
+uint8_t encoder_quadrature_read_pin(uint8_t index, bool pad_b) {
+    uint8_t colIndex = index % 10;
+    uint8_t rowIndex = (index / 10) * 3 + (pad_b ? 1 : 2);
+    uint8_t returnVal = (uint8_t)!!(matrix[rowIndex] & (0x1 << colIndex));
+    return returnVal;
+}
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+     * │ Q │ W │ E │ R │ T │ Y │ U │ I │ O │ P │
+     * ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
+     * │ A │ S │ D │ F │ G │ H │ J │ K │ L │ ; │
+     * ├───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
+     * │ Z │ X │ C │ V │ B │ N │ M │ , │ . │ / │
+     * └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+     */
+    [0] = LAYOUT_ortho_3x10(
+        KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+        KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_ENT,
+        // KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH
+        KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SPC
+    ),
+    [1] = LAYOUT_ortho_3x10(
+        KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  
+        KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_TRNS,  
+        KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_ENC,  KC_TRNS, KC_TRNS, KC_TRNS
+    )
+};
+
+// We store an array of key offset to shift the alpha keys depending on how many times the encoder has been turned
+uint8_t key_offsets[KEY_OFFSET_COUNT];
+
+// Note: we start on layer 1, which is basically just a fancy mask so we can modify layer 0 for alpha keys
+void keyboard_post_init_user(void) {
+    layer_on(1);
+    for (uint8_t i=0; i<KEY_OFFSET_COUNT; i++) {
+        key_offsets[i] = 0; // initialize - might not need to, but doesn't hurt
+    }
+    debug_enable=true;
+    debug_matrix=true;
+}
+
+// We'll need a way to go from row/col to the index in that above array - fortunately we have a pretty convenient macro.
+uint8_t key_positions[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_ortho_3x10(
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 
+    20, 21, 22, 23, 24, 25, 26, 27, 28, 29
+);
+
+// Whenever an encoder is turned, we need to update the key_offset array so we know how much to modify the alphas
+bool encoder_update_user(uint8_t index, bool clockwise) {
+    uint8_t newVal = key_offsets[index];
+    uint8_t oldVal = newVal;
+    newVal += (clockwise ? 1 : -1);
+    newVal += KEY_OFFSET_SIZE;
+    newVal %= KEY_OFFSET_SIZE;
+    key_offsets[index] = newVal;
+    uprintf("Changing index %d from %d to %d\n", index, oldVal, newVal);
+    if (index < 29) {
+        return false;
+    }
+    return true;
+}

--- a/keyboards/oare/keymaps/default/rules.mk
+++ b/keyboards/oare/keymaps/default/rules.mk
@@ -1,0 +1,3 @@
+ENCODER_ENABLE = yes
+SRC += keycode_lookup.c
+CONSOLE_ENABLE = yes

--- a/keyboards/oare/readme.md
+++ b/keyboards/oare/readme.md
@@ -1,0 +1,27 @@
+# oare
+
+![oare](imgur.com image replace me!)
+
+*A short description of the keyboard/project*
+
+* Keyboard Maintainer: [Joshua Broekhuijsen](https://github.com/Snipeye)
+* Hardware Supported: *The PCBs, controllers supported*
+* Hardware Availability: *Links to where you can find this hardware*
+
+Make example for this keyboard (after setting up your build environment):
+
+    make oare:default
+
+Flashing example for this keyboard:
+
+    make oare:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/oare/readme.md
+++ b/keyboards/oare/readme.md
@@ -1,12 +1,12 @@
 # oare
 
-![oare](imgur.com image replace me!)
+![oare](https://imgur.com/a/yFKNxBH)
 
-*A short description of the keyboard/project*
+*Why use mx or choc or alps when you can use encoders?  This demonstrates how to place encoders in the key matrix, though I suspect the debouncing for the matrix is doing weird things.*
 
-* Keyboard Maintainer: [Joshua Broekhuijsen](https://github.com/Snipeye)
-* Hardware Supported: *The PCBs, controllers supported*
-* Hardware Availability: *Links to where you can find this hardware*
+* Keyboard Maintainer: [Snipeye](https://github.com/Snipeye)
+* Hardware Supported: *RP2040, custom PCB*
+* Hardware Availability: *https://imgur.com/a/yFKNxBH*
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/keyboards/oare/rules.mk
+++ b/keyboards/oare/rules.mk
@@ -1,0 +1,1 @@
+# This file intentionally left blank


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Added a new keyboard named "Oops, all rotary encoders (OARE)" that shows you can read encoder pins A and B from the key matrix provided you have fast enough scanning (~2K+/s in testing).

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
