### PR TITLE
Handle `cli._subcommand.__name__` deprecation warning

### DIFF
--- a/lib/python/qmk/decorators.py
+++ b/lib/python/qmk/decorators.py
@@ -9,6 +9,15 @@ from qmk.keyboard import find_keyboard_from_dir
 from qmk.keymap import find_keymap_from_dir
 
 
+def _get_subcommand_name():
+    """Handle missing cli.subcommand_name on older versions of milc
+    """
+    try:
+        return cli.subcommand_name
+    except:
+        return cli._subcommand.__name__
+
+
 def automagic_keyboard(func):
     """Sets `cli.config.<subcommand>.keyboard` based on environment.
 
@@ -16,13 +25,15 @@ def automagic_keyboard(func):
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        cmd = _get_subcommand_name()
+
         # Ensure that `--keyboard` was not passed and CWD is under `qmk_firmware/keyboards`
-        if cli.config_source[cli._subcommand.__name__]['keyboard'] != 'argument':
+        if cli.config_source[cmd]['keyboard'] != 'argument':
             keyboard = find_keyboard_from_dir()
 
             if keyboard:
-                cli.config[cli._subcommand.__name__]['keyboard'] = keyboard
-                cli.config_source[cli._subcommand.__name__]['keyboard'] = 'keyboard_directory'
+                cli.config[cmd]['keyboard'] = keyboard
+                cli.config_source[cmd]['keyboard'] = 'keyboard_directory'
 
         return func(*args, **kwargs)
 
@@ -36,13 +47,15 @@ def automagic_keymap(func):
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        cmd = _get_subcommand_name()
+
         # Ensure that `--keymap` was not passed and that we're under `qmk_firmware`
-        if cli.config_source[cli._subcommand.__name__]['keymap'] != 'argument':
+        if cli.config_source[cmd]['keymap'] != 'argument':
             keymap_name, keymap_type = find_keymap_from_dir()
 
             if keymap_name:
-                cli.config[cli._subcommand.__name__]['keymap'] = keymap_name
-                cli.config_source[cli._subcommand.__name__]['keymap'] = keymap_type
+                cli.config[cmd]['keymap'] = keymap_name
+                cli.config_source[cmd]['keymap'] = keymap_type
 
         return func(*args, **kwargs)
 

--- a/lib/python/qmk/decorators.py
+++ b/lib/python/qmk/decorators.py
@@ -14,7 +14,7 @@ def _get_subcommand_name():
     """
     try:
         return cli.subcommand_name
-    except:
+    except AttributeError:
         return cli._subcommand.__name__
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Handle both `<=1.8.0` and `1.9.0`, as we cant ensure a user has updated their environment.

```
/home/zvecr/qmk_firmware/lib/python/qmk/decorators.py:20: UserWarning: cli._subcommand has been deprecated, please use cli.subcommand_name to get the subcommand name instead.
  if cli.config_source[cli._subcommand.__name__]['keyboard'] != 'argument':
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
