### PR TITLE
[Keyboard] Add RP2040 version for KLOR

### DIFF
--- a/keyboards/geigeigeist/klor/elite_c/keyboard.json
+++ b/keyboards/geigeigeist/klor/elite_c/keyboard.json
@@ -1,0 +1,34 @@
+{
+	"build": {
+        "lto": true
+    },
+    "development_board": "elite_c",
+    "pin_compatible": "elite_c",
+    "encoder": {
+        "rotary": [
+            {"pin_a": "F5", "pin_b": "F4", "resolution": 2}
+        ]
+    },
+    "matrix_pins": {
+        "cols": ["F6", "F7", "B1", "B3", "B2", "B6"],
+        "rows": ["C6", "D7", "E6", "B4"]
+    },
+    "split": {
+        "encoder": {
+            "right": {
+                "rotary": [
+                    {"pin_a": "F4", "pin_b": "F5", "resolution": 2}
+                ]
+            }
+        },
+        "serial": {
+            "pin": "D2"
+        }
+    },
+    "ws2812": {
+        "pin": "D3"
+    },
+    "haptic": {
+        "driver": "drv2605l"
+    }
+}

--- a/keyboards/geigeigeist/klor/info.json
+++ b/keyboards/geigeigeist/klor/info.json
@@ -5,30 +5,17 @@
     "build": {
         "lto": true
     },
-    "development_board": "elite_c",
     "diode_direction": "COL2ROW",
-    "encoder": {
-        "rotary": [
-            {"pin_a": "F5", "pin_b": "F4"}
-        ]
-    },
     "features": {
         "bootmagic": true,
         "encoder": true,
         "extrakey": true,
-        "haptic": true,
+        "haptic": false,
         "mousekey": true,
         "oled": true,
         "pointing_device": false,
         "rgb_matrix": true,
         "audio": false
-    },
-    "haptic": {
-        "driver": "drv2605l"
-    },
-    "matrix_pins": {
-        "cols": ["F6", "F7", "B1", "B3", "B2", "B6"],
-        "rows": ["C6", "D7", "E6", "B4"]
     },
     "rgb_matrix": {
         "driver": "ws2812",
@@ -88,16 +75,6 @@
     },
     "split": {
         "enabled": true,
-        "encoder": {
-            "right": {
-                "rotary": [
-                    {"pin_a": "F4", "pin_b": "F5"}
-                ]
-            }
-        },
-        "serial": {
-            "pin": "D2"
-        },
         "transport": {
             "sync": {
                 "oled": true,
@@ -110,9 +87,6 @@
         "device_version": "1.0.0",
         "pid": "0x0001",
         "vid": "0x3A3C"
-    },
-    "ws2812": {
-        "pin": "D3"
     },
     "layouts": {
         "LAYOUT": {

--- a/keyboards/geigeigeist/klor/rp2040_ce/config.h
+++ b/keyboards/geigeigeist/klor/rp2040_ce/config.h
@@ -1,0 +1,12 @@
+// Copyright 2024 Markus Knutsson (@TweetyDaBird)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// NOTE: Copied from keyboards/tweetydabird/lotus58/rp2040_ce/config.h
+
+#pragma once
+
+#define SERIAL_PIO_USE_PIO1 // Force the usage of PIO1 peripheral, by default the Serial implementation uses the PIO0 peripheral
+
+#define I2C_DRIVER I2CD1
+#define I2C1_SDA_PIN GP2
+#define I2C1_SCL_PIN GP3

--- a/keyboards/geigeigeist/klor/rp2040_ce/halconf.h
+++ b/keyboards/geigeigeist/klor/rp2040_ce/halconf.h
@@ -1,0 +1,23 @@
+/* Copyright 2022 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// NOTE: Copied from keyboards/tweetydabird/lotus58/rp2040_ce/halconf.h
+
+#pragma once
+
+#define HAL_USE_I2C TRUE
+
+#include_next <halconf.h>

--- a/keyboards/geigeigeist/klor/rp2040_ce/keyboard.json
+++ b/keyboards/geigeigeist/klor/rp2040_ce/keyboard.json
@@ -1,0 +1,32 @@
+{
+	"build": {
+        "lto": true
+    },
+    "development_board": "promicro_rp2040",
+    "encoder": {
+        "rotary": [
+            {"pin_a": "GP28", "pin_b": "GP29", "resolution": 2}
+        ]
+    },
+    "matrix_pins": {
+        "cols": ["GP27", "GP26", "GP22", "GP20", "GP23", "GP21" ],
+        "rows": ["GP5", "GP6", "GP7", "GP8"]
+    },
+    "split": {
+        "encoder": {
+            "right": {
+                "rotary": [
+                    {"pin_a": "GP29", "pin_b": "GP28", "resolution": 2}
+                ]
+            }
+        },
+        "serial": {
+            "driver": "vendor",
+            "pin": "GP1"
+        }
+    },
+    "ws2812": {
+		"driver": "vendor",
+		"pin": "GP0"
+    }
+}

--- a/keyboards/geigeigeist/klor/rp2040_ce/mcuconf.h
+++ b/keyboards/geigeigeist/klor/rp2040_ce/mcuconf.h
@@ -1,0 +1,24 @@
+/* Copyright 2022 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// NOTE: Copied from keyboards/tweetydabird/lotus58/rp2040_ce/mcuconf.h
+
+#pragma once
+
+#include_next <mcuconf.h>
+
+#undef RP_I2C_USE_I2C1
+#define RP_I2C_USE_I2C1 TRUE


### PR DESCRIPTION
## Description

Split the KLOR configuration into elite_c and rp2040_ce versions. Took example from lotus58.

As I couldn't test any other features than keys, leds and oleds, I disabled the rest. Also I couldn't verify that I didn't break the Elite-C config.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
