### PR TITLE
Ensure timer_read() is safe to call from interrupt handlers on ARM

### DIFF
--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -78,7 +78,7 @@ uint16_t timer_read(void) {
 }
 
 uint32_t timer_read32(void) {
-    syssts_t sts = chSysGetStatusAndLockX();
+    syssts_t sts   = chSysGetStatusAndLockX();
     uint32_t ticks = get_system_time_ticks() - ticks_offset;
     if (ticks < last_ticks) {
         // The 32-bit tick counter overflowed and wrapped around.  We cannot just extend the counter to 64 bits here,

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -78,7 +78,7 @@ uint16_t timer_read(void) {
 }
 
 uint32_t timer_read32(void) {
-    chSysLock();
+    syssts_t sts = chSysGetStatusAndLockX();
     uint32_t ticks = get_system_time_ticks() - ticks_offset;
     if (ticks < last_ticks) {
         // The 32-bit tick counter overflowed and wrapped around.  We cannot just extend the counter to 64 bits here,
@@ -93,7 +93,7 @@ uint32_t timer_read32(void) {
     }
     last_ticks              = ticks;
     uint32_t ms_offset_copy = ms_offset; // read while still holding the lock to ensure a consistent value
-    chSysUnlock();
+    chSysRestoreStatusX(sts);
 
     return (uint32_t)TIME_I2MS(ticks) + ms_offset_copy;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
[Context on Discord](https://discord.com/channels/440868230475677696/867530303261114398/1298603653413732363)
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
The ARM implementation of `timer_read()`/`timer_read32()` is not inherently safe to call from any context. Specifically, `chSysLock()`/`chSysUnlock()` are not safe to call from within interrupts. [An example](https://github.com/qmk/qmk_firmware/blob/32b6faaf353bf845a835bd7b71e53336fcb6416e/quantum/audio/audio.c#L443) of a system that calls `timer_read()` from an interrupt is `audio_update_state()` in `audio.c`.

This PR replaces the `chSysLock()`/`chSysUnlock()` function calls of `timer_read()` with `chSysGetStatusAndLockX()` and `chSysRestoreStatusX()` instead, which are safe to call from any context.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
