### PR TITLE
Install `dnf copr` plugin if not present (i.e. docker containers).

### DIFF
--- a/util/install/fedora.sh
+++ b/util/install/fedora.sh
@@ -5,6 +5,7 @@ _qmk_install() {
 
     . /etc/os-release
     if [ "$VERSION_ID" -ge "39" ]; then
+        sudo dnf $SKIP_PROMPT copr -h >/dev/null 2>&1 || sudo dnf $SKIP_PROMPT install dnf-plugins-core
         sudo dnf $SKIP_PROMPT copr enable erovia/dfu-programmer
     fi
 

--- a/util/install/fedora.sh
+++ b/util/install/fedora.sh
@@ -5,7 +5,7 @@ _qmk_install() {
 
     . /etc/os-release
     if [ "$VERSION_ID" -ge "39" ]; then
-        sudo dnf $SKIP_PROMPT copr -h >/dev/null 2>&1 || sudo dnf $SKIP_PROMPT install dnf-plugins-core
+        sudo dnf copr -h >/dev/null 2>&1 || sudo dnf $SKIP_PROMPT install dnf-plugins-core
         sudo dnf $SKIP_PROMPT copr enable erovia/dfu-programmer
     fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As per title. Toolchain installation won't proceed if a package for `dfu-programmer` isn't found, but the install script still continues without flagging an error.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
