### PR TITLE
`meme`: adjust layout names

### DIFF
--- a/keyboards/meme/keyboard.json
+++ b/keyboards/meme/keyboard.json
@@ -33,8 +33,15 @@
   },
   "processor": "atmega32u2",
   "bootloader": "atmel-dfu",
+  "community_layouts": ["65_ansi", "65_ansi_split_bs", "65_ansi_blocker", "65_ansi_blocker_split_bs"],
+  "layout_aliases": {
+    "LAYOUT_normie": "LAYOUT_65_ansi",
+    "LAYOUT_spicy": "LAYOUT_65_ansi_split_bs",
+    "LAYOUT_dank": "LAYOUT_65_ansi_blocker",
+    "LAYOUT_meme": "LAYOUT_65_ansi_blocker_split_bs",
+  },
   "layouts": {
-    "LAYOUT_spicy": {
+    "LAYOUT_65_ansi_split_bs": {
       "layout": [
         {"matrix": [0, 0], "x": 0, "y": 0},
         {"matrix": [1, 0], "x": 1, "y": 0},
@@ -111,7 +118,7 @@
         {"matrix": [9, 7], "x": 15, "y": 4}
       ]
     },
-    "LAYOUT_normie": {
+    "LAYOUT_65_ansi": {
       "layout": [
         {"matrix": [0, 0], "x": 0, "y": 0},
         {"matrix": [1, 0], "x": 1, "y": 0},
@@ -187,7 +194,7 @@
         {"matrix": [9, 7], "x": 15, "y": 4}
       ]
     },
-    "LAYOUT_dank": {
+    "LAYOUT_65_ansi_blocker": {
       "layout": [
         {"matrix": [0, 0], "x": 0, "y": 0},
         {"matrix": [1, 0], "x": 1, "y": 0},
@@ -262,7 +269,7 @@
         {"matrix": [9, 7], "x": 15, "y": 4}
       ]
     },
-    "LAYOUT_meme": {
+    "LAYOUT_65_ansi_blocker_split_bs": {
       "layout": [
         {"matrix": [0, 0], "x": 0, "y": 0},
         {"matrix": [1, 0], "x": 1, "y": 0},

--- a/keyboards/meme/keymaps/default/keymap.c
+++ b/keyboards/meme/keymaps/default/keymap.c
@@ -17,7 +17,7 @@
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-[0] = LAYOUT_spicy(
+[0] = LAYOUT_65_ansi_split_bs(
     QK_GESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSLS, KC_BSPC, KC_INS,
     KC_TAB,  KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,
     KC_RCTL, KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,  KC_PGUP,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

```
⚠ meme: Layout "LAYOUT_meme" should not contain name of keyboard.
```

Also worth noting this board is apparently [dead](https://geekhack.org/index.php?topic=94467.0), so perhaps it should instead be removed entirely.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
