### PR TITLE
[docs] `reference_info_json`: add type hints

### DIFF
--- a/docs/reference_info_json.md
+++ b/docs/reference_info_json.md
@@ -6,51 +6,51 @@ You can create `info.json` files at every level under `qmk_firmware/keyboards/<k
 
 ## General Metadata {#general-metadata}
 
-* `keyboard_name` (Required)
+* `keyboard_name` <Badge type="info">String</Badge> <Badge>Required</Badge>
     * A free-form text string describing the keyboard. This will be used as the USB product string. Can include Unicode characters, escaped to ASCII eg. `\u03A8` (Ψ).
     * Example: `"Clueboard 66%"`
-* `maintainer` (Required)
+* `maintainer` <Badge type="info">String</Badge> <Badge>Required</Badge>
     * GitHub username of the maintainer, or `qmk` for community maintained boards.
     * Example: `"skullydazed"`
-* `manufacturer` (Required)
+* `manufacturer` <Badge type="info">String</Badge> <Badge>Required</Badge>
     * A free-form text string describing the keyboard's manufacturer. This will be used as the USB manufacturer string. Can include Unicode characters, escaped to ASCII eg. `\u03A8` (Ψ).
     * Example: `"Clueboard"`
-* `url` (Required)
+* `url` <Badge type="info">String</Badge> <Badge>Required</Badge>
     * A URL to the keyboard's product page, [QMK.fm/keyboards](https://qmk.fm/keyboards) page, or other page describing information about the keyboard.
     * Example: `"https://clueboard.co"`
-* `bootloader_instructions`
+* `bootloader_instructions` <Badge type="info">String</Badge>
     * Instructions for putting the keyboard into a mode that allows for firmware flashing.
     * Example: `"Press the button marked RESET on the back of the PCB"`
-* `tags`
+* `tags` <Badge type="info">Array: String</Badge>
     * A list of tags describing the keyboard.
     * Example: `["ortho", "split", "rgb"]`
 
 ## Hardware Configuration {#hardware-configuration}
 
-* `board`
+* `board` <Badge type="info">String</Badge>
     * Override the default ChibiOS board name (ARM-based keyboards only).
     * Example: `"BLACKPILL_STM32_F411"`
-* `bootloader`
+* `bootloader` <Badge type="info">String</Badge>
     * The bootloader in use on the keyboard. Required if `development_board` is not specified.
-* `development_board`
+* `development_board` <Badge type="info">String</Badge>
     * The microcontroller development board, if applicable.
     * Example: `"promicro"`
-* `pin_compatible`
+* `pin_compatible` <Badge type="info">String</Badge>
     * The form factor of the development board, if applicable. Must be one of `elite_c`, `promicro`.
-* `processor`
+* `processor` <Badge type="info">String</Badge>
     * The microcontroller in use on the keyboard. Required if `development_board` is not specified.
 
 ## Firmware Configuration {#firmware-configuration}
 
 * `build`
-    * `debounce_type`
+    * `debounce_type`<Badge type="info">String</Badge>
         * The debounce algorithm to use. Must be one of `asym_eager_defer_pk`, `custom`, `sym_defer_g`, `sym_defer_pk`, `sym_defer_pr`, `sym_eager_pk`, `sym_eager_pr`.
-    * `firmware_format`
+    * `firmware_format`<Badge type="info">String</Badge>
         * The format of the final output binary. Must be one of `bin`, `hex`, `uf2`.
-    * `lto`
+    * `lto`<Badge type="info">Boolean</Badge>
         * Enable Link-Time Optimization.
         * Default: `false`
-* `features`
+* `features`<Badge type="info">Object: Boolean</Badge>
     * A dictionary of features to enable or disable.
     * Example:
     ```json
@@ -61,36 +61,36 @@ You can create `info.json` files at every level under `qmk_firmware/keyboards/<k
     ```
 * `qmk`
     * `locking`
-        * `enabled`
+        * `enabled` <Badge type="info">Boolean</Badge>
             * Enable locking switch support.
             * Default: `false`
-        * `resync`
+        * `resync` <Badge type="info">Boolean</Badge>
             * Keep switch state consistent with keyboard LED state.
             * Default: `false`
-    * `tap_capslock_delay`
+    * `tap_capslock_delay` <Badge type="info">Number</Badge>
         * The delay between keydown and keyup for Caps Lock tap events in milliseconds.
         * Default: `80` (80 ms)
-    * `tap_keycode_delay`
+    * `tap_keycode_delay` <Badge type="info">Number</Badge>
         * The delay between keydown and keyup for tap events in milliseconds.
         * Default: `0` (no delay)
 * `tapping`
-    * `hold_on_other_key_press`
+    * `hold_on_other_key_press` <Badge type="info">Boolean</Badge>
         * Default: `false`
-    * `hold_on_other_key_press_per_key`
+    * `hold_on_other_key_press_per_key` <Badge type="info">Boolean</Badge>
         * Default: `false`
-    * `permissive_hold`
+    * `permissive_hold` <Badge type="info">Boolean</Badge>
         * Default: `false`
-    * `permissive_hold_per_key`
+    * `permissive_hold_per_key` <Badge type="info">Boolean</Badge>
         * Default: `false`
-    * `retro`
+    * `retro` <Badge type="info">Boolean</Badge>
         * Default: `false`
-    * `retro_per_key`
+    * `retro_per_key` <Badge type="info">Boolean</Badge>
         * Default: `false`
-    * `term`
+    * `term` <Badge type="info">Number</Badge>
         * Default: `200` (200 ms)
-    * `term_per_key`
+    * `term_per_key` <Badge type="info">Boolean</Badge>
         * Default: `false`
-    * `toggle`
+    * `toggle` <Badge type="info">Number</Badge>
         * Default: `5`
 
 ## APA102 {#apa102}
