### PR TITLE
Segregrate keycode at pre-process record quantum

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -246,10 +246,9 @@ uint16_t get_event_keycode(keyevent_t event, bool update_layer_cache) {
 
 /* Get keycode, and then process pre tapping functionality */
 bool pre_process_record_quantum(keyrecord_t *record) {
-    uint16_t keycode = get_record_keycode(record, true);
-    return pre_process_record_kb(keycode, record) &&
+    return pre_process_record_kb(get_record_keycode(record, true), record) &&
 #ifdef COMBO_ENABLE
-           process_combo(keycode, record) &&
+           process_combo(get_record_keycode(record, true), record) &&
 #endif
            true;
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The previous implementation sends the same keycode variable to both pre_process_record_kb and process_combo. If changes are made to the record entry by pre_process_record_* functions that affect the keycode, it will not be reflected in the process_combo function.

This change ensures that the keycode variable in the process_combo function will be updated if modified.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
