### PR TITLE
Rename RGB and HSV structs

### DIFF
--- a/drivers/led/apa102.c
+++ b/drivers/led/apa102.c
@@ -53,8 +53,8 @@
         io_wait;                                          \
     } while (0)
 
-rgb_led_t apa102_leds[APA102_LED_COUNT];
-uint8_t   apa102_led_brightness = APA102_DEFAULT_BRIGHTNESS;
+rgb_t   apa102_leds[APA102_LED_COUNT];
+uint8_t apa102_led_brightness = APA102_DEFAULT_BRIGHTNESS;
 
 static void apa102_send_byte(uint8_t byte) {
     APA102_SEND_BIT(byte, 7);

--- a/drivers/painter/generic/qp_surface_rgb565.c
+++ b/drivers/painter/generic/qp_surface_rgb565.c
@@ -52,7 +52,7 @@ static bool qp_surface_pixdata_rgb565(painter_device_t device, const void *pixel
 // Pixel colour conversion
 static bool qp_surface_palette_convert_rgb565_swapped(painter_device_t device, int16_t palette_size, qp_pixel_t *palette) {
     for (int16_t i = 0; i < palette_size; ++i) {
-        RGB      rgb      = hsv_to_rgb_nocie((HSV){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
+        rgb_t    rgb      = hsv_to_rgb_nocie((hsv_t){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
         uint16_t rgb565   = (((uint16_t)rgb.r) >> 3) << 11 | (((uint16_t)rgb.g) >> 2) << 5 | (((uint16_t)rgb.b) >> 3);
         palette[i].rgb565 = __builtin_bswap16(rgb565);
     }

--- a/drivers/painter/tft_panel/qp_tft_panel.c
+++ b/drivers/painter/tft_panel/qp_tft_panel.c
@@ -90,7 +90,7 @@ bool qp_tft_panel_pixdata(painter_device_t device, const void *pixel_data, uint3
 
 bool qp_tft_panel_palette_convert_rgb565_swapped(painter_device_t device, int16_t palette_size, qp_pixel_t *palette) {
     for (int16_t i = 0; i < palette_size; ++i) {
-        RGB      rgb      = hsv_to_rgb_nocie((HSV){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
+        rgb_t    rgb      = hsv_to_rgb_nocie((hsv_t){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
         uint16_t rgb565   = (((uint16_t)rgb.r) >> 3) << 11 | (((uint16_t)rgb.g) >> 2) << 5 | (((uint16_t)rgb.b) >> 3);
         palette[i].rgb565 = __builtin_bswap16(rgb565);
     }
@@ -99,7 +99,7 @@ bool qp_tft_panel_palette_convert_rgb565_swapped(painter_device_t device, int16_
 
 bool qp_tft_panel_palette_convert_rgb888(painter_device_t device, int16_t palette_size, qp_pixel_t *palette) {
     for (int16_t i = 0; i < palette_size; ++i) {
-        RGB rgb             = hsv_to_rgb_nocie((HSV){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
+        rgb_t rgb           = hsv_to_rgb_nocie((hsv_t){palette[i].hsv888.h, palette[i].hsv888.s, palette[i].hsv888.v});
         palette[i].rgb888.r = rgb.r;
         palette[i].rgb888.g = rgb.g;
         palette[i].rgb888.b = rgb.b;

--- a/quantum/color.c
+++ b/quantum/color.c
@@ -19,8 +19,8 @@
 #include "progmem.h"
 #include "util.h"
 
-RGB hsv_to_rgb_impl(HSV hsv, bool use_cie) {
-    RGB      rgb;
+rgb_t hsv_to_rgb_impl(hsv_t hsv, bool use_cie) {
+    rgb_t    rgb;
     uint8_t  region, remainder, p, q, t;
     uint16_t h, s, v;
 
@@ -97,7 +97,7 @@ RGB hsv_to_rgb_impl(HSV hsv, bool use_cie) {
     return rgb;
 }
 
-RGB hsv_to_rgb(HSV hsv) {
+rgb_t hsv_to_rgb(hsv_t hsv) {
 #ifdef USE_CIE1931_CURVE
     return hsv_to_rgb_impl(hsv, true);
 #else
@@ -105,6 +105,6 @@ RGB hsv_to_rgb(HSV hsv) {
 #endif
 }
 
-RGB hsv_to_rgb_nocie(HSV hsv) {
+rgb_t hsv_to_rgb_nocie(hsv_t hsv) {
     return hsv_to_rgb_impl(hsv, false);
 }

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -84,11 +84,11 @@ typedef struct PACKED rgb_t {
 typedef rgb_t RGB;
 typedef rgb_t rgb_led_t;
 
-typedef struct PACKED HSV {
+typedef struct PACKED hsv_t {
     uint8_t h;
     uint8_t s;
     uint8_t v;
-} HSV;
+} hsv_t;
 
 // DEPRECATED
 typedef hsv_t HSV;

--- a/quantum/color.h
+++ b/quantum/color.h
@@ -74,13 +74,15 @@
 
 // clang-format on
 
-typedef struct PACKED rgb_led_t {
+typedef struct PACKED rgb_t {
     uint8_t r;
     uint8_t g;
     uint8_t b;
-} rgb_led_t;
+} rgb_t;
 
-typedef rgb_led_t RGB;
+// DEPRECATED
+typedef rgb_t RGB;
+typedef rgb_t rgb_led_t;
 
 typedef struct PACKED HSV {
     uint8_t h;
@@ -88,5 +90,8 @@ typedef struct PACKED HSV {
     uint8_t v;
 } HSV;
 
-RGB hsv_to_rgb(HSV hsv);
-RGB hsv_to_rgb_nocie(HSV hsv);
+// DEPRECATED
+typedef hsv_t HSV;
+
+rgb_t hsv_to_rgb(hsv_t hsv);
+rgb_t hsv_to_rgb_nocie(hsv_t hsv);

--- a/quantum/rgb_matrix/animations/alpha_mods_anim.h
+++ b/quantum/rgb_matrix/animations/alpha_mods_anim.h
@@ -6,10 +6,10 @@ RGB_MATRIX_EFFECT(ALPHAS_MODS)
 bool ALPHAS_MODS(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    HSV hsv  = rgb_matrix_config.hsv;
-    RGB rgb1 = rgb_matrix_hsv_to_rgb(hsv);
+    hsv_t hsv  = rgb_matrix_config.hsv;
+    rgb_t rgb1 = rgb_matrix_hsv_to_rgb(hsv);
     hsv.h += rgb_matrix_config.speed;
-    RGB rgb2 = rgb_matrix_hsv_to_rgb(hsv);
+    rgb_t rgb2 = rgb_matrix_hsv_to_rgb(hsv);
 
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();

--- a/quantum/rgb_matrix/animations/breathing_anim.h
+++ b/quantum/rgb_matrix/animations/breathing_anim.h
@@ -8,7 +8,7 @@ bool BREATHING(effect_params_t* params) {
     hsv_t    hsv  = rgb_matrix_config.hsv;
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
-   rgb_t rgb      = rgb_matrix_hsv_to_rgb(hsv);
+    rgb_t rgb     = rgb_matrix_hsv_to_rgb(hsv);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);

--- a/quantum/rgb_matrix/animations/breathing_anim.h
+++ b/quantum/rgb_matrix/animations/breathing_anim.h
@@ -5,10 +5,10 @@ RGB_MATRIX_EFFECT(BREATHING)
 bool BREATHING(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    HSV      hsv  = rgb_matrix_config.hsv;
+    hsv_t    hsv  = rgb_matrix_config.hsv;
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
-    RGB rgb       = rgb_matrix_hsv_to_rgb(hsv);
+   rgb_t rgb      = rgb_matrix_hsv_to_rgb(hsv);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);

--- a/quantum/rgb_matrix/animations/colorband_pinwheel_sat_anim.h
+++ b/quantum/rgb_matrix/animations/colorband_pinwheel_sat_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(BAND_PINWHEEL_SAT)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV BAND_PINWHEEL_SAT_math(HSV hsv, int16_t dx, int16_t dy, uint8_t time) {
+static hsv_t BAND_PINWHEEL_SAT_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t time) {
     hsv.s = scale8(hsv.s - time - atan2_8(dy, dx) * 3, hsv.s);
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/colorband_pinwheel_val_anim.h
+++ b/quantum/rgb_matrix/animations/colorband_pinwheel_val_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(BAND_PINWHEEL_VAL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV BAND_PINWHEEL_VAL_math(HSV hsv, int16_t dx, int16_t dy, uint8_t time) {
+static hsv_t BAND_PINWHEEL_VAL_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t time) {
     hsv.v = scale8(hsv.v - time - atan2_8(dy, dx) * 3, hsv.v);
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/colorband_sat_anim.h
+++ b/quantum/rgb_matrix/animations/colorband_sat_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(BAND_SAT)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV BAND_SAT_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t BAND_SAT_math(hsv_t hsv, uint8_t i, uint8_t time) {
     int16_t s = hsv.s - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
     hsv.s     = scale8(s < 0 ? 0 : s, hsv.s);
     return hsv;

--- a/quantum/rgb_matrix/animations/colorband_spiral_sat_anim.h
+++ b/quantum/rgb_matrix/animations/colorband_spiral_sat_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(BAND_SPIRAL_SAT)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV BAND_SPIRAL_SAT_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+static hsv_t BAND_SPIRAL_SAT_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
     hsv.s = scale8(hsv.s + dist - time - atan2_8(dy, dx), hsv.s);
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/colorband_spiral_val_anim.h
+++ b/quantum/rgb_matrix/animations/colorband_spiral_val_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(BAND_SPIRAL_VAL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV BAND_SPIRAL_VAL_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+static hsv_t BAND_SPIRAL_VAL_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
     hsv.v = scale8(hsv.v + dist - time - atan2_8(dy, dx), hsv.v);
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/colorband_val_anim.h
+++ b/quantum/rgb_matrix/animations/colorband_val_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(BAND_VAL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV BAND_VAL_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t BAND_VAL_math(hsv_t hsv, uint8_t i, uint8_t time) {
     int16_t v = hsv.v - abs(scale8(g_led_config.point[i].x, 228) + 28 - time) * 8;
     hsv.v     = scale8(v < 0 ? 0 : v, hsv.v);
     return hsv;

--- a/quantum/rgb_matrix/animations/cycle_all_anim.h
+++ b/quantum/rgb_matrix/animations/cycle_all_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(CYCLE_ALL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV CYCLE_ALL_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t CYCLE_ALL_math(hsv_t hsv, uint8_t i, uint8_t time) {
     hsv.h = time;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/cycle_left_right_anim.h
+++ b/quantum/rgb_matrix/animations/cycle_left_right_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(CYCLE_LEFT_RIGHT)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV CYCLE_LEFT_RIGHT_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t CYCLE_LEFT_RIGHT_math(hsv_t hsv, uint8_t i, uint8_t time) {
     hsv.h = g_led_config.point[i].x - time;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/cycle_out_in_anim.h
+++ b/quantum/rgb_matrix/animations/cycle_out_in_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(CYCLE_OUT_IN)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV CYCLE_OUT_IN_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+static hsv_t CYCLE_OUT_IN_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
     hsv.h = 3 * dist / 2 + time;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/cycle_out_in_dual_anim.h
+++ b/quantum/rgb_matrix/animations/cycle_out_in_dual_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(CYCLE_OUT_IN_DUAL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV CYCLE_OUT_IN_DUAL_math(HSV hsv, int16_t dx, int16_t dy, uint8_t time) {
+static hsv_t CYCLE_OUT_IN_DUAL_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t time) {
     dx           = (k_rgb_matrix_center.x / 2) - abs8(dx);
     uint8_t dist = sqrt16(dx * dx + dy * dy);
     hsv.h        = 3 * dist + time;

--- a/quantum/rgb_matrix/animations/cycle_pinwheel_anim.h
+++ b/quantum/rgb_matrix/animations/cycle_pinwheel_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(CYCLE_PINWHEEL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV CYCLE_PINWHEEL_math(HSV hsv, int16_t dx, int16_t dy, uint8_t time) {
+static hsv_t CYCLE_PINWHEEL_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t time) {
     hsv.h = atan2_8(dy, dx) + time;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/cycle_spiral_anim.h
+++ b/quantum/rgb_matrix/animations/cycle_spiral_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(CYCLE_SPIRAL)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV CYCLE_SPIRAL_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
+static hsv_t CYCLE_SPIRAL_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time) {
     hsv.h = dist - time - atan2_8(dy, dx);
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/cycle_up_down_anim.h
+++ b/quantum/rgb_matrix/animations/cycle_up_down_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(CYCLE_UP_DOWN)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV CYCLE_UP_DOWN_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t CYCLE_UP_DOWN_math(hsv_t hsv, uint8_t i, uint8_t time) {
     hsv.h = g_led_config.point[i].y - time;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/dual_beacon_anim.h
+++ b/quantum/rgb_matrix/animations/dual_beacon_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(DUAL_BEACON)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV DUAL_BEACON_math(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+static hsv_t DUAL_BEACON_math(hsv_t hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
     hsv.h += ((g_led_config.point[i].y - k_rgb_matrix_center.y) * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * sin) / 128;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/flower_blooming_anim.h
+++ b/quantum/rgb_matrix/animations/flower_blooming_anim.h
@@ -18,7 +18,7 @@
 RGB_MATRIX_EFFECT(FLOWER_BLOOMING)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-typedef HSV (*flower_blooming_f)(HSV hsv, uint8_t i, uint8_t time);
+typedef hsv_t (*flower_blooming_f)(hsv_t hsv, uint8_t i, uint8_t time);
 
 bool effect_runner_bloom(effect_params_t* params, flower_blooming_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
@@ -27,17 +27,17 @@ bool effect_runner_bloom(effect_params_t* params, flower_blooming_f effect_func)
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         if (g_led_config.point[i].y > k_rgb_matrix_center.y) {
-            RGB bgr = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
+            rgb_t bgr = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
             rgb_matrix_set_color(i, bgr.b, bgr.g, bgr.r);
         } else {
-            RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
+            rgb_t rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
             rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
         }
     }
     return rgb_matrix_check_finished_leds(led_max);
 }
 
-static HSV FLOWER_BLOOMING_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t FLOWER_BLOOMING_math(hsv_t hsv, uint8_t i, uint8_t time) {
     if (g_led_config.point[i].y > k_rgb_matrix_center.y)
         hsv.h = g_led_config.point[i].x * 3 - g_led_config.point[i].y * 3 + time;
     else

--- a/quantum/rgb_matrix/animations/gradient_left_right_anim.h
+++ b/quantum/rgb_matrix/animations/gradient_left_right_anim.h
@@ -5,14 +5,14 @@ RGB_MATRIX_EFFECT(GRADIENT_LEFT_RIGHT)
 bool GRADIENT_LEFT_RIGHT(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    HSV     hsv   = rgb_matrix_config.hsv;
+    hsv_t   hsv   = rgb_matrix_config.hsv;
     uint8_t scale = scale8(64, rgb_matrix_config.speed);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         // The x range will be 0..224, map this to 0..7
         // Relies on hue being 8-bit and wrapping
-        hsv.h   = rgb_matrix_config.hsv.h + (scale * g_led_config.point[i].x >> 5);
-        RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+        hsv.h     = rgb_matrix_config.hsv.h + (scale * g_led_config.point[i].x >> 5);
+        rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/gradient_up_down_anim.h
+++ b/quantum/rgb_matrix/animations/gradient_up_down_anim.h
@@ -5,14 +5,14 @@ RGB_MATRIX_EFFECT(GRADIENT_UP_DOWN)
 bool GRADIENT_UP_DOWN(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    HSV     hsv   = rgb_matrix_config.hsv;
+    hsv_t   hsv   = rgb_matrix_config.hsv;
     uint8_t scale = scale8(64, rgb_matrix_config.speed);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         // The y range will be 0..64, map this to 0..4
         // Relies on hue being 8-bit and wrapping
-        hsv.h   = rgb_matrix_config.hsv.h + scale * (g_led_config.point[i].y >> 4);
-        RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+        hsv.h     = rgb_matrix_config.hsv.h + scale * (g_led_config.point[i].y >> 4);
+        rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/hue_breathing_anim.h
+++ b/quantum/rgb_matrix/animations/hue_breathing_anim.h
@@ -7,10 +7,10 @@ RGB_MATRIX_EFFECT(HUE_BREATHING)
 bool HUE_BREATHING(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
     uint8_t  huedelta = 12;
-    HSV      hsv      = rgb_matrix_config.hsv;
+    hsv_t    hsv      = rgb_matrix_config.hsv;
     uint16_t time     = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
     hsv.h             = hsv.h + scale8(abs8(sin8(time) - 128) * 2, huedelta);
-    RGB rgb           = hsv_to_rgb(hsv);
+    rgb_t rgb         = hsv_to_rgb(hsv);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);

--- a/quantum/rgb_matrix/animations/hue_pendulum_anim.h
+++ b/quantum/rgb_matrix/animations/hue_pendulum_anim.h
@@ -5,7 +5,7 @@ RGB_MATRIX_EFFECT(HUE_PENDULUM)
 // Change huedelta to adjust range of hue change. 0-255.
 // Looks better with a low value and slow speed for subtle change.
 // Hue Pendulum - color changes in a wave to the right before reversing direction
-static HSV HUE_PENDULUM_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t HUE_PENDULUM_math(hsv_t hsv, uint8_t i, uint8_t time) {
     uint8_t huedelta = 12;
     hsv.h            = hsv.h + scale8(abs8(sin8(time) + (g_led_config.point[i].x) - 128) * 2, huedelta);
     return hsv;

--- a/quantum/rgb_matrix/animations/hue_wave_anim.h
+++ b/quantum/rgb_matrix/animations/hue_wave_anim.h
@@ -5,7 +5,7 @@ RGB_MATRIX_EFFECT(HUE_WAVE)
 // Change huedelta to adjust range of hue change. 0-255.
 // Looks better with a low value and slow speed for subtle change.
 // Hue Wave - color changes in a wave to the right
-static HSV HUE_WAVE_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t HUE_WAVE_math(hsv_t hsv, uint8_t i, uint8_t time) {
     uint8_t huedelta = 24;
     hsv.h            = hsv.h + scale8(abs8(g_led_config.point[i].x - time), huedelta);
     return hsv;

--- a/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/jellybean_raindrops_anim.h
@@ -4,8 +4,8 @@ RGB_MATRIX_EFFECT(JELLYBEAN_RAINDROPS)
 
 static void jellybean_raindrops_set_color(int i, effect_params_t* params) {
     if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) return;
-    HSV hsv = {random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v};
-    RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+    hsv_t hsv = {random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v};
+    rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }
 

--- a/quantum/rgb_matrix/animations/pixel_flow_anim.h
+++ b/quantum/rgb_matrix/animations/pixel_flow_anim.h
@@ -7,7 +7,7 @@ RGB_MATRIX_EFFECT(PIXEL_FLOW)
 
 static bool PIXEL_FLOW(effect_params_t* params) {
     // LED state array
-    static RGB led[RGB_MATRIX_LED_COUNT];
+    static rgb_t led[RGB_MATRIX_LED_COUNT];
 
     static uint32_t wait_timer = 0;
     if (wait_timer > g_rgb_timer) {
@@ -22,7 +22,7 @@ static bool PIXEL_FLOW(effect_params_t* params) {
         // Clear LEDs and fill the state array
         rgb_matrix_set_color_all(0, 0, 0);
         for (uint8_t j = 0; j < RGB_MATRIX_LED_COUNT; ++j) {
-            led[j] = (random8() & 2) ? (RGB){0, 0, 0} : hsv_to_rgb((HSV){random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v});
+            led[j] = (random8() & 2) ? (rgb_t){0, 0, 0} : hsv_to_rgb((hsv_t){random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v});
         }
     }
 
@@ -39,7 +39,7 @@ static bool PIXEL_FLOW(effect_params_t* params) {
             led[j] = led[j + 1];
         }
         // Fill last LED
-        led[led_max - 1] = (random8() & 2) ? (RGB){0, 0, 0} : hsv_to_rgb((HSV){random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v});
+        led[led_max - 1] = (random8() & 2) ? (rgb_t){0, 0, 0} : hsv_to_rgb((hsv_t){random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v});
         // Set pulse timer
         wait_timer = g_rgb_timer + interval();
     }

--- a/quantum/rgb_matrix/animations/pixel_fractal_anim.h
+++ b/quantum/rgb_matrix/animations/pixel_fractal_anim.h
@@ -26,11 +26,11 @@ static bool PIXEL_FRACTAL(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
     if (g_rgb_timer > wait_timer) {
-        RGB rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
+        rgb_t rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
         for (uint8_t h = 0; h < MATRIX_ROWS; ++h) {
             // Light and copy columns outward
             for (uint8_t l = 0; l < MID_COL - 1; ++l) {
-                RGB index_rgb = led[h][l] ? (RGB){rgb.r, rgb.g, rgb.b} : (RGB){0, 0, 0};
+                rgb_t index_rgb = led[h][l] ? (rgb_t){rgb.r, rgb.g, rgb.b} : (rgb_t){0, 0, 0};
                 if (HAS_ANY_FLAGS(g_led_config.flags[g_led_config.matrix_co[h][l]], params->flags)) {
                     rgb_matrix_set_color(g_led_config.matrix_co[h][l], index_rgb.r, index_rgb.g, index_rgb.b);
                 }
@@ -41,7 +41,7 @@ static bool PIXEL_FRACTAL(effect_params_t* params) {
             }
 
             // Light both middle columns
-            RGB index_rgb = led[h][MID_COL - 1] ? (RGB){rgb.r, rgb.g, rgb.b} : (RGB){0, 0, 0};
+            rgb_t index_rgb = led[h][MID_COL - 1] ? (rgb_t){rgb.r, rgb.g, rgb.b} : (rgb_t){0, 0, 0};
             if (HAS_ANY_FLAGS(g_led_config.flags[g_led_config.matrix_co[h][MID_COL - 1]], params->flags)) {
                 rgb_matrix_set_color(g_led_config.matrix_co[h][MID_COL - 1], index_rgb.r, index_rgb.g, index_rgb.b);
             }

--- a/quantum/rgb_matrix/animations/pixel_rain_anim.h
+++ b/quantum/rgb_matrix/animations/pixel_rain_anim.h
@@ -16,8 +16,8 @@ static bool PIXEL_RAIN(effect_params_t* params) {
         if (!HAS_ANY_FLAGS(g_led_config.flags[led_index], params->flags)) {
             return;
         }
-        HSV hsv = (random8() & 2) ? (HSV){0, 0, 0} : (HSV){random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v};
-        RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+        hsv_t hsv = (random8() & 2) ? (hsv_t){0, 0, 0} : (hsv_t){random8(), random8_min_max(127, 255), rgb_matrix_config.hsv.v};
+        rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(led_index, rgb.r, rgb.g, rgb.b);
         wait_timer = g_rgb_timer + interval();
     }

--- a/quantum/rgb_matrix/animations/rainbow_beacon_anim.h
+++ b/quantum/rgb_matrix/animations/rainbow_beacon_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(RAINBOW_BEACON)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV RAINBOW_BEACON_math(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+static hsv_t RAINBOW_BEACON_math(hsv_t hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
     hsv.h += ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 2 * cos + (g_led_config.point[i].x - k_rgb_matrix_center.x) * 2 * sin) / 128;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/rainbow_moving_chevron_anim.h
+++ b/quantum/rgb_matrix/animations/rainbow_moving_chevron_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(RAINBOW_MOVING_CHEVRON)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV RAINBOW_MOVING_CHEVRON_math(HSV hsv, uint8_t i, uint8_t time) {
+static hsv_t RAINBOW_MOVING_CHEVRON_math(hsv_t hsv, uint8_t i, uint8_t time) {
     hsv.h += abs8(g_led_config.point[i].y - k_rgb_matrix_center.y) + (g_led_config.point[i].x - time);
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/rainbow_pinwheels_anim.h
+++ b/quantum/rgb_matrix/animations/rainbow_pinwheels_anim.h
@@ -2,7 +2,7 @@
 RGB_MATRIX_EFFECT(RAINBOW_PINWHEELS)
 #    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV RAINBOW_PINWHEELS_math(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
+static hsv_t RAINBOW_PINWHEELS_math(hsv_t hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time) {
     hsv.h += ((g_led_config.point[i].y - k_rgb_matrix_center.y) * 3 * cos + (56 - abs8(g_led_config.point[i].x - k_rgb_matrix_center.x)) * 3 * sin) / 128;
     return hsv;
 }

--- a/quantum/rgb_matrix/animations/raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/raindrops_anim.h
@@ -4,7 +4,7 @@ RGB_MATRIX_EFFECT(RAINDROPS)
 
 static void raindrops_set_color(int i, effect_params_t* params) {
     if (!HAS_ANY_FLAGS(g_led_config.flags[i], params->flags)) return;
-    HSV hsv = {0, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v};
+    hsv_t hsv = {0, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v};
 
     // Take the shortest path between hues
     int16_t deltaH = ((rgb_matrix_config.hsv.h + 180) % 360 - rgb_matrix_config.hsv.h) / 4;
@@ -14,8 +14,8 @@ static void raindrops_set_color(int i, effect_params_t* params) {
         deltaH += 256;
     }
 
-    hsv.h   = rgb_matrix_config.hsv.h + (deltaH * (random8() & 0x03));
-    RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+    hsv.h     = rgb_matrix_config.hsv.h + (deltaH * (random8() & 0x03));
+    rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }
 

--- a/quantum/rgb_matrix/animations/riverflow_anim.h
+++ b/quantum/rgb_matrix/animations/riverflow_anim.h
@@ -8,10 +8,10 @@ bool RIVERFLOW(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
-        HSV      hsv  = rgb_matrix_config.hsv;
+        hsv_t    hsv  = rgb_matrix_config.hsv;
         uint16_t time = scale16by8(g_rgb_timer + (i * 315), rgb_matrix_config.speed / 8);
         hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
-        RGB rgb       = rgb_matrix_hsv_to_rgb(hsv);
+        rgb_t rgb     = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
 

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef HSV (*dx_dy_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t time);
+typedef hsv_t (*dx_dy_f)(hsv_t hsv, int16_t dx, int16_t dy, uint8_t time);
 
 bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
@@ -10,7 +10,7 @@ bool effect_runner_dx_dy(effect_params_t* params, dx_dy_f effect_func) {
         RGB_MATRIX_TEST_LED_FLAGS();
         int16_t dx  = g_led_config.point[i].x - k_rgb_matrix_center.x;
         int16_t dy  = g_led_config.point[i].y - k_rgb_matrix_center.y;
-        RGB     rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, time));
+        rgb_t   rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_dx_dy_dist.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef HSV (*dx_dy_dist_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time);
+typedef hsv_t (*dx_dy_dist_f)(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint8_t time);
 
 bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
@@ -11,7 +11,7 @@ bool effect_runner_dx_dy_dist(effect_params_t* params, dx_dy_dist_f effect_func)
         int16_t dx   = g_led_config.point[i].x - k_rgb_matrix_center.x;
         int16_t dy   = g_led_config.point[i].y - k_rgb_matrix_center.y;
         uint8_t dist = sqrt16(dx * dx + dy * dy);
-        RGB     rgb  = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, dist, time));
+        rgb_t   rgb  = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, dx, dy, dist, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/runners/effect_runner_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_i.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef HSV (*i_f)(HSV hsv, uint8_t i, uint8_t time);
+typedef hsv_t (*i_f)(hsv_t hsv, uint8_t i, uint8_t time);
 
 bool effect_runner_i(effect_params_t* params, i_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
@@ -8,7 +8,7 @@ bool effect_runner_i(effect_params_t* params, i_f effect_func) {
     uint8_t time = scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed / 4, 1));
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
-        RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
+        rgb_t rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive.h
@@ -2,7 +2,7 @@
 
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
 
-typedef HSV (*reactive_f)(HSV hsv, uint16_t offset);
+typedef hsv_t (*reactive_f)(hsv_t hsv, uint16_t offset);
 
 bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
@@ -20,7 +20,7 @@ bool effect_runner_reactive(effect_params_t* params, reactive_f effect_func) {
         }
 
         uint16_t offset = scale16by8(tick, qadd8(rgb_matrix_config.speed, 1));
-        RGB      rgb    = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, offset));
+        rgb_t    rgb    = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, offset));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_reactive_splash.h
@@ -2,7 +2,7 @@
 
 #ifdef RGB_MATRIX_KEYREACTIVE_ENABLED
 
-typedef HSV (*reactive_splash_f)(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick);
+typedef hsv_t (*reactive_splash_f)(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick);
 
 bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, reactive_splash_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
@@ -10,8 +10,8 @@ bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, react
     uint8_t count = g_last_hit_tracker.count;
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
-        HSV hsv = rgb_matrix_config.hsv;
-        hsv.v   = 0;
+        hsv_t hsv = rgb_matrix_config.hsv;
+        hsv.v     = 0;
         for (uint8_t j = start; j < count; j++) {
             int16_t  dx   = g_led_config.point[i].x - g_last_hit_tracker.x[j];
             int16_t  dy   = g_led_config.point[i].y - g_last_hit_tracker.y[j];
@@ -19,8 +19,8 @@ bool effect_runner_reactive_splash(uint8_t start, effect_params_t* params, react
             uint16_t tick = scale16by8(g_last_hit_tracker.tick[j], qadd8(rgb_matrix_config.speed, 1));
             hsv           = effect_func(hsv, dx, dy, dist, tick);
         }
-        hsv.v   = scale8(hsv.v, rgb_matrix_config.hsv.v);
-        RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+        hsv.v     = scale8(hsv.v, rgb_matrix_config.hsv.v);
+        rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
+++ b/quantum/rgb_matrix/animations/runners/effect_runner_sin_cos_i.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef HSV (*sin_cos_i_f)(HSV hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time);
+typedef hsv_t (*sin_cos_i_f)(hsv_t hsv, int8_t sin, int8_t cos, uint8_t i, uint8_t time);
 
 bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
@@ -10,7 +10,7 @@ bool effect_runner_sin_cos_i(effect_params_t* params, sin_cos_i_f effect_func) {
     int8_t   sin_value = sin8(time) - 128;
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
-        RGB rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, cos_value, sin_value, i, time));
+        rgb_t rgb = rgb_matrix_hsv_to_rgb(effect_func(rgb_matrix_config.hsv, cos_value, sin_value, i, time));
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
     }
     return rgb_matrix_check_finished_leds(led_max);

--- a/quantum/rgb_matrix/animations/solid_color_anim.h
+++ b/quantum/rgb_matrix/animations/solid_color_anim.h
@@ -4,7 +4,7 @@ RGB_MATRIX_EFFECT(SOLID_COLOR)
 bool SOLID_COLOR(effect_params_t* params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
 
-    RGB rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
+    rgb_t rgb = rgb_matrix_hsv_to_rgb(rgb_matrix_config.hsv);
     for (uint8_t i = led_min; i < led_max; i++) {
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);

--- a/quantum/rgb_matrix/animations/solid_reactive_anim.h
+++ b/quantum/rgb_matrix/animations/solid_reactive_anim.h
@@ -3,7 +3,7 @@
 RGB_MATRIX_EFFECT(SOLID_REACTIVE)
 #        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV SOLID_REACTIVE_math(HSV hsv, uint16_t offset) {
+static hsv_t SOLID_REACTIVE_math(hsv_t hsv, uint16_t offset) {
 #            ifdef RGB_MATRIX_SOLID_REACTIVE_GRADIENT_MODE
     hsv.h = scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 8) >> 4);
 #            endif

--- a/quantum/rgb_matrix/animations/solid_reactive_cross.h
+++ b/quantum/rgb_matrix/animations/solid_reactive_cross.h
@@ -11,7 +11,7 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTICROSS)
 
 #        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV SOLID_REACTIVE_CROSS_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+static hsv_t SOLID_REACTIVE_CROSS_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick + dist;
     dx              = dx < 0 ? dx * -1 : dx;
     dy              = dy < 0 ? dy * -1 : dy;

--- a/quantum/rgb_matrix/animations/solid_reactive_nexus.h
+++ b/quantum/rgb_matrix/animations/solid_reactive_nexus.h
@@ -11,7 +11,7 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTINEXUS)
 
 #        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV SOLID_REACTIVE_NEXUS_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+static hsv_t SOLID_REACTIVE_NEXUS_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick - dist;
     if (effect > 255) effect = 255;
     if (dist > 72) effect = 255;

--- a/quantum/rgb_matrix/animations/solid_reactive_simple_anim.h
+++ b/quantum/rgb_matrix/animations/solid_reactive_simple_anim.h
@@ -3,7 +3,7 @@
 RGB_MATRIX_EFFECT(SOLID_REACTIVE_SIMPLE)
 #        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV SOLID_REACTIVE_SIMPLE_math(HSV hsv, uint16_t offset) {
+static hsv_t SOLID_REACTIVE_SIMPLE_math(hsv_t hsv, uint16_t offset) {
 #            ifdef RGB_MATRIX_SOLID_REACTIVE_GRADIENT_MODE
     hsv.h = scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed, 8) >> 4);
 #            endif

--- a/quantum/rgb_matrix/animations/solid_reactive_wide.h
+++ b/quantum/rgb_matrix/animations/solid_reactive_wide.h
@@ -11,7 +11,7 @@ RGB_MATRIX_EFFECT(SOLID_REACTIVE_MULTIWIDE)
 
 #        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-static HSV SOLID_REACTIVE_WIDE_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+static hsv_t SOLID_REACTIVE_WIDE_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick + dist * 5;
     if (effect > 255) effect = 255;
 #            ifdef RGB_MATRIX_SOLID_REACTIVE_GRADIENT_MODE

--- a/quantum/rgb_matrix/animations/solid_splash_anim.h
+++ b/quantum/rgb_matrix/animations/solid_splash_anim.h
@@ -11,7 +11,7 @@ RGB_MATRIX_EFFECT(SOLID_MULTISPLASH)
 
 #        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-HSV SOLID_SPLASH_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+hsv_t SOLID_SPLASH_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick - dist;
     if (effect > 255) effect = 255;
     hsv.v = qadd8(hsv.v, 255 - effect);

--- a/quantum/rgb_matrix/animations/splash_anim.h
+++ b/quantum/rgb_matrix/animations/splash_anim.h
@@ -11,7 +11,7 @@ RGB_MATRIX_EFFECT(MULTISPLASH)
 
 #        ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
 
-HSV SPLASH_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
+hsv_t SPLASH_math(hsv_t hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t tick) {
     uint16_t effect = tick - dist;
     if (effect > 255) effect = 255;
     hsv.h += effect;

--- a/quantum/rgb_matrix/animations/starlight_anim.h
+++ b/quantum/rgb_matrix/animations/starlight_anim.h
@@ -4,9 +4,9 @@ RGB_MATRIX_EFFECT(STARLIGHT)
 
 void set_starlight_color(uint8_t i, effect_params_t* params) {
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
-    HSV      hsv  = rgb_matrix_config.hsv;
+    hsv_t    hsv  = rgb_matrix_config.hsv;
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
-    RGB rgb       = rgb_matrix_hsv_to_rgb(hsv);
+    rgb_t rgb     = rgb_matrix_hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }
 

--- a/quantum/rgb_matrix/animations/starlight_dual_hue_anim.h
+++ b/quantum/rgb_matrix/animations/starlight_dual_hue_anim.h
@@ -4,10 +4,10 @@ RGB_MATRIX_EFFECT(STARLIGHT_DUAL_HUE)
 
 void set_starlight_dual_hue_color(uint8_t i, effect_params_t* params) {
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
-    HSV      hsv  = rgb_matrix_config.hsv;
+    hsv_t    hsv  = rgb_matrix_config.hsv;
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
     hsv.h         = hsv.h + random8_max((30 + 1 - -30) + -30);
-    RGB rgb       = rgb_matrix_hsv_to_rgb(hsv);
+    rgb_t rgb     = rgb_matrix_hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }
 

--- a/quantum/rgb_matrix/animations/starlight_dual_sat_anim.h
+++ b/quantum/rgb_matrix/animations/starlight_dual_sat_anim.h
@@ -4,10 +4,10 @@ RGB_MATRIX_EFFECT(STARLIGHT_DUAL_SAT)
 
 void set_starlight_dual_sat_color(uint8_t i, effect_params_t* params) {
     uint16_t time = scale16by8(g_rgb_timer, rgb_matrix_config.speed / 8);
-    HSV      hsv  = rgb_matrix_config.hsv;
+    hsv_t    hsv  = rgb_matrix_config.hsv;
     hsv.v         = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
     hsv.s         = hsv.s + random8_max((30 + 1 - -30) + -30);
-    RGB rgb       = rgb_matrix_hsv_to_rgb(hsv);
+    rgb_t rgb     = rgb_matrix_hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }
 

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -82,8 +82,8 @@ bool TYPING_HEATMAP(effect_params_t* params) {
                 uint8_t val = g_rgb_frame_buffer[row][col];
                 if (!HAS_ANY_FLAGS(g_led_config.flags[g_led_config.matrix_co[row][col]], params->flags)) continue;
 
-                HSV hsv = {170 - qsub8(val, 85), rgb_matrix_config.hsv.s, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.hsv.v)};
-                RGB rgb = rgb_matrix_hsv_to_rgb(hsv);
+                hsv_t hsv = {170 - qsub8(val, 85), rgb_matrix_config.hsv.s, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.hsv.v)};
+                rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
                 rgb_matrix_set_color(g_led_config.matrix_co[row][col], rgb.r, rgb.g, rgb.b);
 
                 if (decrease_heatmap_values) {

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -35,7 +35,7 @@ const led_point_t k_rgb_matrix_center = {112, 32};
 const led_point_t k_rgb_matrix_center = RGB_MATRIX_CENTER;
 #endif
 
-__attribute__((weak)) RGB rgb_matrix_hsv_to_rgb(HSV hsv) {
+__attribute__((weak)) rgb_t rgb_matrix_hsv_to_rgb(hsv_t hsv) {
     return hsv_to_rgb(hsv);
 }
 
@@ -98,7 +98,7 @@ void eeconfig_update_rgb_matrix_default(void) {
     dprintf("eeconfig_update_rgb_matrix_default\n");
     rgb_matrix_config.enable = RGB_MATRIX_DEFAULT_ON;
     rgb_matrix_config.mode   = RGB_MATRIX_DEFAULT_MODE;
-    rgb_matrix_config.hsv    = (HSV){RGB_MATRIX_DEFAULT_HUE, RGB_MATRIX_DEFAULT_SAT, RGB_MATRIX_DEFAULT_VAL};
+    rgb_matrix_config.hsv    = (hsv_t){RGB_MATRIX_DEFAULT_HUE, RGB_MATRIX_DEFAULT_SAT, RGB_MATRIX_DEFAULT_VAL};
     rgb_matrix_config.speed  = RGB_MATRIX_DEFAULT_SPD;
     rgb_matrix_config.flags  = RGB_MATRIX_DEFAULT_FLAGS;
     eeconfig_flush_rgb_matrix(true);
@@ -591,7 +591,7 @@ void rgb_matrix_sethsv(uint16_t hue, uint8_t sat, uint8_t val) {
     rgb_matrix_sethsv_eeprom_helper(hue, sat, val, true);
 }
 
-HSV rgb_matrix_get_hsv(void) {
+hsv_t rgb_matrix_get_hsv(void) {
     return rgb_matrix_config.hsv;
 }
 uint8_t rgb_matrix_get_hue(void) {

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -186,7 +186,7 @@ void        rgb_matrix_step_reverse(void);
 void        rgb_matrix_step_reverse_noeeprom(void);
 void        rgb_matrix_sethsv(uint16_t hue, uint8_t sat, uint8_t val);
 void        rgb_matrix_sethsv_noeeprom(uint16_t hue, uint8_t sat, uint8_t val);
-HSV         rgb_matrix_get_hsv(void);
+hsv_t       rgb_matrix_get_hsv(void);
 uint8_t     rgb_matrix_get_hue(void);
 uint8_t     rgb_matrix_get_sat(void);
 uint8_t     rgb_matrix_get_val(void);

--- a/quantum/rgb_matrix/rgb_matrix_types.h
+++ b/quantum/rgb_matrix/rgb_matrix_types.h
@@ -78,7 +78,7 @@ typedef union {
     struct PACKED {
         uint8_t     enable : 2;
         uint8_t     mode : 6;
-        HSV         hsv;
+        hsv_t       hsv;
         uint8_t     speed;
         led_flags_t flags;
     };

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -136,7 +136,7 @@ void rgblight_set_effect_range(uint8_t start_pos, uint8_t num_leds) {
     rgblight_ranges.effect_num_leds  = num_leds;
 }
 
-__attribute__((weak)) RGB rgblight_hsv_to_rgb(HSV hsv) {
+__attribute__((weak)) rgb_t rgblight_hsv_to_rgb(hsv_t hsv) {
     return hsv_to_rgb(hsv);
 }
 
@@ -153,8 +153,8 @@ void setrgb(uint8_t r, uint8_t g, uint8_t b, int index) {
 }
 
 void sethsv_raw(uint8_t hue, uint8_t sat, uint8_t val, int index) {
-    HSV hsv = {hue, sat, val};
-    RGB rgb = rgblight_hsv_to_rgb(hsv);
+    hsv_t hsv = {hue, sat, val};
+    rgb_t rgb = rgblight_hsv_to_rgb(hsv);
     setrgb(rgb.r, rgb.g, rgb.b, index);
 }
 
@@ -513,7 +513,7 @@ void rgblight_decrease_speed_noeeprom(void) {
 
 void rgblight_sethsv_noeeprom_old(uint8_t hue, uint8_t sat, uint8_t val) {
     if (rgblight_config.enable) {
-        RGB rgb = hsv_to_rgb((HSV){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
+        rgb_t rgb = hsv_to_rgb((hsv_t){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
         rgblight_setrgb(rgb.r, rgb.g, rgb.b);
     }
 }
@@ -532,7 +532,7 @@ void rgblight_sethsv_eeprom_helper(uint8_t hue, uint8_t sat, uint8_t val, bool w
             // needed for rgblight_layers_write() to get the new val, since it reads rgblight_config.val
             rgblight_config.val = val;
 #endif
-            RGB rgb = hsv_to_rgb((HSV){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
+            rgb_t rgb = hsv_to_rgb((hsv_t){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
             rgblight_setrgb(rgb.r, rgb.g, rgb.b);
         } else {
             // all LEDs in same color
@@ -635,8 +635,8 @@ uint8_t rgblight_get_val(void) {
     return rgblight_config.val;
 }
 
-HSV rgblight_get_hsv(void) {
-    return (HSV){rgblight_config.hue, rgblight_config.sat, rgblight_config.val};
+hsv_t rgblight_get_hsv(void) {
+    return (hsv_t){rgblight_config.hue, rgblight_config.sat, rgblight_config.val};
 }
 
 void rgblight_setrgb(uint8_t r, uint8_t g, uint8_t b) {
@@ -664,7 +664,7 @@ void rgblight_sethsv_at(uint8_t hue, uint8_t sat, uint8_t val, uint8_t index) {
         return;
     }
 
-    RGB rgb = hsv_to_rgb((HSV){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
+    rgb_t rgb = hsv_to_rgb((hsv_t){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
     rgblight_setrgb_at(rgb.r, rgb.g, rgb.b, index);
 }
 
@@ -696,7 +696,7 @@ void rgblight_sethsv_range(uint8_t hue, uint8_t sat, uint8_t val, uint8_t start,
         return;
     }
 
-    RGB rgb = hsv_to_rgb((HSV){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
+    rgb_t rgb = hsv_to_rgb((hsv_t){hue, sat, val > RGBLIGHT_LIMIT_VAL ? RGBLIGHT_LIMIT_VAL : val});
     rgblight_setrgb_range(rgb.r, rgb.g, rgb.b, start, end);
 }
 
@@ -1348,7 +1348,7 @@ void rgblight_effect_rgbtest(animation_status_t *anim) {
     uint8_t        b;
 
     if (maxval == 0) {
-        RGB rgb = hsv_to_rgb((HSV){0, 255, RGBLIGHT_LIMIT_VAL});
+        rgb_t rgb = hsv_to_rgb((hsv_t){0, 255, RGBLIGHT_LIMIT_VAL});
         maxval  = rgb.r;
     }
     g = r = b = 0;
@@ -1388,7 +1388,7 @@ void rgblight_effect_alternating(animation_status_t *anim) {
 __attribute__((weak)) const uint8_t RGBLED_TWINKLE_INTERVALS[] PROGMEM = {30, 15, 5};
 
 typedef struct PACKED {
-    HSV     hsv;
+    hsv_t   hsv;
     uint8_t life;
     uint8_t max_life;
 } TwinkleState;
@@ -1414,7 +1414,7 @@ void rgblight_effect_twinkle(animation_status_t *anim) {
 
     for (uint8_t i = 0; i < rgblight_ranges.effect_num_leds; i++) {
         TwinkleState *t = &(led_twinkle_state[i]);
-        HSV *         c = &(t->hsv);
+        hsv_t *       c = &(t->hsv);
 
         if (!random_color) {
             c->h = rgblight_config.hue;

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -1349,7 +1349,7 @@ void rgblight_effect_rgbtest(animation_status_t *anim) {
 
     if (maxval == 0) {
         rgb_t rgb = hsv_to_rgb((hsv_t){0, 255, RGBLIGHT_LIMIT_VAL});
-        maxval  = rgb.r;
+        maxval    = rgb.r;
     }
     g = r = b = 0;
     switch (anim->pos) {

--- a/quantum/rgblight/rgblight.h
+++ b/quantum/rgblight/rgblight.h
@@ -362,7 +362,7 @@ uint8_t rgblight_get_hue(void);
 uint8_t rgblight_get_sat(void);
 uint8_t rgblight_get_val(void);
 bool    rgblight_is_enabled(void);
-HSV     rgblight_get_hsv(void);
+hsv_t   rgblight_get_hsv(void);
 
 /* === qmk_firmware (core)internal Functions === */
 void     rgblight_init(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Now that the WS2812-ness of the RGB struct has been removed, the name `rgb_led_t` should go too.

These structs are now called `rgb_t` and `hsv_t` for consistency. The old names `RGB`, `rgb_led_t`, and `HSV` remain as typedefs for backward compatibility for now.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
