### PR TITLE
skyloong/gk61: Remove overriding of core keycode behaviour

### DIFF
--- a/keyboards/skyloong/gk61/pro/config.h
+++ b/keyboards/skyloong/gk61/pro/config.h
@@ -7,6 +7,3 @@
 #define IS31FL3743A_SDB_PIN C1
 
 #define CAPS_LOCK_INDEX 28
-#define WIN_MOD_INDEX 16
-#define MAC_MOD_INDEX 17
-#define WIN_LOCK_INDEX 54

--- a/keyboards/skyloong/gk61/pro/pro.c
+++ b/keyboards/skyloong/gk61/pro/pro.c
@@ -1,11 +1,8 @@
 // Copyright 2023 linlin012 (@linlin012)
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "quantum.h"
-int FN_WIN = 0;
-int FN_MAC = 0;
-int L_WIN = 0;
-int L_MAC = 0;
 
+#if defined(RGB_MATRIX_ENABLE)
 const is31fl3743a_led_t PROGMEM g_is31fl3743a_leds[IS31FL3743A_LED_COUNT] = {
 /* Refer to IS31 manual for these locations
  *   driver
@@ -83,7 +80,32 @@ const is31fl3743a_led_t PROGMEM g_is31fl3743a_leds[IS31FL3743A_LED_COUNT] = {
     {0, SW10_CS13, SW10_CS14, SW10_CS15}
 };
 
-#if defined(RGB_MATRIX_ENABLE)  /*&& defined(CAPS_LOCK_INDEX)*/
+bool rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
+    if (!rgb_matrix_indicators_advanced_user(led_min, led_max)) {
+        return false;
+    }
+
+    if (host_keyboard_led_state().caps_lock) {
+        RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_INDEX, 255, 255, 255);
+    } else {
+        if (!rgb_matrix_get_flags()) {
+            RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_INDEX, 0, 0, 0);
+        }
+    }
+
+    return false;
+}
+
+void suspend_power_down_kb(void) {
+    gpio_write_pin_low(IS31FL3743A_SDB_PIN);
+    suspend_power_down_user();
+}
+
+void suspend_wakeup_init_kb(void) {
+    gpio_write_pin_high(IS31FL3743A_SDB_PIN);
+    suspend_wakeup_init_user();
+}
+#endif
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     if (!process_record_user(keycode, record)) {
@@ -105,124 +127,9 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 #    endif
-        case TO(0):
-            if (record->event.pressed) {
-               L_WIN = 1;
-               set_single_persistent_default_layer(0); // Save default layer 0 to eeprom
-            } else {
-                L_WIN = 0;
-            }
-            return true; // continue all further processing of this key
-
-        case MO(2):
-             if (record->event.pressed) {
-                FN_WIN = 1;
-            } else {
-                FN_WIN = 0;
-            }
-            return true; // continue all further processing of this key
-
-        case TO(1):
-            if (record->event.pressed) {
-               L_MAC = 1;
-               set_single_persistent_default_layer(1);  //Save default layer 1 to eeprom
-            } else {
-               L_MAC = 0;
-            }
-            return true; // continue all further processing of this key
-
-        case MO(3):
-            if (record->event.pressed) {
-               FN_MAC = 1;
-            } else {
-               FN_MAC = 0;
-            }
-            return true; // continue all further processing of this key
-        default:
-            return true;
-        }
-
-}
-
-bool rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
-    if (!rgb_matrix_indicators_advanced_user(led_min, led_max)) {
-        return false;
     }
 
