### PR TITLE
`qmk new-keyboard`: prompt for matrix type and dimensions

### DIFF
--- a/data/templates/keyboard/keyboard.json
+++ b/data/templates/keyboard/keyboard.json
@@ -2,11 +2,6 @@
     "keyboard_name": "%KEYBOARD%",
     "maintainer": "%USER_NAME%",
     "manufacturer": "%REAL_NAME%",
-    "diode_direction": "COL2ROW",
-    "matrix_pins": {
-        "cols": ["C2"],
-        "rows": ["D1"]
-    },
     "usb": {
         "vid": "0xFEED",
         "pid": "0x0000",

--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -97,10 +97,21 @@ def augment_community_info(config, src, dest):
         width = max(width, int(item["x"]) + 1)
         height = max(height, int(item["y"]) + 1)
 
-    info["matrix_pins"] = {
-        "cols": ["C2"] * width,
-        "rows": ["D1"] * height,
-    }
+    matrix_type = prompt_matrix_type()
+    (rows, cols) = prompt_matrix_size(len(first_layout))
+
+    if matrix_type == 'direct':
+        info["matrix_pins"] = {
+            "direct": [
+                ["C2"] * cols
+            ] * rows
+        }
+    elif matrix_type in ['COL2ROW', 'ROW2COL']:
+        info["diode_direction"] = matrix_type
+        info["matrix_pins"] = {
+            "cols": ["C2"] * cols,
+            "rows": ["D1"] * rows,
+        }
 
     # assume a 1:1 mapping on matrix to electrical
     for item in first_layout:
@@ -134,6 +145,32 @@ def _question(*args, **kwargs):
 def prompt_heading_subheading(heading, subheading):
     cli.log.info(f"{{fg_yellow}}{heading}{{style_reset_all}}")
     cli.log.info(subheading)
+
+
+def prompt_matrix_type():
+    prompt_heading_subheading("Specify Matrix Type", "")
+
+    matrix_types = ['COL2ROW', 'ROW2COL', 'direct', 'custom']
+
+    return choice("Matrix type?", matrix_types)
+
+
+def prompt_matrix_size(key_count):
+    prompt_heading_subheading("Specify Matrix Dimensions", "The number of rows and columns in the electrical matrix")
+
+    errmsg = 'Need at least one row or column!'
+
+    ret = True
+    while ret:
+        rows = int(_question("Rows:", reprompt=errmsg, validate=lambda x: int(x) > 0))
+        cols = int(_question("Cols:", reprompt=errmsg, validate=lambda x: int(x) > 0))
+
+        if rows * cols >= key_count:
+            ret = False
+        else:
+            cli.log.error(f"Number of rows ({rows}) * number of cols ({cols}) is not sufficient for the number of keys in the selected layout ({key_count})!")
+
+    return (rows, cols)
 
 
 def prompt_keyboard():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When running `qmk new-keyboard`, ask the user what their matrix setup will be (col2row, row2col, direct, or custom), and do some simple validation based on the layout they've chosen. Pins are still placeholders; the process could be extended to prompt for each but that might be a little too unwieldy...

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
