### PR TITLE
Fix Quantum Painter compiliation issues with heavy optimization

### DIFF
--- a/quantum/painter/qgf.c
+++ b/quantum/painter/qgf.c
@@ -255,10 +255,10 @@ bool qgf_validate_stream(qp_stream_t *stream) {
     // Read and validate all the frames (automatically validates the frame offset descriptor in the process)
     for (uint16_t i = 0; i < frame_count; ++i) {
         // Validate the frame descriptor block
-        uint8_t bpp = 0;
-        bool    has_palette = false;
+        uint8_t bpp             = 0;
+        bool    has_palette     = false;
         bool    is_panel_native = false;
-        bool    has_delta = false;
+        bool    has_delta       = false;
         if (!qgf_validate_frame_descriptor(stream, i, &bpp, &has_palette, &is_panel_native, &has_delta)) {
             return false;
         }

--- a/quantum/painter/qgf.c
+++ b/quantum/painter/qgf.c
@@ -255,10 +255,10 @@ bool qgf_validate_stream(qp_stream_t *stream) {
     // Read and validate all the frames (automatically validates the frame offset descriptor in the process)
     for (uint16_t i = 0; i < frame_count; ++i) {
         // Validate the frame descriptor block
-        uint8_t bpp;
-        bool    has_palette;
-        bool    is_panel_native;
-        bool    has_delta;
+        uint8_t bpp = 0;
+        bool    has_palette = false;
+        bool    is_panel_native = false;
+        bool    has_delta = false;
         if (!qgf_validate_frame_descriptor(stream, i, &bpp, &has_palette, &is_panel_native, &has_delta)) {
             return false;
         }

--- a/quantum/painter/qp_draw_image.c
+++ b/quantum/painter/qp_draw_image.c
@@ -318,9 +318,9 @@ static deferred_token qp_render_animation_state(animation_state_t *state, uint16
 }
 
 static uint32_t animation_callback(uint32_t trigger_time, void *cb_arg) {
-    animation_state_t *state = (animation_state_t *)cb_arg;
+    animation_state_t *state    = (animation_state_t *)cb_arg;
     uint16_t           delay_ms = 0;
-    bool               ret = qp_render_animation_state(state, &delay_ms);
+    bool               ret      = qp_render_animation_state(state, &delay_ms);
     if (!ret) {
         // Setting the device to NULL clears the animation slot
         state->device = NULL;

--- a/quantum/painter/qp_draw_image.c
+++ b/quantum/painter/qp_draw_image.c
@@ -319,7 +319,7 @@ static deferred_token qp_render_animation_state(animation_state_t *state, uint16
 
 static uint32_t animation_callback(uint32_t trigger_time, void *cb_arg) {
     animation_state_t *state = (animation_state_t *)cb_arg;
-    uint16_t           delay_ms;
+    uint16_t           delay_ms = 0;
     bool               ret = qp_render_animation_state(state, &delay_ms);
     if (!ret) {
         // Setting the device to NULL clears the animation slot


### PR DESCRIPTION
## Description

As title says.  When setting `OPT = 3` or similar heavy optimization, errors out with `-Werror=maybe-uninitialized` on a number of variables.  Initializing them should be harmlesss, as they're passed as pointers to other functions to be set, and fixes the errors without changing additional compiler options.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* issues locally

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
