### PR TITLE
High resolution scrolling and extended mouse wheel reports

### DIFF
--- a/quantum/pointing_device/pointing_device.h
+++ b/quantum/pointing_device/pointing_device.h
@@ -25,6 +25,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "pointing_device_auto_mouse.h"
 #endif
 
+#ifdef POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_ENABLE
+#    ifdef POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_MULTIPLIER
+#        if POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_MULTIPLIER > 127 || POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_MULTIPLIER < 1
+#             error "POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_MULTIPLIER must be between 1 and 127, inclusive!"
+#        endif
+#    else
+#        define POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_MULTIPLIER 120
+#    endif
+#    ifdef POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_EXPONENT
+#        if POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_EXPONENT > 127 || POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_EXPONENT < 1
+#            error "POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_EXPONENT must be between 1 and 127, inclusive!"
+#        endif
+#    else
+#        define POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_EXPONENT 0
+#    endif
+#endif
+
 #if defined(POINTING_DEVICE_DRIVER_adns5050)
 #    include "drivers/sensors/adns5050.h"
 #    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -199,6 +199,12 @@ typedef int16_t mouse_xy_report_t;
 typedef int8_t mouse_xy_report_t;
 #endif
 
+#ifdef WHEEL_EXTENDED_REPORT
+typedef int16_t mouse_vh_report_t;
+#else
+typedef int8_t mouse_vh_report_t;
+#endif
+
 typedef struct {
 #ifdef MOUSE_SHARED_EP
     uint8_t report_id;
@@ -210,8 +216,8 @@ typedef struct {
 #endif
     mouse_xy_report_t x;
     mouse_xy_report_t y;
-    int8_t            v;
-    int8_t            h;
+    mouse_vh_report_t v;
+    mouse_vh_report_t h;
 } PACKED report_mouse_t;
 
 typedef struct {

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -155,21 +155,55 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
 #    endif
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
-            // Vertical wheel (1 byte)
-            HID_RI_USAGE(8, 0x38),         // Wheel
-            HID_RI_LOGICAL_MINIMUM(8, -127),
-            HID_RI_LOGICAL_MAXIMUM(8, 127),
-            HID_RI_REPORT_COUNT(8, 0x01),
-            HID_RI_REPORT_SIZE(8, 0x08),
-            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
-            // Horizontal wheel (1 byte)
-            HID_RI_USAGE_PAGE(8, 0x0C),    // Consumer
-            HID_RI_USAGE(16, 0x0238),      // AC Pan
-            HID_RI_LOGICAL_MINIMUM(8, -127),
-            HID_RI_LOGICAL_MAXIMUM(8, 127),
-            HID_RI_REPORT_COUNT(8, 0x01),
-            HID_RI_REPORT_SIZE(8, 0x08),
-            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
+#    ifdef POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_ENABLE
+            HID_RI_COLLECTION(8, 0x02),
+                // Feature report and padding (1 byte)
+                HID_RI_USAGE(8, 0x48),     // Resolution Multiplier
+                HID_RI_REPORT_COUNT(8, 0x01),
+                HID_RI_REPORT_SIZE(8, 0x02),
+                HID_RI_LOGICAL_MINIMUM(8, 0x00),
+                HID_RI_LOGICAL_MAXIMUM(8, 0x01),
+                HID_RI_PHYSICAL_MINIMUM(8, 1),
+                HID_RI_PHYSICAL_MAXIMUM(8, POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_MULTIPLIER),
+                HID_RI_UNIT_EXPONENT(8, POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_EXPONENT),
+                HID_RI_FEATURE(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+                HID_RI_PHYSICAL_MINIMUM(8, 0x00),
+                HID_RI_PHYSICAL_MAXIMUM(8, 0x00),
+                HID_RI_REPORT_SIZE(8, 0x06),
+                HID_RI_FEATURE(8, HID_IOF_CONSTANT),
+#    endif
+                // Vertical wheel (1 or 2 bytes)
+                HID_RI_USAGE(8, 0x38),     // Wheel
+#    ifndef WHEEL_EXTENDED_REPORT
+                HID_RI_LOGICAL_MINIMUM(8, -127),
+                HID_RI_LOGICAL_MAXIMUM(8, 127),
+                HID_RI_REPORT_COUNT(8, 0x01),
+                HID_RI_REPORT_SIZE(8, 0x08),
+#    else
+                HID_RI_LOGICAL_MINIMUM(16, -32767),
+                HID_RI_LOGICAL_MAXIMUM(16,  32767),
+                HID_RI_REPORT_COUNT(8, 0x01),
+                HID_RI_REPORT_SIZE(8, 0x10),
+#    endif
+                HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
+                // Horizontal wheel (1 or 2 bytes)
+                HID_RI_USAGE_PAGE(8, 0x0C),// Consumer
+                HID_RI_USAGE(16, 0x0238),  // AC Pan
+#    ifndef WHEEL_EXTENDED_REPORT
+                HID_RI_LOGICAL_MINIMUM(8, -127),
+                HID_RI_LOGICAL_MAXIMUM(8, 127),
+                HID_RI_REPORT_COUNT(8, 0x01),
+                HID_RI_REPORT_SIZE(8, 0x08),
+#    else
+                HID_RI_LOGICAL_MINIMUM(16, -32767),
+                HID_RI_LOGICAL_MAXIMUM(16,  32767),
+                HID_RI_REPORT_COUNT(8, 0x01),
+                HID_RI_REPORT_SIZE(8, 0x10),
+#    endif
+                HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
+#    ifdef POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_ENABLE
+            HID_RI_END_COLLECTION(0),
+#    endif
         HID_RI_END_COLLECTION(0),
     HID_RI_END_COLLECTION(0),
 #    ifndef MOUSE_SHARED_EP


### PR DESCRIPTION
## Description

This PR is for two closely related features (high resolution scrolling, and extended mouse wheel reports), as well as associated documentation.

Four settings macros/flags are added:

* POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_ENABLE
* POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_MULTIPLIER
* POINTING_DEVICE_HIGH_RESOLUTION_SCROLL_EXPONENT
* WHEEL_EXTENDED_REPORT

The first three modify QMK's mouse report descriptor to enable high resolution scrolling. The fourth enables extended wheel reports, which work just like extended mouse reports. Extended wheel reports are more-or-less necessary for high resolution scrolling to work properly, because otherwise the wheel reports are typically too big to fit in an `int8_t`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/17585

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
