### PR TITLE
Fix i2c received value in georgi and bajjak

### DIFF
--- a/keyboards/bajjak/matrix.c
+++ b/keyboards/bajjak/matrix.c
@@ -146,7 +146,7 @@ static matrix_row_t read_cols(uint8_t row) {
             // reading GPIOB (column port) since in mcp23018's sequential mode
             // it is addressed directly after writing to GPIOA in select_row()
             mcp23018_status = i2c_receive(I2C_ADDR, &data, 1, BAJJAK_EZ_I2C_TIMEOUT);
-            return data;
+            return ~data;
         }
     } else {
         /* read from teensy

--- a/keyboards/gboards/georgi/matrix.c
+++ b/keyboards/gboards/georgi/matrix.c
@@ -255,6 +255,7 @@ static matrix_row_t read_cols(uint8_t row)
         } else {
             uint8_t data = 0;
             mcp23018_status = i2c_read_register(I2C_ADDR, GPIOB, &data, 1, ERGODOX_EZ_I2C_TIMEOUT);
+            data = ~data;
 
 #ifdef DEBUG_MATRIX
             if (data != 0x00) xprintf("I2C: %d\n", data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Commit e9bd7d7a (PR #21273) refactors low-level calls to the i2c API into the current wrapper API calls. When translating for two keyboards (gboards/georgi, bajjak), said PR sadly missed two bitwise negation operators when receiving from i2c. This PR attempts to fix them.

The missed lines are:

- [here](https://github.com/qmk/qmk_firmware/commit/e9bd7d7ad308f9c72c86863bf9f19382c7e2d892#r144205894) for georgi
- [here](https://github.com/qmk/qmk_firmware/commit/e9bd7d7ad308f9c72c86863bf9f19382c7e2d892#r144205888) for bajjak

The other keyboards modified by the referenced PR (gboards/gergo, gboards/gergoplex, handwired/pterodactyl, ergodox_ez) were handled correctly. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #24112

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
  - [x] georgi: tested myself
  - [ ] bajjak: I don't have the board. Modification is done with reasonable extrapolation, but I am unable to test it.
