### PR TITLE
Update rgb_matrix.c

### DIFF
--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -567,13 +567,13 @@ void rgb_matrix_step_reverse(void) {
     rgb_matrix_step_reverse_helper(true);
 }
 
-void rgb_matrix_sethsv_eeprom_helper(uint16_t hue, uint8_t sat, uint8_t val, bool write_to_eeprom) {
+void rgb_matrix_sethsv_eeprom_helper(uint16_t hue, uint16_t sat, uint16_t val, bool write_to_eeprom) {
     if (!rgb_matrix_config.enable) {
         return;
     }
     rgb_matrix_config.hsv.h = hue;
     rgb_matrix_config.hsv.s = sat;
-    rgb_matrix_config.hsv.v = (val > RGB_MATRIX_MAXIMUM_BRIGHTNESS) ? RGB_MATRIX_MAXIMUM_BRIGHTNESS : val;
+    rgb_matrix_config.hsv.v = (val > RGB_MATRIX_MAXIMUM_BRIGHTNESS && val < RGB_MATRIX_MAXIMUM_BRIGHTNESS + ((uint8_t)~RGB_MATRIX_MAXIMUM_BRIGHTNESS >> 1)) ? 0 : (val > RGB_MATRIX_MAXIMUM_BRIGHTNESS + ((uint8_t)~RGB_MATRIX_MAXIMUM_BRIGHTNESS >> 1)) ? RGB_MATRIX_MAXIMUM_BRIGHTNESS : val;
     eeconfig_flag_rgb_matrix(write_to_eeprom);
     dprintf("rgb matrix set hsv [%s]: %u,%u,%u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v);
 }
@@ -618,7 +618,7 @@ void rgb_matrix_decrease_hue(void) {
 }
 
 void rgb_matrix_increase_sat_helper(bool write_to_eeprom) {
-    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, qadd8(rgb_matrix_config.hsv.s, RGB_MATRIX_SAT_STEP), rgb_matrix_config.hsv.v, write_to_eeprom);
+    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s + RGB_MATRIX_SAT_STEP, rgb_matrix_config.hsv.v, write_to_eeprom);
 }
 void rgb_matrix_increase_sat_noeeprom(void) {
     rgb_matrix_increase_sat_helper(false);
@@ -628,7 +628,7 @@ void rgb_matrix_increase_sat(void) {
 }
 
 void rgb_matrix_decrease_sat_helper(bool write_to_eeprom) {
-    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, qsub8(rgb_matrix_config.hsv.s, RGB_MATRIX_SAT_STEP), rgb_matrix_config.hsv.v, write_to_eeprom);
+    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s - RGB_MATRIX_SAT_STEP, rgb_matrix_config.hsv.v, write_to_eeprom);
 }
 void rgb_matrix_decrease_sat_noeeprom(void) {
     rgb_matrix_decrease_sat_helper(false);
@@ -638,7 +638,7 @@ void rgb_matrix_decrease_sat(void) {
 }
 
 void rgb_matrix_increase_val_helper(bool write_to_eeprom) {
-    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, qadd8(rgb_matrix_config.hsv.v, RGB_MATRIX_VAL_STEP), write_to_eeprom);
+    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v + RGB_MATRIX_VAL_STEP, write_to_eeprom);
 }
 void rgb_matrix_increase_val_noeeprom(void) {
     rgb_matrix_increase_val_helper(false);
@@ -648,7 +648,7 @@ void rgb_matrix_increase_val(void) {
 }
 
 void rgb_matrix_decrease_val_helper(bool write_to_eeprom) {
-    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, qsub8(rgb_matrix_config.hsv.v, RGB_MATRIX_VAL_STEP), write_to_eeprom);
+    rgb_matrix_sethsv_eeprom_helper(rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v - RGB_MATRIX_VAL_STEP, write_to_eeprom);
 }
 void rgb_matrix_decrease_val_noeeprom(void) {
     rgb_matrix_decrease_val_helper(false);


### PR DESCRIPTION
Modify the program so that the saturation and brightness values wrap around the maximum and minimum values according to the  RGB Matrix Lighting document.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Since the existing source code supported wraparound only for hua, I followed the Document and changed it so that sat and val also wrap-around.
Since val must correspond to RGB_MATRIX_MAXIMUM_BRIGHTNESS, I set a threshold between the maximum value of 255 and the value defined by RGB_MATRIX_MAXIMUM_BRIGHTNESS, and based on that I perform wraparound.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
