### PR TITLE
Added support for STM32F103 + STM32duino-bootloader with 16 MHz HSE

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -231,6 +231,7 @@
                 "rp2040",
                 "stm32-dfu",
                 "stm32duino",
+                "stm32duino_16mhz",
                 "tinyuf2",
                 "uf2boot",
                 "unknown",

--- a/platforms/chibios/boards/STM32_F103_STM32DUINO/board/board.h
+++ b/platforms/chibios/boards/STM32_F103_STM32DUINO/board/board.h
@@ -31,7 +31,12 @@
  * Board frequencies.
  */
 #define STM32_LSECLK            32768
+
+#if defined(STM32_HSE_16MHZ)    /* user selected 16 MHz HSE */
+#define STM32_HSECLK            16000000
+#else                           /* assume 8 MHz HSE */
 #define STM32_HSECLK            8000000
+#endif
 
 /*
  * MCU type, supported types are defined in ./os/hal/platforms/hal_lld.h.

--- a/platforms/chibios/boards/STM32_F103_STM32DUINO/configs/mcuconf.h
+++ b/platforms/chibios/boards/STM32_F103_STM32DUINO/configs/mcuconf.h
@@ -43,7 +43,13 @@
 #define STM32_LSE_ENABLED                   FALSE
 #define STM32_SW                            STM32_SW_PLL
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
+
+#if defined(STM32_HSE_16MHZ)                /* user selected 16 MHz HSE */
+#define STM32_PLLXTPRE                      STM32_PLLXTPRE_DIV2
+#else                                       /* assume 8 MHz HSE */
 #define STM32_PLLXTPRE                      STM32_PLLXTPRE_DIV1
+#endif
+
 #define STM32_PLLMUL_VALUE                  9
 #define STM32_HPRE                          STM32_HPRE_DIV1
 #define STM32_PPRE1                         STM32_PPRE1_DIV2

--- a/platforms/chibios/bootloader.mk
+++ b/platforms/chibios/bootloader.mk
@@ -100,6 +100,16 @@ ifeq ($(strip $(BOOTLOADER)), stm32duino)
     DFU_ARGS = -d 1EAF:0003 -a 2 -R
     DFU_SUFFIX_ARGS = -v 1EAF -p 0003
 endif
+ifeq ($(strip $(BOOTLOADER)), stm32duino_16mhz)
+    OPT_DEFS += -DBOOTLOADER_STM32DUINO -DSTM32_HSE_16MHZ
+    BOARD = STM32_F103_STM32DUINO
+    BOOTLOADER = stm32duino
+    BOOTLOADER_TYPE = stm32duino
+
+    # Options to pass to dfu-util when flashing
+    DFU_ARGS = -d 1EAF:0003 -a 2 -R
+    DFU_SUFFIX_ARGS = -v 1EAF -p 0003
+endif
 ifeq ($(strip $(BOOTLOADER)), tinyuf2)
     OPT_DEFS += -DBOOTLOADER_TINYUF2
     BOOTLOADER_TYPE = tinyuf2


### PR DESCRIPTION
This PR adds support for STM32F103 + STM32duino-bootloader with an 16 MHz HSE (since the existing QMK version assumes 8 MHz.)

In order to use this feature, the user must use "stm32duino_16mhz" as the "bootloader" in keyboard.json or info.json, instead of "stm32duino".

I tested this code (and my keyboard layout) on my 16 MHz STM32F103 board and it works.

## Description

I have a a pair of custom keyboard PCBs with an STM32F103C8 MCU. One of them has an 8 MHz crystal and the other has an 16 MHz crystal.

The 8 MHz crystal works with QMK + STM32duino bootloader out of the box, but getting the 16 MHz crystal to work requires changing 2 QMK files. Something like:

```c
// platforms/chibios/boards/STM32_F103_STM32DUINO/board/board.h
#if defined(STM32_HSE_16MHZ)    /* user selected 16 MHz HSE */
#define STM32_HSECLK            16000000
#else                           /* assume 8 MHz HSE */
#define STM32_HSECLK            8000000
#endif
```

```c
// platforms/chibios/boards/STM32_F103_STM32DUINO/configs/mcuconf.h
#if defined(STM32_HSE_16MHZ)                /* user selected 16 MHz HSE */
#define STM32_PLLXTPRE                      STM32_PLLXTPRE_DIV2
#else                                       /* assume 8 MHz HSE */
#define STM32_PLLXTPRE                      STM32_PLLXTPRE_DIV1
#endif
```

Then `#define STM32_HSE_16MHZ` somewhere visible to both files.

And then in the keyboard layout's directory the user can set the bootloader in `keyboard.json` as:

```
"bootloader": "stm32duino_16mhz"
```

Making this work requires a few more changes.  
However, in particular, it doesn't require adding a whole new bootloader. You just need to pass the necessary `#define` to the `stm32duino` bootloader (with the changes outlined aboved).

This pull request implements all of this.

(Notice that [STM32duino-bootloader](https://github.com/rogerclarkmelbourne/STM32duino-bootloader) itself needs to be recompiled with support for a 16 MHz crystal. You can do this by, say, adding `#define XTAL16M` in a valid place, like `config.h`. But that's clearly outside the scope of this PR.)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
