### PR TITLE
added phnx keyboard

### DIFF
--- a/keyboards/phnx/config.h
+++ b/keyboards/phnx/config.h
@@ -1,0 +1,27 @@
+// Copyright 2024 Sinisha Stojchevski (@sini6a)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+/* Hold the ESC key while plugging in the keyboard to enter bootloader mode */
+#define BOOTMAGIC_KEY_SALT KC_NO    // No modifier needed
+#define BOOTMAGIC_KEY_SALT2 KC_NO   // No second modifier needed
+#define BOOTMAGIC_KEY_BOOT KC_ESCAPE   // Press 'ESC' key
+
+/* RGB Configuration for SK6812 MINI-E LED */
+#define WS2812_DI_PIN B7
+#define RGBLIGHT_LED_COUNT 54
+
+#define RGBLIGHT_EFFECT_ALTERNATING
+#define RGBLIGHT_EFFECT_BREATHING
+#define RGBLIGHT_EFFECT_CHRISTMAS
+#define RGBLIGHT_EFFECT_KNIGHT
+#define RGBLIGHT_EFFECT_RAINBOW_MOOD
+#define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+#define RGBLIGHT_EFFECT_RGB_TEST
+#define RGBLIGHT_EFFECT_SNAKE
+#define RGBLIGHT_EFFECT_STATIC_GRADIENT
+#define RGBLIGHT_EFFECT_TWINKLE
+
+#define RGBLIGHT_DEFAULT_MODE RGBLIGHT_MODE_RAINBOW_SWIRL
+#define RGBLIGHT_LIMIT_VAL 120

--- a/keyboards/phnx/info.json
+++ b/keyboards/phnx/info.json
@@ -1,0 +1,89 @@
+{
+    "manufacturer": "stojchevski.com",
+    "keyboard_name": "phnx",
+    "maintainer": "sini6a",
+    "diode_direction": "COL2ROW",
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": false
+    },
+    "matrix_pins": {
+        "cols": ["D0", "D1", "D2", "D3", "D5", "D4", "F7", "F6", "F5", "F4", "F1", "F0"],
+        "rows": ["B5", "D7", "D6", "C6", "B4"]
+    },
+    "processor": "atmega32u4",
+    "url": "",
+    "usb": {
+        "vid": "0xACE1",
+        "pid": "0x5449",
+        "device_version": "0.0.1"
+    },
+    "layouts": {
+        "LAYOUT_qwerty": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0},
+                {"matrix": [0, 1], "x": 1, "y": 0},
+                {"matrix": [0, 2], "x": 2, "y": 0},
+                {"matrix": [0, 3], "x": 3, "y": 0},
+                {"matrix": [0, 4], "x": 4, "y": 0},
+                {"matrix": [0, 5], "x": 5, "y": 0},
+                {"matrix": [0, 6], "x": 6, "y": 0},
+                {"matrix": [0, 7], "x": 7, "y": 0},
+                {"matrix": [0, 8], "x": 8, "y": 0},
+                {"matrix": [0, 9], "x": 9, "y": 0},
+                {"matrix": [0, 10], "x": 10, "y": 0},
+                {"matrix": [0, 11], "x": 11, "y": 0},
+                
+                {"matrix": [1, 0], "x": 0, "y": 1},
+                {"matrix": [1, 1], "x": 1, "y": 1},
+                {"matrix": [1, 2], "x": 2, "y": 1},
+                {"matrix": [1, 3], "x": 3, "y": 1},
+                {"matrix": [1, 4], "x": 4, "y": 1},
+                {"matrix": [1, 5], "x": 5, "y": 1},
+                {"matrix": [1, 6], "x": 6, "y": 1},
+                {"matrix": [1, 7], "x": 7, "y": 1},
+                {"matrix": [1, 8], "x": 8, "y": 1},
+                {"matrix": [1, 9], "x": 9, "y": 1},
+                {"matrix": [1, 10], "x": 10, "y": 1},
+                {"matrix": [1, 11], "x": 11, "y": 1},
+                
+                {"matrix": [2, 0], "x": 0, "y": 2},
+                {"matrix": [2, 1], "x": 1, "y": 2},
+                {"matrix": [2, 2], "x": 2, "y": 2},
+                {"matrix": [2, 3], "x": 3, "y": 2},
+                {"matrix": [2, 4], "x": 4, "y": 2},
+                {"matrix": [2, 5], "x": 5, "y": 2},
+                {"matrix": [2, 6], "x": 6, "y": 2},
+                {"matrix": [2, 7], "x": 7, "y": 2},
+                {"matrix": [2, 8], "x": 8, "y": 2},
+                {"matrix": [2, 9], "x": 9, "y": 2},
+                {"matrix": [2, 10], "x": 10, "y": 2},
+                {"matrix": [2, 11], "x": 11, "y": 2},
+                
+                {"matrix": [3, 0], "x": 0, "y": 3},
+                {"matrix": [3, 1], "x": 1, "y": 3},
+                {"matrix": [3, 2], "x": 2, "y": 3},
+                {"matrix": [3, 3], "x": 3, "y": 3},
+                {"matrix": [3, 4], "x": 4, "y": 3},
+                {"matrix": [3, 5], "x": 5, "y": 3},
+                {"matrix": [3, 6], "x": 6, "y": 3},
+                {"matrix": [3, 7], "x": 7, "y": 3},
+                {"matrix": [3, 8], "x": 8, "y": 3},
+                {"matrix": [3, 9], "x": 9, "y": 3},
+                {"matrix": [3, 10], "x": 10, "y": 3},
+                {"matrix": [3, 11], "x": 11, "y": 3},
+
+                {"matrix": [4, 3], "x": 3, "y": 4},
+                {"matrix": [4, 4], "x": 4, "y": 4},
+                {"matrix": [4, 5], "x": 5, "y": 4},
+                {"matrix": [4, 6], "x": 6, "y": 4},
+                {"matrix": [4, 7], "x": 7, "y": 4},
+                {"matrix": [4, 8], "x": 8, "y": 4}
+            ]
+        }
+    }
+}

