### PR TITLE
Remove incorrect use of split.main

### DIFF
--- a/keyboards/aidansmithdotdev/sango/keyboard.json
+++ b/keyboards/aidansmithdotdev/sango/keyboard.json
@@ -120,7 +120,6 @@
             "matrix": [4, 7]
         },
         "enabled": true,
-        "main": "matrix_grid",
         "matrix_pins": {
             "right": {
                 "cols": ["GP7", "GP8", "GP9", "GP11", "GP12", "GP13", "GP14", "GP15"],

--- a/keyboards/takashicompany/heavy_left/keyboard.json
+++ b/keyboards/takashicompany/heavy_left/keyboard.json
@@ -45,8 +45,7 @@
     "diode_direction": "COL2ROW",
     "split": {
         "enabled": true,
-        "soft_serial_pin": "D2",
-        "main": "eeprom"
+        "soft_serial_pin": "D2"
     },
     "development_board": "promicro",
     "layouts": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
* Doesnt do anything
* `aidansmithdotdev/sango` also sets a logically conflicting value to its `config.h`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
