### PR TITLE
always return audio pin to 0 on ARM

### DIFF
--- a/platforms/chibios/drivers/audio_pwm_hardware.c
+++ b/platforms/chibios/drivers/audio_pwm_hardware.c
@@ -46,10 +46,10 @@ void channel_1_set_frequency(float freq) {
 
     if (freq <= 0.0) {
         period = 2;
-        width = 0;
+        width  = 0;
     } else {
         period = (pwmCFG.frequency / freq);
-        width = PWM_PERCENTAGE_TO_WIDTH(&AUDIO_PWM_DRIVER, (100 - note_timbre) * 100);
+        width  = PWM_PERCENTAGE_TO_WIDTH(&AUDIO_PWM_DRIVER, (100 - note_timbre) * 100);
     }
     chSysLockFromISR();
     pwmChangePeriodI(&AUDIO_PWM_DRIVER, period);

--- a/platforms/chibios/drivers/audio_pwm_hardware.c
+++ b/platforms/chibios/drivers/audio_pwm_hardware.c
@@ -49,7 +49,7 @@ void channel_1_set_frequency(float freq) {
         width  = 0;
     } else {
         period = (pwmCFG.frequency / freq);
-        width  = PWM_PERCENTAGE_TO_WIDTH(&AUDIO_PWM_DRIVER, (100 - note_timbre) * 100);
+        width  = (pwmcnt_t)(((period) * (pwmcnt_t)((100 - note_timbre) * 100)) / (pwmcnt_t)(10000));
     }
     chSysLockFromISR();
     pwmChangePeriodI(&AUDIO_PWM_DRIVER, period);
@@ -69,7 +69,7 @@ void channel_1_start(void) {
 void channel_1_stop(void) {
     pwmStop(&AUDIO_PWM_DRIVER);
     pwmStart(&AUDIO_PWM_DRIVER, &pwmCFG);
-    pwmEnableChannelI(&AUDIO_PWM_DRIVER, AUDIO_PWM_CHANNEL - 1, 0);
+    pwmEnableChannel(&AUDIO_PWM_DRIVER, AUDIO_PWM_CHANNEL - 1, 0);
     pwmStop(&AUDIO_PWM_DRIVER);
 }
 

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -259,7 +259,7 @@ void audio_stop_tone(float pitch) {
             found = (tones[i].pitch == pitch);
             if (found) {
                 for (int j = i; (j < AUDIO_TONE_STACKSIZE - 1); j++) {
-                    tones[j]     = tones[j + 1];
+                    tones[j] = tones[j + 1];
                 }
                 tones[AUDIO_TONE_STACKSIZE - 1] = (musical_tone_t){.time_started = 0, .pitch = -1.0f, .duration = 0};
                 break;

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -258,11 +258,10 @@ void audio_stop_tone(float pitch) {
         for (int i = AUDIO_TONE_STACKSIZE - 1; i >= 0; i--) {
             found = (tones[i].pitch == pitch);
             if (found) {
-                tones[i] = (musical_tone_t){.time_started = 0, .pitch = -1.0f, .duration = 0};
                 for (int j = i; (j < AUDIO_TONE_STACKSIZE - 1); j++) {
                     tones[j]     = tones[j + 1];
-                    tones[j + 1] = (musical_tone_t){.time_started = 0, .pitch = -1.0f, .duration = 0};
                 }
+                tones[AUDIO_TONE_STACKSIZE - 1] = (musical_tone_t){.time_started = 0, .pitch = -1.0f, .duration = 0};
                 break;
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
The ARM audio PWM hardware implementation does not always return the audio pin to 0 when stopping the PWM. If the audio pin is held high while not playing audio, for magnetic speakers/buzzers, this will result in excessive current consumption while also producing undesirable audible noise.

This PR ensures that the audio pin is cleared whenever the PWM is stopped.


<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
[Context (Discord)](https://discord.com/channels/440868230475677696/867530303261114398/1296753666723676183)

Only specific timers fully support disabling (clearing) the PWM output pin when the PWM is stopped. For timers that don't clear the output pin, this PR enforces stopping while the pin is low by ~(1) increasing the frequency as high as possible, (2) waiting for the pin to go low, and (3) only~ _edit:setting the PWM width to 0 and_ then stopping the PWM.

Additionally, when changing the frequency change to 0Hz, this implementation also changes the pulse width to be zero.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
