### PR TITLE
fix(docs): add missing file extension to CLI console link

### DIFF
--- a/docs/faq_debug.md
+++ b/docs/faq_debug.md
@@ -26,7 +26,7 @@ For compatible platforms, [QMK Toolbox](https://github.com/qmk/qmk_toolbox) can 
 
 ### Debugging with QMK CLI
 
-Prefer a terminal based solution? The [QMK CLI console command](cli_commands#qmk-console) can be used to display debug messages from your keyboard.
+Prefer a terminal based solution? The [QMK CLI console command](cli_commands.md#qmk-console) can be used to display debug messages from your keyboard.
 
 ### Debugging With hid_listen
 


### PR DESCRIPTION
## Description

Added the missing `.md` file extension to the CLI console link in the `faq_debug.md` document. This ensures that the link correctly points to the intended section in the documentation.

## Types of Changes

- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
