### PR TITLE
Provide method to save a single default layer in the full range of 0-31

### DIFF
--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -3,7 +3,6 @@
 #include <stdbool.h>
 #include "eeprom.h"
 #include "eeconfig.h"
-#include "action_layer.h"
 
 #if defined(EEPROM_DRIVER)
 #    include "eeprom_driver.h"
@@ -52,7 +51,7 @@ void eeconfig_init_quantum(void) {
     eeprom_update_word(EECONFIG_MAGIC, EECONFIG_MAGIC_NUMBER);
     eeprom_update_byte(EECONFIG_DEBUG, 0);
     default_layer_state = (layer_state_t)1 << 0;
-    eeprom_update_byte(EECONFIG_DEFAULT_LAYER, default_layer_state);
+    eeconfig_update_default_layer(default_layer_state);
     // Enable oneshot and autocorrect by default: 0b0001 0100 0000 0000
     eeprom_update_word(EECONFIG_KEYMAP, 0x1400);
     eeprom_update_byte(EECONFIG_BACKLIGHT, 0);
@@ -160,14 +159,30 @@ void eeconfig_update_debug(uint8_t val) {
  *
  * FIXME: needs doc
  */
-uint8_t eeconfig_read_default_layer(void) {
-    return eeprom_read_byte(EECONFIG_DEFAULT_LAYER);
+layer_state_t eeconfig_read_default_layer(void) {
+    uint8_t val = eeprom_read_byte(EECONFIG_DEFAULT_LAYER);
+
+#ifdef DEFAULT_LAYER_STATE_IS_VALUE_NOT_BITMASK
+    // stored as a layer number, so convert back to bitmask
+    return 1 << val;
+#else
+    // stored as 8-bit-wide bitmask, so read the value directly - handling padding to 16/32 bit layer_state_t
+    return val;
+#endif
 }
 /** \brief eeconfig update default layer
  *
  * FIXME: needs doc
  */
-void eeconfig_update_default_layer(uint8_t val) {
+void eeconfig_update_default_layer(layer_state_t state) {
+#ifdef DEFAULT_LAYER_STATE_IS_VALUE_NOT_BITMASK
+    // stored as a layer number, so only store the highest layer
+    uint8_t val = get_highest_layer(state);
+#else
+    // stored as 8-bit-wide bitmask, so write the value directly - handling truncation from 16/32 bit layer_state_t
+    uint8_t val = state;
+#endif
+
     eeprom_update_byte(EECONFIG_DEFAULT_LAYER, val);
 }
 

--- a/quantum/eeconfig.h
+++ b/quantum/eeconfig.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stddef.h> // offsetof
 #include "eeprom.h"
 #include "util.h"
+#include "action_layer.h" // layer_state_t
 
 #ifndef EECONFIG_MAGIC_NUMBER
 #    define EECONFIG_MAGIC_NUMBER (uint16_t)0xFEE5 // When changing, decrement this value to avoid future re-init issues
@@ -122,8 +123,8 @@ void eeconfig_disable(void);
 uint8_t eeconfig_read_debug(void);
 void    eeconfig_update_debug(uint8_t val);
 
-uint8_t eeconfig_read_default_layer(void);
-void    eeconfig_update_default_layer(uint8_t val);
+layer_state_t eeconfig_read_default_layer(void);
+void    eeconfig_update_default_layer(layer_state_t val);
 
 uint16_t eeconfig_read_keymap(void);
 void     eeconfig_update_keymap(uint16_t val);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Staging #22933 but with the current behaviour as default.

* Updated to keep storage behaviour differences within a single file
* Addresses issue with init of `default_layer_state`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
