### PR TITLE
Tweak OS detection, add set_single_default_layer

### DIFF
--- a/docs/feature_layers.md
+++ b/docs/feature_layers.md
@@ -74,6 +74,7 @@ There are a number of functions (and variables) related to how you can use or ma
 | `default_layer_and(layer_mask)`              | Turns on layers based on matching enabled bits between specifed layer and existing default layer state. |
 | `default_layer_xor(layer_mask)`              | Turns on layers based on non-matching bits between specifed layer and existing default layer state.     |
 | `default_layer_debug(layer_mask)`            | Prints out the current bit mask and highest active default layer to debugger console.                   |
+| [`set_single_default_layer(layer)`](ref_functions.md#setting-the-persistent-default-layer)            | Sets the default layer, but does _not_ write it to persistent memory (EEPROM). | 
 | [`set_single_persistent_default_layer(layer)`](ref_functions.md#setting-the-persistent-default-layer) | Sets the default layer and writes it to persistent memory (EEPROM).  |
 | [`update_tri_layer(x, y, z)`](ref_functions.md#update_tri_layerx-y-z) | Checks if layers `x` and `y` are both on, and sets `z` based on that (on if both on, otherwise off). |
 | [`update_tri_layer_state(state, x, y, z)`](ref_functions.md#update_tri_layer_statestate-x-y-z) | Does the same as `update_tri_layer(x, y, z)`, but from `layer_state_set_*` functions. |

--- a/docs/features/os_detection.md
+++ b/docs/features/os_detection.md
@@ -77,10 +77,12 @@ If your keyboard does not redetect the OS in this situation, you can force the k
 
 ## Configuration Options
 
-* `#define OS_DETECTION_DEBOUNCE 200`
+* `#define OS_DETECTION_DEBOUNCE 250`
   * defined the debounce time for OS detection, in milliseconds
 * `#define OS_DETECTION_KEYBOARD_RESET`
   * enables the keyboard reset upon a USB device reinitilization, such as switching devices on some KVMs
+* `#define OS_DETECTION_MULTI_REPORT`
+  * allows the callbacks to be called after the first report in case the detected OS changes afterwards
 
 ## Debug
 

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -69,7 +69,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 Do you want to set the default layer, so that it's retained even after you unplug the board?  If so, this is the function for you.
 
-To use this, you would use `set_single_persistent_default_layer(layer)`.  If you have a name defined for your layer, you can use that instead (such as _QWERTY, _DVORAK or _COLEMAK).
+To do this, you would use `set_single_persistent_default_layer(layer)`.  If you have a name defined for your layer, you can use that instead (such as _QWERTY, _DVORAK or _COLEMAK).
 
 This will set the default layer, update the persistent settings, and play a tune if you have [Audio](features/audio) enabled on your board, and the default layer sounds set.
 
@@ -81,6 +81,8 @@ To configure the default layer sounds, you would want to define this in your `co
                               SONG(DVORAK_SOUND) \
                             }
 ```
+
+If you do not require it to be retained after you unplug the board, use `set_single_default_layer(layer)` instead.
 
 
 ::: tip

--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -34,7 +34,7 @@ static uint16_t usb_setups[STORED_USB_SETUPS];
 #endif
 
 #ifndef OS_DETECTION_DEBOUNCE
-#    define OS_DETECTION_DEBOUNCE 200
+#    define OS_DETECTION_DEBOUNCE 250
 #endif
 
 // 2s should always be more than enough (otherwise, you may have other issues)
@@ -59,28 +59,32 @@ struct setups_data_t setups_data = {
 };
 
 static volatile os_variant_t detected_os = OS_UNSURE;
-static os_variant_t          reported_os = OS_UNSURE;
+#ifdef OS_DETECTION_MULTI_REPORT
+static volatile os_variant_t reported_os = OS_UNSURE;
+#endif
 
 // we need to be able to report OS_UNSURE if that is the stable result of the guesses
-static bool first_report = true;
+static volatile bool first_report = true;
 
 // to react on USB state changes
-static volatile enum usb_device_state current_usb_device_state  = USB_DEVICE_STATE_INIT;
-static enum usb_device_state          reported_usb_device_state = USB_DEVICE_STATE_INIT;
+static volatile enum usb_device_state current_usb_device_state = USB_DEVICE_STATE_INIT;
 
 // the OS detection might be unstable for a while, "debounce" it
 static volatile bool         debouncing = false;
-static volatile fast_timer_t last_time;
+static volatile fast_timer_t last_time  = 0;
 
 void os_detection_task(void) {
     if (current_usb_device_state == USB_DEVICE_STATE_CONFIGURED) {
         // debouncing goes for both the detected OS as well as the USB state
         if (debouncing && timer_elapsed_fast(last_time) >= OS_DETECTION_DEBOUNCE) {
-            debouncing                = false;
-            reported_usb_device_state = current_usb_device_state;
+            debouncing = false;
+#ifdef OS_DETECTION_MULTI_REPORT
             if (detected_os != reported_os || first_report) {
+                reported_os = detected_os;
+#else
+            if (first_report) {
+#endif
                 first_report = false;
-                reported_os  = detected_os;
                 process_detected_host_os_kb(detected_os);
             }
         }
@@ -88,7 +92,7 @@ void os_detection_task(void) {
 #ifdef OS_DETECTION_KEYBOARD_RESET
     // resetting the keyboard on the USB device state change callback results in instability, so delegate that to this task
     // only take action if it's been stable at least once, to avoid issues with some KVMs
-    else if (current_usb_device_state == USB_DEVICE_STATE_INIT && reported_usb_device_state != USB_DEVICE_STATE_INIT) {
+    else if (current_usb_device_state == USB_DEVICE_STATE_INIT && !first_report) {
         soft_reset_keyboard();
     }
 #endif
@@ -155,12 +159,14 @@ os_variant_t detected_host_os(void) {
 
 void erase_wlength_data(void) {
     memset(&setups_data, 0, sizeof(setups_data));
-    detected_os               = OS_UNSURE;
-    reported_os               = OS_UNSURE;
-    current_usb_device_state  = USB_DEVICE_STATE_INIT;
-    reported_usb_device_state = USB_DEVICE_STATE_INIT;
-    debouncing                = false;
-    first_report              = true;
+    detected_os = OS_UNSURE;
+#ifdef OS_DETECTION_MULTI_REPORT
+    reported_os = OS_UNSURE;
+#endif
+    current_usb_device_state = USB_DEVICE_STATE_INIT;
+    debouncing               = false;
+    last_time                = 0;
+    first_report             = true;
 }
 
 void os_detection_notify_usb_device_state_change(enum usb_device_state usb_device_state) {

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -486,6 +486,13 @@ bool process_record_quantum(keyrecord_t *record) {
     return process_action_kb(record);
 }
 
+void set_single_default_layer(uint8_t default_layer) {
+#if defined(AUDIO_ENABLE) && defined(DEFAULT_LAYER_SONGS)
+    PLAY_SONG(default_layer_songs[default_layer]);
+#endif
+    default_layer_set((layer_state_t)1 << default_layer);
+}
+
 void set_single_persistent_default_layer(uint8_t default_layer) {
 #if defined(AUDIO_ENABLE) && defined(DEFAULT_LAYER_SONGS)
     PLAY_SONG(default_layer_songs[default_layer]);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -240,6 +240,7 @@ extern layer_state_t layer_state;
 #    include "os_detection.h"
 #endif
 
+void set_single_default_layer(uint8_t default_layer);
 void set_single_persistent_default_layer(uint8_t default_layer);
 
 #define IS_LAYER_ON(layer) layer_state_is(layer)


### PR DESCRIPTION
## Description

* `OS_DETECTION_DEBOUNCE` bumped from 200 to 250
* Add `OS_DETECTION_MULTI_REPORT` to control multiple reports
* Default is now a single report, unless multiple is enabled
* Prevents cases of instability when USB events are a bit funky
* Works for every device I could test, including ARM MacBooks
* Add `set_single_default_layer` to match `set_single_persistent_default_layer`

## Types of Changes

- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
