### PR TITLE
Fix rendering of `keymap_config.no_gui` within `led_update_kb`

### DIFF
--- a/keyboards/akko/5108/5108.c
+++ b/keyboards/akko/5108/5108.c
@@ -150,13 +150,10 @@ const snled27351_led_t PROGMEM g_snled27351_leds[SNLED27351_LED_COUNT] = {
 void keyboard_pre_init_kb(void) {
     gpio_set_pin_output(LED_WIN_LOCK_PIN); // LED3 Win Lock
     gpio_write_pin_low(LED_WIN_LOCK_PIN);
+
     keyboard_pre_init_user();
 }
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if (res) {
-        gpio_write_pin(LED_WIN_LOCK_PIN, keymap_config.no_gui);
-    }
-    return res;
+void housekeeping_task_kb(void){
+    gpio_write_pin(LED_WIN_LOCK_PIN, keymap_config.no_gui);
 }

--- a/keyboards/monsgeek/m5/m5.c
+++ b/keyboards/monsgeek/m5/m5.c
@@ -151,14 +151,10 @@ const snled27351_led_t PROGMEM g_snled27351_leds[SNLED27351_LED_COUNT] = {
 void keyboard_pre_init_kb(void) {
     gpio_set_pin_output(LED_WIN_LOCK_PIN); // LED3 Win Lock
     gpio_write_pin_low(LED_WIN_LOCK_PIN);
+
     keyboard_pre_init_user();
 }
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-    if (res) {
-        led_update_ports(led_state);
-        gpio_write_pin(LED_WIN_LOCK_PIN, keymap_config.no_gui);
-    }
-    return res;
+void housekeeping_task_kb(void){
+    gpio_write_pin(LED_WIN_LOCK_PIN, keymap_config.no_gui);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Using host led callbacks to render will not correctly catch the cases where `keymap_config.no_gui` is mutated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
