### PR TITLE
Allow overriding `get_hardware_id()`.

### DIFF
--- a/platforms/arm_atsam/hardware_id.c
+++ b/platforms/arm_atsam/hardware_id.c
@@ -3,7 +3,7 @@
 
 #include "hardware_id.h"
 
-hardware_id_t get_hardware_id(void) {
+__attribute__((weak)) hardware_id_t get_hardware_id(void) {
     hardware_id_t id = {0};
     return id;
 }

--- a/platforms/avr/hardware_id.c
+++ b/platforms/avr/hardware_id.c
@@ -10,7 +10,7 @@
 #include <avr/boot.h>
 #include "hardware_id.h"
 
-hardware_id_t get_hardware_id(void) {
+__attribute__((weak)) hardware_id_t get_hardware_id(void) {
     hardware_id_t id = {0};
     for (uint8_t i = 0; i < 10; i += 1) {
         ((uint8_t*)&id)[i] = boot_signature_byte_get(i + 0x0E);

--- a/platforms/chibios/hardware_id.c
+++ b/platforms/chibios/hardware_id.c
@@ -4,7 +4,7 @@
 #include <ch.h>
 #include "hardware_id.h"
 
-hardware_id_t get_hardware_id(void) {
+__attribute__((weak)) hardware_id_t get_hardware_id(void) {
     hardware_id_t id = {0};
 #if defined(RP2040)
     // Forward declare as including "hardware/flash.h" here causes more issues...


### PR DESCRIPTION
## Description

As per title. Makes it so we can use a separate chip identifier or preload a separate EEPROM or something with hardware identifiers during board bringup.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