--- a/keyboards/phnx/keymaps/default/keymap.c
+++ b/keyboards/phnx/keymaps/default/keymap.c
@@ -1,0 +1,77 @@
+// Copyright 2024 Sinisha Stojchevski (@sini6a)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * ┌───┬───┬───┬───┬───┬───┐             ┌───┬───┬───┬───┬───┬───┐
+     * │   │ 1 │ 2 │ 3 │ 4 │ 5 │             │ 6 │ 7 │ 8 │ 9 │ 0 │   │
+     * ├───┼───┼───┼───┼───┼───│             ├───┼───┼───┼───┴───┴───│
+     * │   │ Q │ W │ E │ R │ T │             │ Y │ U │ I │ O │ P │   │
+     * ├───┼───┼───┼───┼───┼───│             ├───┼───┼───┼───┴───┴───│
+     * │   │ A │ S │ D │ F │ G │             │ H │ J │ K │ L │ ; │   │
+     * ├───┼───┼───┼───┼───┼───│             ├───┼───┼───┼───┼───┼───│
+     * │   │ Z │ X │ C │ V │ B │             │ N │ M │ , │ . │ / │   │
+     * └───┴───┴───┴───┼───┼───┼───┐     ┌───┼───┼───┼───┴───┴───┴───┘
+     *                 │   │   │   │     │   │   │   │
+     *                 └───┴───┴───┘     └───┴───┴───┘
+     */
+    [0] = LAYOUT_qwerty( // base layer
+         KC_TILDE,      KC_1,   KC_2,   KC_3,   KC_4,   KC_5,         KC_6,   KC_7,   KC_8,   KC_9,   KC_0,    KC_PSCR,
+        KC_LPRN,         KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,         KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,             KC_RPRN,
+        KC_LT,  LGUI_T(KC_A),   LALT_T(KC_S),   LCTL_T(KC_D),   LSFT_T(KC_F),   KC_G,         KC_H,   RSFT_T(KC_J),   RCTL_T(KC_K),   ALGR_T(KC_L),   RGUI_T(KC_SEMICOLON),     KC_GT,
+        KC_LCBR,   KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,         KC_N,   KC_M,   KC_COMMA,   KC_DOT,   KC_SLSH,    KC_RCBR,
+                                   LT(5, KC_ESCAPE), LT(1, KC_SPC), LT(6, KC_TAB),         LT(4, KC_ENTER), LT(3, KC_BACKSPACE), LT(2, KC_DELETE)
+    ),
+    [1] = LAYOUT_qwerty( // nav layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_AGIN,   KC_PASTE,   KC_COPY,   KC_CUT,   KC_UNDO,             KC_NO,
+        KC_NO,  KC_LGUI,   KC_LALT,   KC_LCTL,   KC_LSFT,   KC_NO,         KC_CAPS,   KC_LEFT,   KC_DOWN,   KC_UP,   KC_RIGHT,     KC_NO,
+        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_INS,   KC_HOME,   KC_PAGE_DOWN,   KC_PAGE_UP,   KC_END,    KC_NO,
+                                   KC_NO, KC_NO, KC_NO,         KC_ENTER, KC_BACKSPACE, KC_DELETE
+    ),
+    [2] = LAYOUT_qwerty( // function layer
+        QK_BOOT,      KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,         KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,             KC_NO,
+        KC_NO,     KC_F12,   KC_F7,   KC_F8,   KC_F9,   KC_PSCR,         KC_NO,   KC_NO,   KC_NO,   KC_F11,   KC_F12,             KC_NO,
+        KC_NO,     KC_F11,   KC_F4,   KC_F5,   KC_F6,   KC_SCRL,         KC_NO,   KC_RSFT,   KC_RCTL,   KC_RALT,   KC_RGUI,     KC_NO,
+        KC_NO,     KC_F10,   KC_F1,   KC_F2,   KC_F3,   KC_PAUS,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,    KC_NO,
+                                         KC_APP, KC_SPC, KC_TAB,         KC_NO, KC_NO, KC_NO
+    ),
+    [3] = LAYOUT_qwerty( // number layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_LBRC,   KC_7,   KC_8,   KC_9,   KC_RCBR,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_SCLN,   KC_4,   KC_5,   KC_6,   KC_EQL,         KC_NO,   KC_RSFT,   KC_RCTL,   KC_RALT,   KC_RGUI,     KC_NO,
+        KC_NO,     KC_COMM,   KC_1,   KC_2,   KC_3,   KC_BSLS,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,    KC_NO,
+                                         KC_DOT, KC_0, KC_MINUS,         KC_NO, KC_NO, KC_NO
+    ),
+    [4] = LAYOUT_qwerty( // symbol layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_LCBR,   KC_AMPR,   KC_ASTR,   KC_LPRN,   KC_RCBR,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_COLN,   KC_DLR,   KC_PERC,   KC_CIRC,   KC_PLUS,         KC_NO,   KC_RSFT,   KC_RCTL,   KC_RALT,   KC_RGUI,     KC_NO,
+        KC_NO,     KC_TILD,   KC_EXLM,   KC_AT,   KC_HASH,   KC_PIPE,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,    KC_NO,
+                                         KC_LPRN, KC_RPRN, KC_UNDS,         KC_NO, KC_NO, KC_NO
+    ),
+    [5] = LAYOUT_qwerty( // media layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         RGB_TOG,   RGB_MOD,   RGB_HUI,   RGB_SAI,   RGB_VAI,             KC_NO,
+        KC_NO,     KC_LGUI,   KC_LALT,   KC_LCTL,   KC_LSFT,   KC_NO,         KC_NO,   KC_MPRV,   KC_VOLD,   KC_VOLU,   KC_MNXT,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+                                         KC_NO, KC_NO, KC_NO,         KC_MSTP, KC_MPLY, KC_MUTE
+    ),
+    [6] = LAYOUT_qwerty( // mouse layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_AGIN,   KC_PASTE,   KC_COPY,   KC_CUT,   KC_UNDO,             KC_NO,
+        KC_NO,  KC_LGUI,   KC_LALT,   KC_LCTL,   KC_LSFT,   KC_NO,         KC_NO,   KC_MS_L,   KC_MS_D,   KC_MS_U,   KC_MS_R,     KC_NO,
+        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_WH_L,   KC_WH_D,   KC_WH_U,   KC_WH_R,    KC_NO,
+                                   KC_NO, KC_NO, KC_NO,         KC_BTN2, KC_BTN1, KC_BTN3
+    )
+};
+
+/*  [0] = LAYOUT_qwerty( // empty layer
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+                                         KC_NO, KC_NO, KC_NO,         KC_NO, KC_NO, KC_NO
+) */

