### PR TITLE
Skip parsing g_led_config when matrix_size is missing

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -754,23 +754,25 @@ def find_keyboard_c(keyboard):
 def _extract_led_config(info_data, keyboard):
     """Scan all <keyboard>.c files for led config
     """
-    cols = info_data['matrix_size']['cols']
-    rows = info_data['matrix_size']['rows']
-
     for feature in ['rgb_matrix', 'led_matrix']:
         if info_data.get('features', {}).get(feature, False) or feature in info_data:
 
             # Only attempt search if dd led config is missing
             if 'layout' not in info_data.get(feature, {}):
-                # Process
-                for file in find_keyboard_c(keyboard):
-                    try:
-                        ret = find_led_config(file, cols, rows)
-                        if ret:
-                            info_data[feature] = info_data.get(feature, {})
-                            info_data[feature]['layout'] = ret
-                    except Exception as e:
-                        _log_warning(info_data, f'led_config: {file.name}: {e}')
+                cols = info_data.get('matrix_size', {}).get('cols')
+                rows = info_data.get('matrix_size', {}).get('rows')
+                if cols and rows:
+                    # Process
+                    for file in find_keyboard_c(keyboard):
+                        try:
+                            ret = find_led_config(file, cols, rows)
+                            if ret:
+                                info_data[feature] = info_data.get(feature, {})
+                                info_data[feature]['layout'] = ret
+                        except Exception as e:
+                            _log_warning(info_data, f'led_config: {file.name}: {e}')
+                else:
+                    _log_warning(info_data, f'led_config: matrix size required to parse g_led_config')
 
             if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
                 info_data[feature]['led_count'] = len(info_data[feature]['layout'])

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -772,7 +772,7 @@ def _extract_led_config(info_data, keyboard):
                         except Exception as e:
                             _log_warning(info_data, f'led_config: {file.name}: {e}')
                 else:
-                    _log_warning(info_data, f'led_config: matrix size required to parse g_led_config')
+                    _log_warning(info_data, 'led_config: matrix size required to parse g_led_config')
 
             if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
                 info_data[feature]['led_count'] = len(info_data[feature]['layout'])

--- a/lib/python/qmk/search.py
+++ b/lib/python/qmk/search.py
@@ -104,9 +104,16 @@ def _set_log_level(level):
 
 @contextlib.contextmanager
 def ignore_logging():
-    old = _set_log_level(logging.CRITICAL)
+    """suppress logging unless verbose execution
+    """
+    old = None
+    if not cli.config.general.verbose:
+        old = _set_log_level(logging.CRITICAL)
+
     yield
-    _set_log_level(old)
+
+    if old is not None:
+        _set_log_level(old)
 
 
 def _all_keymaps(keyboard):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
From the recent core CI runs, `qmk find -km all` currently falls over due to recent changes, where `matrix_size` is no longer present in `.json`. 

Also added `qmk --verbose find` handling so that diagnosing issues is somewhat easier.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
