### PR TITLE
[CLI] Allow for rich progress bars.

### DIFF
--- a/lib/python/qmk/util.py
+++ b/lib/python/qmk/util.py
@@ -70,13 +70,20 @@ def parallelize():
 
     # Prefer mpire's `WorkerPool` if it's available
     with contextlib.suppress(ImportError):
+        style = 'std'
+        try:
+            import rich  # noqa: F401 -- we're just testing if it's available
+            style = 'rich'
+        except ImportError:
+            pass
+
         from mpire import WorkerPool
         from mpire.utils import make_single_arguments
         with WorkerPool() as pool:
 
             def _worker(func, *args):
                 # Ensure we don't unpack tuples -- mpire's `WorkerPool` tries to do so normally so we tell it not to.
-                for r in pool.imap_unordered(func, make_single_arguments(*args, generator=False), progress_bar=True):
+                for r in pool.imap_unordered(func, make_single_arguments(*args, generator=False), progress_bar=True, progress_bar_style=style):
                     yield r
 
             yield _worker


### PR DESCRIPTION
## Description

Some prep work for toolchain installation showed that we could use nicer progress bars with the current `mpire` progress bars, specifically for `qmk find`, `qmk mass-compile`, and `qmk userspace-compile`.

`python3 -m pip install mpire tqdm rich`

Will be adding the three dependencies to `qmk/qmk_cli` relatively shortly, along with `httpx` so that we can retrieve the toolchains.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
