### PR TITLE
Draft: Add Atari XL keyboard

### DIFF
--- a/keyboards/atari/xl/keyboard.json
+++ b/keyboards/atari/xl/keyboard.json
@@ -1,0 +1,96 @@
+{
+    "keyboard_name": "Atari XL",
+    "manufacturer": "atari",
+    "url": "https://github.com/qmk/qmk_firmware/tree/master/keyboards/atari/xl",
+    "maintainer": "moparisthebest",
+    "processor": "RP2040",
+    "bootloader": "rp2040",
+    "board": "GENERIC_RP_RP2040",
+    "usb": {
+        "vid": "0xFEED",
+        "pid": "0xDAD0",
+        "device_version": "0.0.1"
+    },
+    "features": {
+        "bootmagic": true,
+        "command": false,
+        "console": false,
+        "extrakey": true,
+        "mousekey": false,
+        "nkro": false
+    },
+    "debounce": 5,
+    "diode_direction": "ROW2COL",
+    "matrix_pins": {
+        "ghost": true,
+        "cols": ["GP7","GP8","GP9","GP10","GP11","GP12","GP15","GP13","GP14"],
+        "rows": ["GP0","GP1","GP2","GP3","GP4","GP16","GP5","GP6"]
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"label": "Esc", "matrix": [1, 8], "y": 0, "x": 0},
+                {"label": "1", "matrix": [1, 7], "y": 0, "x": 1},
+                {"label": "2", "matrix": [1, 6], "y": 0, "x": 2},
+                {"label": "3", "matrix": [1, 5], "y": 0, "x": 3},
+                {"label": "4", "matrix": [1, 4], "y": 0, "x": 4},
+                {"label": "5", "matrix": [1, 3], "y": 0, "x": 5},
+                {"label": "6", "matrix": [1, 1], "y": 0, "x": 6},
+                {"label": "7", "matrix": [0, 1], "y": 0, "x": 7},
+                {"label": "8", "matrix": [0, 3], "y": 0, "x": 8},
+                {"label": "9", "matrix": [0, 4], "y": 0, "x": 9},
+                {"label": "0", "matrix": [0, 5], "y": 0, "x": 10},
+                {"label": "<", "matrix": [0, 6], "y": 0, "x": 11},
+                {"label": ">", "matrix": [0, 7], "y": 0, "x": 12},
+                {"label": "Del", "matrix": [0, 8], "y": 0, "x": 13},
+                {"label": "Break", "matrix": [0, 0], "y": 0, "x": 14},
+
+                {"label": "Tab", "matrix": [3, 8], "y": 1, "x": 0},
+                {"label": "Q", "matrix": [3, 7], "y": 1, "x": 1},
+                {"label": "W", "matrix": [3, 6], "y": 1, "x": 2},
+                {"label": "E", "matrix": [3, 5], "y": 1, "x": 3},
+                {"label": "R", "matrix": [3, 4], "y": 1, "x": 4},
+                {"label": "T", "matrix": [3, 3], "y": 1, "x": 5},
+                {"label": "Y", "matrix": [3, 1], "y": 1, "x": 6},
+                {"label": "U", "matrix": [2, 1], "y": 1, "x": 7},
+                {"label": "I", "matrix": [2, 3], "y": 1, "x": 8},
+                {"label": "O", "matrix": [2, 4], "y": 1, "x": 9},
+                {"label": "P", "matrix": [2, 5], "y": 1, "x": 10},
+                {"label": "-", "matrix": [2, 6], "y": 1, "x": 11},
+                {"label": "=", "matrix": [2, 7], "y": 1, "x": 12},
+                {"label": "Return", "matrix": [2, 8], "y": 1, "x": 13},
+
+                {"label": "Control", "matrix": [4, 0], "y": 2, "x": 0},
+                {"label": "A", "matrix": [5, 7], "y": 2, "x": 1},
+                {"label": "S", "matrix": [5, 6], "y": 2, "x": 2},
+                {"label": "D", "matrix": [5, 5], "y": 2, "x": 3},
+                {"label": "F", "matrix": [5, 4], "y": 2, "x": 4},
+                {"label": "G", "matrix": [5, 3], "y": 2, "x": 5},
+                {"label": "H", "matrix": [5, 2], "y": 2, "x": 6},
+                {"label": "J", "matrix": [4, 2], "y": 2, "x": 7},
+                {"label": "K", "matrix": [4, 3], "y": 2, "x": 8},
+                {"label": "L", "matrix": [4, 4], "y": 2, "x": 9},
+                {"label": ";", "matrix": [4, 5], "y": 2, "x": 10},
+                {"label": "+", "matrix": [4, 6], "y": 2, "x": 11},
+                {"label": "*", "matrix": [4, 7], "y": 2, "x": 12},
+                {"label": "Caps", "matrix": [5, 8], "y": 2, "x": 13},
+
+                {"label": "Shift", "matrix": [7, 0], "y": 3, "x": 0},
+                {"label": "Z", "matrix": [7, 7], "y": 3, "x": 1},
+                {"label": "X", "matrix": [7, 6], "y": 3, "x": 2},
+                {"label": "C", "matrix": [7, 5], "y": 3, "x": 3},
+                {"label": "V", "matrix": [7, 4], "y": 3, "x": 4},
+                {"label": "B", "matrix": [7, 3], "y": 3, "x": 5},
+                {"label": "N", "matrix": [6, 1], "y": 3, "x": 6},
+                {"label": "M", "matrix": [6, 3], "y": 3, "x": 7},
+                {"label": ",", "matrix": [6, 4], "y": 3, "x": 8},
+                {"label": ".", "matrix": [6, 5], "y": 3, "x": 9},
+                {"label": "/", "matrix": [6, 6], "y": 3, "x": 10},
+
+                {"label": "HalfSquare", "matrix": [6, 7], "y": 3, "x": 11},
+
+                {"label": "Space", "matrix": [6, 2], "y": 4, "x": 3, "w": 9},
+            ]
+        }
+    }
+}