-    if (host_keyboard_led_state().caps_lock) {
-        RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_INDEX, 255, 255, 255);
-    } else {
-        if (!rgb_matrix_get_flags()) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(CAPS_LOCK_INDEX, 0, 0, 0);
-        }
-    }
-
-    switch (get_highest_layer(layer_state)) {
-      case 0:{
-        if (L_WIN) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 255, 255, 255);
-            if (!rgb_matrix_get_flags()) {
-               RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-            }
-            }else{
-                if (!rgb_matrix_get_flags()) {
-                   RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-                 }
-              }
-         } break;
-
-      case 1:{
-         if (L_MAC) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 255, 255, 255);
-            if (!rgb_matrix_get_flags()) {
-               RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-            }
-            }else{
-                if (!rgb_matrix_get_flags()) {
-                   RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-                 }
-              }
-         } break;
-
-
-      case 2:{
-       RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 255, 255, 255);
-        if (!rgb_matrix_get_flags()) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-         }
-      } break;
-
-      case 3:{
-       RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 255, 255, 255);
-        if (!rgb_matrix_get_flags()) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-         }
-      } break;
-
-      default:{
-        if (!rgb_matrix_get_flags()) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-            RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-        }
-      }
-    }
-    return false;
-}
-
-#endif
-
-void suspend_power_down_kb() {
-#    ifdef RGB_MATRIX_ENABLE
-    gpio_write_pin_low(IS31FL3743A_SDB_PIN);
-#    endif
-     suspend_power_down_user();
-}
-
-void suspend_wakeup_init_kb() {
-#    ifdef RGB_MATRIX_ENABLE
-    gpio_write_pin_high(IS31FL3743A_SDB_PIN);
-#    endif
-     suspend_wakeup_init_user();
+    return true;
 }
 
 void board_init(void) {

--- a/keyboards/skyloong/gk61/pro_48/config.h
+++ b/keyboards/skyloong/gk61/pro_48/config.h
@@ -7,7 +7,3 @@
 #define IS31FL3743A_SDB_PIN A4
 
 #define CAPS_LOCK_INDEX 28
-#define WIN_MOD_INDEX 16
-#define MAC_MOD_INDEX 17
-
-#define g_suspend_state rgb_matrix_get_suspend_state()

--- a/keyboards/skyloong/gk61/pro_48/pro_48.c
+++ b/keyboards/skyloong/gk61/pro_48/pro_48.c
@@ -1,12 +1,8 @@
 // Copyright 2023 linlin012 (@linlin012)
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "quantum.h"
-_Bool FN_WIN = 0;
-_Bool FN_MAC = 0;
-_Bool L_WIN = 0;
-_Bool L_MAC = 0;
 
-#if defined(RGB_MATRIX_ENABLE)  /*&& defined(CAPS_LOCK_INDEX)*/
+#if defined(RGB_MATRIX_ENABLE)
 const is31fl3743a_led_t PROGMEM g_is31fl3743a_leds[IS31FL3743A_LED_COUNT] = {
 /* Refer to IS31 manual for these locations
  *   driver
@@ -97,56 +93,8 @@ bool rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
         }
     }
 
-   switch (get_highest_layer(layer_state)) {
-      case 2:{
-        RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 255, 255, 255);
-        if (!rgb_matrix_get_flags()) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-         }
-      } break;
-      case 3:{
-        RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 255, 255, 255);
-        if (!rgb_matrix_get_flags()) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-         }
-      } break;
-
-      case 0:{
-       if (L_WIN) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 255, 255, 255);
-            if (!rgb_matrix_get_flags()) {
-               RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-            }
-            }else{
-                if (!rgb_matrix_get_flags()) {
-                   RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-                 }
-              }
-         } break;
-
-     case 1:{
-       if (L_MAC) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 255, 255, 255);
-            if (!rgb_matrix_get_flags()) {
-               RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-            }
-            }else{
-                if (!rgb_matrix_get_flags()) {
-                   RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-                 }
-              }
-         } break;
-
-      default:{
-         if (!rgb_matrix_get_flags()) {
-            RGB_MATRIX_INDICATOR_SET_COLOR(WIN_MOD_INDEX, 0, 0, 0);
-            RGB_MATRIX_INDICATOR_SET_COLOR(MAC_MOD_INDEX, 0, 0, 0);
-         }
-      }
-    }
     return false;
 }
-
 
 void suspend_power_down_kb(void) {
     gpio_write_pin_low(IS31FL3743A_SDB_PIN);
@@ -177,44 +125,11 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                     } break;
                 }
             }
-         return false;
+            return false;
 #    endif
-     case TO(0):
-      if (record->event.pressed) {
-       L_WIN = 1;
-       set_single_persistent_default_layer(0); // Save default layer 0 to eeprom
-      } else {
-       L_WIN = 0;
-      }
-      return true; // continue all further processing of this key
-
-     case MO(2):
-      if (record->event.pressed) {
-       FN_WIN = 1;
-      } else {
-       FN_WIN = 0;
-      }
-      return true; // continue all further processing of this key
-
-     case TO(1):
-      if (record->event.pressed) {
-       L_MAC = 1;
-       set_single_persistent_default_layer(1);  //Save default layer 1 to eeprom
-      } else {
-       L_MAC = 0;
-      }
-      return true; // continue all further processing of this key
-
-     case MO(3):
-      if (record->event.pressed) {
-       FN_MAC = 1;
-      } else {
-       FN_MAC = 0;
-      }
-      return true; // continue all further processing of this key
-    default:
-      return true;
     }
+
+    return true;
 }
 
 void board_init(void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Keyboards should not override keycodes like `TO(x)` to behave like `PDF(x)`.

Also,
* Partially indicator logic as was dependent on overriding keycode behaviour
  * Also made bad assumptions on configuration of keymap which user changes can invalidate
* Aligned implementations between the two pro revisions
* Remove some unused defines

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
