### PR TITLE
23775 rgblight.h compile time bug

### DIFF
--- a/quantum/rgblight/rgblight.h
+++ b/quantum/rgblight/rgblight.h
@@ -18,6 +18,7 @@
 
 // DEPRECATED DEFINES - DO NOT USE
 #if defined(RGBLED_NUM)
+#    undef RGBLIGHT_LED_COUNT
 #    define RGBLIGHT_LED_COUNT RGBLED_NUM
 #endif
 // ========


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Patching the bug where defining a specific number of addressable RGB LEDs causes RGBLIGHT_LED_COUNT to be redefined.

When specifying the number of RGB LEDs in the keymap's `config.h` (as below), there's a compile error redefining `RGBLIGHT_LED_COUNT`. This fixes that compile time error.

I'm not sure how to add a test other than compiling this.

This is the relevant sections of my keymap's `config.h` (my specific keymap is not included.)
```cpp
// keyboards/handwired/dactyl_manuform/5x6/keymaps/kaze/config.h

//#define RGB_DI_PIN F4
#undef WS2812_DI_PIN
#define WS2812_DI_PIN F4
#undef RGBLED_NUM
#define RGBLED_NUM 10
#define RGBLIGHT_ANIMATIONS
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #23775 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
