### PR TITLE
Add timer_save and _restore functions.

### DIFF
--- a/platforms/avr/timer.c
+++ b/platforms/avr/timer.c
@@ -82,7 +82,7 @@ inline void timer_clear(void) {
  *
  * FIXME: needs doc
  */
-inline void timer_set(uint32_t time_ms) {
+void timer_set(uint32_t time_ms) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
         timer_count = time_ms;
     }

--- a/platforms/avr/timer.c
+++ b/platforms/avr/timer.c
@@ -78,6 +78,16 @@ inline void timer_clear(void) {
     }
 }
 
+/** \brief timer set
+ *
+ * FIXME: needs doc
+ */
+inline void timer_set(uint32_t time_ms) {
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+        timer_count = time_ms;
+    }
+}
+
 /** \brief timer read
  *
  * FIXME: needs doc

--- a/platforms/avr/timer.c
+++ b/platforms/avr/timer.c
@@ -91,7 +91,7 @@ void timer_save(void) {
  *
  * Set timer_count to saved_ms
  */
-void timer_restore(uint32_t time_ms) {
+void timer_restore(void) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
         timer_count = saved_ms;
     }

--- a/platforms/avr/timer.c
+++ b/platforms/avr/timer.c
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // counter resolution 1ms
 // NOTE: union { uint32_t timer32; struct { uint16_t dummy; uint16_t timer16; }}
 volatile uint32_t timer_count;
+static uint32_t   saved_ms;
 
 /** \brief timer initialization
  *
@@ -78,13 +79,21 @@ inline void timer_clear(void) {
     }
 }
 
-/** \brief timer set
+/** \brief timer save
  *
- * FIXME: needs doc
+ * Set saved_ms to current time.
  */
-void timer_set(uint32_t time_ms) {
+void timer_save(void) {
+    saved_ms = timer_read32();
+}
+
+/** \brief timer restore
+ *
+ * Set timer_count to saved_ms
+ */
+void timer_restore(uint32_t time_ms) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        timer_count = time_ms;
+        timer_count = saved_ms;
     }
 }
 

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -73,6 +73,12 @@ void timer_clear(void) {
     chSysUnlock();
 }
 
+void timer_set(uint32_t time_ms) {
+    ticks_offset = get_system_time_ticks();
+    last_ticks   = 0;
+    ms_offset    = time_ms;
+}
+
 uint16_t timer_read(void) {
     return (uint16_t)timer_read32();
 }

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -74,9 +74,11 @@ void timer_clear(void) {
 }
 
 void timer_set(uint32_t time_ms) {
+    chSysLock();
     ticks_offset = get_system_time_ticks();
     last_ticks   = 0;
     ms_offset    = time_ms;
+    chSysUnlock();
 }
 
 uint16_t timer_read(void) {

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -74,12 +74,12 @@ void timer_clear(void) {
     chSysUnlock();
 }
 
-void platform_timer_save_value(uint32_t value) __attribute__((weak)) {
-	saved_ms = value;
+__attribute__((weak)) void platform_timer_save_value(uint32_t value) {
+    saved_ms = value;
 }
 
-uint32_t platform_timer_restore_value(void) __attribute__((weak)) {
-	return saved_ms;
+__attribute__((weak)) uint32_t platform_timer_restore_value(void) {
+    return saved_ms;
 }
 
 void timer_restore(void) {

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -74,16 +74,24 @@ void timer_clear(void) {
     chSysUnlock();
 }
 
-void timer_restore(void) __attribute__((weak)) {
+void platform_timer_save_value(uint32_t value) __attribute__((weak)) {
+	saved_ms = value;
+}
+
+uint32_t platform_timer_restore_value(void) __attribute__((weak)) {
+	return saved_ms;
+}
+
+void timer_restore(void) {
     chSysLock();
     ticks_offset = get_system_time_ticks();
     last_ticks   = 0;
-    ms_offset    = saved_ms;
+    ms_offset    = platform_timer_restore_value();
     chSysUnlock();
 }
 
-void timer_save(void) __attribute__((weak)) {
-    saved_ms = timer_read32();
+void timer_save(void) {
+    platform_timer_save_value(timer_read32());
 }
 
 uint16_t timer_read(void) {

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -74,7 +74,7 @@ void timer_clear(void) {
     chSysUnlock();
 }
 
-void timer_restore(void) {
+void timer_restore(void) __attribute__((weak)) {
     chSysLock();
     ticks_offset = get_system_time_ticks();
     last_ticks   = 0;
@@ -82,7 +82,7 @@ void timer_restore(void) {
     chSysUnlock();
 }
 
-void timer_save(void) {
+void timer_save(void) __attribute__((weak)) {
     saved_ms = timer_read32();
 }
 

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -5,6 +5,7 @@
 static uint32_t ticks_offset = 0;
 static uint32_t last_ticks   = 0;
 static uint32_t ms_offset    = 0;
+static uint32_t saved_ms     = 0;
 #if CH_CFG_ST_RESOLUTION < 32
 static uint32_t last_systime = 0;
 static uint32_t overflow     = 0;
@@ -73,12 +74,16 @@ void timer_clear(void) {
     chSysUnlock();
 }
 
-void timer_set(uint32_t time_ms) {
+void timer_restore(void) {
     chSysLock();
     ticks_offset = get_system_time_ticks();
     last_ticks   = 0;
-    ms_offset    = time_ms;
+    ms_offset    = saved_ms;
     chSysUnlock();
+}
+
+void timer_save(void) {
+    saved_ms = timer_read32();
 }
 
 uint16_t timer_read(void) {

--- a/platforms/timer.h
+++ b/platforms/timer.h
@@ -38,6 +38,7 @@ extern volatile uint32_t timer_count;
 
 void     timer_init(void);
 void     timer_clear(void);
+void     timer_set(uint32_t time_ms);
 uint16_t timer_read(void);
 uint32_t timer_read32(void);
 uint16_t timer_elapsed(uint16_t last);

--- a/platforms/timer.h
+++ b/platforms/timer.h
@@ -38,7 +38,8 @@ extern volatile uint32_t timer_count;
 
 void     timer_init(void);
 void     timer_clear(void);
-void     timer_set(uint32_t time_ms);
+void     timer_save(void);
+void     timer_restore(void);
 uint16_t timer_read(void);
 uint32_t timer_read32(void);
 uint16_t timer_elapsed(uint16_t last);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Needed to be able to set timer after exiting low power mode which requires clocks to be setup again. This allows things like timer_elapsed and deferred_exec to continue as normal.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
