### PR TITLE
Fix `thumbsup:default` keymap

### DIFF
--- a/keyboards/thumbsup/keymaps/default/keymap.c
+++ b/keyboards/thumbsup/keymaps/default/keymap.c
@@ -15,8 +15,6 @@
  */
 #include QMK_KEYBOARD_H
 
-
-
 // Defines names for use in layer keycodes and the keymap
 enum layer_names {
     _QWERTY,
@@ -26,12 +24,7 @@ enum layer_names {
     _EXTRARIGHT
 };
 
-// Aliases for this command to make the thumb keys work as LOWER/RAISE on hold and as space on hit.
-//#define CURSORRGHT LT(_CURSORRGHT,KC_SPC)
-//#define CURSORLEFT LT(_CURSORLEFT,KC_SPC)
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-
 
 /* Qwerty                                 
  * ,-----------------------------------------+		+-----------------------------------------.
@@ -55,7 +48,7 @@ Single hit:  |		       |      |Space |		|Space |      |                 |
   KC_ESC,                  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,       KC_Y,       KC_U,    KC_I,    KC_O,   KC_P,    KC_BSPC,
   LT(_EXTRARIGHT,KC_TAB),  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,       KC_H,       KC_J,    KC_K,    KC_L,   KC_SCLN, KC_PENT,
   KC_LCTL,                 KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,       KC_N,       KC_M,    KC_COMM, KC_DOT, KC_SLSH, KC_RCTL,
-                  	   KC_SPC,  KC_LGUI, KC_LALT, KC_LSFT, LT(TL_LOWR,KC_SPC), LT(TL_UPPR ,KC_SPC), KC_RSFT, KC_RALT, KC_APP, KC_SPC
+      KC_SPC,  KC_LGUI, KC_LALT, KC_LSFT, LT(_CURSORLEFT,KC_SPC), LT(_CURSORRGHT ,KC_SPC), KC_RSFT, KC_RALT, KC_APP, KC_SPC
 ),
 
 
@@ -173,3 +166,6 @@ without separate thumbcluster.
 )
 };
 
+layer_state_t layer_state_set_user(layer_state_t state) {
+  return update_tri_layer_state(state, _CURSORLEFT, _CURSORRGHT, _NUMBERS);
+}

--- a/keyboards/thumbsup/keymaps/default/rules.mk
+++ b/keyboards/thumbsup/keymaps/default/rules.mk
@@ -1,1 +1,0 @@
-TRI_LAYER_ENABLE = yes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fix invalid use of Tri-Layer keycodes.

`LT(TL_LOWR,KC_SPC), LT(TL_UPPR ,KC_SPC)` would not work. The use of `TL_LOWR` as a layer number, would effectively give `LT(12,KC_SPC)` and go out of bounds.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
