### PR TITLE
Draytronics Elise V2 - Refactor - Sleep wake key repeat fix,  RBG sleep tweak, readme update.

### DIFF
--- a/keyboards/draytronics/elise_v2/config.h
+++ b/keyboards/draytronics/elise_v2/config.h
@@ -1,0 +1,23 @@
+/*Copyright 2021 Blake Drayson / Draytronics
+
+Contact info@draytronics.co.uk
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//Fix to prevent key repeat on wake from sleep when using a KVM / non direct usb connection.
+#pragma once
+
+#define USB_POLLING_INTERVAL_MS 8
+#define USB_SUSPEND_WAKEUP_DELAY 3000

--- a/keyboards/draytronics/elise_v2/keyboard.json
+++ b/keyboards/draytronics/elise_v2/keyboard.json
@@ -9,8 +9,6 @@
         "device_version": "2.0.0"
     },
     "rgblight": {
-        "saturation_steps": 8,
-        "brightness_steps": 8,
         "led_count": 16,
         "sleep": true,
         "animations": {
@@ -39,6 +37,7 @@
         "rgblight": true
     },
     "qmk": {
+        "tap_keycode_delay": 10,
         "locking": {
             "enabled": true,
             "resync": true

--- a/keyboards/draytronics/elise_v2/readme.md
+++ b/keyboards/draytronics/elise_v2/readme.md
@@ -19,14 +19,14 @@ Entering DFU mode (to allow flashing):
  - If you have one of the provided keymaps flashed, then pressing FN-Tab will enter DFU.
     
 Make example for this keyboard (after setting up your build environment):
-
+    
     make draytronics/elise_v2:default
 
 Flashing example for this keyboard:
 
     make draytronics/elise_v2:default:flash
 
-See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with [The QMK Tutorial](https://docs.qmk.fm/#/newbs).
 
 
 ![elise-pcb-top](https://www.draytronics.co.uk/wp-content/uploads/2021/08/Draytronics-Elise-PCB-V2-top.png)


### PR DESCRIPTION
## Description

A re-factoring of the V2 Elise board, that includes a fix for key repeat after waking from sleep.  This is more prevalent when using a KVM or other non direct connection.  This maybe related to the use of underglow but these adjustments fix the issue in testing.  At the same time there is a small update to the README.md.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Specific to the Elise V2 board this fixes key repeat after wake from sleep. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
