### PR TITLE
Add helper `make` targets for formatting and pytest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,3 +465,21 @@ distclean_userspace: clean
 	rm -f $(QMK_USERSPACE)/*.bin $(QMK_USERSPACE)/*.hex $(QMK_USERSPACE)/*.uf2
 	echo 'done.'
 endif
+
+# Extra targets for formatting and/or pytest, running within the qmk/qmk_cli container to match GHA.
+CONTAINER_PREAMBLE := export HOME="/tmp"; export PATH="/tmp/.local/bin:\$$PATH"; python3 -m pip install --upgrade pip; python3 -m pip install -r requirements-dev.txt
+
+.PHONY: format-core
+format-core:
+	cd $(QMK_USERSPACE)/qmk_firmware \
+		&& RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a"
+
+.PHONY: pytest
+pytest:
+	cd $(QMK_USERSPACE)/qmk_firmware \
+		&& RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk pytest"
+
+.PHONY: format-and-pytest
+format-and-pytest:
+	cd $(QMK_USERSPACE)/qmk_firmware \
+		&& RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a && qmk pytest"

--- a/Makefile
+++ b/Makefile
@@ -471,15 +471,12 @@ CONTAINER_PREAMBLE := export HOME="/tmp"; export PATH="/tmp/.local/bin:\$$PATH";
 
 .PHONY: format-core
 format-core:
-	cd $(QMK_USERSPACE)/qmk_firmware \
-		&& RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a"
+	RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a"
 
 .PHONY: pytest
 pytest:
-	cd $(QMK_USERSPACE)/qmk_firmware \
-		&& RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk pytest"
+	RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk pytest"
 
 .PHONY: format-and-pytest
 format-and-pytest:
-	cd $(QMK_USERSPACE)/qmk_firmware \
-		&& RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a && qmk pytest"
+	RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a && qmk pytest"


### PR DESCRIPTION
## Description

Adds `make format-core`, `make pytest`, and `make format-and-pytest` targets to the base `Makefile`.
These launch the formatting and testing routines within docker using the same `qmk/qmk_cli` container as run on GHA. Should simplify ensuring the version of `clang-format` and the like is consistent.

Have used these in my userspace for several years at this point, figured it'd be a useful thing to upstream given comments on #23854.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
