### PR TITLE
Bugfix: enable encoder in firmware and setting mousekey enable to ANSI and solder version

### DIFF
--- a/keyboards/4pplet/waffling60/rev_e/keyboard.json
+++ b/keyboards/4pplet/waffling60/rev_e/keyboard.json
@@ -15,7 +15,8 @@
         "console": false,
         "extrakey": true,
         "key_lock": true,
-        "mousekey": false,
+        "mousekey": true,
+        "encoder": true,
         "nkro": true,
         "rgblight": true
     },

--- a/keyboards/4pplet/waffling60/rev_e_ansi/keyboard.json
+++ b/keyboards/4pplet/waffling60/rev_e_ansi/keyboard.json
@@ -15,7 +15,8 @@
         "console": false,
         "extrakey": true,
         "key_lock": true,
-        "mousekey": false,
+        "mousekey": true,
+        "encoder": true,
         "nkro": true,
         "rgblight": true
     },

--- a/keyboards/4pplet/waffling60/rev_e_iso/keyboard.json
+++ b/keyboards/4pplet/waffling60/rev_e_iso/keyboard.json
@@ -16,6 +16,7 @@
         "extrakey": true,
         "key_lock": true,
         "mousekey": true,
+        "encoder": true,
         "nkro": true,
         "rgblight": true
     },


### PR DESCRIPTION
## Description

Bugfix: enable encoder in firmware and setting mousekey enable to ANSI and solder version

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Not being able to change encoder settings in VIA or FW.

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
