### PR TITLE
Fix build failure on zsa/moonlander with DYNAMIC_MACRO_ENABLE

### DIFF
--- a/keyboards/zsa/moonlander/moonlander.c
+++ b/keyboards/zsa/moonlander/moonlander.c
@@ -44,7 +44,7 @@ bool dynamic_macro_record_start_kb(int8_t direction) {
         ML_LED_3(true);
         dynamic_macro_token = defer_exec(100, dynamic_macro_led, NULL);
     }
-    return true
+    return true;
 }
 
 bool dynamic_macro_record_end_kb(int8_t direction) {
@@ -55,7 +55,7 @@ bool dynamic_macro_record_end_kb(int8_t direction) {
         dynamic_macro_token = INVALID_DEFERRED_TOKEN;
         ML_LED_3(false);
     }
-    return false
+    return false;
 }
 #    endif
 


### PR DESCRIPTION
## Description

In current `develop`, `zsa/moonlander` fails to build if `DEFERRED_EXEC_ENABLE` and `DYNAMIC_MACRO_ENABLE` are both defined:

```
keyboards/zsa/moonlander/moonlander.c: In function 'dynamic_macro_record_start_kb':
keyboards/zsa/moonlander/moonlander.c:48:1: error: expected ';' before '}' token
   48 | }
      | ^
keyboards/zsa/moonlander/moonlander.c: In function 'dynamic_macro_record_end_kb':
keyboards/zsa/moonlander/moonlander.c:59:1: error: expected ';' before '}' token
   59 | }
      | ^
```

Semicolons are actually missing from the preceding lines, which read
```c
return true
```
and
```c
return false
```
and this PR fixes the build.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
