### PR TITLE
docs: move description of host_language from Macros to Language-specific Keycodes

### DIFF
--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -42,38 +42,7 @@ You can define up to 32 macros in a `keymap.json` file, as used by [Configurator
 
 ### Selecting Your Host Keyboard Layout
 
-If you type in a language other than English, or use a non-QWERTY layout like Colemak, Dvorak, or Workman, you may have set your computer's input language to match this layout. This presents a challenge when creating macros - you may need to type different keys to get the same letters! To address this you can add the `host_language` key to your `keymap.json`, like so:
-
-```json
-{
-    "keyboard": "handwired/my_macropad",
-    "keymap": "my_keymap",
-    "host_language": "dvorak",
-    "macros": [
-        ["Hello, World!"]
-    ],
-    "layout": "LAYOUT_all",
-    "layers": [
-        ["QK_MACRO_0"]
-    ]
-}
-```
-
-The current list of available languages is:
-
-| belgian | bepo | br_abnt2 | canadian_multilingual |
-|:-------:|:----:|:--------:|:---------------------:|
-| **colemak** | **croatian** | **czech** | **danish** |
-| **dvorak_fr** | **dvorak** | **dvp** | **estonian** |
-| **finnish** | **fr_ch** | **french_afnor** | **french** |
-| **french_osx** | **german_ch** | **german** | **german_osx** |
-| **hungarian** | **icelandic** | **italian** | **italian_osx_ansi** |
-| **italian_osx_iso** | **jis** | **latvian** | **lithuanian_azerty** |
-| **lithuanian_qwerty** | **norman** | **norwegian** | **portuguese** |
-| **portuguese_osx_iso** | **romanian** | **serbian_latin** | **slovak** |
-| **slovenian** | **spanish_dvorak** | **spanish_latin_america** | **spanish** |
-| **swedish** | **turkish_f** | **turkish_q** | **uk** |
-| **us_international** | **workman** | **workman_zxcvm** |
+If you type in a language other than English, or use a non-QWERTY layout like Colemak, Dvorak, or Workman, you may have set your computer's input language to match this layout. This presents a challenge when creating macros - you may need to type different keys to get the same letters! To address this you can use [language-specific keycodes](./reference_keymap_extras.md).
 
 ### Macro Basics
 

--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -42,7 +42,7 @@ You can define up to 32 macros in a `keymap.json` file, as used by [Configurator
 
 ### Selecting Your Host Keyboard Layout
 
-If you type in a language other than English, or use a non-QWERTY layout like Colemak, Dvorak, or Workman, you may have set your computer's input language to match this layout. This presents a challenge when creating macros - you may need to type different keys to get the same letters! To address this you can use [language-specific keycodes](./reference_keymap_extras.md).
+If you type in a language other than English, or use a non-QWERTY layout like Colemak, Dvorak, or Workman, you may have set your computer's input language to match this layout. This presents a challenge when creating macros — you may need to type different keys to get the same letters! To address this you can use [language-specific keycodes](./reference_keymap_extras.md).
 
 ### Macro Basics
 

--- a/docs/feature_macros.md
+++ b/docs/feature_macros.md
@@ -42,7 +42,7 @@ You can define up to 32 macros in a `keymap.json` file, as used by [Configurator
 
 ### Selecting Your Host Keyboard Layout
 
-If you type in a language other than English, or use a non-QWERTY layout like Colemak, Dvorak, or Workman, you may have set your computer's input language to match this layout. This presents a challenge when creating macros — you may need to type different keys to get the same letters! To address this you can use [language-specific keycodes](./reference_keymap_extras.md).
+If you type in a language other than English, or use a non-QWERTY layout like Colemak, Dvorak, or Workman, you may have set your computer's input language to match this layout. This presents a challenge when creating macros — you may need to type different keys to get the same letters! To address this you can use [language-specific keycodes](reference_keymap_extras).
 
 ### Macro Basics
 

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -9,7 +9,7 @@ Obviously, this can get confusing, so QMK provides language-specific keycode ali
 To select a host keyboard layout, simply `#include` one of the [keycode headers](#header-files) below at the top of your `keymap.c`. Example:
 
 ```c
-#include keymap_japanese.h
+#include "keymap_japanese.h"
 ```
 
 Alternatively, if using `keymap.json`, add the `host_language` key as shown in the following example. The available languages are those with a _Sendstring LUT Header_ entry in one of the [Header Files](#header-files) tables.

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -18,7 +18,7 @@ Alternatively, if using `keymap.json`, add the `host_language` key as shown in t
 {
     "keyboard": "handwired/my_macropad",
     "keymap": "my_keymap",
-    "host_language": "swedish",
+    "host_language": "swedish", // [!code focus]
     "layout": "LAYOUT_all",
     "layers": [
         ["SE_ARNG"]

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -9,7 +9,9 @@ Obviously, this can get confusing, so QMK provides language-specific keycode ali
 To select a host keyboard layout, simply `#include` one of the [keycode headers](#header-files) below at the top of your `keymap.c`. Example:
 
 ```c
-#include "keymap_japanese.h"
+#include QMK_KEYBOARD_H
+
+#include "keymap_japanese.h" // [!code focus]
 ```
 
 Alternatively, if using `keymap.json`, add the `host_language` key as shown in the following example. The available languages are those with a _Sendstring LUT Header_ entry in one of the [Header Files](#header-files) tables.

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -6,7 +6,11 @@ Obviously, this can get confusing, so QMK provides language-specific keycode ali
 
 ## Selecting Your Host Keyboard Layout
 
-To select a host keyboard layout, simply `#include` one of the [keycode headers](#header-files) below at the top of your `keymap.c`.
+To select a host keyboard layout, simply `#include` one of the [keycode headers](#header-files) below at the top of your `keymap.c`. Example:
+
+```c
+#include keymap_japanese.h
+```
 
 Alternatively, if using `keymap.json`, add the `host_language` key as shown in the following example. The available languages are those with a _Sendstring LUT Header_ entry in one of the [Header Files](#header-files) tables.
 

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -14,13 +14,10 @@ Alternatively, if using `keymap.json`, add the `host_language` key as shown in t
 {
     "keyboard": "handwired/my_macropad",
     "keymap": "my_keymap",
-    "host_language": "dvorak",
-    "macros": [
-        ["Hello, World!"]
-    ],
+    "host_language": "swedish",
     "layout": "LAYOUT_all",
     "layers": [
-        ["QK_MACRO_0"]
+        ["SE_A"]
     ]
 }
 ```

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -2,9 +2,28 @@
 
 Keyboards are able to support a wide range of languages. However, this support is not actually achieved within the keyboard itself - instead, it sends numerical codes, which the operating system maps to the appropriate characters depending on the user's configured keyboard layout. By default (and per the HID spec), this is the US ANSI layout. For example, when a Swedish person presses the key with the `å` character printed on it, the keyboard is *actually* sending the keycode for `[`.
 
-Obviously, this can get confusing, so QMK provides language-specific keycode aliases for many keyboard layouts. These won't do much on their own - you still have to set the matching keyboard layout in your OS settings. Think of them more as keycap labels for your keymap.
+Obviously, this can get confusing, so QMK provides language-specific keycode aliases for many keyboard layouts. These are used in place of the `KC_` prefixed ones. They won't do much on their own - you still have to set the matching keyboard layout in your OS settings. Think of them more as keycap labels for your keymap. The language-specific keycode aliases are defined in the files listed in the [Keycodes Header](#header-files) column below.
 
-Simply `#include` one of the keycode headers below at the top of your `keymap.c`, or set the `host_language` field in your `keymap.json` to the corresponding language. Then assign the keycodes defined in the header in place of the `KC_` prefixed ones.
+## Selecting Your Host Keyboard Layout
+
+To select a host keyboard layout, simply `#include` one of the [keycode headers](#header-files) below at the top of your `keymap.c`.
+
+Alternatively, if using `keymap.json`, add the `host_language` key as shown in the following example. The available languages are those with a _Sendstring LUT Header_ entry in one of the [Header Files](#header-files) tables.
+
+```json
+{
+    "keyboard": "handwired/my_macropad",
+    "keymap": "my_keymap",
+    "host_language": "dvorak",
+    "macros": [
+        ["Hello, World!"]
+    ],
+    "layout": "LAYOUT_all",
+    "layers": [
+        ["QK_MACRO_0"]
+    ]
+}
+```
 
 ## Sendstring Support
 

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -4,7 +4,7 @@ Keyboards are able to support a wide range of languages. However, this support i
 
 Obviously, this can get confusing, so QMK provides language-specific keycode aliases for many keyboard layouts. These won't do much on their own - you still have to set the matching keyboard layout in your OS settings. Think of them more as keycap labels for your keymap.
 
-Simply `#include` one of the keycode headers below at the top of your `keymap.c`, and assign the keycodes defined in the header in place of the `KC_` prefixed ones.
+Simply `#include` one of the keycode headers below at the top of your `keymap.c`, or set the `host_language` field in your `keymap.json` to the corresponding language. Then assign the keycodes defined in the header in place of the `KC_` prefixed ones.
 
 ## Sendstring Support
 

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -21,7 +21,7 @@ Alternatively, if using `keymap.json`, add the `host_language` key as shown in t
     "host_language": "swedish",
     "layout": "LAYOUT_all",
     "layers": [
-        ["SE_A"]
+        ["SE_ARNG"]
     ]
 }
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

- Document `host_language` in _Language-specific Keycodes_ instead of _Macros_.
- Removes the need for (outdated) table of supported languages.
- Mostly just shuffles existing text around.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Mention `host_language` in _Language-specific Keycodes_ so that those who use `keymap.json` instead of `keymap.c` also know how to include specific language headers. It's quite confusing to attempt including these language-specific headers without this information. E.g. trying to create `.h` files that includes them - but don't compile.

EDIT: as the _Macros_ page already had a description and example, I moved it into _Language-specific Keycodes_ and referenced it in _Macros_. I think it makes more sense to have it here, as the outdated list of supported languages can then also be removed, in favor of the _Header Files_ table.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
