### PR TITLE
[CI] Pull full history before generating index

### DIFF
--- a/.github/workflows/ci_build_major_branch.yml
+++ b/.github/workflows/ci_build_major_branch.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Checkout QMK Firmware
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Download firmwares
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Description

https://ci.qmk.fm/master/latest/index.html has a really long log entry -- I think because actions/checkout isn't actually getting anything other than a copy of the active revision. Testing locally doesn't trigger this, seemingly because of the full history being available.

This makes it so the whole repo is pulled down, including history.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
