### PR TITLE
Added MATRIX_HAS_GHOST definition for IBM Model H controller

### DIFF
--- a/keyboards/ibm/model_m/modelh/config.h
+++ b/keyboards/ibm/model_m/modelh/config.h
@@ -27,6 +27,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
 
+/* define if matrix has ghost */
+#define MATRIX_HAS_GHOST
+
 
 /*
  * Feature disable options

--- a/keyboards/ibm/model_m/modelh/config.h
+++ b/keyboards/ibm/model_m/modelh/config.h
@@ -27,9 +27,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
 
-/* define if matrix has ghost */
-#define MATRIX_HAS_GHOST
-
 
 /*
  * Feature disable options

--- a/keyboards/ibm/model_m/modelh/info.json
+++ b/keyboards/ibm/model_m/modelh/info.json
@@ -25,7 +25,7 @@
     "processor": "STM32F103",
     "url": "modelh.club",
     "usb": {
-        "device_version": "1.0.0",
+        "device_version": "1.0.1",
         "max_power": 100,
         "pid": "0xB155",
         "vid": "0xFEED"

--- a/keyboards/ibm/model_m/modelh/info.json
+++ b/keyboards/ibm/model_m/modelh/info.json
@@ -20,12 +20,13 @@
     },
     "matrix_pins": {
         "cols": ["A10", "A9", "A8", "B15", "B14", "B13", "B12", "B11", "B10", "B1", "B0", "A7", "A6", "A5", "A4", "A3"],
-        "rows": ["B6", "B5", "B4", "A15", "B3", "A0", "A2", "A1"]
+        "rows": ["B6", "B5", "B4", "A15", "B3", "A0", "A2", "A1"],
+        "ghost": true
     },
     "processor": "STM32F103",
     "url": "modelh.club",
     "usb": {
-        "device_version": "1.0.1",
+        "device_version": "1.0.0",
         "max_power": 100,
         "pid": "0xB155",
         "vid": "0xFEED"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The Model M's matrix is 2-key rollover and can suffer from ghosting. This PR adds the constant `MATRIX_HAS_GHOST` to the Model H controller, so that the firmware addresses the issue.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
