### PR TITLE
docs: Fix links to key_keylock.md and  leader_key.md in docs/keycodes.md

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -369,7 +369,7 @@ See also: [Joystick](features/joystick)
 
 ## Key Lock {#key-lock}
 
-See also: [Key Lock](features/key_lock)
+See also: [Key Lock](features/key_lock.md)
 
 |Key      |Description                                                   |
 |---------|--------------------------------------------------------------|
@@ -392,7 +392,7 @@ See also: [Layer Switching](feature_layers#switching-and-toggling-layers)
 
 ## Leader Key {#leader-key}
 
-See also: [Leader Key](features/leader_key)
+See also: [Leader Key](features/leader_key.md)
 
 |Key      |Description             |
 |---------|------------------------|


### PR DESCRIPTION
The link to the docs for Leader key and Key lock are broken. I think it's because they are missing the .md exctension at the end

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The link to the docs for Leader key and Key lock are broken in `docs/keycodes.md`.
I think it's because they are missing the `.md` exctension at the end


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