@@ -98,11 +98,11 @@ You can create `info.json` files at every level under `qmk_firmware/keyboards/<k
 Configures the [APA102](drivers/apa102) driver.
 
 * `apa102`
-    * `clock_pin` (Required)
+    * `clock_pin` <Badge type="info">Pin</Badge> <Badge>Required</Badge>
         * The GPIO pin connected to `CI` on the first LED in the chain.
-    * `data_pin` (Required)
+    * `data_pin` <Badge type="info">Pin</Badge> <Badge>Required</Badge>
         * The GPIO pin connected to `DI` on the first LED in the chain.
-    * `default_brightness`
+    * `default_brightness` <Badge type="info">Number</Badge>
         * The initial global brightness level (independent of the RGB data), from 0 to 31.
         * Default: `31`
 
@@ -112,26 +112,26 @@ Configures the [Audio](features/audio) feature.
 
 * `audio`
     * `default`
-        * `on`
+        * `on` <Badge type="info">Boolean</Badge>
             * The default audio enabled state.
             * Default: `true`
-        * `clicky`
+        * `clicky` <Badge type="info">Boolean</Badge>
             * The default audio clicky enabled state.
             * Default: `true`
-    * `driver`
+    * `driver` <Badge type="info">String</Badge>
         * The driver to use. Must be one of `dac_additive`, `dac_basic`, `pwm_software`, `pwm_hardware`.
-    * `macro_beep`
+    * `macro_beep` <Badge type="info">Boolean</Badge>
         * Play a short beep for `\a` (ASCII `BEL`) characters in Send String macros.
         * Default: `false`
-    * `pins` (Required)
+    * `pins` <Badge type="info">Array: Pin</Badge> <Badge>Required</Badge>
         * The GPIO pin(s) connected to the speaker(s).
     * `power_control`
-        * `on_state`
+        * `on_state` <Badge type="info">0|1</Badge>
             * The logical GPIO state required to turn the speaker on.
             * Default: `1` (on = high)
-        * `pin`
+        * `pin` <Badge type="info">Pin</Badge>
             * The GPIO pin connected to speaker power circuit.
-    * `voices`
+    * `voices` <Badge type="info">Boolean</Badge>
         * Use multiple audio voices.
         * Default: `false`
 
@@ -141,40 +141,40 @@ Configures the [Audio](features/audio) feature.
 Configures the [Backlight](features/backlight) feature.
 
 * `backlight`
-    * `as_caps_lock`
+    * `as_caps_lock` <Badge type="info">Boolean</Badge>
         * Use the backlight as a Caps Lock indicator.
         * Default: `false`
-    * `breathing`
+    * `breathing` <Badge type="info">Boolean</Badge>
         * Whether backlight breathing is enabled.
         * Default: `false`
-    * `breathing_period`
+    * `breathing_period` <Badge type="info">Number</Badge>
         * The length of one backlight breathing cycle in seconds.
         * Default: `6` (6 seconds)
     * `default`
-        * `on`
+        * `on` <Badge type="info">Boolean</Badge>
             * The default backlight enabled state.
             * Default: `true`
-        * `breathing`
+        * `breathing` <Badge type="info">Boolean</Badge>
             * The default backlight breathing state.
             * Default: `false`
-        * `brightness`
+        * `brightness` <Badge type="info">Number</Badge>
             * The default brightness level.
             * Default: `max_brightness`
-    * `driver`
+    * `driver` <Badge type="info">String</Badge>
         * The driver to use. Must be one of `custom`, `pwm`, `software`, `timer`.
         * Default: `"pwm"`
-    * `levels`
+    * `levels` <Badge type="info">Number</Badge>
         * The number of brightness levels (excluding off), from 1 to 31.
         * Default: `3`
-    * `max_brightness`
+    * `max_brightness` <Badge type="info">Number</Badge>
         * The maximum PWM value which brightness is scaled to, from 0 to 255.
         * Default: `255`
-    * `on_state`
+    * `on_state` <Badge type="info">0|1</Badge>
         * The logical GPIO state required to turn the LEDs on.
         * Default: `1` (on = high)
-    * `pin`
+    * `pin` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to the backlight circuit.
-    * `pins`
+    * `pins` <Badge type="info">Array: Pin</Badge>
         * A list of GPIO pins connected to the backlight LEDs (`software` and `timer` drivers only).
 
 ## Bluetooth {#bluetooth}
@@ -182,7 +182,7 @@ Configures the [Backlight](features/backlight) feature.
 Configures the [Bluetooth](features/bluetooth) feature.
 
 * `bluetooth`
-    * `driver`
+    * `driver` <Badge type="info">String</Badge>
         * The driver to use. Must be one of `custom`, `bluefruit_le`, `rn42`.
 
 ## Bootmagic {#bootmagic}
@@ -190,10 +190,10 @@ Configures the [Bluetooth](features/bluetooth) feature.
 Configures the [Bootmagic](features/bootmagic) feature.
 
 * `bootmagic`
-    * `enabled`
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enables the Bootmagic feature.
         * Default: `false`
-    * `matrix`
+    * `matrix` <Badge type="info">Matrix</Badge>
         * The matrix position of the key to check during startup. This should generally be set to the (physically) top left key.
         * Default: `[0, 0]`
 
@@ -202,19 +202,19 @@ Configures the [Bootmagic](features/bootmagic) feature.
 Configures the [Caps Word](features/caps_word) feature.
 
 * `caps_word`
-    * `both_shifts_turns_on`
+    * `both_shifts_turns_on` <Badge type="info">Boolean</Badge>
         * Activate Caps Word by pressing both Shift keys.
         * Default: `false`
-    * `double_tap_shift_turns_on`
+    * `double_tap_shift_turns_on` <Badge type="info">Boolean</Badge>
         * Activate Caps Word by pressing Left Shift twice.
         * Default: `false`
-    * `enabled`
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enables the Caps Word feature.
         * Default: `false`
-    * `idle_timeout`
+    * `idle_timeout` <Badge type="info">Number</Badge>
         * The amount of time before Caps Word automatically deactivates in milliseconds.
         * Default: `5000` (5 seconds)
-    * `invert_on_shift`
+    * `invert_on_shift` <Badge type="info">Boolean</Badge>
         * Invert shift state instead of deactivating Caps Word when Shift is pressed.
         * Default: `false`
 
@@ -223,7 +223,7 @@ Configures the [Caps Word](features/caps_word) feature.
 Configures the [Combo](features/combo) feature.
 
 * `combo`
-    * `term`
+    * `term` <Badge type="info">Number</Badge>
         * The amount of time to recognize a combo in milliseconds.
         * Default: `50` (50 ms)
 
@@ -232,12 +232,12 @@ Configures the [Combo](features/combo) feature.
 Configures the [DIP Switches](features/dip_switch) feature.
 
 * `dip_switch`
-    * `enabled`
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enable the DIP Switches feature.
         * Default: `false`
-    * `pins`
+    * `pins` <Badge type="info">Array: Pin</Badge>
         * A list of GPIO pins connected to the MCU.
-    * `matrix_grid`
+    * `matrix_grid` <Badge type="info">Array: Matrix</Badge>
         * A list of matrix locations in the key matrix.
         * Example: `[ [0,6], [1,6], [2,6] ]`
 
@@ -246,15 +246,15 @@ Configures the [DIP Switches](features/dip_switch) feature.
 Configures the [EEPROM](drivers/eeprom) driver.
 
 * `eeprom`
-    * `driver`
+    * `driver` <Badge type="info">String</Badge>
         * The EEPROM backend to use. Must be one of `custom`, `i2c`, `legacy_stm32_flash`, `spi`, `transient`, `vendor`, `wear_leveling`.
         * Default: `"vendor"`
     * `wear_leveling`
-        * `driver`
+        * `driver` <Badge type="info">String</Badge>
             * The driver to use. Must be one of `embedded_flash`, `legacy`, `rp2040_flash`, `spi_flash`, `custom`.
-        * `backing_size`
+        * `backing_size` <Badge type="info">Number</Badge>
             * Number of bytes used by the wear-leveling algorithm for its underlying storage, and needs to be a multiple of the logical size.
-        * `logical_size`
+        * `logical_size` <Badge type="info">Number</Badge>
             * Number of bytes “exposed” to the rest of QMK and denotes the size of the usable EEPROM.
 
 ## Encoder {#encoder}
@@ -262,13 +262,13 @@ Configures the [EEPROM](drivers/eeprom) driver.
 Configures the [Encoder](features/encoders) feature.
 
 * `encoder`
-    * `rotary`
+    * `rotary` <Badge type="info">Array: Object</Badge>
         * A list of encoder objects.
-            * `pin_a` (Required)
+            * `pin_a` <Badge type="info">Pin</Badge> <Badge>Required</Badge>
                 * The GPIO pin connected to the encoder's `A` pin.
-            * `pin_b` (Required)
+            * `pin_b` <Badge type="info">Pin</Badge> <Badge>Required</Badge>
                 * The GPIO pin connected to the encoder's `B` pin.
-            * `resolution`
+            * `resolution` <Badge type="info">Number</Badge>
                 * The number of edge transitions on both pins required to register an input.
                 * Default: `4`
 
@@ -277,18 +277,18 @@ Configures the [Encoder](features/encoders) feature.
 Configures the [LED Indicators](features/led_indicators) feature.
 
 * `indicators`
-    * `caps_lock`
+    * `caps_lock` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to the Caps Lock LED.
-    * `compose`
+    * `compose` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to the Compose LED.
-    * `kana`
+    * `kana` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to the Kana LED.
-    * `num_lock`
+    * `num_lock` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to the Num Lock LED.
-    * `on_state`
+    * `on_state` <Badge type="info">0|1</Badge>
         * The logical GPIO state required to turn the LEDs on.
         * Default: `1` (on = high)
-    * `scroll_lock`
+    * `scroll_lock` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to the Scroll Lock LED.
 
 ## Layouts {#layouts}
@@ -301,10 +301,10 @@ All key positions and rotations are specified in relation to the top-left corner
 
 The ISO enter key is represented by a 1.25u×2uh key. Renderers which utilize info.json layout data (such as `qmk info -l` and the QMK Configurator) should display this key as expected.
 
-* `community_layouts`
+* `community_layouts` <Badge type="info">Array: String</Badge>
     * A list of community layouts supported by the keyboard.
     * Example: `["60_ansi", "60_iso"]`
-* `layout_aliases`
+* `layout_aliases` <Badge type="info">Object: String</Badge>
     * A mapping of layout aliases to layout definitions.
     * Example:
     ```json
