### PR TITLE
Remove deprecated `led_set_user`

### DIFF
--- a/docs/features/led_indicators.md
+++ b/docs/features/led_indicators.md
@@ -21,9 +21,8 @@ There are three ways to get the lock LED state:
 The `host_keyboard_led_state()` may reflect an updated state before `led_update_user()` is called.
 :::
 
-Two deprecated functions that provide the LED state as `uint8_t`:
+Deprecated functions that provide the LED state as `uint8_t`:
 
-* `uint8_t led_set_user(uint8_t usb_led)`
 * `uint8_t host_keyboard_leds()`
 
 ## Configuration Options
@@ -49,10 +48,6 @@ When the configuration options do not provide enough flexibility, the following 
 * Keymap: `bool led_update_user(led_t led_state)`
 
 Both receives LED state as a struct parameter. Returning `true` in `led_update_user()` will allow the keyboard level code in `led_update_kb()` to run as well. Returning `false` will override the keyboard level code, depending on how the keyboard level function is set up.
-
-::: tip
-This boolean return type of `led_update_user` allows for overriding keyboard LED controls, and is thus recommended over the void `led_set_user` function.
-:::
 
 ### Example of keyboard LED update implementation
 

--- a/keyboards/converter/usb_usb/custom_matrix.cpp
+++ b/keyboards/converter/usb_usb/custom_matrix.cpp
@@ -229,7 +229,6 @@ extern "C" {
         if (kbd2.isReady()) kbd2.SetReport(0, 0, 2, 0, 1, &usb_led);
         if (kbd3.isReady()) kbd3.SetReport(0, 0, 2, 0, 1, &usb_led);
         if (kbd4.isReady()) kbd4.SetReport(0, 0, 2, 0, 1, &usb_led);
-        led_set_user(usb_led);
         led_update_kb((led_t){.raw = usb_led});
     }
 }

--- a/keyboards/sirius/unigo66/custom_matrix.cpp
+++ b/keyboards/sirius/unigo66/custom_matrix.cpp
@@ -216,7 +216,6 @@ extern "C"
         kbd2.SetReport(0, 0, 2, 0, 1, &usb_led);
         kbd3.SetReport(0, 0, 2, 0, 1, &usb_led);
         kbd4.SetReport(0, 0, 2, 0, 1, &usb_led);
-        led_set_user(usb_led);
         led_update_kb((led_t){.raw = usb_led});
     }
 

--- a/quantum/led.c
+++ b/quantum/led.c
@@ -56,18 +56,14 @@ static void handle_backlight_caps_lock(led_t led_state) {
 #endif
 
 static uint32_t last_led_modification_time = 0;
-uint32_t        last_led_activity_time(void) {
+
+uint32_t last_led_activity_time(void) {
     return last_led_modification_time;
 }
+
 uint32_t last_led_activity_elapsed(void) {
     return timer_elapsed32(last_led_modification_time);
 }
-
-/** \brief Lock LED set callback - keymap/user level
- *
- * \deprecated Use led_update_user() instead.
- */
-__attribute__((weak)) void led_set_user(uint8_t usb_led) {}
 
 /** \brief Lock LED update callback - keymap/user level
  *
@@ -146,7 +142,6 @@ __attribute__((weak)) void led_set(uint8_t usb_led) {
     handle_backlight_caps_lock((led_t)usb_led);
 #endif
 
-    led_set_user(usb_led);
     led_update_kb((led_t)usb_led);
 }
 

--- a/quantum/led.h
+++ b/quantum/led.h
@@ -48,9 +48,6 @@ void led_wakeup(void);
 
 void led_task(void);
 
-/* Deprecated callbacks */
-void led_set_user(uint8_t usb_led);
-
 /* Callbacks */
 bool led_update_user(led_t led_state);
 bool led_update_kb(led_t led_state);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Deprecated for 1.5 years, so probably safe to now remove.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
