### PR TITLE
Remove duplicate calls to `housekeeping_task_user`

### DIFF
--- a/keyboards/1upkeyboards/1upslider8/1upslider8.c
+++ b/keyboards/1upkeyboards/1upslider8/1upslider8.c
@@ -33,7 +33,6 @@ void slider(void) {
 
 void housekeeping_task_kb(void) {
     slider();
-    housekeeping_task_user();
 }
 
 static uint32_t oled_logo_timer = 0;

--- a/keyboards/boardsource/equals/equals.c
+++ b/keyboards/boardsource/equals/equals.c
@@ -49,6 +49,5 @@ void keyboard_post_init_kb(void) {
 
 void housekeeping_task_kb(void) {
     ui_task();
-    housekeeping_task_user();
 }
 #endif // QUANTUM_PAINTER_ENABLE

--- a/keyboards/hardwareabstraction/handwire/handwire.c
+++ b/keyboards/hardwareabstraction/handwire/handwire.c
@@ -39,7 +39,6 @@ void housekeeping_task_kb(void){
         gpio_write_pin_low(BUZZER_PIN);
         }
     }
-    housekeeping_task_user();
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/neson_design/700e/700e.c
+++ b/keyboards/neson_design/700e/700e.c
@@ -333,8 +333,6 @@ void housekeeping_task_kb(void)
     }
 
     is31fl3731_flush();
-
-    housekeeping_task_user();
 }
 
 void setleds_custom(rgb_led_t *start_led, uint16_t num_leds)

--- a/keyboards/neson_design/n6/n6.c
+++ b/keyboards/neson_design/n6/n6.c
@@ -335,8 +335,6 @@ void housekeeping_task_kb(void)
     }
 
     is31fl3731_flush();
-
-    housekeeping_task_user();
 }
 
 void setleds_custom(rgb_led_t *start_led, uint16_t num_leds)

--- a/keyboards/pica40/rev1/rev1.c
+++ b/keyboards/pica40/rev1/rev1.c
@@ -23,8 +23,6 @@ void housekeeping_task_kb(void) {
             rgblight_disable_noeeprom();
         }
     }
-
-    housekeeping_task_user();
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/pica40/rev2/rev2.c
+++ b/keyboards/pica40/rev2/rev2.c
@@ -120,6 +120,4 @@ void housekeeping_task_kb(void) {
         }
     }
 #endif // defined(RGBLIGHT_ENABLE) && defined(RGBLIGHT_LAYERS)
-
-    housekeeping_task_user();
 }

--- a/keyboards/stront/stront.c
+++ b/keyboards/stront/stront.c
@@ -46,8 +46,6 @@ void housekeeping_task_kb(void) {
     if (display_enabled) {
         display_housekeeping_task();
     }
-
-    housekeeping_task_user();
 }
 
 void keyboard_post_init_kb(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Unlike other callbacks, `housekeeping_task_kb` should not itself call `housekeeping_task_user`. Doing so would cause it to be called twice as frequently as it should.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
