### PR TITLE
[CI] Disable Discord webhook when CI run is cancelled.

### DIFF
--- a/.github/workflows/ci_build_major_branch_keymap.yml
+++ b/.github/workflows/ci_build_major_branch_keymap.yml
@@ -178,4 +178,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.CI_DISCORD_WEBHOOK }}
         run: |
           python3 -m pip install -r requirements.txt
-          python3 ./discord-results.py --branch ${{ inputs.branch || github.ref_name }} --keymap ${{ inputs.keymap }} --url ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          python3 ./discord-results.py --branch ${{ inputs.branch || github.ref_name }} --sha $(git rev-parse HEAD) --keymap ${{ inputs.keymap }} --url ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ci_build_major_branch_keymap.yml
+++ b/.github/workflows/ci_build_major_branch_keymap.yml
@@ -172,7 +172,7 @@ jobs:
             targets-${{ inputs.keymap }}
 
       - name: 'CI Discord Notification'
-        if: always()
+        if: always() && !cancelled()
         working-directory: util/ci/
         env:
           DISCORD_WEBHOOK: ${{ secrets.CI_DISCORD_WEBHOOK }}

--- a/util/ci/discord-results.py
+++ b/util/ci/discord-results.py
@@ -11,6 +11,7 @@ parser = argparse.ArgumentParser(prog='discord-results.py', description='Sends a
 parser.add_argument('-b', '--branch')
 parser.add_argument('-k', '--keymap')
 parser.add_argument('-u', '--url')
+parser.add_argument('-s', '--sha')
 args = parser.parse_args()
 
 qmk_dir = Path(__file__).resolve().parents[2].resolve()
@@ -43,6 +44,7 @@ else:
 
 embed.add_embed_field(name='Build Target', value=f'[**{args.branch}**](https://github.com/qmk/qmk_firmware/tree/{args.branch}) / **{args.keymap}** keymap')
 embed.add_embed_field(name='Workflow Run', value=f'[**Link**]({args.url})')
+embed.add_embed_field(name='Firmware Binaries', value=f'[**ci.qmk.fm**](https://ci.qmk.fm/{args.branch}/{args.sha}/index.html)')
 embed.set_timestamp()
 
 webhook.add_embed(embed)


### PR DESCRIPTION
As per title.
`#webhooks_ci` has builds which report success but zero (or less than normal) successfully built targets.
Seemingly this is when a CI run is cancelled due to a newer run being queued up.

Also fixes up the Discord notification so that it actually includes a link to the CI run with firmware downloads.