### PR TITLE
Expose rgb_matrix_update_pwm_buffers to be available in keymaps

### DIFF
--- a/keyboards/bastardkb/charybdis/charybdis.c
+++ b/keyboards/bastardkb/charybdis/charybdis.c
@@ -393,7 +393,6 @@ bool shutdown_kb(bool jump_to_bootloader) {
     rgblight_setrgb(RGB_RED);
 #endif // RGBLIGHT_ENABLE
 #ifdef RGB_MATRIX_ENABLE
-    void rgb_matrix_update_pwm_buffers(void);
     rgb_matrix_set_color_all(RGB_RED);
     rgb_matrix_update_pwm_buffers();
 #endif // RGB_MATRIX_ENABLE

--- a/keyboards/bastardkb/dilemma/dilemma.c
+++ b/keyboards/bastardkb/dilemma/dilemma.c
@@ -354,7 +354,6 @@ bool shutdown_kb(bool jump_to_bootloader) {
     rgblight_setrgb(RGB_RED);
 #endif // RGBLIGHT_ENABLE
 #ifdef RGB_MATRIX_ENABLE
-    void rgb_matrix_update_pwm_buffers(void);
     rgb_matrix_set_color_all(RGB_RED);
     rgb_matrix_update_pwm_buffers();
 #endif // RGB_MATRIX_ENABLE

--- a/keyboards/miiiw/blackio83/rev_0100/rev_0100.c
+++ b/keyboards/miiiw/blackio83/rev_0100/rev_0100.c
@@ -165,7 +165,6 @@ uint32_t loop_10Hz(uint32_t trigger_time, void *cb_arg) {
             wait_ms(50);
             eeconfig_init();
     #ifdef RGB_MATRIX_ENABLE
-            extern void rgb_matrix_update_pwm_buffers(void);
             for(int i = 0; i < 5; i++) {
                 rgb_matrix_set_color_all(RGB_WHITE);
                 rgb_matrix_update_pwm_buffers();

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -210,6 +210,7 @@ void        rgb_matrix_decrease_speed_noeeprom(void);
 led_flags_t rgb_matrix_get_flags(void);
 void        rgb_matrix_set_flags(led_flags_t flags);
 void        rgb_matrix_set_flags_noeeprom(led_flags_t flags);
+void        rgb_matrix_update_pwm_buffers(void);
 
 #ifndef RGBLIGHT_ENABLE
 #    define eeconfig_update_rgblight_current eeconfig_update_rgb_matrix


### PR DESCRIPTION
Exposing this API enables the examples in the keyboard shutdown/reboot documentation to compile instead of calling `rgb_matrix_driver.flush` directly.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #24572

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
