### PR TITLE
Changelog update with actual `qmk_userspace_via` link.

### DIFF
--- a/docs/ChangeLog/20240825.md
+++ b/docs/ChangeLog/20240825.md
@@ -4,7 +4,7 @@
 
 August 2024 brings another maintenance release of QMK. Almost all PRs this cycle were to do with cleanup or re-organization of existing features and code.
 
-One key item is that there are no longer any `via`-enabled keymaps in the QMK repository -- these have all transitioned to an [External Userspace](../newbs_external_userspace) repository under the VIA team's control. Going forward, all PRs to `qmk_firmware` must not contain `via` keymaps; these should instead be redirected to the the VIA team's repo: `https://github.com/the-via/qmk_userspace_via` (link placeholder until transfer is completed).
+One key item is that there are no longer any `via`-enabled keymaps in the QMK repository -- these have all transitioned to an [External Userspace](../newbs_external_userspace) repository under the VIA team's control. Going forward, all PRs to `qmk_firmware` must not contain `via` keymaps; these should instead be redirected to the [VIA QMK Userspace](https://github.com/the-via/qmk_userspace_via) repository.
 
 ## Changes Requiring User Action
 
@@ -76,7 +76,7 @@ In line with the [notice period](../support_deprecation_policy#how-much-advance-
 
 ### Migration of VIA keymaps to VIA team control
 
-Last breaking changes cycle, the QMK team informed that [`via` keymaps are moving](./20240526#migration-of-via-keymaps-to-via-team-control) to the control of the VIA team. As of this merge, any `via`-enabled keymaps should now be PR'ed to `https://github.com/the-via/qmk_userspace_via` (link placeholder until transfer is completed).
+Last breaking changes cycle, the QMK team informed that [`via` keymaps are moving](./20240526#migration-of-via-keymaps-to-via-team-control) to the control of the VIA team. As of this merge, any `via`-enabled keymaps should now be PR'ed to the [VIA QMK Userspace](https://github.com/the-via/qmk_userspace_via) repository.
 
 Any existing or newly-opened PRs against `qmk_firmware` will now be asked to remove any `via`-enabled keymaps from their submissions.
 


### PR DESCRIPTION
As per title. As discussed on Discord.