### PR TITLE
Reject via keymaps in lint

### DIFF
--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -14,15 +14,16 @@ from qmk.c_parse import c_source_files
 
 CHIBIOS_CONF_CHECKS = ['chconf.h', 'halconf.h', 'mcuconf.h', 'board.h']
 INVALID_KB_FEATURES = set(['encoder_map', 'dip_switch_map', 'combo', 'tap_dance', 'via'])
+INVALID_KM_NAMES = ['via', 'vial']
 
 
 def _list_defaultish_keymaps(kb):
     """Return default like keymaps for a given keyboard
     """
-    defaultish = ['ansi', 'iso', 'via']
+    defaultish = ['ansi', 'iso']
 
     # This is only here to flag it as "testable", so it doesn't fly under the radar during PR
-    defaultish.append('vial')
+    defaultish.extend(INVALID_KM_NAMES)
 
     keymaps = set()
     for x in list_keymaps(kb):
@@ -134,6 +135,11 @@ def keymap_check(kb, km):
     if not keymap_path:
         ok = False
         cli.log.error("%s: Can't find %s keymap.", kb, km)
+        return ok
+
+    if km in INVALID_KM_NAMES:
+        ok = False
+        cli.log.error("%s: The keymap %s should not exist!", kb, km)
         return ok
 
     # Additional checks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Shorter term change to follow #24322 and catch 'via' keymaps in keyboard PRs.

Rejecting arbitrary keymaps that have the via feature enabled in `rules.mk`/`keymap.json` will follow later,.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
