### PR TITLE
Allow running Docker container on MacOS (without in-container USB support)

### DIFF
--- a/docs/getting_started_docker.md
+++ b/docs/getting_started_docker.md
@@ -50,6 +50,13 @@ By default docker or podman are automatically detected and docker is preferred o
 RUNTIME="podman" util/docker_build.sh keyboard:keymap:target
 ```
 
+If flashing is not required, it's possible to run the container as unprivileged (on Linux), and without docker-machine (on Windows/macOS):
+
+```
+SKIP_FLASHING_SUPPORT=1 util/docker_build.sh keyboard:keymap:target
+```
+
+
 ## FAQ
 
 ### Why can't I flash on Windows/macOS

--- a/util/docker_cmd.sh
+++ b/util/docker_cmd.sh
@@ -34,15 +34,17 @@ if [ -z "$RUNTIME" ]; then
 	fi
 fi
 
-
-# IF we are using docker on non Linux and docker-machine isn't working print an error
-# ELSE set usb_args
-if [ ! "$(uname)" = "Linux" ] && [ "$RUNTIME" = "docker" ] && ! docker-machine active >/dev/null 2>&1; then
-	errcho "Error: target requires docker-machine to work on your platform"
-	errcho "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos"
-	exit 3
-else
-	usb_args="--privileged -v /dev:/dev"
+# If SKIP_FLASHING_SUPPORT is defined, do not check for docker-machine and do not run a privileged container
+if [ -z "$SKIP_FLASHING_SUPPORT" ]; then
+  # IF we are using docker on non Linux and docker-machine isn't working print an error
+  # ELSE set usb_args
+  if [ ! "$(uname)" = "Linux" ] && [ "$RUNTIME" = "docker" ] && ! docker-machine active >/dev/null 2>&1; then
+    errcho "Error: target requires docker-machine to work on your platform"
+    errcho "See http://gw.tnode.com/docker/docker-machine-with-usb-support-on-windows-macos"
+    exit 3
+  else
+    usb_args="--privileged -v /dev:/dev"
+  fi
 fi
 
 qmk_firmware_dir=$(pwd -W 2>/dev/null) || qmk_firmware_dir=$PWD  # Use Windows path if on Windows


### PR DESCRIPTION
## Description
Allow running Docker container on MacOS (without in-container USB support), if flashing is unnecessary.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
* #24273
 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
