### PR TITLE
Add easier way to set default single layer

### DIFF
--- a/docs/feature_layers.md
+++ b/docs/feature_layers.md
@@ -74,6 +74,7 @@ There are a number of functions (and variables) related to how you can use or ma
 | `default_layer_and(layer_mask)`              | Turns on layers based on matching enabled bits between specifed layer and existing default layer state. |
 | `default_layer_xor(layer_mask)`              | Turns on layers based on non-matching bits between specifed layer and existing default layer state.     |
 | `default_layer_debug(layer_mask)`            | Prints out the current bit mask and highest active default layer to debugger console.                   |
+| [`set_single_default_layer(layer)`](ref_functions.md#setting-the-persistent-default-layer)            | Sets the default layer, but does _not_ write it to persistent memory (EEPROM). | 
 | [`set_single_persistent_default_layer(layer)`](ref_functions.md#setting-the-persistent-default-layer) | Sets the default layer and writes it to persistent memory (EEPROM).  |
 | [`update_tri_layer(x, y, z)`](ref_functions.md#update_tri_layerx-y-z) | Checks if layers `x` and `y` are both on, and sets `z` based on that (on if both on, otherwise off). |
 | [`update_tri_layer_state(state, x, y, z)`](ref_functions.md#update_tri_layer_statestate-x-y-z) | Does the same as `update_tri_layer(x, y, z)`, but from `layer_state_set_*` functions. |

--- a/docs/ref_functions.md
+++ b/docs/ref_functions.md
@@ -69,7 +69,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 Do you want to set the default layer, so that it's retained even after you unplug the board?  If so, this is the function for you.
 
-To use this, you would use `set_single_persistent_default_layer(layer)`.  If you have a name defined for your layer, you can use that instead (such as _QWERTY, _DVORAK or _COLEMAK).
+To do this, you would use `set_single_persistent_default_layer(layer)`.  If you have a name defined for your layer, you can use that instead (such as _QWERTY, _DVORAK or _COLEMAK).
 
 This will set the default layer, update the persistent settings, and play a tune if you have [Audio](features/audio) enabled on your board, and the default layer sounds set.
 
@@ -81,6 +81,8 @@ To configure the default layer sounds, you would want to define this in your `co
                               SONG(DVORAK_SOUND) \
                             }
 ```
+
+If you do not require it to be retained after you unplug the board, use `set_single_default_layer(layer)` instead.
 
 
 ::: tip

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -477,12 +477,16 @@ bool process_record_quantum(keyrecord_t *record) {
     return process_action_kb(record);
 }
 
-void set_single_persistent_default_layer(uint8_t default_layer) {
+void set_single_default_layer(uint8_t default_layer) {
 #if defined(AUDIO_ENABLE) && defined(DEFAULT_LAYER_SONGS)
     PLAY_SONG(default_layer_songs[default_layer]);
 #endif
-    eeconfig_update_default_layer((layer_state_t)1 << default_layer);
     default_layer_set((layer_state_t)1 << default_layer);
+}
+
+void set_single_persistent_default_layer(uint8_t default_layer) {
+    eeconfig_update_default_layer((layer_state_t)1 << default_layer);
+    set_single_default_layer(default_layer);
 }
 
 //------------------------------------------------------------------------------

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -240,6 +240,7 @@ extern layer_state_t layer_state;
 #    include "os_detection.h"
 #endif
 
+void set_single_default_layer(uint8_t default_layer);
 void set_single_persistent_default_layer(uint8_t default_layer);
 
 #define IS_LAYER_ON(layer) layer_state_is(layer)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Add `set_single_default_layer` to match `set_single_persistent_default_layer`
* Implements exactly the same behavior, except the write to EEPROM

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* None that I know of

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
