### PR TITLE
macOS install: remove bad ARM toolchains

### DIFF
--- a/util/install/macos.sh
+++ b/util/install/macos.sh
@@ -9,6 +9,12 @@ _qmk_install_prepare() {
         return 1
     fi
 
+    # Conflicts with arm-none-eabi toolchain from osx-cross
+    brew uninstall --ignore-dependencies --cask gcc-arm-embedded >/dev/null 2>&1
+    brew uninstall --ignore-dependencies homebrew/core/arm-none-eabi-gcc >/dev/null 2>&1
+    brew uninstall --ignore-dependencies homebrew/core/arm-none-eabi-binutils >/dev/null 2>&1
+    brew uninstall --ignore-dependencies osx-cross/arm/arm-gcc-bin@8 >/dev/null 2>&1
+
     brew update && brew upgrade --formulae
 }
 
@@ -18,9 +24,6 @@ _qmk_install() {
     # All macOS dependencies are managed in the Homebrew package:
     # https://github.com/qmk/homebrew-qmk
     brew install qmk/qmk/qmk
-
-    # Conflicts with new toolchain formulae
-    brew uninstall --ignore-dependencies arm-gcc-bin@8 >/dev/null 2>&1
 
     # Keg-only, so need to be manually linked
     brew link --force avr-gcc@8

--- a/util/install/macos.sh
+++ b/util/install/macos.sh
@@ -21,14 +21,12 @@ _qmk_install_prepare() {
 _qmk_install() {
     echo "Installing dependencies"
 
-    # All macOS dependencies are managed in the Homebrew package:
-    # https://github.com/qmk/homebrew-qmk
+    # All macOS & Python dependencies are managed in the Homebrew package:
+    #   https://github.com/qmk/homebrew-qmk
     brew install qmk/qmk/qmk
 
     # Keg-only, so need to be manually linked
     brew link --force avr-gcc@8
     brew link --force arm-none-eabi-binutils
     brew link --force arm-none-eabi-gcc@8
-
-    python3 -m pip install -r $QMK_FIRMWARE_DIR/requirements.txt
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

All of these will conflict with the ARM toolchain that the `qmk` formula specifies as a dependency (`osx-cross/arm/arm-none-eabi-gcc@8`). This should help users who've accidentally installed the wrong one as they just need to rerun `qmk setup` or the install script directly instead of messing around with brew to manually uninstall the "bad" formulae.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