@@ -313,34 +313,34 @@ The ISO enter key is represented by a 1.25u×2uh key. Renderers which utilize in
         "LAYOUT_iso": "LAYOUT_60_iso"
     }
     ```
-* `layouts`
+* `layouts` <Badge type="info">Object</Badge>
     * A dictionary of layouts supported by the keyboard.
-    * `LAYOUT_<layout_name>`
-        * `layout`
+    * `LAYOUT_<layout_name>` <Badge type="info">Object</Badge>
+        * `layout` <Badge type="info">Array: Object</Badge>
             * A list of key dictionaries comprising the layout. Each key dictionary contains:
-                * `matrix` (Required)
+                * `matrix` <Badge type="info">Matrix</Badge> <Badge>Required</Badge>
                     * The matrix position for the key.
                     * Example: `[0, 4]` (row 0, column 4)
-                * `x` (Required)
+                * `x` <Badge type="info">KeyUnit</Badge> <Badge>Required</Badge>
                     * The absolute position of the key in the horizontal axis, in key units.
-                * `y` (Required)
+                * `y` <Badge type="info">KeyUnit</Badge> <Badge>Required</Badge>
                     * The absolute position of the key in the vertical axis, in key units.
-                * `h`
+                * `h` <Badge type="info">KeyUnit</Badge>
                     * The height of the key, in key units.
                     * Default: `1` (1u)
-                * `label`
+                * `label` <Badge type="info">String</Badge>
                     * What to name the key. This is *not* a key assignment as in the keymap, but should usually correspond to the keycode for the first layer of the default keymap.
                     * Example: `"Escape"`
-                * `r`
+                * `r` <Badge type="info">Number</Badge>
                     * The rotation angle in degrees. Currently not implemented.
-                * `rx`
+                * `rx` <Badge type="info">Number</Badge>
                     * The absolute X position of the rotation axis. Currently not implemented.
-                * `ry`
+                * `ry` <Badge type="info">Number</Badge>
                     * The absolute Y position of the rotation axis. Currently not implemented.
-                * `w`
+                * `w` <Badge type="info">KeyUnit</Badge>
                     * The width of the key, in key units.
                     * Default: `1` (1u)
-                * `encoder`
+                * `encoder` <Badge type="info">Number</Badge>
                     * The index of an encoder this key should be linked to
                 * Example: `{"label": "Shift", "matrix": [4, 0], "x": 0, "y": 4.25, "w": 2.25}`
 
@@ -349,13 +349,13 @@ The ISO enter key is represented by a 1.25u×2uh key. Renderers which utilize in
 Configures the [Leader Key](features/leader_key) feature.
 
 * `leader_key`
-    * `timing`
+    * `timing` <Badge type="info">Boolean</Badge>
         * Reset the `timeout` on each keypress.
         * Default: `false`
-    * `strict_processing`
+    * `strict_processing` <Badge type="info">Boolean</Badge>
         * Do not extract the tap keycodes from Layer-Tap and Mod-Tap key events.
         * Default: `false`
-    * `timeout`
+    * `timeout` <Badge type="info">Number</Badge>
         * The amount of time to complete a leader sequence in milliseconds.
         * Default: `300` (300 ms)
 
@@ -364,7 +364,7 @@ Configures the [Leader Key](features/leader_key) feature.
 Configures the [LED Matrix](features/led_matrix) feature.
 
 * `led_matrix`
-    * `animations`
+    * `animations` <Badge type="info">Object: Boolean</Badge>
         * A dictionary of effects to enable or disable. Effects which are absent default to `false`.
         * Example:
         ```json
