### PR TITLE
[murcielago] Enable split watchdog

### DIFF
--- a/keyboards/murcielago/rev1/config.h
+++ b/keyboards/murcielago/rev1/config.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* split options, use EEPROM for side detection */
 #define EE_HANDS
 #define SPLIT_USB_DETECT
+#define SPLIT_WATCHDOG_ENABLE
 
 /*
  * Feature disable options

--- a/keyboards/murcielago/rev1/keymaps/default/keymap.c
+++ b/keyboards/murcielago/rev1/keymaps/default/keymap.c
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 elagil
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
 #include QMK_KEYBOARD_H
 
 enum layers {


### PR DESCRIPTION
## Description

Enable split watchdog for Murcielago for the keyboard to be detected on boot.

Tested on my own Murcielago running VIAL.
See: https://github.com/vial-kb/vial-qmk/pull/791

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