--- a/keyboards/phnx/keymaps/via/config.h
+++ b/keyboards/phnx/keymaps/via/config.h
@@ -1,0 +1,4 @@
+// Copyright 2024 Sinisha Stojchevski (@sini6a)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#define DYNAMIC_KEYMAP_LAYER_COUNT 7

--- a/keyboards/phnx/keymaps/via/keymap.c
+++ b/keyboards/phnx/keymaps/via/keymap.c
@@ -1,0 +1,77 @@
+// Copyright 2024 Sinisha Stojchevski (@sini6a)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * ┌───┬───┬───┬───┬───┬───┐             ┌───┬───┬───┬───┬───┬───┐
+     * │   │ 1 │ 2 │ 3 │ 4 │ 5 │             │ 6 │ 7 │ 8 │ 9 │ 0 │   │
+     * ├───┼───┼───┼───┼───┼───│             ├───┼───┼───┼───┴───┴───│
+     * │   │ Q │ W │ E │ R │ T │             │ Y │ U │ I │ O │ P │   │
+     * ├───┼───┼───┼───┼───┼───│             ├───┼───┼───┼───┴───┴───│
+     * │   │ A │ S │ D │ F │ G │             │ H │ J │ K │ L │ ; │   │
+     * ├───┼───┼───┼───┼───┼───│             ├───┼───┼───┼───┼───┼───│
+     * │   │ Z │ X │ C │ V │ B │             │ N │ M │ , │ . │ / │   │
+     * └───┴───┴───┴───┼───┼───┼───┐     ┌───┼───┼───┼───┴───┴───┴───┘
+     *                 │   │   │   │     │   │   │   │
+     *                 └───┴───┴───┘     └───┴───┴───┘
+     */
+    [0] = LAYOUT_qwerty( // base layer
+         KC_TILDE,      KC_1,   KC_2,   KC_3,   KC_4,   KC_5,         KC_6,   KC_7,   KC_8,   KC_9,   KC_0,    KC_PSCR,
+        KC_LPRN,         KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,         KC_Y,   KC_U,   KC_I,   KC_O,   KC_P,             KC_RPRN,
+        KC_LT,  LGUI_T(KC_A),   LALT_T(KC_S),   LCTL_T(KC_D),   LSFT_T(KC_F),   KC_G,         KC_H,   RSFT_T(KC_J),   RCTL_T(KC_K),   ALGR_T(KC_L),   RGUI_T(KC_SEMICOLON),     KC_GT,
+        KC_LCBR,   KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,         KC_N,   KC_M,   KC_COMMA,   KC_DOT,   KC_SLSH,    KC_RCBR,
+                                   LT(5, KC_ESCAPE), LT(1, KC_SPC), LT(6, KC_TAB),         LT(4, KC_ENTER), LT(3, KC_BACKSPACE), LT(2, KC_DELETE)
+    ),
+    [1] = LAYOUT_qwerty( // nav layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_AGIN,   KC_PASTE,   KC_COPY,   KC_CUT,   KC_UNDO,             KC_NO,
+        KC_NO,  KC_LGUI,   KC_LALT,   KC_LCTL,   KC_LSFT,   KC_NO,         KC_CAPS,   KC_LEFT,   KC_DOWN,   KC_UP,   KC_RIGHT,     KC_NO,
+        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_INS,   KC_HOME,   KC_PAGE_DOWN,   KC_PAGE_UP,   KC_END,    KC_NO,
+                                   KC_NO, KC_NO, KC_NO,         KC_ENTER, KC_BACKSPACE, KC_DELETE
+    ),
+    [2] = LAYOUT_qwerty( // function layer
+        QK_BOOT,      KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,         KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,             KC_NO,
+        KC_NO,     KC_F12,   KC_F7,   KC_F8,   KC_F9,   KC_PSCR,         KC_NO,   KC_NO,   KC_NO,   KC_F11,   KC_F12,             KC_NO,
+        KC_NO,     KC_F11,   KC_F4,   KC_F5,   KC_F6,   KC_SCRL,         KC_NO,   KC_RSFT,   KC_RCTL,   KC_RALT,   KC_RGUI,     KC_NO,
+        KC_NO,     KC_F10,   KC_F1,   KC_F2,   KC_F3,   KC_PAUS,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,    KC_NO,
+                                         KC_APP, KC_SPC, KC_TAB,         KC_NO, KC_NO, KC_NO
+    ),
+    [3] = LAYOUT_qwerty( // number layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_LBRC,   KC_7,   KC_8,   KC_9,   KC_RCBR,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_SCLN,   KC_4,   KC_5,   KC_6,   KC_EQL,         KC_NO,   KC_RSFT,   KC_RCTL,   KC_RALT,   KC_RGUI,     KC_NO,
+        KC_NO,     KC_COMM,   KC_1,   KC_2,   KC_3,   KC_BSLS,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,    KC_NO,
+                                         KC_DOT, KC_0, KC_MINUS,         KC_NO, KC_NO, KC_NO
+    ),
+    [4] = LAYOUT_qwerty( // symbol layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_LCBR,   KC_AMPR,   KC_ASTR,   KC_LPRN,   KC_RCBR,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_COLN,   KC_DLR,   KC_PERC,   KC_CIRC,   KC_PLUS,         KC_NO,   KC_RSFT,   KC_RCTL,   KC_RALT,   KC_RGUI,     KC_NO,
+        KC_NO,     KC_TILD,   KC_EXLM,   KC_AT,   KC_HASH,   KC_PIPE,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,    KC_NO,
+                                         KC_LPRN, KC_RPRN, KC_UNDS,         KC_NO, KC_NO, KC_NO
+    ),
+    [5] = LAYOUT_qwerty( // media layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         RGB_TOG,   RGB_MOD,   RGB_HUI,   RGB_SAI,   RGB_VAI,             KC_NO,
+        KC_NO,     KC_LGUI,   KC_LALT,   KC_LCTL,   KC_LSFT,   KC_NO,         KC_NO,   KC_MPRV,   KC_VOLD,   KC_VOLU,   KC_MNXT,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+                                         KC_NO, KC_NO, KC_NO,         KC_MSTP, KC_MPLY, KC_MUTE
+    ),
+    [6] = LAYOUT_qwerty( // mouse layer
+        KC_NO,      KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,             KC_NO,
+        KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_AGIN,   KC_PASTE,   KC_COPY,   KC_CUT,   KC_UNDO,             KC_NO,
+        KC_NO,  KC_LGUI,   KC_LALT,   KC_LCTL,   KC_LSFT,   KC_NO,         KC_NO,   KC_MS_L,   KC_MS_D,   KC_MS_U,   KC_MS_R,     KC_NO,
+        KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_WH_L,   KC_WH_D,   KC_WH_U,   KC_WH_R,    KC_NO,
+                                   KC_NO, KC_NO, KC_NO,         KC_BTN2, KC_BTN1, KC_BTN3
+    )
+};
+
+/*  [0] = LAYOUT_qwerty( // media layer
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+        KC_NO,     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,         KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,     KC_NO,
+                                         KC_NO, KC_NO, KC_NO,         KC_NO, KC_NO, KC_NO
+) */

