### PR TITLE
[CLI] Only generate files if contents change.

### DIFF
--- a/lib/python/qmk/commands.py
+++ b/lib/python/qmk/commands.py
@@ -101,6 +101,12 @@ def dump_lines(output_file, lines, quiet=True):
     if output_file and output_file.name != '-':
         output_file.parent.mkdir(parents=True, exist_ok=True)
         if output_file.exists():
+            with open(output_file, 'r', encoding='utf-8', newline='\n') as f:
+                existing = f.read()
+            if existing == generated:
+                if not quiet:
+                    cli.log.info(f'No changes to {output_file.name}.')
+                return
             output_file.replace(output_file.parent / (output_file.name + '.bak'))
         output_file.write_text(generated, encoding='utf-8')
 


### PR DESCRIPTION
## Description

Compilation tends to do everything each time -- we're constantly generating files as a precursor to a build, which updates `mtime`s and the like.

If regenerating the file doesn't change the content, then don't perform the write.

Doing rebuilds of the same board are significantly faster as a result.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
