### PR TITLE
doc: "docker getting started" mentions `flash` limitations

### DIFF
--- a/docs/getting_started_docker.md
+++ b/docs/getting_started_docker.md
@@ -34,7 +34,7 @@ util/docker_build.sh keyboard:keymap:target
 # For example: util/docker_build.sh planck/rev6:default:flash
 ```
 
-Note that mass storage bootloader are not supported by the `flash` target. In this case you have to manually copy over the firmware file to the keyboard.
+Note that mass storage bootloaders are not supported by the `flash` target. In this case you will have to manually copy the firmware file to the keyboard.
 
 You can also start the script without any parameters, in which case it will ask you to input the build parameters one by one, which you may find easier to use:
 

--- a/docs/getting_started_docker.md
+++ b/docs/getting_started_docker.md
@@ -5,6 +5,7 @@ This project includes a Docker workflow that will allow you to build a new firmw
 ## Requirements
 
 The main prerequisite is a working `docker` or `podman` install.
+
 * [Docker CE](https://docs.docker.com/install/#supported-platforms)
 * [Podman](https://podman.io/getting-started/installation)
 
@@ -18,6 +19,7 @@ cd qmk_firmware
 ```
 
 Run the following command to build a keymap:
+
 ```
 util/docker_build.sh <keyboard>:<keymap>
 # For example: util/docker_build.sh planck/rev6:default
@@ -31,6 +33,8 @@ There is also support for building _and_ flashing the keyboard straight from Doc
 util/docker_build.sh keyboard:keymap:target
 # For example: util/docker_build.sh planck/rev6:default:flash
 ```
+
+Note that mass storage bootloader are not supported by the `flash` target. In this case you have to manually copy over the firmware file to the keyboard.
 
 You can also start the script without any parameters, in which case it will ask you to input the build parameters one by one, which you may find easier to use:
 


### PR DESCRIPTION
## Description

Little doc improvement for the docker getting started guide as result of a discussion on discord.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

none 

## Checklist


- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