--- a/keyboards/phnx/keymaps/via/rules.mk
+++ b/keyboards/phnx/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/phnx/readme.md
+++ b/keyboards/phnx/readme.md
@@ -1,0 +1,25 @@
+# PHNX Unibody Split
+
+[![phnx.png](https://raw.githubusercontent.com/sini6a/phnx/main/assets/20240428_165111.jpg)](https://www.youtube.com/watch?v=Z5Uw6cO_Igg)
+
+An unibody split ergonomic keyboard featuring 54 keys, each equipped with customizable addressable LEDs. Powered by ATMega and based on Miryoku.
+
+-   Keyboard Maintainer: [sini6a](https://github.com/sini6a)
+-   Hardware Supported: PHNX PCB
+
+Make example for this keyboard (after setting up your build environment):
+
+    make phnx:default
+
+Flashing example for this keyboard:
+
+    make phnx:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+-   **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard.
+-   **Keycode in layout**: Press the key mapped to `QK_BOOT`. Accessible through function layer plus Escape key.

--- a/keyboards/phnx/rules.mk
+++ b/keyboards/phnx/rules.mk
@@ -1,0 +1,6 @@
+# This file intentionally left blank
+MCU = atmega32u4
+F_CPU = 16000000
+ARCH = AVR8
+BOOTLOADER = atmel-dfu
+RGBLIGHT_ENABLE = yes


### PR DESCRIPTION
## Description

Added custom unibody split ergonomic keyboard featuring 54 keys, each equipped with customizable addressable LEDs. Powered by ATMega and based on Miryoku.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
