### PR TITLE
Attempt to fix auto 'keyboard' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,15 +11,15 @@ core:
       - Makefile
       - '*.mk'
 dependencies:
-  - all:
-    - changed-files:
-      - any-glob-to-any-file: lib/**
-      - all-globs-to-all-files: '!lib/python/**'
+  - changed-files:
+    - all-globs-to-any-file:
+      - lib/**
+      - '!lib/python/**'
 keyboard:
-  - all:
-    - changed-files:
-      - any-glob-to-any-file: keyboards/**
-      - all-globs-to-all-files: '!keyboards/**/keymaps/**'
+  - changed-files:
+    - all-globs-to-any-file:
+      - keyboards/**
+      - '!keyboards/**/keymaps/**'
 keymap:
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Looks like the docs for actions/labeler@v5 do not line up with the actual behaviour.

When migrating, I copied the example `# Add 'source' label to any change to src files within the source dir EXCEPT for the docs sub-folder` as it was what was previously used. But for keyboard PRs with keymaps, this does not add the label at all.

Bit of a stab... who knows.....

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
