### PR TITLE
Export layer names into json when cli arg is set

### DIFF
--- a/lib/python/qmk/cli/c2json.py
+++ b/lib/python/qmk/cli/c2json.py
@@ -16,6 +16,7 @@ from qmk.commands import dump_lines
 
 
 @cli.argument('--no-cpp', arg_only=True, action='store_false', help='Do not use \'cpp\' on keymap.c')
+@cli.argument('--export-layer-names', arg_only=True, action='store_true', help='Export layer names when they are defined as enum')
 @cli.argument('-o', '--output', arg_only=True, type=qmk.path.normpath, help='File to write to')
 @cli.argument('-q', '--quiet', arg_only=True, action='store_true', help="Quiet mode, only output error messages")
 @cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, help='The keyboard\'s name')
@@ -51,7 +52,7 @@ def c2json(cli):
         return False
 
     try:
-        keymap_json = c2json_impl(keyboard, keymap, filename, use_cpp=cli.args.no_cpp)
+        keymap_json = c2json_impl(keyboard, keymap, filename, use_cpp=cli.args.no_cpp, export_layer_names=cli.args.export_layer_names)
     except CppError as e:
         if cli.config.general.verbose:
             cli.log.debug('The C pre-processor ran into a fatal error: %s', e)
@@ -60,7 +61,7 @@ def c2json(cli):
 
     # Generate the keymap.json
     try:
-        keymap_json = generate_json(keymap_json['keymap'], keymap_json['keyboard'], keymap_json['layout'], keymap_json['layers'])
+        keymap_json = generate_json(keymap_json['keymap'], keymap_json['keyboard'], keymap_json['layout'], keymap_json['layers'], keymap_json['layer_names'] if cli.args.export_layer_names else None)
     except KeyError:
         cli.log.error('Something went wrong. Try to use --no-cpp.')
         return False

--- a/lib/python/qmk/cli/via2json.py
+++ b/lib/python/qmk/cli/via2json.py
@@ -161,7 +161,7 @@ def via2json(cli):
         keymap_data = _fix_macro_keys(keymap_data)
 
     # Generate the keymap.json
-    keymap_json = generate_json(cli.args.keymap, cli.args.keyboard, keymap_layout, keymap_data, macro_data)
+    keymap_json = generate_json(cli.args.keymap, cli.args.keyboard, keymap_layout, keymap_data, None, macro_data)
 
     keymap_lines = [json.dumps(keymap_json, cls=KeymapJSONEncoder, sort_keys=True)]
     dump_lines(cli.args.output, keymap_lines, cli.args.quiet)


### PR DESCRIPTION
## Description

You can define layer names by enum. When you want to convert your `keymap.c` file to json with the `--no-cpp` flag the layer names will be used within your keycodes.
But then you don't know what layer name points to what layer.

With the new `--export-layer-names` the layer names will be exported under the `layer_names` attribute within the json file.
Then the indices will point to the corresponding layer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
[24570](https://github.com/qmk/qmk_firmware/issues/24570)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