@@ -374,82 +374,82 @@ Configures the [LED Matrix](features/led_matrix) feature.
             "cycle_left_right": false
         }
         ```
-    * `center_point`
+    * `center_point` <Badge type="info">Array: Number</Badge>
         * The centroid (geometric center) of the LEDs. Used for certain effects.
         * Default: `[112, 32]`
     * `default`
-        * `animation`
+        * `animation` <Badge type="info">String</Badge>
             * The default effect. Must be one of `led_matrix.animations`
             * Default: `"solid"`
-        * `on`
+        * `on` <Badge type="info">Boolean</Badge>
             * The default enabled state.
             * Default: `true`
-        * `val`
+        * `val` <Badge type="info">Number</Badge>
             * The default brightness level.
             * Default: `max_brightness`
-        * `speed`
+        * `speed` <Badge type="info">Number</Badge>
             * The default animation speed.
             * Default: `128`
-    * `driver` (Required)
+    * `driver` <Badge type="info">String</Badge> <Badge>Required</Badge>
         * The driver to use. Must be one of `custom`, `is31fl3218`, `is31fl3731`, `is31fl3733`, `is31fl3736`, `is31fl3737`, `is31fl3741`, `is31fl3742a`, `is31fl3743a`, `is31fl3745`, `is31fl3746a`, `snled27351`.
-    * `layout` (Required)
+    * `layout` <Badge type="info">Array: Object</Badge> <Badge>Required</Badge>
         * List of LED configuration dictionaries. Each dictionary contains:
-            * `flags` (Required)
+            * `flags` <Badge type="info">Number</Badge> <Badge>Required</Badge>
                 * A bitfield of flags describing the type of LED.
-            * `x` (Required)
+            * `x` <Badge type="info">Number</Badge> <Badge>Required</Badge>
                 * The position of the LED in the horizontal axis, from 0 to 224.
-            * `y` (Required)
+            * `y` <Badge type="info">Number</Badge> <Badge>Required</Badge>
                 * The position of the LED in the vertical axis, from 0 to 64.
-            * `matrix`
+            * `matrix` <Badge type="info">Matrix</Badge>
                 * The key matrix position associated with the LED.
                 * Example: `[0, 2]`
             * Example: `{"matrix": [2, 1], "x": 20, "y": 48, "flags": 2}`
-    * `led_flush_limit`
+    * `led_flush_limit` <Badge type="info">Number</Badge>
         * Limits in milliseconds how frequently an animation will update the LEDs.
         * Default: `16`
-    * `led_process_limit`
+    * `led_process_limit` <Badge type="info">Number</Badge>
         * Limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness).
         * Default: `led_count / 5`
-    * `max_brightness`
+    * `max_brightness` <Badge type="info">Number</Badge>
         * The maximum value which brightness is scaled to, from 0 to 255.
         * Default: `255`
-    * `react_on_keyup`
+    * `react_on_keyup` <Badge type="info">Boolean</Badge>
         * Animations react to keyup instead of keydown.
         * Default: `false`
-    * `sleep`
+    * `sleep` <Badge type="info">Boolean</Badge>
         * Turn off the LEDs when the host goes to sleep.
         * Default: `false`
-    * `speed_steps`
+    * `speed_steps` <Badge type="info">Number</Badge>
         * The number of speed adjustment steps.
         * Default: `16`
-    * `split_count`
+    * `split_count` <Badge type="info">Array: Number</Badge>
         * For split keyboards, the number of LEDs on each half.
         * Example: `[16, 16]`
-    * `timeout`
+    * `timeout` <Badge type="info">Number</Badge>
         * The LED activity timeout in milliseconds.
         * Default: `0` (no timeout)
-    * `val_steps`
+    * `val_steps` <Badge type="info">Number</Badge>
         * The number of brightness adjustment steps.
         * Default: `8`
 
 ## Matrix {#matrix}
 
-* `debounce`
+* `debounce` <Badge type="info">Number</Badge>
     * The debounce time in milliseconds.
     * Default: `5` (5 ms)
-* `diode_direction`
+* `diode_direction` <Badge type="info">String</Badge>
     * Which way the diodes are "pointing". Unused for `matrix_pins.direct`. Must be one of `COL2ROW`, `ROW2COL`.
 * `matrix_pins`
-    * `cols`
+    * `cols` <Badge type="info">Array: Pin</Badge>
         * A list of GPIO pins connected to the matrix columns.
         * Example: `["A0", "A1", "A2"]`
-    * `custom`
+    * `custom` <Badge type="info">Boolean</Badge>
         * Whether to use a custom matrix scanning implementation.
         * Default: `false`
-    * `custom_lite`
+    * `custom_lite` <Badge type="info">Boolean</Badge>
         * Whether to use a "lite" custom matrix scanning implementation.
         * Default: `false`
-    * `direct`
+    * `direct` <Badge type="info">Array: Array: Pin</Badge>
         * A 2-dimensional list of GPIO pins connected to each keyswitch, forming the "matrix" rows and columns.
         * Example:
         ```json
