### PR TITLE
Fix tap-hold processing for multiple hold actions #24002

### DIFF
--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -59,10 +59,11 @@ __attribute__((weak)) bool get_hold_on_other_key_press(uint16_t keycode, keyreco
 #        include "process_auto_shift.h"
 #    endif
 
-static keyrecord_t tapping_key                         = {};
-static keyrecord_t waiting_buffer[WAITING_BUFFER_SIZE] = {};
-static uint8_t     waiting_buffer_head                 = 0;
-static uint8_t     waiting_buffer_tail                 = 0;
+static keyrecord_t *deferred_typing_key;
+static keyrecord_t  tapping_key                         = {};
+static keyrecord_t  waiting_buffer[WAITING_BUFFER_SIZE] = {};
+static uint8_t      waiting_buffer_head                 = 0;
+static uint8_t      waiting_buffer_tail                 = 0;
 
 static bool process_tapping(keyrecord_t *record);
 static bool waiting_buffer_enq(keyrecord_t record);
@@ -174,15 +175,26 @@ bool process_tapping(keyrecord_t *keyp) {
         } else if (event.pressed && is_tap_record(keyp)) {
             // the currently pressed key is a tapping key, therefore transition
             // into the "pressed" tapping key state
-            ac_dprintf("Tapping: Start(Press tap key).\n");
-            tapping_key = *keyp;
-            process_record_tap_hint(&tapping_key);
-            waiting_buffer_scan_tap();
-            debug_tapping_key();
+            if (!deferred_typing_key || KEYEQ(deferred_typing_key->event.key, keyp->event.key)) {
+                ac_dprintf("Tapping: Start(Press tap key).\n");
+                tapping_key = *keyp;
+                process_record_tap_hint(&tapping_key);
+                waiting_buffer_scan_tap();
+                debug_tapping_key();
+                // for case when it was deferred tap press action
+                deferred_typing_key = 0;
+            } else {
+                // current pressed key is hold action that processed in waiting buffer before deferred tap processing
+                ac_dprintf("Tapping: Deferred typing key processing. Hold action processing. ");
+                process_record(keyp);
+                tapping_key = (keyrecord_t){0};
+            }
         } else {
             // the current key is just a regular key, pass it on for regular
             // processing
             process_record(keyp);
+            // for case when it was a deferred typing key
+            deferred_typing_key = 0;
         }
 
         return true;
@@ -231,6 +243,7 @@ bool process_tapping(keyrecord_t *keyp) {
                     process_record(&tapping_key);
                     tapping_key = (keyrecord_t){0};
                     debug_tapping_key();
+                    deferred_typing_key = keyp;
                     // enqueue
                     return false;
                 }

--- a/tests/tap_hold_configurations/permissive_hold/test_multiple_tap_hold.cpp
+++ b/tests/tap_hold_configurations/permissive_hold/test_multiple_tap_hold.cpp
@@ -1,0 +1,176 @@
+/* Copyright 2024 Mercury Wilberforce
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.hpp"
+#include "action_tapping.h"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+class PermissiveHold : public TestFixture {};
+
+TEST_F(PermissiveHold, tap_regular_key_while_mod_tap_key_and_another_mod_tap_key_are_held) {
+    TestDriver driver;
+    InSequence s;
+    auto       first_mod_tap_hold_key  = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       second_mod_tap_hold_key = KeymapKey(0, 2, 0, CTL_T(KC_Q));
+    auto       regular_key             = KeymapKey(0, 3, 0, KC_A);
+
+    set_keymap({first_mod_tap_hold_key, second_mod_tap_hold_key, regular_key});
+
+    /* Press first mod-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    first_mod_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press second mod-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    second_mod_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press regular key */
+    EXPECT_NO_REPORT(driver);
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_CTRL));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_CTRL, regular_key.report_code));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_CTRL));
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release second mod-tap-hold key */
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    second_mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release first mod-tap-hold key */
+    EXPECT_EMPTY_REPORT(driver);
+    first_mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(PermissiveHold, tap_a_mod_tap_key_while_two_other_mod_tap_keys_are_held) {
+    TestDriver driver;
+    InSequence s;
+    auto       first_mod_tap_hold_key  = KeymapKey(0, 1, 0, SFT_T(KC_P));
+    auto       second_mod_tap_hold_key = KeymapKey(0, 2, 0, CTL_T(KC_A));
+    auto       third_mod_tap_hold_key  = KeymapKey(0, 3, 0, RSFT_T(KC_Q));
+
+    set_keymap({first_mod_tap_hold_key, second_mod_tap_hold_key, third_mod_tap_hold_key});
+
+    /* Press first mod-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    first_mod_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press second mod-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    second_mod_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press third mod-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    third_mod_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release third mod-tap-hold key */
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_CTRL));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_CTRL, third_mod_tap_hold_key.report_code));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_LEFT_CTRL));
+    third_mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release second mod-tap-hold key */
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    second_mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release first mod-tap-hold key */
+    EXPECT_EMPTY_REPORT(driver);
+    first_mod_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(PermissiveHold, tap_regular_key_while_layer_and_another_layer_tap_key_are_held) {
+    TestDriver driver;
+    InSequence s;
+    auto       first_layer_tap_hold_key  = KeymapKey(0, 1, 0, LT(1, KC_P));
+    auto       regular_1_key             = KeymapKey(0, 2, 0, KC_A);
+    auto       regular_2_key             = KeymapKey(0, 3, 0, KC_G);
+    auto       second_layer_tap_hold_key = KeymapKey(1, 3, 0, LT(2, KC_X));
+    auto       first_layer_1_key         = KeymapKey(1, 2, 0, KC_B);
+    auto       first_layer_2_key         = KeymapKey(1, 1, 0, KC_Z);
+    auto       second_layer_1_key        = KeymapKey(2, 2, 0, KC_Y);
+    auto       second_layer_2_key        = KeymapKey(2, 1, 0, KC_V);
+
+    set_keymap({first_layer_tap_hold_key, second_layer_tap_hold_key, regular_1_key, first_layer_1_key, second_layer_1_key, regular_2_key, first_layer_2_key, second_layer_2_key});
+
+    /* Press first layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    first_layer_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press second layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    second_layer_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press regular key */
+    EXPECT_NO_REPORT(driver);
+    regular_1_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_REPORT(driver, (second_layer_1_key.report_code));
+    EXPECT_EMPTY_REPORT(driver);
+    regular_1_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release second layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    second_layer_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release first layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    first_layer_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
This PR purpose is to fix the problem with processing multiple hold actions and one tap action when PERMISSIVE_HOLD is defined and TAPPING_TERM hasn't elapsed. When such conditions are met, keys not fired, contrary to the PERMISSIVE_HOLD decision mode and the firmware continues to wait for new actions in reset state of process_tapping SM. To trigger hold actions selection user have to tap amount of keys equal to holded keys. This PR fix this by adding deferring tap key entity that indicate that processing of hold actions must be continued till tap key. As side effect of this fix, bigger number of simultaneous hold actions now can be fired in PERMISSIVE_HOLD style decision: (WAITING_BUFFER_SIZE - 1) vs old ceiling(WAITING_BUFFER_SIZE/3).
This is just a draft and I totally not qualified enough for this so I will be happy if someone with experience take a look at the issue and make more consistent alternation in process_tapping if appropriate.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #24002

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
