### PR TITLE
Update nixpkgs (2024-07-31)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -53,7 +53,7 @@ mkShell {
   name = "qmk-firmware";
 
   buildInputs = [ clang-tools_12 dfu-programmer dfu-util diffutils git pythonEnv niv ]
-    ++ lib.optional avr [
+    ++ lib.optionals avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8
       avrlibc

--- a/shell.nix
+++ b/shell.nix
@@ -52,7 +52,7 @@ in
 mkShell {
   name = "qmk-firmware";
 
-  buildInputs = [ clang-tools_11 dfu-programmer dfu-util diffutils git pythonEnv niv ]
+  buildInputs = [ clang-tools_12 dfu-programmer dfu-util diffutils git pythonEnv niv ]
     ++ lib.optional avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8

--- a/util/nix/pyproject.toml
+++ b/util/nix/pyproject.toml
@@ -8,7 +8,7 @@ description = ""
 authors = []
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 appdirs = "*"
 argcomplete = "*"
 colorama = "*"

--- a/util/nix/sources.json
+++ b/util/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
-        "sha256": "1m6dm144mbm56n9293m26f46bjrklknyr4q4kzvxkiv036ijma98",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
+        "sha256": "1klhr7mrfhrzcqfzngk268jspikbivkxg96x2wncjv1ik3zb8i75",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/98b00b6947a9214381112bdb6f89c25498db4959.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c3392ad349a5227f4a3464dce87bcc5046692fce.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Updates nixpkgs to latest version
* Includes a fix to avrdude that allows using serial devices such as Arduinos as ISP programmers.
* Updates python and all its packages to their latest versions.
* Changes clang-tools to version 12, since version 11 is no longer supported.
* Fixes a minor typo on the nix shell packaging.

This was tested by compiling and flashing my corne keyboard on an x86_64-linux machine.

### Major version changes:
* clang: 11.1.0 -> 12.0.1
* python3: 3.11.7 -> 3.12.4
* python3-setuptools: 69.0.3 -> 70.0.0

### Minor version changes:
* avr-binutils: 2.40 -> 2.42
* avr-libc-avr: 2.1.0 -> 2.2.0
* binutils: 2.40 -> 2.42
* curl: 8.6.0 -> 8.8.0
* gcc: 13.2.0 -> 13.3.0
* glibc: 2.38-44 -> 2.39-52
* libffi: 3.4.4 -> 3.4.6
* python3-importlib-resources: 6.1.1 -> 6.4.0
* sqlite: 3.45.1 -> 3.46.0
* teensy-loader-cli: 2.2 -> 2.3

### Others
These changes listed above seem to be the relevant ones, the rest appear to just be transitive dependencies. Still, here's the full list of changes if someone else wants to double check this.

<details><summary>Full diff</summary>

```
~ acl: 2.3.2 (-600 B)
~ attr: 2.5.2 (-600 B)
~ avr-binutils: 2.40 -> 2.42 (+683.6 KiB)
~ avr-binutils-wrapper: 2.40 -> 2.42 (+1.5 KiB)
~ avr-gcc: 8.5.0 -> 8.5.0-lib (-743.0 MiB)
~ avr-gcc-wrapper: 8.5.0 (+1.5 KiB)
~ avr-libc-avr: 2.1.0 -> 2.2.0 (+74.4 MiB)
~ avrdude: 7.3 (-35.6 KiB)
+ aws-c-auth: 0.7.22 (+365.6 KiB)
+ aws-c-cal: 0.6.15 (+143.6 KiB)
+ aws-c-common: 0.9.23 (+1.0 MiB)
+ aws-c-compression: 0.2.18 (+31.6 KiB)
+ aws-c-event-stream: 0.4.2 (+169.5 KiB)
+ aws-c-http: 0.8.2 (+609.5 KiB)
+ aws-c-io: 0.14.9 (+608.7 KiB)
+ aws-c-mqtt: 0.10.4 (+472.4 KiB)
+ aws-c-s3: 0.6.0 (+340.7 KiB)
+ aws-c-sdkutils: 0.1.16 (+150.3 KiB)
+ aws-checksums: 0.1.18 (+61.7 KiB)
+ aws-crt-cpp: 0.26.12 (+949.6 KiB)
+ aws-sdk-cpp: 1.11.336 (+5.7 MiB)
~ bash: 5.2p26 (-9.7 KiB)
~ binutils: 2.40-lib -> 2.42 (+26.4 MiB)
~ binutils-wrapper: 2.40 -> 2.42 (+424 B)
+ boehm-gc: 8.2.6 (+312.9 KiB)
~ brotli: 1.1.0-lib (+8 KiB)
+ busybox-static-x86_64-unknown-linux-musl: 1.36.1 (+215.9 KiB)
~ bzip2: 1.0.8-bin (-1.1 KiB)
~ clang: 11.1.0-lib -> 12.0.1 (-512.8 MiB)
~ clang-tools: 11.1.0 -> 12.0.1
~ clang-wrapper: 11.1.0 -> 12.0.1 (+456 B)
~ compiler-rt-libc: 11.1.0-dev -> 12.0.1 (+22.2 MiB)
~ coreutils: 9.4 -> 9.5 (-1.2 KiB)
~ curl: 8.6.0 -> 8.8.0 (+22.5 KiB)
~ dfu-programmer: 0.7.2 (+4 KiB)
~ dfu-util: 0.11 (+4 KiB)
~ diffutils: 3.10 (+5.5 KiB)
~ ed: 1.20 -> 1.20.2 (-720 B)
+ editline: 1.17.1 (+54.4 KiB)
+ elfutils: 0.191 (+3.8 MiB)
~ expand-response-params: ∅
~ expat: 2.5.0 -> 2.6.2 (+18.0 KiB)
~ file: 5.45 (-1.1 KiB)
~ findutils: 4.9.0 -> 4.10.0 (+399.9 KiB)
~ freetype: 2.13.2 (+35.8 KiB)
~ gawk: 5.2.2 (+3.3 KiB)
~ gcc: 13.2.0-libgcc -> 13.3.0 (+220.6 MiB)
~ gcc-arm-embedded: 12.3.rel1 (+16 B)
~ gcc-wrapper: 13.2.0 -> 13.3.0 (+456 B)
~ gdbm: 1.23
~ gettext: 0.21.1 (+235.0 KiB)
~ giflib: 5.2.1 -> 5.2.2 (-2 KiB)
~ git: 2.43.0 -> 2.45.2 (+1.8 MiB)
~ glibc: 2.38-44-dev -> 2.39-52-bin (+400.9 KiB)
~ gmp: 6.3.0 (+7.5 KiB)
~ gmp-with-cxx: 6.3.0 (+8 KiB)
~ gnu-config: 2023-09-19 -> 2024-01-01 (+464 B)
~ gnugrep: 3.11 (+3.3 KiB)
~ gnumake: 4.4.1 (+3.3 KiB)
~ gnused: 4.9 (+3.3 KiB)
~ gnutar: 1.35 (+6.7 KiB)
~ gzip: 1.13 (-624 B)
~ hidapi: 0.14.0 (+88 B)
~ isl: 0.20 (+47.5 KiB)
~ keyutils: 1.6.3-lib (+256 B)
~ lcms2: 2.16 (+8 KiB)
+ lerc: 4.0.0 (+840.2 KiB)
+ libarchive: 3.7.4-lib (+899.7 KiB)
~ libcap: 2.69-lib -> 2.70-lib
~ libconfuse: 3.3 (+4 KiB)
+ libcpuid: 0.6.5 (+263.1 KiB)
~ libdeflate: 1.19 -> 1.20 (+32.7 KiB)
- libelf: 0.8.13 (-335.4 KiB)
~ libffi: 3.4.4 -> 3.4.6 (+8 B)
~ libftdi: 1.5 -> 1.5-unstable-2023-12-21 (+24.5 KiB)
~ libidn2: 2.3.7 (+64 B)
~ libimagequant: 4.3.0 -> 4.3.1 (+223.5 KiB)
~ libjpeg-turbo: 3.0.2 -> 3.0.3 (+32.4 KiB)
~ libkrb5: 1.21.2 -> 1.21.3 (+40 KiB)
~ libmpc: 1.3.1 (+3.5 KiB)
~ libpng-apng: 1.6.40 -> 1.6.43 (+7.9 KiB)
~ libpsl: 0.21.5 (-57.7 KiB)
+ libseccomp: 2.5.5-lib (+138.9 KiB)
+ libserialport: 0.1.1 (+134.3 KiB)
+ libsodium: 1.0.20 (+505.6 KiB)
~ libssh2: 1.11.0 (+8 KiB)
~ libtiff: 4.6.0 (+36.2 KiB)
~ libunistring: 1.1 -> 1.2 (+31.2 KiB)
~ libusb: 1.0.27
~ libusb-compat: 0.1.8
~ libwebp: 1.3.2 -> 1.4.0 (+48.7 KiB)
~ libXau: 1.0.11
~ libxcb: 1.16 -> 1.17.0 (+32.9 KiB)
~ libxcrypt: 4.4.36
~ libXdmcp: 1.1.4 -> 1.1.5
~ libxml2: 2.12.4 -> 2.13.2 (+28.4 KiB)
~ linux-headers: 6.7 -> 6.9 (+159.3 KiB)
~ llvm: 11.1.0-lib -> 12.0.1-lib (+30.2 MiB)
+ lowdown: 1.1.0-lib (+279.4 KiB)
~ mailcap: 2.1.53 -> 2.1.54 (+7.1 KiB)
~ mpdecimal: 2.5.1 -> 4.0.0 (-279.1 KiB)
~ mpfr: 4.2.1 (+3.4 KiB)
~ ncurses: 6.4 -> 6.4.20221231 (+13.5 KiB)
~ ncurses-abi5-compat: 6.4 -> 6.4.20221231 (+9.5 KiB)
~ nghttp2: 1.59.0-lib -> 1.62.1-lib (+9.1 KiB)
~ niv: 0.2.22-bin (+1.0 MiB)
+ nix: 2.18.5-man (+562.7 KiB)
~ openjpeg: 2.5.0 -> 2.5.2 (+20.0 KiB)
~ openssl: 3.0.13 -> 3.0.14 (+92.4 KiB)
~ patch: 2.7.6 (+3.3 KiB)
~ patch-shebangs.sh: ∅ (+232 B)
~ patchelf: 0.15.0 (+3.3 KiB)
~ pcre2: 10.42 -> 10.44 (+51.2 KiB)
~ perl: 5.38.2 (+52 KiB)
~ perl5.38.2-Authen-SASL: 2.1700
~ perl5.38.2-CGI: 4.59
~ perl5.38.2-CGI-Fast: 2.16
~ perl5.38.2-Clone: 0.46
~ perl5.38.2-Digest-HMAC: 1.04
~ perl5.38.2-Encode-Locale: 1.05
~ perl5.38.2-FCGI: 0.82
~ perl5.38.2-FCGI-ProcManager: 0.28
~ perl5.38.2-File-Listing: 6.16
~ perl5.38.2-HTML-Parser: 3.81
~ perl5.38.2-HTML-TagCloud: 0.38
~ perl5.38.2-HTML-Tagset: 3.20
~ perl5.38.2-HTTP-CookieJar: 0.014
~ perl5.38.2-HTTP-Cookies: 6.10
~ perl5.38.2-HTTP-Daemon: 6.16
~ perl5.38.2-HTTP-Date: 6.06
~ perl5.38.2-HTTP-Message: 6.45
~ perl5.38.2-HTTP-Negotiate: 6.01
~ perl5.38.2-IO-HTML: 1.004
~ perl5.38.2-IO-Socket-SSL: 2.083
~ perl5.38.2-libnet: 3.15
~ perl5.38.2-libwww-perl: 6.72
~ perl5.38.2-LWP-MediaTypes: 6.04
~ perl5.38.2-Mozilla-CA: 20230821 (+11.7 KiB)
~ perl5.38.2-Net-HTTP: 6.23
~ perl5.38.2-Net-SMTP-SSL: 1.04
~ perl5.38.2-Net-SSLeay: 1.92 (+8 KiB)
~ perl5.38.2-TermReadKey: 2.38
~ perl5.38.2-Test-Fatal: 0.017
~ perl5.38.2-Test-Needs: 0.002010
~ perl5.38.2-Test-RequiresInternet: 0.05
~ perl5.38.2-TimeDate: 2.33
~ perl5.38.2-Try-Tiny: 0.31
~ perl5.38.2-URI: 5.21
~ perl5.38.2-WWW-RobotRules: 6.02
~ publicsuffix-list: 0-unstable-2024-01-07
~ python3: 3.11.7 -> 3.12.4 (-7.3 MiB)
- python3.11-appdirs: 1.4.4 (-95.4 KiB)
- python3.11-argcomplete: 3.2.2 (-309.0 KiB)
- python3.11-attrs: 23.2.0 (-601.9 KiB)
- python3.11-colorama: 0.4.6 (-284.3 KiB)
- python3.11-dotty-dict: 1.3.1 (-59.3 KiB)
- python3.11-flake8: 7.0.0 (-610.3 KiB)
- python3.11-halo: 0.0.31 (-108.7 KiB)
- python3.11-hid: 1.0.6 (-42.0 KiB)
- python3.11-hjson: 3.1.0 (-647.4 KiB)
- python3.11-importlib-metadata: 7.0.1 (-237.7 KiB)
- python3.11-importlib-resources: 6.1.1 (-394.5 KiB)
- python3.11-jsonschema: 4.21.1 (-1.4 MiB)
- python3.11-jsonschema-specifications: 2023.12.1 (-66.1 KiB)
- python3.11-log-symbols: 0.0.14 (-12.1 KiB)
- python3.11-mccabe: 0.7.0 (-60.4 KiB)
- python3.11-milc: 1.8.0 (-261.8 KiB)
- python3.11-nose2: 0.14.1 (-2.5 MiB)
- python3.11-pep8-naming: 0.13.3 (-88.3 KiB)
- python3.11-pillow: 10.2.0 (-4.2 MiB)
- python3.11-platformdirs: 4.2.0 (-255.9 KiB)
- python3.11-pycodestyle: 2.11.1 (-336.1 KiB)
- python3.11-pyflakes: 3.2.0 (-1.1 MiB)
- python3.11-pygments: 2.17.2 (-11.5 MiB)
- python3.11-pyserial: 3.5 (-1.1 MiB)
- python3.11-pyusb: 1.2.1 (-697.2 KiB)
- python3.11-qmk: 1.1.5 (-126.2 KiB)
- python3.11-referencing: 0.33.0 (-431.7 KiB)
- python3.11-rpds-py: 0.18.0 (-736.4 KiB)
- python3.11-setuptools: 69.0.3 (-9.2 MiB)
- python3.11-six: 1.16.0 (-130.6 KiB)
- python3.11-spinners: 0.0.24 (-47.3 KiB)
- python3.11-termcolor: 2.4.0 (-45.2 KiB)
- python3.11-toml: 0.10.2 (-207.0 KiB)
- python3.11-tomli: 2.0.1 (-112.1 KiB)
- python3.11-types-colorama: 0.4.15.20240205 (-13.6 KiB)
- python3.11-yapf: 0.40.2 (-3.3 MiB)
- python3.11-zipp: 3.17.0 (-67.2 KiB)
+ python3.12-appdirs: 1.4.4 (+92.1 KiB)
+ python3.12-argcomplete: 3.2.2 (+291.3 KiB)
+ python3.12-attrs: 23.2.0 (+569.0 KiB)
+ python3.12-colorama: 0.4.6 (+265.1 KiB)
+ python3.12-dotty-dict: 1.3.1 (+55.5 KiB)
+ python3.12-flake8: 7.0.0 (+580.8 KiB)
+ python3.12-halo: 0.0.31 (+103.8 KiB)
+ python3.12-hid: 1.0.6 (+43.4 KiB)
+ python3.12-hjson: 3.1.0 (+600.5 KiB)
+ python3.12-importlib-metadata: 7.0.1 (+220.1 KiB)
+ python3.12-importlib-resources: 6.4.0 (+425.0 KiB)
+ python3.12-jsonschema: 4.21.1 (+1.3 MiB)
+ python3.12-jsonschema-specifications: 2023.12.1 (+65.1 KiB)
+ python3.12-log-symbols: 0.0.14 (+11.8 KiB)
+ python3.12-mccabe: 0.7.0 (+56.2 KiB)
+ python3.12-milc: 1.8.0 (+251.8 KiB)
+ python3.12-nose2: 0.14.1 (+2.3 MiB)
+ python3.12-pep8-naming: 0.13.3 (+84.6 KiB)
+ python3.12-pillow: 10.2.0 (+4.1 MiB)
+ python3.12-platformdirs: 4.2.0 (+246.1 KiB)
+ python3.12-pycodestyle: 2.11.1 (+315.6 KiB)
+ python3.12-pyflakes: 3.2.0 (+1.0 MiB)
+ python3.12-pygments: 2.17.2 (+11.3 MiB)
+ python3.12-pyserial: 3.5 (+1.0 MiB)
+ python3.12-pyusb: 1.2.1 (+671.0 KiB)
+ python3.12-qmk: 1.1.5 (+120.5 KiB)
+ python3.12-referencing: 0.33.0 (+398.4 KiB)
+ python3.12-rpds-py: 0.18.0 (+1000.0 KiB)
+ python3.12-setuptools: 70.0.0 (+9.1 MiB)
+ python3.12-six: 1.16.0 (+120.6 KiB)
+ python3.12-spinners: 0.0.24 (+45.4 KiB)
+ python3.12-termcolor: 2.4.0 (+42.8 KiB)
+ python3.12-toml: 0.10.2 (+184.8 KiB)
+ python3.12-tomli: 2.0.1 (+103.1 KiB)
+ python3.12-types-colorama: 0.4.15.20240205 (+13.6 KiB)
+ python3.12-yapf: 0.40.2 (+3.2 MiB)
+ python3.12-zipp: 3.17.0 (+63.8 KiB)
~ qmk-firmware: ∅ (+24 B)
~ readline: 8.2p10 (+4 KiB)
+ s2n-tls: 1.4.17 (+1.2 MiB)
~ set-source-date-epoch-to-latest.sh: ∅ (+200 B)
~ sqlite: 3.45.1 -> 3.46.0 (+45.0 KiB)
~ stdenv-linux: ∅ (+3.2 KiB)
~ strip.sh: ∅ (+328 B)
~ systemd-minimal-libs: 255.2-dev -> 256.2-dev (+1.5 KiB)
~ teensy-loader-cli: 2.2 -> 2.3
~ tzdata: 2024a
~ update-autotools-gnu-config-scripts-hook: ∅
~ xgcc: 13.2.0-libgcc -> 13.3.0-libgcc (-528 B)
~ xz: 5.4.6 -> 5.6.2-bin (-613.2 KiB)
~ zlib: 1.3.1 (-520 B)
~ zstd: 1.5.5 -> 1.5.6 (+20.3 KiB)
```

</details>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None, since I noticed the issue with avrdude and Arduino ISP and saw that the fix was a simple update, so I just took the liberty to do it directly. I can open an issue for reference if needed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
