### PR TITLE
ISSI RGB SPLIT MATRIX POC

### DIFF
--- a/drivers/led/issi/is31fl3731.h
+++ b/drivers/led/issi/is31fl3731.h
@@ -83,17 +83,48 @@
 #define IS31FL3731_I2C_ADDRESS_VCC 0x77
 
 #if defined(RGB_MATRIX_IS31FL3731)
+#    if defined(RGB_MATRIX_SPLIT)
+#        define RGB_MATRIX_LED_COUNT_SPLIT(left, right) ((left) + (right))
+#        define RGB_MATRIX_LED_COUNT_LEFT(left, right) (left)
+#        define RGB_MATRIX_LED_COUNT_RIGHT(left, right) (right)
+#        define IS31FL3731_LED_COUNT RGB_MATRIX_LED_COUNT_SPLIT(RGB_MATRIX_SPLIT)
+#        define IS31FL3731_LED_COUNT_LEFT RGB_MATRIX_LED_COUNT_LEFT(RGB_MATRIX_SPLIT)
+#        define IS31FL3731_LED_COUNT_RIGHT RGB_MATRIX_LED_COUNT_RIGHT(RGB_MATRIX_SPLIT)
+#    else
 #    define IS31FL3731_LED_COUNT RGB_MATRIX_LED_COUNT
 #endif
+#endif
 
-#if defined(IS31FL3731_I2C_ADDRESS_4)
-#    define IS31FL3731_DRIVER_COUNT 4
-#elif defined(IS31FL3731_I2C_ADDRESS_3)
-#    define IS31FL3731_DRIVER_COUNT 3
-#elif defined(IS31FL3731_I2C_ADDRESS_2)
-#    define IS31FL3731_DRIVER_COUNT 2
-#elif defined(IS31FL3731_I2C_ADDRESS_1)
-#    define IS31FL3731_DRIVER_COUNT 1
+#if defined(RGB_MATRIX_SPLIT)
+#    if defined(IS31FL3731_I2C_ADDRESS_LEFT_4)
+#        define IS31FL3731_DRIVER_COUNT_LEFT 4
+#    elif defined(IS31FL3731_I2C_ADDRESS_LEFT_3)
+#        define IS31FL3731_DRIVER_COUNT_LEFT 3
+#    elif defined(IS31FL3731_I2C_ADDRESS_LEFT_2)
+#        define IS31FL3731_DRIVER_COUNT_LEFT 2
+#    elif defined(IS31FL3731_I2C_ADDRESS_LEFT_1)
+#        define IS31FL3731_DRIVER_COUNT_LEFT 1
+#    endif
+#    if defined(IS31FL3731_I2C_ADDRESS_RIGHT_4)
+#        define IS31FL3731_DRIVER_COUNT_RIGHT 4
+#    elif defined(IS31FL3731_I2C_ADDRESS_RIGHT_3)
+#        define IS31FL3731_DRIVER_COUNT_RIGHT 3
+#    elif defined(IS31FL3731_I2C_ADDRESS_RIGHT_2)
+#        define IS31FL3731_DRIVER_COUNT_RIGHT 2
+#    elif defined(IS31FL3731_I2C_ADDRESS_RIGHT_1)
+#        define IS31FL3731_DRIVER_COUNT_RIGHT 1
+#    endif
+#    define IS31FL3731_DRIVER_COUNT (IS31FL3731_DRIVER_COUNT_LEFT + IS31FL3731_DRIVER_COUNT_RIGHT)
+#else
+#    if defined(IS31FL3731_I2C_ADDRESS_4)
+#        define IS31FL3731_DRIVER_COUNT 4
+#    elif defined(IS31FL3731_I2C_ADDRESS_3)
+#        define IS31FL3731_DRIVER_COUNT 3
+#    elif defined(IS31FL3731_I2C_ADDRESS_2)
+#        define IS31FL3731_DRIVER_COUNT 2
+#    elif defined(IS31FL3731_I2C_ADDRESS_1)
+#        define IS31FL3731_DRIVER_COUNT 1
+#    endif
 #endif
 
 typedef struct is31fl3731_led_t {
@@ -103,7 +134,12 @@ typedef struct is31fl3731_led_t {
     uint8_t b;
 } PACKED is31fl3731_led_t;
 
+#    if defined(RGB_MATRIX_SPLIT)
+extern const is31fl3731_led_t PROGMEM g_is31fl3731_leds_left[IS31FL3731_LED_COUNT_LEFT];
+extern const is31fl3731_led_t PROGMEM g_is31fl3731_leds_right[IS31FL3731_DRIVER_COUNT_RIGHT];
+#    else
 extern const is31fl3731_led_t PROGMEM g_is31fl3731_leds[IS31FL3731_LED_COUNT];
+#    endif
 
 void is31fl3731_init_drivers(void);
 void is31fl3731_init(uint8_t index);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
POC for split RGB on issi drivers.

This takes advantage of the existing stack, using `split_count` to generate 2 seperate led tables instead of 1 common one.
```c
const is31fl3731_led_t PROGMEM g_is31fl3731_leds_left[IS31FL3731_LED_COUNT_LEFT] = {
/* Refer to IS31 manual for these locations
 *   driver
 *   |  R location
 *   |  |      G location
 *   |  |      |      B location
 *   |  |      |      | */
    {0, C1_3,  C2_3,  C3_3},
    ....
}
const is31fl3731_led_t PROGMEM g_is31fl3731_leds_right[IS31FL3731_DRIVER_COUNT_RIGHT]= {
/* Refer to IS31 manual for these locations
 *   driver
 *   |  R location
 *   |  |      G location
 *   |  |      |      B location
 *   |  |      |      | */
    {0, C1_3,  C2_3,  C3_3},
    ....
}

```
Allowing for individual control without being heavy on RAM/wasted cycles.

LED indexing is now treated similarly to the matrix indexing on split
[leds left]
[leds right]

but it should be transparent to the core driver.

User has to define individual driver I2C addresses for each half.
```c
#define  IS31FL3731_I2C_ADDRESS_LEFT_1 
#define  IS31FL3731_I2C_ADDRESS_LEFT_2
..
#define IS31FL3731_I2C_ADDRESS_RIGHT_1
#define IS31FL3731_I2C_ADDRESS_RIGHT_2
..
```
and define the size of each
```c
#define RGB_MATRIX_SPLIT 34 65
```

This is a POC, suggestions most welcome.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
