### PR TITLE
Fix leftover reference to previous AW20216S EN pin definition

### DIFF
--- a/keyboards/gmmk/numpad/numpad.c
+++ b/keyboards/gmmk/numpad/numpad.c
@@ -109,10 +109,12 @@ led_config_t g_led_config = {{
 
 #    ifdef AW20216S_PW_EN_PIN
 
-void keyboard_pre_init_user(void) {
+void keyboard_pre_init_kb(void) {
     wait_ms(2000);
     gpio_set_pin_output(AW20216S_PW_EN_PIN);
     gpio_write_pin_high(AW20216S_PW_EN_PIN);
+
+    keyboard_pre_init_user();
 }
 #    endif
 

--- a/keyboards/gmmk/numpad/numpad.c
+++ b/keyboards/gmmk/numpad/numpad.c
@@ -107,7 +107,7 @@ led_config_t g_led_config = {{
 	2, 2, 2, 2, 2, 2, 2
 } };
 
-#    ifdef AW20216S_PW_EN_PIN_1
+#    ifdef AW20216S_PW_EN_PIN
 
 void keyboard_pre_init_user(void) {
     wait_ms(2000);


### PR DESCRIPTION
See issue https://github.com/qmk/qmk_firmware/issues/23973 for exact details on how the error has surfaced.

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #23973

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
