### PR TITLE
Simple Python script to show polling rate

### DIFF
--- a/util/polling_rate.py
+++ b/util/polling_rate.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import usb
+
+USB_INTERFACE_CLASS_HID = 0x03
+
+def usb_device_spec(spec):
+    major = spec >> 8
+    minor = (spec >> 4) & 0xF
+    return f"{major}.{minor}"
+
+def usb_device_speed(speed):
+    if speed == 1:
+        return "Low-speed"
+    elif speed == 2:
+        return "Full-speed"
+    elif speed == 3:
+        return "High-speed"
+    elif speed == 4:
+        return "SuperSpeed"
+    elif speed == 5:
+        return "SuperSpeed+"
+
+    return "Speed unknown"
+
+def usb_hid_interface_subclass(subclass):
+    if subclass == 0x00:
+        return "None"
+    elif subclass == 0x01:
+        return "Boot"
+    else:
+        return f"Unknown (0x{subclass:02X})"
+
+def usb_hid_interface_protocol(subclass, protocol):
+    if subclass == 0x00 and protocol == 0x00:
+        return "None"
+    elif subclass == 0x01:
+        if protocol == 0x00:
+            return "None"
+        elif protocol == 0x01:
+            return "Keyboard"
+        elif protocol == 0x02:
+            return "Mouse"
+
+    return f"Unknown (0x{protocol:02X})"
+
+def usb_interface_polling_rate(speed, interval):
+    if speed >= 3:
+        return f"{interval * 125} μs ({8000 // interval} Hz)"
+    else:
+        return f"{interval} ms ({1000 // interval} Hz)"
+
+if __name__ == '__main__':
+    devices = usb.core.find(find_all=True)
+
+    for device in devices:
+        try:
+            configuration = device.get_active_configuration()
+        except NotImplementedError:
+            continue
+
+        hid_interfaces = []
+        for interface in configuration.interfaces():
+            if interface.bInterfaceClass == USB_INTERFACE_CLASS_HID:
+                hid_interfaces.append(interface)
+
+        if len(hid_interfaces) > 0:
+            print(f"{device.manufacturer} {device.product} ({device.idVendor:04X}:{device.idProduct:04X}:{device.bcdDevice:04X}), {usb_device_spec(device.bcdUSB)} {usb_device_speed(device.speed)}")
+
+            for interface in hid_interfaces:
+                print(f"└─ HID Interface {interface.bInterfaceNumber}")
+                subclass = interface.bInterfaceSubClass
+                protocol = interface.bInterfaceProtocol
+                print(f"   ├─ Subclass: {usb_hid_interface_subclass(subclass)}")
+                print(f"   ├─ Protocol: {usb_hid_interface_protocol(subclass, protocol)}")
+
+                for endpoint in interface.endpoints():
+                    endpoint_address = endpoint.bEndpointAddress & 0xF
+                    endpoint_direction = "IN" if endpoint.bEndpointAddress & 0x80 else "OUT"
+                    print(f"   └─ Endpoint {endpoint_address} {endpoint_direction}")
+                    print(f"      ├─ Endpoint Size: {endpoint.wMaxPacketSize} bytes")
+                    print(f"      └─ Polling Rate: {usb_interface_polling_rate(device.speed, endpoint.bInterval)}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Since we often get users asking how to verify their board is actually running at 1000 Hz. Browser based testers may be "inaccurate" due to their measurement method; this script shows the requested polling rate from the device. Whether this is what the OS is truly polling at is out of QMK's control.

```
$ ./util/polling_rate.py
Evyd13 Wasdat (4705:C474:0001), 2.0 Full-speed
└─ HID Interface 0
   ├─ Subclass: Boot
   ├─ Protocol: Keyboard
   └─ Endpoint 1 IN
      ├─ Endpoint Size: 8 bytes
      └─ Polling Rate: 1 ms (1000 Hz)
└─ HID Interface 1
   ├─ Subclass: None
   ├─ Protocol: None
   └─ Endpoint 2 IN
      ├─ Endpoint Size: 32 bytes
      └─ Polling Rate: 1 ms (1000 Hz)
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
