### PR TITLE
Change ADNS9800 and PMW33XX SROM uploads to opt in.

### DIFF
--- a/drivers/sensors/adns9800.c
+++ b/drivers/sensors/adns9800.c
@@ -115,6 +115,7 @@ void adns9800_init(void) {
     adns9800_read(REG_Delta_Y_L);
     adns9800_read(REG_Delta_Y_H);
 
+#ifdef ADNS9800_UPLOAD_SROM
     // upload firmware
 
     // 3k firmware mode
@@ -145,6 +146,16 @@ void adns9800_init(void) {
     spi_stop();
 
     wait_ms(10);
+#else
+    // write reset value to REG_Configuration_IV
+    adns9800_write(REG_Configuration_IV, 0x0);
+
+    // write reset value to REG_SROM_Enable
+    adns9800_write(REG_SROM_Enable, 0x0);
+
+    // wait a frame
+    wait_ms(10);
+#endif
 
     // enable laser
     uint8_t laser_ctrl0 = adns9800_read(REG_LASER_CTRL0);

--- a/drivers/sensors/pmw33xx_common.c
+++ b/drivers/sensors/pmw33xx_common.c
@@ -154,10 +154,12 @@ bool pmw33xx_init(uint8_t sensor) {
     pmw33xx_read(sensor, REG_Delta_Y_L);
     pmw33xx_read(sensor, REG_Delta_Y_H);
 
+#ifdef PMW33XX_UPLOAD_SROM
     if (!pmw33xx_upload_firmware(sensor)) {
         pd_dprintf("PMW33XX (%d): firmware upload failed!\n", sensor);
         return false;
     }
+#endif
 
     spi_stop();
 
@@ -200,7 +202,7 @@ pmw33xx_report_t pmw33xx_read_burst(uint8_t sensor) {
     spi_write(REG_Motion_Burst);
     wait_us(35); // waits for tSRAD_MOTBR
 
-    spi_receive((uint8_t*)&report, sizeof(report));
+    spi_receive((uint8_t *)&report, sizeof(report));
 
     // panic recovery, sometimes burst mode works weird.
     if (report.motion.w & 0b111) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Tested 3360, 3389 and ADNS9800 are functional without SROM upload.

I did get some odd behaviour with the ADNS9800 but my sensor has always seemed a little iffy.

I chose not to document the defines as the idea is to have a larger test base running no SROM uploads. Ultimately they'll be reworked so the SROM can be included in the users keymap or uploaded by other means. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
