### PR TITLE
Remove VIA_ENABLE from default keymaps.

### DIFF
--- a/keyboards/keychron/q9_plus/ansi_encoder/keymaps/default/rules.mk
+++ b/keyboards/keychron/q9_plus/ansi_encoder/keymaps/default/rules.mk
@@ -1,2 +1,1 @@
-VIA_ENABLE = yes
 ENCODER_MAP_ENABLE = yes

--- a/keyboards/mechlovin/zed65/no_backlight/wearhaus66/keymaps/default/rules.mk
+++ b/keyboards/mechlovin/zed65/no_backlight/wearhaus66/keymaps/default/rules.mk
@@ -1,2 +1,1 @@
-VIA_ENABLE = yes
 LTO_ENABLE = yes


### PR DESCRIPTION
## Description

As title, we seem to have missed these during review.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
