### PR TITLE
[Bug][Keyboard] Fix encoder resolution issue with Binepad BNK9

### DIFF
--- a/keyboards/binepad/bnk9/config.h
+++ b/keyboards/binepad/bnk9/config.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#define ENCODER_DEFAULT_POS 0x3  // enable 1:1 resolution
-
 // Default PIO0 cases flickering in this board.  Setting to PIO1 resolves this issue.
 #define WS2812_PIO_USE_PIO1
 

--- a/keyboards/binepad/bnk9/info.json
+++ b/keyboards/binepad/bnk9/info.json
@@ -8,7 +8,7 @@
     "diode_direction": "COL2ROW",
     "encoder": {
         "rotary": [
-            {"pin_a": "GP13", "pin_b": "GP14"}
+            {"pin_a": "GP13", "pin_b": "GP14", "resolution": 2}
         ]
     },
     "features": {


### PR DESCRIPTION
## Description

Binpad BNK9 rotary encoder does 2 "bumps" for every "key press" ... this should be 1:1.  This fix corrects that.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* No issue on GH.  This is a customer issue escalation.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
