### PR TITLE
Add ability to poweroff ADNS5050 sensor

### DIFF
--- a/drivers/sensors/adns5050.h
+++ b/drivers/sensors/adns5050.h
@@ -83,3 +83,4 @@ void              adns5050_set_cpi(uint16_t cpi);
 uint16_t          adns5050_get_cpi(void);
 int8_t            convert_twoscomp(uint8_t data);
 bool              adns5050_check_signature(void);
+void              adns5050_power_down(void);

--- a/keyboards/ploopyco/trackball_nano/keymaps/default/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/default/keymap.c
@@ -20,3 +20,12 @@
 
 // Dummy
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {{{ KC_NO }}};
+
+void suspend_power_down_user(void) {
+    // Switch off sensor + LED making trackball unable to wake host
+    adns5050_power_down();
+}
+
+void suspend_wakeup_init_user(void) {
+    adns5050_init();
+}


### PR DESCRIPTION
This adds the ability to poweroff the ADNS5050 sensor and set this to happen on `suspend_power_down_user` for the ploopy nano.

As the LED on the trackball points up it can be a little annoying when the computer is suspended/off. 

I'm on the fence as to whether this should be the default for the ploopy as it would stop the trackball from being used to wake the computer.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
