### PR TITLE
splitkb/kyria: remove `CONVERT_TO` at keyboard level

### DIFF
--- a/keyboards/splitkb/kyria/info.json
+++ b/keyboards/splitkb/kyria/info.json
@@ -6,7 +6,6 @@
         "vid": "0x8D1D",
         "device_version": "1.0.0"
     },
-    "development_board": "elite_c",
     "split": {
         "enabled": true
     },

--- a/keyboards/splitkb/kyria/rev1/base/keyboard.json
+++ b/keyboards/splitkb/kyria/rev1/base/keyboard.json
@@ -1,5 +1,26 @@
 {
-    "build": {
-        "lto": true
+    "development_board": "elite_c",
+    "matrix_pins": {
+        "cols": ["B6", "B2", "B3", "B1", "F7", "F6", "F5", "F4"],
+        "rows": ["B4", "E6", "D7", "D4"]
+    },
+    "diode_direction": "COL2ROW",
+    "encoder": {
+        "rotary": [
+            {"pin_a": "C6", "pin_b": "B5"}
+        ]
+    },
+    "split": {
+        "soft_serial_pin": "D2",
+        "encoder": {
+            "right": {
+                "rotary": [
+                    {"pin_a": "B5", "pin_b": "C6"}
+                ]
+            }
+        }
+    },
+    "ws2812": {
+        "pin": "D3"
     }
 }

--- a/keyboards/splitkb/kyria/rev1/config.h
+++ b/keyboards/splitkb/kyria/rev1/config.h
@@ -17,31 +17,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-/*
- * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
- */
-
-#if defined(CONVERT_TO_PROTON_C)
-#    define SERIAL_USART_FULL_DUPLEX      // Enable full duplex operation mode.
-#    define SERIAL_USART_PIN_SWAP         // Swap TX and RX pins if keyboard is master halve.
-#    define SERIAL_USART_DRIVER      SD1  // USART driver of TX pin. default: SD1
-#    define SERIAL_USART_TX_PAL_MODE 7    // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 7
-#    define SERIAL_USART_TX_PIN      D3
-#    define SERIAL_USART_RX_PIN      D2
-
-#    define WS2812_DI_PIN            PAL_LINE(GPIOA, 3)
-#    define WS2812_PWM_DRIVER        PWMD2                  // default: PWMD2
-#    define WS2812_PWM_CHANNEL       4                      // default: 2
-#    define WS2812_PWM_PAL_MODE      1                      // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 2
-#    define WS2812_PWM_DMA_STREAM        STM32_DMA1_STREAM2     // DMA Stream for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
-#    define WS2812_PWM_DMA_CHANNEL       2                      // DMA Channel for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
-#    define WS2812_PWM_DMAMUX_ID         STM32_DMAMUX1_TIM2_UP  // DMAMUX configuration for TIMx_UP -- only required if your MCU has a DMAMUX peripheral, see the respective reference manual for the appropriate values for your MCU.
-#else
-#    define WS2812_DI_PIN D3
-#    define SOFT_SERIAL_PIN D2
-#endif
-
-#ifdef OLED_ENABLE
-#    define OLED_DISPLAY_128X64
-#    define SPLIT_OLED_ENABLE
-#endif
+#define OLED_DISPLAY_128X64
+#define SPLIT_OLED_ENABLE

--- a/keyboards/splitkb/kyria/rev1/info.json
+++ b/keyboards/splitkb/kyria/rev1/info.json
@@ -23,24 +23,7 @@
         "sleep": true,
         "split_count": [10, 10]
     },
