### PR TITLE
fix: KC_MEDIA_PLAY_PAUSE label

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.1_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_basic.hjson
@@ -1140,7 +1140,7 @@
         "0x00AE": {
             "group": "media",
             "key": "KC_MEDIA_PLAY_PAUSE",
-            "label": "Mute",
+            "label": "Play/Pause Track",
             "aliases": [
                 "KC_MPLY"
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Fixes label for KC_MEDIA_PLAY_PAUSE 

New label was copied from https://github.com/qmk/qmk_firmware/blob/782f91a73a0f6d4128f9454509b4a207af269f8b/docs/keycodes_basic.md?plain=1#L209

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Not sure if this should be fixed in the old version, or if a new one should be created. Did not find the key in any other versions.

Feel free to close if this update is not desired.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
