### PR TITLE
Add media key support to Riot Pad

### DIFF
--- a/keyboards/shandoncodes/riot_pad/keyboard.json
+++ b/keyboards/shandoncodes/riot_pad/keyboard.json
@@ -9,7 +9,8 @@
         "command": false,
         "console": false,
         "nkro": true,
-        "rgblight": true
+        "rgblight": true,
+        "extrakey": true
     },
     "matrix_pins": {
         "cols": ["B14", "A8", "A9"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add the required config to enable media key usage on the Riot Pad.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Media key config added
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