-    "matrix_pins": {
-        "cols": ["B6", "B2", "B3", "B1", "F7", "F6", "F5", "F4"],
-        "rows": ["B4", "E6", "D7", "D4"]
-    },
-    "diode_direction": "COL2ROW",
-    "encoder": {
-        "rotary": [
-            {"pin_a": "C6", "pin_b": "B5"}
-        ]
-    },
     "split": {
-        "encoder": {
-            "right": {
-                "rotary": [
-                    {"pin_a": "B5", "pin_b": "C6"}
-                ]
-            }
-        },
         "transport": {
             "sync": {
                 "matrix_state": true

--- a/keyboards/splitkb/kyria/rev1/proton_c/config.h
+++ b/keyboards/splitkb/kyria/rev1/proton_c/config.h
@@ -1,0 +1,17 @@
+// Copyright 2024 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define SERIAL_USART_FULL_DUPLEX      // Enable full duplex operation mode.
+#define SERIAL_USART_PIN_SWAP         // Swap TX and RX pins if keyboard is master halve.
+#define SERIAL_USART_DRIVER      SD1  // USART driver of TX pin. default: SD1
+#define SERIAL_USART_TX_PAL_MODE 7    // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 7
+#define SERIAL_USART_TX_PIN      A9
+#define SERIAL_USART_RX_PIN      A10
+
+#define WS2812_PWM_CHANNEL     4
+#define WS2812_PWM_PAL_MODE    1
+#define WS2812_PWM_DMA_STREAM  STM32_DMA1_STREAM2     // DMA Stream for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
+#define WS2812_PWM_DMA_CHANNEL 2                      // DMA Channel for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
+#define WS2812_PWM_DMAMUX_ID   STM32_DMAMUX1_TIM2_UP  // DMAMUX configuration for TIMx_UP -- only required if your MCU has a DMAMUX peripheral, see the respective reference manual for the appropriate values for your MCU.

--- a/keyboards/splitkb/kyria/rev1/proton_c/keyboard.json
+++ b/keyboards/splitkb/kyria/rev1/proton_c/keyboard.json
@@ -1,5 +1,26 @@
 {
+    "development_board": "proton_c",
+    "matrix_pins": {
+        "cols": ["B9", "B15", "B14", "B13", "B8", "A0", "A1", "A2"],
+        "rows": ["B1", "B2", "B3", "B5"]
+    },
+    "diode_direction": "COL2ROW",
+    "encoder": {
+        "rotary": [
+            {"pin_a": "B4", "pin_b": "B0"}
+        ]
+    },
+    "split": {
+        "encoder": {
+            "right": {
+                "rotary": [
+                    {"pin_a": "B0", "pin_b": "B4"}
+                ]
+            }
+        }
+    },
     "ws2812": {
-        "driver": "pwm"
+        "driver": "pwm",
+        "pin": "A3"
     }
 }

--- a/keyboards/splitkb/kyria/rev1/proton_c/rules.mk
+++ b/keyboards/splitkb/kyria/rev1/proton_c/rules.mk
@@ -1,2 +1,1 @@
 SERIAL_DRIVER = usart
-CONVERT_TO = proton_c

--- a/keyboards/splitkb/kyria/rev2/base/keyboard.json
+++ b/keyboards/splitkb/kyria/rev2/base/keyboard.json
@@ -1,5 +1,35 @@
 {
-    "build": {
-        "lto": true
+    "development_board": "elite_c",
+    "matrix_pins": {
+        "cols": ["B2", "B6", "B5", "B4", "E6", "D7", "C6", "D4"],
+        "rows": ["F6", "F7", "B1", "B3"]
+    },
+    "diode_direction": "COL2ROW",
+    "encoder": {
+        "rotary": [
+            {"pin_a": "F4", "pin_b": "F5"}
+        ]
+    },
+    "split": {
+        "handedness": {
+            "matrix_grid": ["E6", "B3"]
+        },
+        "soft_serial_pin": "D2",
+        "encoder": {
+            "right": {
+                "rotary": [
+                    {"pin_a": "F5", "pin_b": "F4"}
+                ]
+            }
+        },
+        "matrix_pins": {
+            "right": {
+                "cols": ["B4", "B5", "B6", "B2", "B3", "B1", "F7", "F6"],
+                "rows": ["D4", "C6", "D7", "E6"]
+            }
+        }
+    },
+    "ws2812": {
+        "pin": "D3"
     }
 }

--- a/keyboards/splitkb/kyria/rev2/config.h
+++ b/keyboards/splitkb/kyria/rev2/config.h
@@ -19,34 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Side detection
 // col 4 row 3 on right-hand-side
-#define SPLIT_HAND_MATRIX_GRID E6, B3 // row first because the board is col2row
 #define MATRIX_MASKED // actual mask is defined by `matrix_mask` in `rev2.c`
 
-/*
- * Split Keyboard specific options, make sure you have 'SPLIT_KEYBOARD = yes' in your rules.mk, and define SOFT_SERIAL_PIN.
- */
-
-#if defined(CONVERT_TO_PROTON_C)
-#    define SERIAL_USART_FULL_DUPLEX      // Enable full duplex operation mode.
-#    define SERIAL_USART_PIN_SWAP         // Swap TX and RX pins if keyboard is master halve.
-#    define SERIAL_USART_DRIVER      SD1  // USART driver of TX pin. default: SD1
-#    define SERIAL_USART_TX_PAL_MODE 7    // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 7
-#    define SERIAL_USART_TX_PIN      D3
-#    define SERIAL_USART_RX_PIN      D2
-
-#    define WS2812_DI_PIN            PAL_LINE(GPIOA, 3)
-#    define WS2812_PWM_DRIVER        PWMD2                  // default: PWMD2
-#    define WS2812_PWM_CHANNEL       4                      // default: 2
-#    define WS2812_PWM_PAL_MODE      1                      // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 2
-#    define WS2812_PWM_DMA_STREAM        STM32_DMA1_STREAM2     // DMA Stream for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
-#    define WS2812_PWM_DMA_CHANNEL       2                      // DMA Channel for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
-#    define WS2812_PWM_DMAMUX_ID         STM32_DMAMUX1_TIM2_UP  // DMAMUX configuration for TIMx_UP -- only required if your MCU has a DMAMUX peripheral, see the respective reference manual for the appropriate values for your MCU.
-#else
-#    define WS2812_DI_PIN D3
-#    define SOFT_SERIAL_PIN D2
-#endif
-
-#ifdef OLED_ENABLE
-#    define OLED_DISPLAY_128X64
-#    define SPLIT_OLED_ENABLE
-#endif
+#define OLED_DISPLAY_128X64
+#define SPLIT_OLED_ENABLE

--- a/keyboards/splitkb/kyria/rev2/info.json
+++ b/keyboards/splitkb/kyria/rev2/info.json
@@ -23,30 +23,7 @@
         "sleep": true,
         "split_count": [10, 10]
     },
-    "matrix_pins": {
-        "cols": ["B2", "B6", "B5", "B4", "E6", "D7", "C6", "D4"],
-        "rows": ["F6", "F7", "B1", "B3"]
-    },
-    "diode_direction": "COL2ROW",
-    "encoder": {
-        "rotary": [
-            {"pin_a": "F4", "pin_b": "F5"}
-        ]
-    },
     "split": {
-        "encoder": {
-            "right": {
-                "rotary": [
-                    {"pin_a": "F5", "pin_b": "F4"}
-                ]
-            }
-        },
-        "matrix_pins": {
-            "right": {
-                "cols": ["B4", "B5", "B6", "B2", "B3", "B1", "F7", "F6"],
-                "rows": ["D4", "C6", "D7", "E6"]
-            }
-        },
         "transport": {
             "sync": {
                 "matrix_state": true

--- a/keyboards/splitkb/kyria/rev2/proton_c/config.h
+++ b/keyboards/splitkb/kyria/rev2/proton_c/config.h
@@ -1,0 +1,17 @@
+// Copyright 2024 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define SERIAL_USART_FULL_DUPLEX      // Enable full duplex operation mode.
+#define SERIAL_USART_PIN_SWAP         // Swap TX and RX pins if keyboard is master halve.
+#define SERIAL_USART_DRIVER      SD1  // USART driver of TX pin. default: SD1
+#define SERIAL_USART_TX_PAL_MODE 7    // Pin "alternate function", see the respective datasheet for the appropriate values for your MCU. default: 7
+#define SERIAL_USART_TX_PIN      A9
+#define SERIAL_USART_RX_PIN      A10
+
+#define WS2812_PWM_CHANNEL     4
+#define WS2812_PWM_PAL_MODE    1
+#define WS2812_PWM_DMA_STREAM  STM32_DMA1_STREAM2     // DMA Stream for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
+#define WS2812_PWM_DMA_CHANNEL 2                      // DMA Channel for TIMx_UP, see the respective reference manual for the appropriate values for your MCU.
+#define WS2812_PWM_DMAMUX_ID   STM32_DMAMUX1_TIM2_UP  // DMAMUX configuration for TIMx_UP -- only required if your MCU has a DMAMUX peripheral, see the respective reference manual for the appropriate values for your MCU.

--- a/keyboards/splitkb/kyria/rev2/proton_c/keyboard.json
+++ b/keyboards/splitkb/kyria/rev2/proton_c/keyboard.json
@@ -1,5 +1,35 @@
 {
+    "development_board": "proton_c",
+    "matrix_pins": {
+        "cols": ["B15", "B9", "B0", "B1", "B2", "B3", "B4", "B5"],
+        "rows": ["A0", "B8", "B13", "B14"]
+    },
+    "diode_direction": "COL2ROW",
+    "encoder": {
+        "rotary": [
+            {"pin_a": "A2", "pin_b": "A1"}
+        ]
+    },
+    "split": {
+        "handedness": {
+            "matrix_grid": ["B2", "B14"]
+        },
+        "encoder": {
+            "right": {
+                "rotary": [
+                    {"pin_a": "A1", "pin_b": "A2"}
+                ]
+            }
+        },
+        "matrix_pins": {
+            "right": {
+                "cols": ["B1", "B0", "B9", "B15", "B14", "B13", "B8", "A0"],
+                "rows": ["B5", "B4", "B3", "B2"]
+            }
+        }
+    },
     "ws2812": {
-        "driver": "pwm"
+        "driver": "pwm",
+        "pin": "A3"
     }
 }

--- a/keyboards/splitkb/kyria/rev2/proton_c/rules.mk
+++ b/keyboards/splitkb/kyria/rev2/proton_c/rules.mk
@@ -1,2 +1,1 @@
 SERIAL_DRIVER = usart
-CONVERT_TO = proton_c

--- a/keyboards/splitkb/kyria/rev3/config.h
+++ b/keyboards/splitkb/kyria/rev3/config.h
@@ -20,8 +20,5 @@
 // but can't yet be given a value
 #define SPLIT_HAND_PIN B5
 
-// Not yet available in `info.json`
-#ifdef OLED_ENABLE
-#    define OLED_DISPLAY_128X64
-#    define SPLIT_OLED_ENABLE
-#endif
+#define OLED_DISPLAY_128X64
+#define SPLIT_OLED_ENABLE

--- a/keyboards/splitkb/kyria/rev3/keyboard.json
+++ b/keyboards/splitkb/kyria/rev3/keyboard.json
@@ -1,13 +1,11 @@
 {
     "keyboard_name": "Kyria rev3",
+    "development_board": "elite_c",
     "usb": {
         "pid": "0xCF44"
     },
     "bootmagic": {
         "matrix": [0, 6]
-    },
-    "build": {
-        "lto": true
     },
     "features": {
         "mousekey": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Configurator/`api_tasks` cannot handle converted boards, resulting in the following on the status page:

```
Ψ Compiling keymap with gmake -r -R -f builddefs/build_keyboard.mk -s KEYBOARD=splitkb/kyria/rev1/proton_c KEYMAP=default_configurator KEYBOARD_FILESAFE=splitkb_kyria_rev1_proton_c TARGET=splitkb_kyria_rev1_proton_c_default_configurator INTERMEDIATE_OUTPUT=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator VERBOSE=false COLOR=true SILENT=false QMK_BIN="qmk" MAIN_KEYMAP_PATH_1=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator MAIN_KEYMAP_PATH_2=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator MAIN_KEYMAP_PATH_3=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator MAIN_KEYMAP_PATH_4=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator MAIN_KEYMAP_PATH_5=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator KEYMAP_JSON=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator/src/keymap.json KEYMAP_PATH=.build/obj_splitkb_kyria_rev1_proton_c_default_configurator/src


platforms/chibios/platform.mk:266: lib/chibios/os/hal/lib/streams/streams.mk: No such file or directory
gmake: *** No rule to make target 'lib/chibios/os/hal/lib/streams/streams.mk'.  Stop.

```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
