### PR TITLE
Viper/Eagle Replacement PCB: Fix bug where the last underglow led don't update sometimes

### DIFF
--- a/keyboards/4pplet/eagle_viper_rep/rev_b/keyboard.json
+++ b/keyboards/4pplet/eagle_viper_rep/rev_b/keyboard.json
@@ -44,7 +44,7 @@
     "rgblight": {
         "saturation_steps": 8,
         "brightness_steps": 8,
-        "led_count": 16,
+        "led_count": 17,
         "animations": {
             "breathing": true,
             "rainbow_mood": true,

--- a/keyboards/4pplet/eagle_viper_rep/rev_b/rev_b.c
+++ b/keyboards/4pplet/eagle_viper_rep/rev_b/rev_b.c
@@ -22,6 +22,7 @@ void keyboard_pre_init_kb(void) {
     gpio_set_pin_output(LAYER_3);
     gpio_set_pin_output(LAYER_4);
     gpio_set_pin_output(LAYER_5);
+    rgblight_set_effect_range(0, 16);
     keyboard_pre_init_user();
 }
 


### PR DESCRIPTION
## Description

There is a bug where sometimes when unplugging and reconnecting the PCB, the last LED in the underglow chain does not update. This is a workaround where I add a "dummy LED" after the last LED to combat the problem.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