@@ -459,16 +459,16 @@ Configures the [LED Matrix](features/led_matrix) feature.
             ["C0", "C1", "C2"]
         ]
         ```
-    * `ghost`
+    * `ghost` <Badge type="info">Boolean</Badge>
         * Whether the matrix has no anti-ghosting diodes.
         * Default: `false`
-    * `input_pressed_state`
+    * `input_pressed_state` <Badge type="info">0|1</Badge>
         * The logical GPIO state of the input pins when a key is pressed.
         * Default: `0` (pressed = low)
-    * `io_delay`
+    * `io_delay` <Badge type="info">Number</Badge>
         * The amount of time to wait between row/col selection and col/row pin reading, in microseconds.
         * Default: `30` (30 µs)
-    * `rows`
+    * `rows` <Badge type="info">Array: Pin</Badge>
         * A list of GPIO pins connected to the matrix rows.
         * Example: `["B0", "B1", "B2"]`
 
@@ -477,23 +477,23 @@ Configures the [LED Matrix](features/led_matrix) feature.
 Configures the [Mouse Keys](features/mouse_keys) feature.
 
 * `mouse_key`
-    * `delay`
-    * `enabled`
+    * `delay` <Badge type="info">Number</Badge>
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enables the Mouse Keys feature.
         * Default: `false`
-    * `interval`
-    * `max_speed`
-    * `time_to_max`
-    * `wheel_delay`
+    * `interval` <Badge type="info">Number</Badge>
+    * `max_speed` <Badge type="info">Number</Badge>
+    * `time_to_max` <Badge type="info">Number</Badge>
+    * `wheel_delay` <Badge type="info">Number</Badge>
 
 ## One Shot {#one-shot}
 
 Configures [One Shot keys](one_shot_keys).
 
 * `oneshot`
-    * `tap_toggle`
+    * `tap_toggle` <Badge type="info">Number</Badge>
         * The number of times to tap the key in order to hold it.
-    * `timeout`
+    * `timeout` <Badge type="info">Number</Badge>
         * The amount of time before the key is released in milliseconds.
 
 ## PS/2 {#ps2}
@@ -501,30 +501,30 @@ Configures [One Shot keys](one_shot_keys).
 Configures the [PS/2](features/ps2_mouse) feature.
 
 * `ps2`
-    * `clock_pin`
+    * `clock_pin` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to `CLK` on the PS/2 device.
-    * `data_pin`
+    * `data_pin` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to `DATA` on the PS/2 device.
-    * `driver`
+    * `driver` <Badge type="info">String</Badge>
         * The PS/2 driver to use. Must be one of `busywait`, `interrupt`, `usart`, `vendor`.
         * Default: `"busywait"`
-    * `enabled`
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enable the PS/2 feature.
         * Default: `false`
-    * `mouse_enabled`
+    * `mouse_enabled` <Badge type="info">Boolean</Badge>
         * Enable the PS/2 mouse handling.
         * Default: `false`
 
 ## QMK LUFA Bootloader {#qmk-lufa-bootloader}
 
 * `qmk_lufa_bootloader`
-    * `esc_input` (Required)
+    * `esc_input` <Badge type="info">Pin</Badge> <Badge>Required</Badge>
         * The GPIO pin connected to the designated "exit bootloader" key's row (if `COL2ROW`).
-    * `esc_output` (Required)
+    * `esc_output` <Badge type="info">Pin</Badge> <Badge>Required</Badge>
         * The GPIO pin connected to the designated "exit bootloader" key's column (if `COL2ROW`).
-    * `led`
+    * `led` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to an LED to flash.
-    * `speaker`
+    * `speaker` <Badge type="info">Pin</Badge>
         * The GPIO pin connected to a speaker to click (can also be used for a second LED).
 
 ## RGBLight {#rgblight}
@@ -532,9 +532,9 @@ Configures the [PS/2](features/ps2_mouse) feature.
 Configures the [RGB Lighting](features/rgblight) feature.
 
 * `rgblight`
-    * `led_count` (Required)
+    * `led_count` <Badge type="info">Number</Badge> <Badge>Required</Badge>
         * The number of LEDs in the chain.
-    * `animations`
+    * `animations` <Badge type="info">Object: Boolean</Badge>
         * A dictionary of effects to enable or disable. Effects which are absent default to `false`.
         * Example:
         ```json
