### PR TITLE
fix: corne oled modifiers

### DIFF
--- a/keyboards/splitkb/aurora/corne/corne.c
+++ b/keyboards/splitkb/aurora/corne/corne.c
@@ -85,7 +85,7 @@ static void render_mod_status_gui_alt(uint8_t modifiers) {
         oled_write_P(gui_off_2, false);
     }
 
-    if (modifiers & MOD_MASK_GUI & MOD_MASK_ALT) {
+    if ((modifiers & MOD_MASK_GUI) && (modifiers & MOD_MASK_ALT)) {
         oled_write_P(on_on_2, false);
     } else if(modifiers & MOD_MASK_GUI) {
         oled_write_P(on_off_2, false);
@@ -151,7 +151,7 @@ static void render_mod_status_ctrl_shift(uint8_t modifiers) {
         oled_write_P(ctrl_off_2, false);
     }
 
-    if (modifiers & MOD_MASK_CTRL & MOD_MASK_SHIFT) {
+    if ((modifiers & MOD_MASK_CTRL) && (modifiers & MOD_MASK_SHIFT)) {
         oled_write_P(on_on_2, false);
     } else if(modifiers & MOD_MASK_CTRL) {
         oled_write_P(on_off_2, false);


### PR DESCRIPTION
There is a bug causing a visual glitch when multiple modifiers are pressed at the same time

## Description
Fix it

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None, I created the PR without issues first

## Checklist
Does not apply

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
