### PR TITLE
Exclude external userspace from lint checking

### DIFF
--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -26,7 +26,7 @@ def _list_defaultish_keymaps(kb):
     defaultish.extend(INVALID_KM_NAMES)
 
     keymaps = set()
-    for x in list_keymaps(kb):
+    for x in list_keymaps(kb, include_userspace=False):
         if x in defaultish or x.startswith('default'):
             keymaps.add(x)
 

--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -399,7 +399,7 @@ def is_keymap_target(keyboard, keymap):
     return False
 
 
-def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=False):
+def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=False, include_userspace=True):
     """List the available keymaps for a keyboard.
 
     Args:
@@ -418,14 +418,19 @@ def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=Fa
         fullpath
             When set to True the full path of the keymap relative to the `qmk_firmware` root will be provided.
 
+        include_userspace
+            When set to True, also search userspace for available keymaps
+
     Returns:
         a sorted list of valid keymap names.
     """
     names = set()
 
+    has_userspace = HAS_QMK_USERSPACE and include_userspace
+
     # walk up the directory tree until keyboards_dir
     # and collect all directories' name with keymap.c file in it
-    for search_dir in [QMK_FIRMWARE, QMK_USERSPACE] if HAS_QMK_USERSPACE else [QMK_FIRMWARE]:
+    for search_dir in [QMK_FIRMWARE, QMK_USERSPACE] if has_userspace else [QMK_FIRMWARE]:
         keyboards_dir = search_dir / Path('keyboards')
         kb_path = keyboards_dir / keyboard
 
@@ -443,7 +448,7 @@ def list_keymaps(keyboard, c=True, json=True, additional_files=None, fullpath=Fa
     info = info_json(keyboard)
 
     community_parents = list(Path('layouts').glob('*/'))
-    if HAS_QMK_USERSPACE and (Path(QMK_USERSPACE) / "layouts").exists():
+    if has_userspace and (Path(QMK_USERSPACE) / "layouts").exists():
         community_parents.append(Path(QMK_USERSPACE) / "layouts")
 
     for community_parent in community_parents:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Updated `qmk lint` default behaviour of checking "default-ish" keymaps to ignore userspace.

There are a few things to consider,

* someone might want to actually lint userspace keymaps?
  * not a ton of value right now, but with the recent `keymap.json` changes will become more important
  * can still do `qmk lint -kb whatever -km my_important_keymap`
* `-km all` behaviour?
  * currently still checks userspace
  * would prefer not to have to add an additional `--userspace`/`--no-userspace` arg 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #24676

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
