### PR TITLE
Tweak OS detect, add OS_DETECTION_SINGLE_REPORT

### DIFF
--- a/docs/features/os_detection.md
+++ b/docs/features/os_detection.md
@@ -70,17 +70,39 @@ The process is done in steps, generating a number of intermediate results until 
 We therefore resort to debouncing the result until it has been stable for a given amount of milliseconds.
 This amount can be configured, in case your board is not stable within the default debouncing time of 200ms.
 
-## KVM and USB switches
-
-Some KVM and USB switches may not trigger the USB controller on the keyboard to fully reset upon switching machines.
-If your keyboard does not redetect the OS in this situation, you can force the keyboard to reset when the USB initialization event is detected, forcing the USB controller to be reconfigured.
-
 ## Configuration Options
 
-* `#define OS_DETECTION_DEBOUNCE 200`
+* `#define OS_DETECTION_DEBOUNCE 250`
   * defined the debounce time for OS detection, in milliseconds
+  * defaults to 250ms
 * `#define OS_DETECTION_KEYBOARD_RESET`
-  * enables the keyboard reset upon a USB device reinitilization, such as switching devices on some KVMs
+  * enables the keyboard reset upon a USB device reinitilization
+  * this setting may help with detection issues when switching between devices on some KVMs (see [Troubleshooting](#troubleshooting))
+* `#define OS_DETECTION_SINGLE_REPORT`
+  * allows the report callbacks to be called only once, when the OS detection result is considered stable
+  * subsequent changes in the detection results, if any, are ignored
+  * this setting may help with stability issues after boot on some KVM OS combinations (see [Troubleshooting](#troubleshooting))
+  * this setting may help with delayed stability issues when switching devices on some KVMs (see [Troubleshooting](#troubleshooting))
+  
+## Troubleshooting
+
+Some KVMs and USB switches may cause issues when the OS detection is turned on. 
+Here is a list of common issues and how to fix them:
+
+* **Problem**: _keyboard won't redetect the OS when switching between machines using a KVM_
+    * **Explanation**: some KVMs keep the USB controller powered on during the switch and OS
+    detection happens when the USB device description is being assembled.
+    * **Solution**: use `OS_DETECTION_KEYBOARD_RESET` to force the keyboard to reset upon switching.
+* **Problem**: _keyboard won't register key-presses after initialization when connected to a KVM_
+    * **Explanation**: some KVM and OS combinations may cause the keyboard to hang when multiple 
+    reports are allowed. The actual cause is not known at this time. This has been noticed on 
+    a few recent _Ugreen_-branded KVMs when cold-booting Windows.
+    * **Solution**: use `OS_DETECTION_SINGLE_REPORT` to prevent the issue.
+* **Problem**: _keyboard OS detection callback gets invoked even minuted after startup_
+    * **Explanation**: some OSes, notably macOS on ARM-based Macs, may cause this behavior. 
+    The actual cause is not known at this time.'
+    * **Solution**: use `OS_DETECTION_SINGLE_REPORT` to suppress repeated callback invocations.
+
 
 ## Debug
 

--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -34,7 +34,7 @@ static uint16_t usb_setups[STORED_USB_SETUPS];
 #endif
 
 #ifndef OS_DETECTION_DEBOUNCE
-#    define OS_DETECTION_DEBOUNCE 200
+#    define OS_DETECTION_DEBOUNCE 250
 #endif
 
 // 2s should always be more than enough (otherwise, you may have other issues)
@@ -59,28 +59,32 @@ struct setups_data_t setups_data = {
 };
 
 static volatile os_variant_t detected_os = OS_UNSURE;
-static os_variant_t          reported_os = OS_UNSURE;
+#ifndef OS_DETECTION_SINGLE_REPORT
+static volatile os_variant_t reported_os = OS_UNSURE;
+#endif
 
 // we need to be able to report OS_UNSURE if that is the stable result of the guesses
-static bool first_report = true;
+static volatile bool first_report = true;
 
 // to react on USB state changes
-static volatile enum usb_device_state current_usb_device_state  = USB_DEVICE_STATE_INIT;
-static enum usb_device_state          reported_usb_device_state = USB_DEVICE_STATE_INIT;
+static volatile enum usb_device_state current_usb_device_state = USB_DEVICE_STATE_INIT;
 
 // the OS detection might be unstable for a while, "debounce" it
 static volatile bool         debouncing = false;
-static volatile fast_timer_t last_time;
+static volatile fast_timer_t last_time  = 0;
 
 void os_detection_task(void) {
     if (current_usb_device_state == USB_DEVICE_STATE_CONFIGURED) {
         // debouncing goes for both the detected OS as well as the USB state
         if (debouncing && timer_elapsed_fast(last_time) >= OS_DETECTION_DEBOUNCE) {
-            debouncing                = false;
-            reported_usb_device_state = current_usb_device_state;
+            debouncing = false;
+#ifndef OS_DETECTION_SINGLE_REPORT
             if (detected_os != reported_os || first_report) {
+                reported_os = detected_os;
+#else
+            if (first_report) {
+#endif
                 first_report = false;
-                reported_os  = detected_os;
                 process_detected_host_os_kb(detected_os);
             }
         }
@@ -88,7 +92,7 @@ void os_detection_task(void) {
 #ifdef OS_DETECTION_KEYBOARD_RESET
     // resetting the keyboard on the USB device state change callback results in instability, so delegate that to this task
     // only take action if it's been stable at least once, to avoid issues with some KVMs
-    else if (current_usb_device_state == USB_DEVICE_STATE_INIT && reported_usb_device_state != USB_DEVICE_STATE_INIT) {
+    else if (current_usb_device_state == USB_DEVICE_STATE_INIT && !first_report) {
         soft_reset_keyboard();
     }
 #endif
@@ -155,12 +159,14 @@ os_variant_t detected_host_os(void) {
 
 void erase_wlength_data(void) {
     memset(&setups_data, 0, sizeof(setups_data));
-    detected_os               = OS_UNSURE;
-    reported_os               = OS_UNSURE;
-    current_usb_device_state  = USB_DEVICE_STATE_INIT;
-    reported_usb_device_state = USB_DEVICE_STATE_INIT;
-    debouncing                = false;
-    first_report              = true;
+    detected_os = OS_UNSURE;
+#ifndef OS_DETECTION_SINGLE_REPORT
+    reported_os = OS_UNSURE;
+#endif
+    current_usb_device_state = USB_DEVICE_STATE_INIT;
+    debouncing               = false;
+    last_time                = 0;
+    first_report             = true;
 }
 
 void os_detection_notify_usb_device_state_change(enum usb_device_state usb_device_state) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Tweak OS detect, add OS_DETECTION_SINGLE_REPORT

* Default OS_DETECTION_DEBOUNCE bumped from 200ms to 250ms
* Add OS_DETECTION_SINGLE_REPORT to prevent undesired multiple reports
* Prevents random stability issues on ARM MacBooks after switching via KVM
* Works for every device I could test, including ARM MacBooks
* Disabled by default to keep current behavior
* Add Troubleshooting section on documentation

The USB stack on ARM MacBooks is more similar to that of iOS and,
for some reason, it seems to like sending packets that influence
the OS detection and results in a second OS_MACOS report being sent
at a random period of time after plugging the keyboard back. This
does not always happen and the consequences of this vary based on
what the user is doing in the callback, but since this is not
obvious and it's hard to debug, I've decided to add a flag for
those affected by such issue. The stability issue I had in mine was
a combination of factors and I found the actual cause being my own
bad math when changing the default layer, but this change alone is
also confirmed to fix it. Another issue was found when cold-booting
Windows with specific KVMs, causing the keyboard to hang. This
setting also solves that. The actual cause is unknown and does not
happen when directly connected to the computer or with other models
of KVMs.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

* None that I'm aware of, though I myself had issues as described in the commit message.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
