### PR TITLE
[Converter] Elite-C to Sea Picro converter, with dedicated rgb pin

### DIFF
--- a/docs/feature_converters.md
+++ b/docs/feature_converters.md
@@ -26,6 +26,7 @@ The following converters are available at this time:
 | `elite_c`  | `elite_pi`        |
 | `elite_c`  | `helios`          |
 | `elite_c`  | `liatris`         |
+| `elite_c`  | `sea_picro`       |
 
 
 ## Overview
@@ -173,22 +174,24 @@ Feature set is identical to [Adafruit KB2040](#kb2040). VBUS detection is enable
 
 If a board currently supported in QMK uses an [Elite-C](https://keeb.io/products/elite-c-low-profile-version-usb-c-pro-micro-replacement-atmega32u4), the supported alternative controllers are:
 
-| Device                                                                           | Target            |
-|----------------------------------------------------------------------------------|-------------------|
-| [STeMCell](https://github.com/megamind4089/STeMCell)                             | `stemcell`        |
-| [Elite-Pi](https://keeb.io/products/elite-pi-usb-c-pro-micro-replacement-rp2040) | `elite_pi`        |
-| [0xCB Helios](https://keeb.supply/products/0xcb-helios)                          | `helios`          |
-| [Liatris](https://splitkb.com/products/liatris)                                  | `liatris`         |
+| Device                                                                           | Target      |
+|----------------------------------------------------------------------------------|-------------|
+| [STeMCell](https://github.com/megamind4089/STeMCell)                             | `stemcell`  |
+| [Elite-Pi](https://keeb.io/products/elite-pi-usb-c-pro-micro-replacement-rp2040) | `elite_pi`  |
+| [0xCB Helios](https://keeb.supply/products/0xcb-helios)                          | `helios`    |
+| [Liatris](https://splitkb.com/products/liatris)                                  | `liatris`   |
+| [Sea-Picro](https://github.com/joshajohnson/sea-picro)                           | `sea_picro` |
 
 Converter summary:
 
-| Target            | Argument                        | `rules.mk`                   | Condition                           |
-|-------------------|---------------------------------|------------------------------|-------------------------------------|
-| `stemcell`        | `-e CONVERT_TO=stemcell`        | `CONVERT_TO=stemcell`        | `#ifdef CONVERT_TO_STEMCELL`        |
-| `rp2040_ce`       | `-e CONVERT_TO=rp2040_ce`       | `CONVERT_TO=rp2040_ce`       | `#ifdef CONVERT_TO_RP2040_CE`       |
-| `elite_pi`        | `-e CONVERT_TO=elite_pi`        | `CONVERT_TO=elite_pi`        | `#ifdef CONVERT_TO_ELITE_PI`        |
-| `helios`          | `-e CONVERT_TO=helios`          | `CONVERT_TO=helios`          | `#ifdef CONVERT_TO_HELIOS`          |
-| `liatris`         | `-e CONVERT_TO=liatris`         | `CONVERT_TO=liatris`         | `#ifdef CONVERT_TO_LIATRIS`         |
+| Target      | Argument                  | `rules.mk`                   | Condition                     |
+|-------------|---------------------------|------------------------------|-------------------------------|
+| `stemcell`  | `-e CONVERT_TO=stemcell`  | `CONVERT_TO=stemcell`        | `#ifdef CONVERT_TO_STEMCELL`  |
+| `rp2040_ce` | `-e CONVERT_TO=rp2040_ce` | `CONVERT_TO=rp2040_ce`       | `#ifdef CONVERT_TO_RP2040_CE` |
+| `elite_pi`  | `-e CONVERT_TO=elite_pi`  | `CONVERT_TO=elite_pi`        | `#ifdef CONVERT_TO_ELITE_PI`  |
+| `helios`    | `-e CONVERT_TO=helios`    | `CONVERT_TO=helios`          | `#ifdef CONVERT_TO_HELIOS`    |
+| `liatris`   | `-e CONVERT_TO=liatris`   | `CONVERT_TO=liatris`         | `#ifdef CONVERT_TO_LIATRIS`   |
+| `sea_picro` | `-e CONVERT_TO=sea_picro` | `CONVERT_TO=sea_picro`       | `#ifdef CONVERT_TO_SEA_PICRO` |
 
 ### STeMCell :id=stemcell_elite
 

--- a/platforms/chibios/converters/elite_c_to_sea_picro/_pin_defs.h
+++ b/platforms/chibios/converters/elite_c_to_sea_picro/_pin_defs.h
@@ -1,0 +1,42 @@
+// Copyright 2023 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// Left side (front)
+#define D3 0U
+#define D2 1U
+//      GND
+//      GND
+#define D1 2U
+#define D0 3U
+#define D4 4U
+#define C6 5U
+#define D7 6U
+#define E6 7U
+#define B4 8U
+#define B5 9U
+
+// Right side (front)
+//      RAW
+//      GND
+//      RESET
+//      VCC
+#define F4 29U
+#define F5 28U
+#define F6 27U
+#define F7 26U
+#define B1 22U
+#define B3 20U
+#define B2 23U
+#define B6 21U
+
+// Bottom row
+#define B7 12U
+#define D5 13U
+#define C7 14U
+#define F1 15U
+#define F0 16U
+
+// Dedicated 5V RGB signal pin
+#define GP25 25U

--- a/platforms/chibios/converters/elite_c_to_sea_picro/converter.mk
+++ b/platforms/chibios/converters/elite_c_to_sea_picro/converter.mk
@@ -1,0 +1,10 @@
+# rp2040_ce MCU settings for converting AVR projects
+MCU := RP2040
+BOARD := QMK_PM2040
+BOOTLOADER := rp2040
+
+# These are defaults based on what has been implemented for RP2040 boards
+SERIAL_DRIVER ?= vendor
+WS2812_DRIVER ?= vendor
+BACKLIGHT_DRIVER ?= software
+OPT_DEFS += -DUSB_VBUS_PIN=19U


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Added a converter for Elite-c to Sea-Picro that includes the dedicated 5v RGB pin.
Updated the documentation to include this converter.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