@@ -544,60 +544,60 @@ Configures the [RGB Lighting](features/rgblight) feature.
             "snake": false
         }
         ```
-    * `brightness_steps`
+    * `brightness_steps` <Badge type="info">Number</Badge>
         * The number of brightness adjustment steps.
         * Default: `17`
     * `default`
-        * `animation`
+        * `animation` <Badge type="info">String</Badge>
             * The default effect. Must be one of `rgblight.animations`
             * Default: `"static_light"`
-        * `on`
+        * `on` <Badge type="info">Boolean</Badge>
             * The default enabled state.
             * Default: `true`
-        * `hue`
+        * `hue` <Badge type="info">Number</Badge>
             * The default hue value.
             * Default: `0`
-        * `sat`
+        * `sat` <Badge type="info">Number</Badge>
             * The default saturation value.
             * Default: `255`
-        * `val`
+        * `val` <Badge type="info">Number</Badge>
             * The default brightness level.
             * Default: `max_brightness`
-        * `speed`
+        * `speed` <Badge type="info">Number</Badge>
             * The default animation speed.
             * Default: `0`
-    * `driver`
+    * `driver` <Badge type="info">String</Badge>
         * The driver to use. Must be one of `apa102`, `custom`, `ws2812`.
         * Default: `"ws2812"`
-    * `hue_steps`
+    * `hue_steps` <Badge type="info">Number</Badge>
         * The number of hue adjustment steps.
         * Default: `8`
     * `layers`
-        * `blink`
+        * `blink` <Badge type="info">Boolean</Badge>
             * Enable layer blinking API.
             * Default: `false`
-        * `enabled`
+        * `enabled` <Badge type="info">Boolean</Badge>
             * Enable RGB Lighting Layers.
             * Default: `false`
-        * `max`
+        * `max` <Badge type="info">Number</Badge>
             * The maximum layer count, from 1 to 32.
             * Default: `8`
-    * `led_map`
+    * `led_map` <Badge type="info">Array: Number</Badge>
         * Remap LED indices.
         * Example: `[4, 3, 2, 1, 0]`
-    * `max_brightness`
+    * `max_brightness` <Badge type="info">Number</Badge>
         * The maximum value which the HSV "V" component is scaled to, from 0 to 255.
         * Default: `255`
-    * `saturation_steps`
+    * `saturation_steps` <Badge type="info">Number</Badge>
         * The number of saturation adjustment steps.
         * Default: `17`
-    * `sleep`
+    * `sleep` <Badge type="info">Boolean</Badge>
         * Turn off the LEDs when the host goes to sleep.
         * Default: `false`
-    * `split`
+    * `split` <Badge type="info">Boolean</Badge>
         * Enable synchronization between split halves.
         * Default: `false`
-    * `split_count`
+    * `split_count` <Badge type="info">Array: Number</Badge>
         * When `rgblight.split` is enabled, the number of LEDs on each half.
         * Example: `[10, 10]`
 
@@ -606,7 +606,7 @@ Configures the [RGB Lighting](features/rgblight) feature.
 Configures the [RGB Matrix](features/rgb_matrix) feature.
 
 * `rgb_matrix`
-    * `animations`
+    * `animations` <Badge type="info">Object: Boolean</Badge>
         * A dictionary of effects to enable or disable. Effects which are absent default to `false`.
         * Example:
         ```json
