### PR TITLE
small refactoring of TIMER_DIFF

### DIFF
--- a/platforms/timer.h
+++ b/platforms/timer.h
@@ -24,10 +24,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdint.h>
 
-#define TIMER_DIFF(a, b, max) ((max == UINT8_MAX) ? ((uint8_t)((a) - (b))) : ((max == UINT16_MAX) ? ((uint16_t)((a) - (b))) : ((max == UINT32_MAX) ? ((uint32_t)((a) - (b))) : ((a) >= (b) ? (a) - (b) : (max) + 1 - (b) + (a)))))
-#define TIMER_DIFF_8(a, b) TIMER_DIFF(a, b, UINT8_MAX)
-#define TIMER_DIFF_16(a, b) TIMER_DIFF(a, b, UINT16_MAX)
-#define TIMER_DIFF_32(a, b) TIMER_DIFF(a, b, UINT32_MAX)
+#define TIMER_DIFF_8(a, b) (uint8_t)((a) - (b))
+#define TIMER_DIFF_16(a, b) (uint16_t)((a) - (b))
+#define TIMER_DIFF_32(a, b) (uint32_t)((a) - (b))
 #define TIMER_DIFF_RAW(a, b) TIMER_DIFF_8(a, b)
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description

A small refactoring of the defines `TIMER_DIFF_8`, `TIMER_DIFF_16`, `TIMER_DIFF_32` and `TIMER_DIFF_RAW`. Removing obsolete `TIMER_DIFF` helper definition. It makes the code more readable, understandable and maintainable.
Furthermore, it removes the "helper" `#define TIMER_DIFF`, which shouldn't be used directly by any code.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/24652

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
