### PR TITLE
Fix space cadet auto shift interaction

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -364,14 +364,14 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef LEADER_ENABLE
             process_leader(keycode, record) &&
 #endif
+#ifdef SPACE_CADET_ENABLE
+            process_space_cadet(keycode, record) &&
+#endif
 #ifdef AUTO_SHIFT_ENABLE
             process_auto_shift(keycode, record) &&
 #endif
 #ifdef DYNAMIC_TAPPING_TERM_ENABLE
             process_dynamic_tapping_term(keycode, record) &&
-#endif
-#ifdef SPACE_CADET_ENABLE
-            process_space_cadet(keycode, record) &&
 #endif
 #ifdef MAGIC_ENABLE
             process_magic(keycode, record) &&

--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -73,7 +73,7 @@ TEST_F(AutoShift, key_release_after_timeout) {
 // press shift, press key, release shift, release key
 // the right interaction is we only get the shifted key
 // the wrong interaction is we get a bracket and a shifted key
-TEST_F(AutoShift, key_release_after_timeout) {
+TEST_F(AutoShift, auto_shift_with_space_cadet) {
     TestDriver driver;
     InSequence s;
     auto       left_shift = KeymapKey(0, 0, 0, SC_LSPO);

--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -69,7 +69,6 @@ TEST_F(AutoShift, key_release_after_timeout) {
     VERIFY_AND_CLEAR(driver);
 }
 
-
 // test auto shift and space cadet interaction
 // press shift, press key, release shift, release key
 // the right interaction is we only get the shifted key

--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -68,3 +68,31 @@ TEST_F(AutoShift, key_release_after_timeout) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
+
+
+// test auto shift and space cadet interaction
+// press shift, press key, release shift, release key
+// the right interaction is we only get the shifted key
+// the wrong interaction is we get a bracket and a shifted key
+TEST_F(AutoShift, key_release_after_timeout) {
+    TestDriver driver;
+    InSequence s;
+    auto       left_shift = KeymapKey(0, 0, 0, SC_LSPO);
+    auto       key_a = KeymapKey(0, 1, 0, KC_A);
+
+    set_keymap({regular_key});
+
+    /* Press regular key */
+    EXPECT_NO_REPORT(driver);
+    left_shift.press();
+    key_a.press();
+    left_shift.release();
+    key_a.release();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_REPORT(driver, (KC_LSFT, KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -79,7 +79,7 @@ TEST_F(AutoShift, auto_shift_with_space_cadet) {
     auto       left_shift = KeymapKey(0, 0, 0, SC_LSPO);
     auto       key_a      = KeymapKey(0, 1, 0, KC_A);
 
-    set_keymap({regular_key});
+    set_keymap({left_shift, key_a});
 
     /* Press regular key */
     EXPECT_NO_REPORT(driver);

--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -77,7 +77,7 @@ TEST_F(AutoShift, key_release_after_timeout) {
     TestDriver driver;
     InSequence s;
     auto       left_shift = KeymapKey(0, 0, 0, SC_LSPO);
-    auto       key_a = KeymapKey(0, 1, 0, KC_A);
+    auto       key_a      = KeymapKey(0, 1, 0, KC_A);
 
     set_keymap({regular_key});
 

--- a/tests/auto_shift/test_auto_shift.cpp
+++ b/tests/auto_shift/test_auto_shift.cpp
@@ -68,7 +68,6 @@ TEST_F(AutoShift, key_release_after_timeout) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
-
 // test auto shift and space cadet interaction
 // press shift, press key, release shift, release key
 // the right interaction is we only get the shifted key


### PR DESCRIPTION
Fix for this bug: https://github.com/qmk/qmk_firmware/issues/20978

Enable space cadet shift - left shift (, right shift )
Enable auto shift

Press shift, press a letter, and release shift before releasing the letter.

When using left shift, the ( will be before the letter. When using right shift, the ) will be after the letter.

If you release shift after releasing the letter, the () will not print, and the keyboard works as you would want.

## Description

Fix space cadet-auto shift interaction bug

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes https://github.com/qmk/qmk_firmware/issues/20978

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