@@ -616,73 +616,73 @@ Configures the [RGB Matrix](features/rgb_matrix) feature.
             "cycle_left_right": false
         }
         ```
-    * `center_point`
+    * `center_point` <Badge type="info">Array: Number</Badge>
         * The centroid (geometric center) of the LEDs. Used for certain effects.
         * Default: `[112, 32]`
     * `default`
-        * `animation`
+        * `animation` <Badge type="info">String</Badge>
             * The default effect. Must be one of `rgb_matrix.animations`
             * Default: `"solid_color"`
-        * `on`
+        * `on` <Badge type="info">Boolean</Badge>
             * The default enabled state.
             * Default: `true`
-        * `hue`
+        * `hue` <Badge type="info">Number</Badge>
             * The default hue value.
             * Default: `0`
-        * `sat`
+        * `sat` <Badge type="info">Number</Badge>
             * The default saturation value.
             * Default: `255`
-        * `val`
+        * `val` <Badge type="info">Number</Badge>
             * The default brightness level.
             * Default: `max_brightness`
-        * `speed`
+        * `speed` <Badge type="info">Number</Badge>
             * The default animation speed.
             * Default: `128`
-    * `driver` (Required)
+    * `driver` <Badge type="info">String</Badge> <Badge>Required</Badge>
         * The driver to use. Must be one of `aw20216s`, `custom`, `is31fl3218`, `is31fl3236`, `is31fl3729`, `is31fl3731`, `is31fl3733`, `is31fl3736`, `is31fl3737`, `is31fl3741`, `is31fl3742a`, `is31fl3743a`, `is31fl3745`, `is31fl3746a`, `snled27351`, `ws2812`.
-    * `hue_steps`
+    * `hue_steps` <Badge type="info">Number</Badge>
         * The number of hue adjustment steps.
         * Default: `8`
-    * `layout` (Required)
+    * `layout` <Badge type="info">Array: Object</Badge> <Badge>Required</Badge>
         * List of LED configuration dictionaries. Each dictionary contains:
-            * `flags` (Required)
+            * `flags` <Badge type="info">Number</Badge> <Badge>Required</Badge>
                 * A bitfield of flags describing the type of LED.
-            * `x` (Required)
+            * `x` <Badge type="info">Number</Badge> <Badge>Required</Badge>
                 * The position of the LED in the horizontal axis, from 0 to 224.
-            * `y` (Required)
+            * `y` <Badge type="info">Number</Badge> <Badge>Required</Badge>
                 * The position of the LED in the vertical axis, from 0 to 64.
-            * `matrix`
+            * `matrix` <Badge type="info">Matrix</Badge>
                 * The key matrix position associated with the LED.
                 * Example: `[0, 2]`
             * Example: `{"matrix": [2, 1], "x": 20, "y": 48, "flags": 2}`
-    * `led_flush_limit`
+    * `led_flush_limit` <Badge type="info">Number</Badge>
         * Limits in milliseconds how frequently an animation will update the LEDs.
         * Default: `16`
-    * `led_process_limit`
+    * `led_process_limit` <Badge type="info">Number</Badge>
         * Limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness).
         * Default: `led_count / 5`
-    * `max_brightness`
+    * `max_brightness` <Badge type="info">Number</Badge>
         * The maximum value which the HSV "V" component is scaled to, from 0 to 255.
         * Default: `255`
-    * `react_on_keyup`
+    * `react_on_keyup` <Badge type="info">Boolean</Badge>
         * Animations react to keyup instead of keydown.
         * Default: `false`
-    * `sat_steps`
+    * `sat_steps` <Badge type="info">Number</Badge>
         * The number of saturation adjustment steps.
         * Default: `16`
-    * `sleep`
+    * `sleep` <Badge type="info">Boolean</Badge>
         * Turn off the LEDs when the host goes to sleep.
         * Default: `false`
-    * `speed_steps`
+    * `speed_steps` <Badge type="info">Number</Badge>
         * The number of speed adjustment steps.
         * Default: `16`
-    * `split_count`
+    * `split_count` <Badge type="info">Array: Number</Badge>
         * For split keyboards, the number of LEDs on each half.
         * Example: `[16, 16]`
-    * `timeout`
+    * `timeout` <Badge type="info">Number</Badge>
         * The LED activity timeout in milliseconds.
         * Default: `0` (no timeout)
-    * `val_steps`
+    * `val_steps` <Badge type="info">Number</Badge>
         * The number of brightness adjustment steps.
         * Default: `16`
 
@@ -691,16 +691,16 @@ Configures the [RGB Matrix](features/rgb_matrix) feature.
 Configures the [Secure](features/secure) feature.
 
 * `secure`
-    * `enabled`
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enable the Secure feature.
         * Default: `false`
-    * `idle_timeout`
+    * `idle_timeout` <Badge type="info">Number</Badge>
         * Timeout while unlocked before returning to the locked state. Set to `0` to disable.
         * Default: `60000` (1 minute)
-    * `unlock_sequence`
+    * `unlock_sequence` <Badge type="info">Array: Matrix</Badge>
         * A list of up to five matrix locations comprising the "unlock sequence".
         * Example: `[[0, 0], [0, 1], [4, 3]]`
-    * `unlock_timeout`
+    * `unlock_timeout` <Badge type="info">Number</Badge>
         * Timeout for the user to perform the unlock sequence. Set to `0` to disable.
         * Default: `5000` (5 seconds)
 
@@ -716,7 +716,7 @@ Configures the [Split Keyboard](features/split_keyboard) feature.
         * `right`
             * `pins`
                 * See [DIP Switches](#dip-switch) config.
-    * `enabled`
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enable the Split Keyboard feature.
         * Default: `false`
     * `encoder`
@@ -724,69 +724,69 @@ Configures the [Split Keyboard](features/split_keyboard) feature.
             * `rotary`
                 * See [Encoder](#encoder) config.
     * `handedness`
-        * `pin`
+        * `pin` <Badge type="info">Pin</Badge>
             * The GPIO pin connected to determine handedness.
-        * `matrix_grid`
+        * `matrix_grid` <Badge type="info">Array: Pin</Badge>
             * The GPIO pins of the matrix position which determines the handedness.
             * Example: `["A1", "B5"]`
     * `matrix_pins`
         * `right`
             * See [Matrix](#matrix) config.
     * `serial`
-        * `driver`
+        * `driver` <Badge type="info">String</Badge>
             * The driver to use. Must be one of `bitbang`, `usart`, `vendor`.
             * Default: `"bitbang"`
-        * `pin`
+        * `pin` <Badge type="info">Pin</Badge>
             * The GPIO pin to use for transmit and receive.
-    * `soft_serial_speed`
+    * `soft_serial_speed` <Badge type="info">Number</Badge>
         * The protocol speed, from `0` to `5` (`serial` transport protocol only).
         * Default: `1`
     * `transport`
-        * `protocol`
+        * `protocol` <Badge type="info">String</Badge>
             * The split transport protocol to use. Must be one of `custom`, `i2c`, `serial`.
         * `sync`
-            * `activity`
+            * `activity` <Badge type="info">Boolean</Badge>
                 * Mirror the activity timestamps to the secondary half.
                 * Default: `false`
-            * `detected_os`
+            * `detected_os` <Badge type="info">Boolean</Badge>
                 * Mirror the [detected OS](features/os_detection) to the secondary half.
                 * Default: `false`
-            * `haptic`
+            * `haptic` <Badge type="info">Boolean</Badge>
                 * Mirror the haptic state and process haptic feedback to the secondary half.
                 * Default: `false`
-            * `layer_state`
+            * `layer_state` <Badge type="info">Boolean</Badge>
                 * Mirror the layer state to the secondary half.
                 * Default: `false`
-            * `indicators`
+            * `indicators` <Badge type="info">Boolean</Badge>
                 * Mirror the indicator state to the secondary half.
                 * Default: `false`
-            * `matrix_state`
+            * `matrix_state` <Badge type="info">Boolean</Badge>
                 * Mirror the main/primary half's matrix state to the secondary half.
                 * Default: `false`
-            * `modifiers`
+            * `modifiers` <Badge type="info">Boolean</Badge>
                 * Mirror the modifier state to the secondary half.
                 * Default: `false`
-            * `oled`
+            * `oled` <Badge type="info">Boolean</Badge>
                 * Mirror the OLED on/off status to the secondary half.
                 * Default: `false`
-            * `st7565`
+            * `st7565` <Badge type="info">Boolean</Badge>
                 * Mirror the ST7565 on/off status to the secondary half.
                 * Default: `false`
-            * `wpm`
+            * `wpm` <Badge type="info">Boolean</Badge>
                 * Mirror the current WPM value to the secondary half.
                 * Default: `false`
-        * `watchdog`
+        * `watchdog` <Badge type="info">Boolean</Badge>
             * Reboot the secondary half if it loses connection.
             * Default: `false`
-        * `watchdog_timeout`
+        * `watchdog_timeout` <Badge type="info">Number</Badge>
             * The amount of time to wait for communication from the primary half in milliseconds.
     * `usb_detect`
-        * `enabled`
+        * `enabled` <Badge type="info">Boolean</Badge>
             * Detect USB connection when determining split half roles.
-        * `polling_interval`
+        * `polling_interval` <Badge type="info">Number</Badge>
             * The polling frequency in milliseconds.
             * Default: `10` (10 ms)
-        * `timeout`
+        * `timeout` <Badge type="info">Number</Badge>
             * The amount of time to wait for a USB connection in milliseconds.
             * Default: `2000` (2 seconds)
 
@@ -795,48 +795,48 @@ Configures the [Split Keyboard](features/split_keyboard) feature.
 Configures the [Stenography](features/stenography) feature.
 
 * `stenography`
-    * `enabled`
+    * `enabled` <Badge type="info">Boolean</Badge>
         * Enable the Stenography feature.
         * Default: `false`
-    * `protocol`
+    * `protocol` <Badge type="info">String</Badge>
         * The Steno protocol to use. Must be one of `all`, `geminipr`, `txbolt`.
         * Default: `"all"`
 
 ## USB {#usb}
 
 * `usb`
-    * `device_version` (Required)
+    * `device_version` <Badge type="info">String</Badge> <Badge>Required</Badge>
         * A BCD version number in the format `MM.m.r` (up to `99.9.9`).
         * Example: `"1.0.0"`
-    * `pid` (Required)
+    * `pid` <Badge type="info">String</Badge> <Badge>Required</Badge>
         * The USB product ID as a four-digit hexadecimal number.
         * Example: `"0x23B0"`
-    * `vid` (Required)
+    * `vid` <Badge type="info">String</Badge> <Badge>Required</Badge>
         * The USB vendor ID as a four-digit hexadecimal number.
         * Example: `"0xC1ED"`
-    * `force_nkro`
+    * `force_nkro` <Badge type="info">Boolean</Badge>
         * Force NKRO to be active.
         * Default: `false`
-    * `max_power`
+    * `max_power` <Badge type="info">Number</Badge>
         * The maximum current draw the host should expect from the device. This does not control the actual current usage.
         * Default: `500` (500 mA)
-    * `no_startup_check`
+    * `no_startup_check` <Badge type="info">Boolean</Badge>
         * Disable USB suspend check after keyboard startup.
         * Default: `false`
-    * `polling_interval`
+    * `polling_interval` <Badge type="info">Number</Badge>
         * The frequency at which the host should poll the keyboard for reports.
         * Default: `1` (1 ms/1000 Hz)
     * `shared_endpoint`
-        * `keyboard`
+        * `keyboard` <Badge type="info">Boolean</Badge>
             * Send keyboard reports through the "shared" USB endpoint.
             * Default: `false`
-        * `mouse`
+        * `mouse` <Badge type="info">Boolean</Badge>
             * Send mouse reports through the "shared" USB endpoint.
             * Default: `true`
-    * `suspend_wakeup_delay`
+    * `suspend_wakeup_delay` <Badge type="info">Number</Badge>
         * The amount of time to wait after sending a wakeup packet, in milliseconds.
         * Default: `0` (disabled)
-    * `wait_for_enumeration`
+    * `wait_for_enumeration` <Badge type="info">Boolean</Badge>
         * Force the keyboard to wait for USB enumeration before starting up.
         * Default: `false`
 
@@ -845,17 +845,17 @@ Configures the [Stenography](features/stenography) feature.
 Configures the [WS2812](drivers/ws2812) driver.
 
 * `ws2812`
-    * `driver`
+    * `driver` <Badge type="info">String</Badge>
         * The driver to use. Must be one of `bitbang`, `custom`, `i2c`, `pwm`, `spi`, `vendor`.
         * Default: `"bitbang"`
-    * `pin` (Required)
+    * `pin` <Badge type="info">Pin</Badge> <Badge>Required</Badge>
         * The GPIO pin connected to `DI` on the first LED in the chain (`bitbang`, `pwm`, `spi` and `vendor` drivers only).
-    * `i2c_address`
+    * `i2c_address` <Badge type="info">String</Badge>
         * The I²C address of the WS2812 controller (`i2c` driver only).
         * Default: `"0xB0"`
-    * `i2c_timeout`
+    * `i2c_timeout` <Badge type="info">Number</Badge>
         * The I²C timeout in milliseconds (`i2c` driver only).
         * Default: `100` (100 ms)
-    * `rgbw`
+    * `rgbw` <Badge type="info">Boolean</Badge>
         * Enable RGBW LEDs.
         * Default: `false`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Using the [builtin `<Badge>` component in Vitepress](https://vitepress.dev/reference/default-theme-badge) to add some general type information for properties, and make the `(Required)`s look a bit nicer.

![image](https://github.com/user-attachments/assets/ceb989bc-5674-419a-b36c-2f08537b6778)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
