### PR TITLE
Fix starlight RGB animation to observe rgb on/off state & indicators

### DIFF
--- a/quantum/rgb_matrix/animations/starlight_anim.h
+++ b/quantum/rgb_matrix/animations/starlight_anim.h
@@ -3,6 +3,7 @@ RGB_MATRIX_EFFECT(STARLIGHT)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 void set_starlight_color(int i, effect_params_t* params) {
+    if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) return;
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
     HSV      hsv  = rgb_matrix_config.hsv;
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
@@ -11,17 +12,16 @@ void set_starlight_color(int i, effect_params_t* params) {
 }
 
 bool STARLIGHT(effect_params_t* params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
     if (!params->init) {
         if (scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 5)) % 5 == 0) {
             int rand_led = rand() % RGB_MATRIX_LED_COUNT;
             set_starlight_color(rand_led, params);
         }
-        return false;
-    }
-
-    RGB_MATRIX_USE_LIMITS(led_min, led_max);
-    for (int i = led_min; i < led_max; i++) {
-        set_starlight_color(i, params);
+    } else {
+        for (int i = led_min; i < led_max; i++) {
+            set_starlight_color(i, params);
+        }
     }
     return rgb_matrix_check_finished_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/starlight_dual_hue_anim.h
+++ b/quantum/rgb_matrix/animations/starlight_dual_hue_anim.h
@@ -3,6 +3,7 @@ RGB_MATRIX_EFFECT(STARLIGHT_DUAL_HUE)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 void set_starlight_dual_hue_color(int i, effect_params_t* params) {
+    if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) return;
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
     HSV      hsv  = rgb_matrix_config.hsv;
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
@@ -12,17 +13,16 @@ void set_starlight_dual_hue_color(int i, effect_params_t* params) {
 }
 
 bool STARLIGHT_DUAL_HUE(effect_params_t* params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
     if (!params->init) {
         if (scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 5)) % 5 == 0) {
             int rand_led = rand() % RGB_MATRIX_LED_COUNT;
             set_starlight_dual_hue_color(rand_led, params);
         }
-        return false;
-    }
-
-    RGB_MATRIX_USE_LIMITS(led_min, led_max);
-    for (int i = led_min; i < led_max; i++) {
-        set_starlight_dual_hue_color(i, params);
+    } else {
+        for (int i = led_min; i < led_max; i++) {
+            set_starlight_dual_hue_color(i, params);
+        }
     }
     return rgb_matrix_check_finished_leds(led_max);
 }

--- a/quantum/rgb_matrix/animations/starlight_dual_sat_anim.h
+++ b/quantum/rgb_matrix/animations/starlight_dual_sat_anim.h
@@ -3,6 +3,7 @@ RGB_MATRIX_EFFECT(STARLIGHT_DUAL_SAT)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
 void set_starlight_dual_sat_color(int i, effect_params_t* params) {
+    if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) return;
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
     HSV      hsv  = rgb_matrix_config.hsv;
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
@@ -12,17 +13,16 @@ void set_starlight_dual_sat_color(int i, effect_params_t* params) {
 }
 
 bool STARLIGHT_DUAL_SAT(effect_params_t* params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
     if (!params->init) {
         if (scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 5)) % 5 == 0) {
             int rand_led = rand() % RGB_MATRIX_LED_COUNT;
             set_starlight_dual_sat_color(rand_led, params);
         }
-        return false;
-    }
-
-    RGB_MATRIX_USE_LIMITS(led_min, led_max);
-    for (int i = led_min; i < led_max; i++) {
-        set_starlight_dual_sat_color(i, params);
+    } else {
+        for (int i = led_min; i < led_max; i++) {
+            set_starlight_dual_sat_color(i, params);
+        }
     }
     return rgb_matrix_check_finished_leds(led_max);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
3 animations named "starlight" don't initialize properly, run while RGB is disabled and do not display indicators.
Inidicator issue similar to #21792, affecting the `jellybean raindrops` animation.

`set_starlight_color()` function does not check an led's flags, which appears to explain why effect remains on while RGB is off.
the animations also return false after updating each LED, so indicator check does not run.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
