### PR TITLE
Expand count checks in keymap introspection

### DIFF
--- a/quantum/keymap_introspection.c
+++ b/quantum/keymap_introspection.c
@@ -127,6 +127,8 @@ __attribute__((weak)) uint16_t tap_dance_count(void) {
     return tap_dance_count_raw();
 }
 
+_Static_assert(ARRAY_SIZE(tap_dance_actions) <= (QK_TAP_DANCE_MAX - QK_TAP_DANCE), "Number of tap dance actions exceeds maximum. Are you using SAFE_RANGE in tap dance enum?");
+
 tap_dance_action_t* tap_dance_get_raw(uint16_t tap_dance_idx) {
     if (tap_dance_idx >= tap_dance_count_raw()) {
         return NULL;

--- a/quantum/keymap_introspection.c
+++ b/quantum/keymap_introspection.c
@@ -102,6 +102,8 @@ __attribute__((weak)) uint16_t combo_count(void) {
     return combo_count_raw();
 }
 
+_Static_assert(ARRAY_SIZE(key_combos) <= (QK_KB), "Number of combos is abnormally high. Are you using SAFE_RANGE in an enum for combos?");
+
 combo_t* combo_get_raw(uint16_t combo_idx) {
     if (combo_idx >= combo_count_raw()) {
         return NULL;
@@ -154,6 +156,8 @@ uint16_t key_override_count_raw(void) {
 __attribute__((weak)) uint16_t key_override_count(void) {
     return key_override_count_raw();
 }
+
+_Static_assert(ARRAY_SIZE(key_overrides) <= (QK_KB), "Number of key overrides is abnormally high. Are you using SAFE_RANGE in an enum for key overrides?");
 
 const key_override_t* key_override_get_raw(uint16_t key_override_idx) {
     if (key_override_idx >= key_override_count_raw()) {


### PR DESCRIPTION
## Description

Checks the count for tap dance to ensure it's not exceeding the max (0xFF), and to provide a more meaningful error when it is misconfigured.

The message is ... meh.  But have verified that it works.


based on master, so can retarget to that, if needed.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] Enhancement/optimization

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
