### PR TITLE
`.editorconfig`: fix inline comment, tidy name section for yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
  # To match GitHub Actions formatting
-[{*.yaml,*.yml}]
+[*.{yaml,yml}]
 indent_size = 2
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{*.yaml,*.yml}] # To match GitHub Actions formatting
+ # To match GitHub Actions formatting
+[{*.yaml,*.yml}]
 indent_size = 2
 
 [*.md]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

On a recent PR (#23186) a section for YAML files was added, that included an inline comment (not starting on the first column), which used to be valid, but no longer¹. This produces an error at least with Emacs 29.4.

Also, normalize the name section expressing the file selection following a customary pattern. 

¹: https://spec.editorconfig.org/#no-inline-comments
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* (change is so minor that I'll directly PR; hope that I’m not crossing a line here)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
