### PR TITLE
Port miniMACRO5 to RP2040 CE

### DIFF
--- a/keyboards/minimacro5/info.json
+++ b/keyboards/minimacro5/info.json
@@ -23,20 +23,6 @@
       "twinkle": true
     }
   },
-  "ws2812": {
-    "pin": "B5"
-  },
-  "encoder": {
-    "rotary": [
-      {"pin_a": "D3", "pin_b": "F5", "resolution": 2},
-      {"pin_a": "F6", "pin_b": "D2", "resolution": 2},
-      {"pin_a": "F7", "pin_b": "D1", "resolution": 2},
-      {"pin_a": "D4", "pin_b": "D0", "resolution": 2},
-      {"pin_a": "C6", "pin_b": "E6", "resolution": 2}
-    ]
-  },
-  "processor": "atmega32u4",
-  "bootloader": "caterina",
   "features": {
     "bootmagic": false,
     "command": false,
@@ -46,11 +32,6 @@
     "mousekey": true,
     "nkro": true,
     "rgblight": true
-  },
-  "matrix_pins": {
-    "direct": [
-      ["F4", "B6", "B2", "D7", "B4"]
-    ]
   },
   "layouts": {
     "LAYOUT_ortho_1x5": {

--- a/keyboards/minimacro5/promicro/keyboard.json
+++ b/keyboards/minimacro5/promicro/keyboard.json
@@ -1,0 +1,20 @@
+{
+  "development_board": "promicro",
+  "ws2812": {
+    "pin": "B5"
+  },
+  "encoder": {
+    "rotary": [
+      {"pin_a": "D3", "pin_b": "F5", "resolution": 2},
+      {"pin_a": "F6", "pin_b": "D2", "resolution": 2},
+      {"pin_a": "F7", "pin_b": "D1", "resolution": 2},
+      {"pin_a": "D4", "pin_b": "D0", "resolution": 2},
+      {"pin_a": "C6", "pin_b": "E6", "resolution": 2}
+    ]
+  },
+  "matrix_pins": {
+    "direct": [
+      ["F4", "B6", "B2", "D7", "B4"]
+    ]
+  }
+}

--- a/keyboards/minimacro5/readme.md
+++ b/keyboards/minimacro5/readme.md
@@ -5,7 +5,7 @@ A 5 key Macropad based on Arduino Pro Micro with support for a combination of ro
 ![](https://i.imgur.com/lxA8DSCl.jpg)
 
 * Keyboard Maintainer: [LeafCutterLabs](https://github.com/LeafCutterLabs)
-* Hardware Supported: Pro Micro 5V/16MHz and compatible.
+* Hardware Supported: Pro Micro 5V/16MHz and compatible or RP2040 Community Edition.
 * Hardware availability: PCB Files are available [here](https://github.com/LeafCutterLabs/miniMACRO5), which you can get produced.
 
 Make example for this keyboard (after setting up your build environment):

--- a/keyboards/minimacro5/rp2040_ce/config.h
+++ b/keyboards/minimacro5/rp2040_ce/config.h
@@ -1,0 +1,7 @@
+// Copyright 2024 JP Roemer (@0rax)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500U

--- a/keyboards/minimacro5/rp2040_ce/keyboard.json
+++ b/keyboards/minimacro5/rp2040_ce/keyboard.json
@@ -1,0 +1,21 @@
+{
+  "development_board": "promicro_rp2040",
+  "ws2812": {
+    "driver": "vendor",
+    "pin": "GP9"
+  },
+  "encoder": {
+    "rotary": [
+      {"pin_a": "GP0", "pin_b": "GP28", "resolution": 2},
+      {"pin_a": "GP27", "pin_b": "GP1", "resolution": 2},
+      {"pin_a": "GP26", "pin_b": "GP2", "resolution": 2},
+      {"pin_a": "GP4", "pin_b": "GP3", "resolution": 2},
+      {"pin_a": "GP5", "pin_b": "GP7", "resolution": 2}
+    ]
+  },
+  "matrix_pins": {
+    "direct": [
+      ["GP29", "GP21", "GP23", "GP6", "GP8"]
+    ]
+  }
+}

--- a/keyboards/minimacro5/rules.mk
+++ b/keyboards/minimacro5/rules.mk
@@ -1,0 +1,1 @@
+DEFAULT_FOLDER = minimacro5/promicro


### PR DESCRIPTION
Add support for RP2040CE controller to the [`miniMACRO5`](https://github.com/LeafCutterLabs/miniMACRO5) keyboard.

## Description

Add configuration for using an alternative RP2040 Community Edition based controller on the `miniMACRO5` keyboard. This has been tested and verified on two different board using an RP2040CE compatible board.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
	- `make minimacro5` produces no errors and builds `minimacro5_promicro_default.hex`
	- `make minimacro5/promicro` produces no errors and builds `minimacro5_promicro_default.hex`
	- `make minimacro5/rp2040_ce` produces no errors and builds `minimacro5_rp2040_ce_default.uf2`
	- `qmk compile -kb minimacro5 -km default` produces no errors and builds `minimacro5_promicro_default.hex`
	- `qmk compile -kb minimacro5/promicro -km default` produces no errors and builds `minimacro5_promicro_default.hex`
	- `qmk compile -kb minimacro5/rp2040_ce -km default` produces no errors and builds `minimacro5_rp2040_ce_default.uf2`
	- The resulting `minimacro5_rp2040_ce_default.uf2` has been tested on a real board and works as expected

## Note

I have targeted the `master` branch here. Looking at the PR checklist I am not sure if what I am doing here is considered a refactor or not and thus should target the `develop` branch. Especially since the new default build binary when running `make minimacro5` or `make minimacro5:default` is `minimacro5_promicro_default.hex` instead of `minimacro5_default.hex`, it may introduce a breaking change for some users. Let me know if I need to change that.