### PR TITLE
`qmk docs`: restore `--port` and `--browser` arguments

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -717,23 +717,26 @@ Now open your dev environment and live a squiggly-free life.
 
 ## `qmk docs`
 
-This command starts a local HTTP server which you can use for browsing or improving the docs. Default port is 5173.
+This command starts a local HTTP server which you can use for browsing or improving the docs, and provides live reload capability whilst editing. Default port is 8936.
+Use the `-b`/`--browser` flag to automatically open the local webserver in your default browser.
 
-This command requires `node` and `yarn` to be installed as prerequisites, and provides live reload capability whilst editing.
+Requires `node` and `yarn` to be installed as prerequisites.
 
 **Usage**:
 
 ```
-usage: qmk docs [-h]
+usage: qmk docs [-h] [-b] [-p PORT]
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help       show this help message and exit
+  -b, --browser    Open the docs in the default browser.
+  -p, --port PORT  Port number to use.
 ```
 
 ## `qmk generate-docs`
 
-This command allows you to generate QMK documentation locally. It can be uses for general browsing or improving the docs.
-Use the `-s`/`--serve` flag to also serve the static site once built. Default port is 4173.
+This command generates QMK documentation for production.
+Use the `-s`/`--serve` flag to also serve the static site on port 4173 once built. Note that this does not provide live reloading; use `qmk docs` instead for development purposes.
 
 This command requires `node` and `yarn` to be installed as prerequisites, and requires the operating system to support symlinks.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -106,10 +106,10 @@ enum my_keycodes {
 Before opening a pull request, you can preview your changes if you have set up the development environment by running this command from the `qmk_firmware/` folder:
 
 ```
-qmk docs
+qmk docs -b
 ```
 
-and navigating to `http://localhost:5173/`.
+Which should automatically open your browser; otherwise, navigate to `http://localhost:8936/`.
 
 ## Keyboards
 

--- a/lib/python/qmk/cli/docs.py
+++ b/lib/python/qmk/cli/docs.py
@@ -6,6 +6,8 @@ from qmk.docs import prepare_docs_build_area, run_docs_command
 from milc import cli
 
 
+@cli.argument('-p', '--port', default=8936, type=int, help='Port number to use.')
+@cli.argument('-b', '--browser', action='store_true', help='Open the docs in the default browser.')
 @cli.subcommand('Run a local webserver for QMK documentation.', hidden=False if cli.config.user.developer else True)
 def docs(cli):
     """Spin up a local HTTP server for the QMK docs.
@@ -22,6 +24,7 @@ def docs(cli):
     if not prepare_docs_build_area(is_production=False):
         return False
 
-    if not cli.config.general.verbose:
-        cli.log.info('Serving docs at http://localhost:5173/ (Ctrl+C to stop)')
-    run_docs_command('run', 'docs:dev')
+    cmd = ['docs:dev', '--port', f'{cli.args.port}']
+    if cli.args.browser:
+        cmd.append('--open')
+    run_docs_command('run', cmd)

--- a/lib/python/qmk/cli/generate/docs.py
+++ b/lib/python/qmk/cli/generate/docs.py
@@ -27,8 +27,8 @@ def generate_docs(cli):
         return False
 
     cli.log.info('Building vitepress docs')
-    run_docs_command('run', 'docs:build')
+    run_docs_command('run', ['docs:build'])
     cli.log.info('Successfully generated docs to %s.', BUILD_DOCS_PATH)
 
     if cli.args.serve:
-        run_docs_command('run', 'docs:preview')
+        run_docs_command('run', ['docs:preview'])

--- a/lib/python/qmk/cli/generate/docs.py
+++ b/lib/python/qmk/cli/generate/docs.py
@@ -31,6 +31,4 @@ def generate_docs(cli):
     cli.log.info('Successfully generated docs to %s.', BUILD_DOCS_PATH)
 
     if cli.args.serve:
-        if not cli.config.general.verbose:
-            cli.log.info('Serving docs at http://localhost:4173/ (Ctrl+C to stop)')
         run_docs_command('run', 'docs:preview')

--- a/lib/python/qmk/docs.py
+++ b/lib/python/qmk/docs.py
@@ -17,7 +17,7 @@ BUILD_DOCS_PATH = BUILD_PATH / 'docs'
 DOXYGEN_PATH = BUILD_DOCS_PATH / 'static' / 'doxygen'
 
 
-def run_docs_command(verb, cmd=None):
+def run_docs_command(verb, cmd_args=None):
     environ['PATH'] += pathsep + str(NODE_MODULES_PATH / '.bin')
 
     args = {'capture_output': False, 'check': True}
@@ -27,8 +27,8 @@ def run_docs_command(verb, cmd=None):
     args['env'] = docs_env
 
     arg_list = ['yarn', verb]
-    if cmd:
-        arg_list += cmd
+    if cmd_args:
+        arg_list.extend(cmd_args)
 
     chdir(BUILDDEFS_PATH)
     cli.run(arg_list, **args)

--- a/lib/python/qmk/docs.py
+++ b/lib/python/qmk/docs.py
@@ -20,7 +20,7 @@ DOXYGEN_PATH = BUILD_DOCS_PATH / 'static' / 'doxygen'
 def run_docs_command(verb, cmd=None):
     environ['PATH'] += pathsep + str(NODE_MODULES_PATH / '.bin')
 
-    args = {'capture_output': False if cli.config.general.verbose else True, 'check': True, 'stdin': DEVNULL}
+    args = {'capture_output': False, 'check': True}
     docs_env = environ.copy()
     if cli.config.general.verbose:
         docs_env['DEBUG'] = 'vitepress:*,vite:*'
@@ -28,7 +28,7 @@ def run_docs_command(verb, cmd=None):
 
     arg_list = ['yarn', verb]
     if cmd:
-        arg_list.append(cmd)
+        arg_list += cmd
 
     chdir(BUILDDEFS_PATH)
     cli.run(arg_list, **args)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

These were removed during the move to Vitepress, however `vitepress dev` does have equivalent arguments.

Documentation for `qmk generate-docs` has been tweaked to emphasise it's only for emitting the production docs.

I've also adjusted `run_docs_command()` to make the dev server interactive, which provides a cleaner way to shut down than hitting Ctrl+C.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
