### PR TITLE
[Core] chibios: usb_main: remove OTG sof workaround

### DIFF
--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -325,18 +325,10 @@ static bool usb_requests_hook_cb(USBDriver *usbp) {
     return false;
 }
 
-static __attribute__((unused)) void dummy_cb(USBDriver *usbp) {
-    (void)usbp;
-}
-
 static const USBConfig usbcfg = {
     usb_event_cb,          /* USB events callback */
     usb_get_descriptor_cb, /* Device GET_DESCRIPTOR request callback */
     usb_requests_hook_cb,  /* Requests hook callback */
-#if STM32_USB_USE_OTG1 == TRUE || STM32_USB_USE_OTG2 == TRUE
-    dummy_cb, /* Workaround for OTG Peripherals not servicing new interrupts
-    after resuming from suspend. */
-#endif
 };
 
 void init_usb_driver(USBDriver *usbp) {


### PR DESCRIPTION
## Description

Depends on #24714 being merged

With the update of ChibiOS containing fixes for the OTGv1 LLD the workaround is not necessary anymore.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
