### PR TITLE
[Core] quantum: util: add bit and bitmask helpers

### DIFF
--- a/quantum/bits.h
+++ b/quantum/bits.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#pragma once
+
+#include <stdint.h>
+
+/* Remove these once we transitioned to C23 across all platfroms */
+#define UINT32_WIDTH 32
+#define UINT64_WIDTH 64
+
+/**
+ *  @brief Mask for the little endian nth bit (0-31) in a 32-bit integer.
+ */
+#define BIT32(n) (UINT32_C(1) << (n))
+
+/**
+ * @brief Mask for the little endian nth bit (0-63) in a 64-bit integer.
+ */
+#define BIT64(n) (UINT64_C(1) << (n))
+
+/**
+ * @brief Create a contiguous 32-bit wide bitmask starting at bit position @l
+ * and ending at position @h. The range is inclusive, meaning GENMASK32(20, 10)
+ * gives us the 32-bit mask 0x001ffc00.
+ */
+#define GENMASK32(h, l) (((~UINT32_C(0)) - (UINT32_C(1) << (l)) + 1) & (~UINT32_C(0) >> (UINT32_WIDTH - 1 - (h))))
+
+/**
+ * @brief Create a contiguous 64-bit wide bitmask starting at bit position @l
+ * and ending at position @h. The range is inclusive, meaning GENMASK64(39, 21)
+ * gives us the 64-bit mask 0x000000ffffe00000.
+ */
+#define GENMASK64(h, l) (((~UINT64_C(0)) - (UINT64_C(1) << (l)) + 1) & (~UINT64_C(0) >> (UINT64_WIDTH - 1 - (h))))

--- a/quantum/util.h
+++ b/quantum/util.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "bits.h"
 #include "bitwise.h"
 
 // convert to string


### PR DESCRIPTION
## Description

These helpers are handy and can prevent off-by-one errors when working
with registers and general low level bit manipulation tasks. The macros
themself are inspired by the bits.h macros from the linux kernel source
code.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
