### PR TITLE
[Feature Improvement]add option to keep layer state when recording dynamic macros

### DIFF
--- a/docs/features/dynamic_macros.md
+++ b/docs/features/dynamic_macros.md
@@ -32,12 +32,13 @@ For the details about the internals of the dynamic macros, please read the comme
 
 There are a number of options added that should allow some additional degree of customization
 
-|Define                      |Default         |Description                                                                                                      |
-|----------------------------|----------------|-----------------------------------------------------------------------------------------------------------------|
-|`DYNAMIC_MACRO_SIZE`        |128             |Sets the amount of memory that Dynamic Macros can use. This is a limited resource, dependent on the controller.  |
-|`DYNAMIC_MACRO_USER_CALL`   |*Not defined*   |Defining this falls back to using the user `keymap.c` file to trigger the macro behavior.                        |
-|`DYNAMIC_MACRO_NO_NESTING`  |*Not Defined*   |Defining this disables the ability to call a macro from another macro (nested macros).                           | 
-|`DYNAMIC_MACRO_DELAY`        |*Not Defined*   |Sets the waiting time (ms unit) when sending each key.                                                           |
+|Define                           |Default         |Description                                                                                                      |
+|---------------------------------|----------------|-----------------------------------------------------------------------------------------------------------------|
+|`DYNAMIC_MACRO_SIZE`             |128             |Sets the amount of memory that Dynamic Macros can use. This is a limited resource, dependent on the controller.  |
+|`DYNAMIC_MACRO_USER_CALL`        |*Not defined*   |Defining this falls back to using the user `keymap.c` file to trigger the macro behavior.                        |
+|`DYNAMIC_MACRO_NO_NESTING`       |*Not Defined*   |Defining this disables the ability to call a macro from another macro (nested macros).                           |
+|`DYNAMIC_MACRO_DELAY`            |*Not Defined*   |Sets the waiting time (ms unit) when sending each key.                                                           |
+|`DYNAMIC_MACRO_KEEP_LAYER_STATE` |*Not Defined*   |Defining this keeps the layer state when starting to record a macro                                              |
 
 
 If the LEDs start blinking during the recording with each keypress, it means there is no more space for the macro in the macro buffer. To fit the macro in, either make the other macro shorter (they share the same buffer) or increase the buffer size by adding the `DYNAMIC_MACRO_SIZE` define in your `config.h` (default value: 128; please read the comments for it in the header).

--- a/quantum/process_keycode/process_dynamic_macro.c
+++ b/quantum/process_keycode/process_dynamic_macro.c
@@ -89,6 +89,11 @@ __attribute__((weak)) bool dynamic_macro_valid_key_user(uint16_t keycode, keyrec
 #define DYNAMIC_MACRO_CURRENT_LENGTH(BEGIN, POINTER) ((int)(direction * ((POINTER) - (BEGIN))))
 #define DYNAMIC_MACRO_CURRENT_CAPACITY(BEGIN, END2) ((int)(direction * ((END2) - (BEGIN)) + 1))
 
+#ifdef DYNAMIC_MACRO_KEEP_LAYER_STATE
+    static layer_state_t dm1_layer_state;
+    static layer_state_t dm2_layer_state;
+#endif
+
 /**
  * Start recording of the dynamic macro.
  *
@@ -100,8 +105,16 @@ void dynamic_macro_record_start(keyrecord_t **macro_pointer, keyrecord_t *macro_
 
     dynamic_macro_record_start_kb(direction);
 
-    clear_keyboard();
+#ifdef DYNAMIC_MACRO_KEEP_LAYER_STATE
+    if (direction == 1) {
+        dm1_layer_state = layer_state;
+    } else if (direction == -1) {
+        dm2_layer_state = layer_state;
+    }
+#else
     layer_clear();
+#endif
+    clear_keyboard();
     *macro_pointer = macro_buffer;
 }
 
@@ -118,7 +131,15 @@ void dynamic_macro_play(keyrecord_t *macro_buffer, keyrecord_t *macro_end, int8_
     layer_state_t saved_layer_state = layer_state;
 
     clear_keyboard();
+#ifdef DYNAMIC_MACRO_KEEP_LAYER_STATE
+    if (direction == 1) {
+        layer_state_set(dm1_layer_state);
+    } else if (direction == -1) {
+        layer_state_set(dm2_layer_state);
+    }
+#else
     layer_clear();
+#endif
 
     while (macro_buffer != macro_end) {
         process_record(macro_buffer);


### PR DESCRIPTION
## Description

This PR enables a new option to the dynamic macros feature that keeps and saves the layer state when starting to record a dynamic macro.

I use another entire layer for gaming and sometimes uses dynamic macros for games. Occasionally I need to change the macro on the fly and it feels pretty annoying that starting to record a macro will clear all layers and I need to switch back to my gaming layer before modifying any macro. This PR enables me to do all macro related operations from a certain layer without need to switch back and forth.

## Types of Changes


- [ ] Core
- [ ] Bugfix
- [X] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR

N/A 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
