### PR TITLE
[CLI] Force `dump_lines()` to always use Unix line endings

### DIFF
--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -102,7 +102,9 @@ def dump_lines(output_file, lines, quiet=True):
         output_file.parent.mkdir(parents=True, exist_ok=True)
         if output_file.exists():
             output_file.replace(output_file.parent / (output_file.name + '.bak'))
-        output_file.write_text(generated, encoding='utf-8', newline='\n')
+        with open(output_file, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(generated)
+        #output_file.write_text(generated, encoding='utf-8', newline='\n') # `newline` needs Python 3.10
 
         if not quiet:
             cli.log.info(f'Wrote {output_file.name} to {output_file}.')

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -102,7 +102,7 @@ def dump_lines(output_file, lines, quiet=True):
         output_file.parent.mkdir(parents=True, exist_ok=True)
         if output_file.exists():
             output_file.replace(output_file.parent / (output_file.name + '.bak'))
-        output_file.write_text(generated, encoding='utf-8')
+        output_file.write_text(generated, encoding='utf-8', newline='\n')
 
         if not quiet:
             cli.log.info(f'Wrote {output_file.name} to {output_file}.')

--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -104,7 +104,7 @@ def dump_lines(output_file, lines, quiet=True):
             output_file.replace(output_file.parent / (output_file.name + '.bak'))
         with open(output_file, 'w', encoding='utf-8', newline='\n') as f:
             f.write(generated)
-        #output_file.write_text(generated, encoding='utf-8', newline='\n') # `newline` needs Python 3.10
+        # output_file.write_text(generated, encoding='utf-8', newline='\n') # `newline` needs Python 3.10
 
         if not quiet:
             cli.log.info(f'Wrote {output_file.name} to {output_file}.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When running `./util/regen.sh` on Windows, every file generated (using `dump_lines()`) gets its newlines changed from LF to CRLF regardless of if there are any substantial changes to them. Since we enforce LF through Git anyway, this shouldn't really affect anything but we can turn off this noise by telling `write_text()` to use LF all the time.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
