### PR TITLE
Add missing encode enable for BAMFK-1

### DIFF
--- a/keyboards/keebio/bamfk1/keyboard.json
+++ b/keyboards/keebio/bamfk1/keyboard.json
@@ -4,6 +4,7 @@
     "maintainer": "nooges",
     "bootloader": "atmel-dfu",
     "encoder": {
+        "enabled": true,
         "rotary": [
             {"pin_a": "C7", "pin_b": "B5"},
             {"pin_a": "D7", "pin_b": "D4"}


### PR DESCRIPTION
## Description

Fixes non-working encoder due to missing enable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
