### PR TITLE
`qmk find`: Fix handling of keys with dots in filter functions

### DIFF
--- a/lib/python/qmk/search.py
+++ b/lib/python/qmk/search.py
@@ -74,28 +74,30 @@ class Exists(FilterFunction):
     func_name = "exists"
 
     def apply(self, target_info: KeyboardKeymapDesc) -> bool:
-        return self.key in target_info.data
+        return self.key in target_info.dotty
 
 
 class Absent(FilterFunction):
     func_name = "absent"
 
     def apply(self, target_info: KeyboardKeymapDesc) -> bool:
-        return self.key not in target_info.data
+        return self.key not in target_info.dotty
 
 
 class Length(FilterFunction):
     func_name = "length"
 
     def apply(self, target_info: KeyboardKeymapDesc) -> bool:
-        return (self.key in target_info.data and len(target_info.data[self.key]) == int(self.value))
+        info_dotty = target_info.dotty
+        return (self.key in info_dotty and len(info_dotty[self.key]) == int(self.value))
 
 
 class Contains(FilterFunction):
     func_name = "contains"
 
     def apply(self, target_info: KeyboardKeymapDesc) -> bool:
-        return (self.key in target_info.data and self.value in target_info.data[self.key])
+        info_dotty = target_info.dotty
+        return (self.key in info_dotty and self.value in info_dotty[self.key])
 
 
 def _get_filter_class(func_name: str, key: str, value: str) -> Optional[FilterFunction]:


### PR DESCRIPTION
## Description

Filters like `-f "exists(rgb_matrix.split_count)"` broke after #22887, because a plain dict was used instead of the `dotty` wrapper, therefore only keys with a single component worked.  Fix the implementation of filtering functions to use the `dotty` wrapper properly, so that keys with dots could be used in functions again.

Also add some tests for `qmk find` which get run by `qmk pytest` and should have caught the breakage introduced in #22887 if they existed at that time.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Commands like `qmk find -f "exists(rgb_matrix.split_count)"` did not give the expected result if the specified key name contained multiple components separated with dots.  Other filtering functions (`absent`, `length`, `contains`) were also affected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
