### PR TITLE
Fix RGBW not turning off when saturation is set to `0`.

### DIFF
--- a/quantum/color.c
+++ b/quantum/color.c
@@ -115,9 +115,9 @@ void convert_rgb_to_rgbw(rgb_led_t *led) {
     // the white channel and then shift all colors by that amount
     if (led->r == led->g && led->r == led->b) {
         led->w = led->r;
-        led->r -= 0;
-        led->g -= 0;
-        led->b -= 0;
+        led->r = 0;
+        led->g = 0;
+        led->b = 0;
     } else {
         led->w = MIN(led->r, MIN(led->g, led->b));
         led->r -= led->w;

--- a/quantum/color.c
+++ b/quantum/color.c
@@ -115,9 +115,6 @@ void convert_rgb_to_rgbw(rgb_led_t *led) {
     // the white channel and then shift all colors by that amount
     if (led->r == led->g && led->r == led->b) {
         led->w = led->r;
-        led->r = 0;
-        led->g = 0;
-        led->b = 0;
     } else {
         led->w = MIN(led->r, MIN(led->g, led->b));
         led->r -= led->w;

--- a/quantum/color.c
+++ b/quantum/color.c
@@ -113,9 +113,16 @@ RGB hsv_to_rgb_nocie(HSV hsv) {
 void convert_rgb_to_rgbw(rgb_led_t *led) {
     // Determine lowest value in all three colors, put that into
     // the white channel and then shift all colors by that amount
-    led->w = MIN(led->r, MIN(led->g, led->b));
-    led->r -= led->w;
-    led->g -= led->w;
-    led->b -= led->w;
+    if (led->r == led->g && led->r == led->b) {
+        led->w = led->r;
+        led->r -= 0;
+        led->g -= 0;
+        led->b -= 0;
+    } else {
+        led->w = MIN(led->r, MIN(led->g, led->b));
+        led->r -= led->w;
+        led->g -= led->w;
+        led->b -= led->w;
+    }
 }
 #endif


### PR DESCRIPTION
(Temporary?) Fix for RGBW not turning off when saturation is set to `0`.

## Description

Using RGB_MATRIX and RGBW LED's, when any LED's are set to `0` saturation, they won't turn off when toggled/timeout/sleep.

_Warning:_ My white LED shines much brighter now when set to `0` saturation and true white (instead of RGB array white), this resulted in my keyboard pulling about 30% more power when the full keyboard LEDs are set to white. Had to turn down maximum brightness accordingly (which would also limit your RGB LED brightness). _Future PR for separate RGB maximum brightness and W maximum brightness perhaps?_

Code credited to @drashna .

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