--- a/keyboards/atari/xl/keymaps/default/keymap.c
+++ b/keyboards/atari/xl/keymaps/default/keymap.c
@@ -1,0 +1,26 @@
+/* Copyright 2019 iw0rm3r
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT( /* Base layer */
+    KC_ESC,  KC_1,    KC_2,   KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_DEL, KC_INS,   KC_BSPC,   KC_PAUS,
+    KC_TAB,  KC_Q,    KC_W,   KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_MINS, KC_EQL,  KC_ENT,
+    KC_LCTL, KC_A,    KC_S,   KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS, KC_CAPS,
+    KC_LSFT, KC_Z,    KC_X,   KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,                   KC_LALT,
+                                                   KC_SPC
+  ),
+};

--- a/keyboards/atari/xl/readme.md
+++ b/keyboards/atari/xl/readme.md
@@ -1,0 +1,51 @@
+# atari_xl
+
+![Atari XL layout](./keyxl.gif)
+
+Atari pins are numbered 0-23 with 0 closest to back of machine.
+
+matrix, row vs col:
+```
+P |     8 |  9 |  10 | 11 | 12 | 13 | 14 | 15 |  16 |
+I |     0 |  1 |   2 |  3 |  4 |  5 |  6 |  7 |   8 |
+-----------------------------------------------------
+0 | BREAK |  7 |  [] |  8 |  9 |  0 |  < |  > | DEL |
+1 |    [] |  6 |  [] |  5 |  4 |  3 |  2 |  1 | ESC |
+2 |    [] |  U |  [] |  I |  O |  P |  - |  = | RET |
+3 |    [] |  Y |  [] |  T |  R |  E |  W |  Q | TAB |
+4 |  CTRL | F1 |   J |  K |  L |  ; |  + |  * |  F2 |
+5 |    [] | [] |   H |  G |  F |  D |  S |  A | CAP |
+6 |    [] |  N | SPC |  M |  , |  . |  / |  ◪|  [] |
+7 | SHIFT | F3 | HLP |  B |  V |  C |  X |  Z |  F4 |
+```
+
+pin 18 on the kb is connected to nothing, maybe +5v
+pin 23 on the kb is connected to + on the LED, probably +5v
+
+there is a second direct "matrix" where individual switches are connected to ground (17):
+```
+ P |    19 |     20 |     21 |    22 |
+ I |     0 |      1 |      2 |     3 |
+17 | START | SELECT | OPTION | RESET |
+```
+
+Pins of the Pico board you should use by default:
+```
+--------------------------------------------------------
+Rows:      0 1 2 3 4  5 6 7
+GPIO Pins: 0 1 2 3 4 16 5 6
+--------------------------------------------------------
+Columns:   8 9 10 11 12 13 14 15 16
+GPIO Pins: 7 8  9 10 11 12 15 13 14
+--------------------------------------------------------
+```
+for now the above is excluding reset+option+select+start
+
+Keyboard Maintainer: [moparisthebest](https://github.com/moparisthebest)
+Hardware Supported: RPI Pico
+
+Make example for this keyboard (after setting up your build environment):
+
+    qmk compile -kb atari/xl -km default
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).


### PR DESCRIPTION
This is draft because, though the rest of the keys work, START/SELECT/OPTION/RESET are wired "direct" and I'm not clear the best way to wire and/or represent these in the QMK config, so I was hoping for some guidance there.

## Description

This adds support for an original Atari XL (800XL in my tests) keyboard connected to a rp2040.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
