### PR TITLE
Add svlinky converter

### DIFF
--- a/data/mappings/defaults.hjson
+++ b/data/mappings/defaults.hjson
@@ -86,7 +86,7 @@
             "processor": "STM32F411"
         },
         "svlinky": {
-            "board": "SVLINKY",
+            "board": "QMK_PM2040",
             "bootloader": "rp2040",
             "processor": "RP2040"
         }

--- a/data/mappings/defaults.hjson
+++ b/data/mappings/defaults.hjson
@@ -84,6 +84,11 @@
             "board": "STEMCELL",
             "bootloader": "tinyuf2",
             "processor": "STM32F411"
+        },
+        "svlinky": {
+            "board": "SVLINKY",
+            "bootloader": "rp2040",
+            "processor": "RP2040"
         }
     }
 }

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -45,7 +45,7 @@
         },
         "development_board": {
             "type": "string",
-            "enum": ["promicro", "elite_c", "elite_pi", "proton_c", "kb2040", "promicro_rp2040", "blok", "michi", "bit_c_pro", "stemcell", "bluepill", "blackpill_f401", "blackpill_f411", "bonsai_c4", "helios", "liatris", "imera"]
+            "enum": ["promicro", "elite_c", "elite_pi", "proton_c", "kb2040", "promicro_rp2040", "blok", "michi", "bit_c_pro", "stemcell", "bluepill", "blackpill_f401", "blackpill_f411", "bonsai_c4", "helios", "liatris", "imera", "svlinky"]
         },
         "pin_compatible": {
             "type": "string",

--- a/docs/feature_converters.md
+++ b/docs/feature_converters.md
@@ -21,6 +21,7 @@ The following converters are available at this time:
 | `promicro` | `liatris`         |
 | `promicro` | `imera`           |
 | `promicro` | `michi`           |
+| `promicro` | `svlinky`         |
 | `elite_c`  | `stemcell`        |
 | `elite_c`  | `rp2040_ce`       |
 | `elite_c`  | `elite_pi`        |
@@ -87,6 +88,7 @@ If a board currently supported in QMK uses a [Pro Micro](https://www.sparkfun.co
 | [Liatris](https://splitkb.com/products/liatris)                                          | `liatris`         |
 | [Imera](https://splitkb.com/products/imera)                                              | `imera`           |
 | [Michi](https://github.com/ci-bus/michi-promicro-rp2040)                                 | `michi`           |
+| [Svlinky](https://github.com/sadekbaroudi/svlinky)                                       | `svlinky`         |
 
 Converter summary:
 
@@ -105,6 +107,7 @@ Converter summary:
 | `liatris`         | `-e CONVERT_TO=liatris`         | `CONVERT_TO=liatris`         | `#ifdef CONVERT_TO_LIATRIS`         |
 | `imera`           | `-e CONVERT_TO=imera`           | `CONVERT_TO=imera`           | `#ifdef CONVERT_TO_IMERA`           |
 | `michi`           | `-e CONVERT_TO=michi`           | `CONVERT_TO=michi`           | `#ifdef CONVERT_TO_MICHI`           |
+| `svlinky`         | `-e CONVERT_TO=svlinky`         | `CONVERT_TO=svlinky`         | `#ifdef CONVERT_TO_SVLINKY`         |
 
 ### Proton C {#proton_c}
 

--- a/docs/feature_converters.md
+++ b/docs/feature_converters.md
@@ -173,6 +173,9 @@ The Bonsai C4 only has one on-board LED (B2), and by default, both the Pro Micro
 
 Feature set is identical to [Adafruit KB2040](#kb2040). VBUS detection is enabled by default for superior split keyboard support. For more information, refer to the [Community Edition pinout](platformdev_rp2040#rp2040_ce) docs.
 
+### Svlinky {#svlinky}
+
+Feature set is a pro micro equivalent of the [RP2040 Community Edition](#rp2040_ce), except that two of the analog GPIO have been replaced with digital only GPIO. These two were moved to the FPC connector to support the [VIK specification](https://github.com/sadekbaroudi/vik). This means that if you are expecting analog support on all 4 pins as provided on a RP2040 Community Edition pinout, you will not have that. Please see the [Svlinky github page](https://github.com/sadekbaroudi/svlinky) for more details.
 
 ## Elite-C
 

--- a/platforms/chibios/converters/promicro_to_svlinky/_pin_defs.h
+++ b/platforms/chibios/converters/promicro_to_svlinky/_pin_defs.h
@@ -1,0 +1,36 @@
+// Copyright 2023 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// Left side (front)
+#define D3 0U
+#define D2 1U
+//      GND
+//      GND
+#define D1 2U
+#define D0 3U
+#define D4 4U
+#define C6 5U
+#define D7 6U
+#define E6 7U
+#define B4 8U
+#define B5 9U
+
+// Right side (front)
+//      RAW
+//      GND
+//      RESET
+//      VCC
+#define F4 29U
+#define F5 28U
+#define F6 18U
+#define F7 24U
+#define B1 22U
+#define B3 20U
+#define B2 23U
+#define B6 21U
+
+// LEDs
+#define D5 17U
+#define B0 25U

--- a/platforms/chibios/converters/promicro_to_svlinky/converter.mk
+++ b/platforms/chibios/converters/promicro_to_svlinky/converter.mk
@@ -1,0 +1,10 @@
+# rp2040_ce MCU settings for converting AVR projects
+MCU := RP2040
+BOARD := QMK_PM2040
+BOOTLOADER := rp2040
+
+# These are defaults based on what has been implemented for RP2040 boards
+SERIAL_DRIVER ?= vendor
+WS2812_DRIVER ?= vendor
+BACKLIGHT_DRIVER ?= software
+OPT_DEFS += -DUSB_VBUS_PIN=19U


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add the svlinky RP2040 to the converters so that existing projects can be converted. The svlinky board is open source and available at:
https://github.com/sadekbaroudi/svlinky

This converter is for the v0.2. The v0.1 is already compatible with the `rp2040_ce` converter. I had to change the pinout to allow the controller to be fully compliant with the [vik specifications](https://github.com/sadekbaroudi/vik). The specification requires that the 2 extra gpio in the fpc connector are digital/analog. Given the RP2040 only has 4 analog capable pins, and all of them are used in the standard pinout on a pro micro controller, I had to take two of those out and swap them with different gpio, leading to this.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
