### PR TITLE
Make PS2 mouse reset configurable

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -129,6 +129,7 @@
     // PS/2
     "PS2_CLOCK_PIN": {"info_key": "ps2.clock_pin"},
     "PS2_DATA_PIN": {"info_key": "ps2.data_pin"},
+    "PS2_MOUSE_DISABLE_RESET": {"info_key": "ps2.no_mouse_reset", "value_type": "bool"},
 
     // RGB Matrix
     "RGB_MATRIX_CENTER": {"info_key": "rgb_matrix.center_point", "value_type": "array.int"},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -752,6 +752,7 @@
                     "type": "string",
                     "enum": ["busywait", "interrupt", "usart", "vendor"]
                 }
+                "no_mouse_reset": {"type": "boolean"},
             }
         },
         "split": {

--- a/docs/features/ps2_mouse.md
+++ b/docs/features/ps2_mouse.md
@@ -347,3 +347,26 @@ a layer.  To use, define the following function in your keymap:
 ```c
 void ps2_mouse_moved_user(report_mouse_t *mouse_report);
 ```
+
+### PS/2 device fails to initialize {#ps2-device-fails-to-initialize}
+
+Some PS/2 pointer devices (specifically, Logitech T-SBC12-CPQ Trackball, which is
+installed in Compaq MX-11800 keyboard) may do not work if "Reset" command is sent
+during the init sequence.
+
+To make the things working without hacking PS/2 driver, the following configuration
+option is available:
+
+```c
+#define PS2_MOUSE_DISABLE_RESET
+```
+
+The same for data-driver JSON config:
+
+```json
+    "ps2": {
+        ...
+        "no_mouse_reset": true,
+        ...
+    }
+```

--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -514,6 +514,9 @@ Configures the [PS/2](features/ps2_mouse) feature.
     * `mouse_enabled`
         * Enable the PS/2 mouse handling.
         * Default: `false`
+    * `no_mouse_reset`
+        * Disable sending "Reset" command in PS/2 mouse init sequence.
+        * Default: `false`
 
 ## QMK LUFA Bootloader {#qmk-lufa-bootloader}
 

--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -44,7 +44,9 @@ void ps2_mouse_init(void) {
 
     wait_ms(PS2_MOUSE_INIT_DELAY); // wait for powering up
 
+#ifndef PS2_MOUSE_DISABLE_RESET
     PS2_MOUSE_SEND(PS2_MOUSE_RESET, "ps2_mouse_init: sending reset");
+#endif
 
     PS2_MOUSE_RECEIVE("ps2_mouse_init: read BAT");
     PS2_MOUSE_RECEIVE("ps2_mouse_init: read DevID");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

For some reason, PS/2 mouse reset which is sent during PS2 mouse init sequence makes some PS2 pointing devices completely non-functional (specifically, Logitech T-SBC12-CPQ Trackball, which is installed in Compaq MX-11800 keyboard). I have confirmed with logic analyzer that two PS/2 host devices I was able to test (desktop PC and cheap Aliexpress PS/2 adapter) are not sending the "Reset" command, so the trackball is working.

This change is targeted to add the option to disable reset in PS2 mouse sequence in order to make the trackball in Compaq MX-11800 working and do not break other keyboards with PS2 pointing devices.

After this change I plan to add support of the Compaq MX-11800 keyboard I'm working on in my fork. Actually, it was ready and has been working as my main keyboard for over half a year, I just was too lazy to prepare the docs for a PR :)

I would appreciate any ideas on how to overcome the reset issue (in either software or hardware way) without QMK core modification.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
