### PR TITLE
Skip parsing g_led_config when matrix_size is missing

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -773,23 +773,24 @@ def find_keyboard_c(keyboard):
 def _extract_led_config(info_data, keyboard):
     """Scan all <keyboard>.c files for led config
     """
-    cols = info_data['matrix_size']['cols']
-    rows = info_data['matrix_size']['rows']
-
     for feature in ['rgb_matrix', 'led_matrix']:
         if info_data.get('features', {}).get(feature, False) or feature in info_data:
-
             # Only attempt search if dd led config is missing
             if 'layout' not in info_data.get(feature, {}):
-                # Process
-                for file in find_keyboard_c(keyboard):
-                    try:
-                        ret = find_led_config(file, cols, rows)
-                        if ret:
-                            info_data[feature] = info_data.get(feature, {})
-                            info_data[feature]['layout'] = ret
-                    except Exception as e:
-                        _log_warning(info_data, f'led_config: {file.name}: {e}')
+                cols = info_data.get('matrix_size', {}).get('cols')
+                rows = info_data.get('matrix_size', {}).get('rows')
+                if cols and rows:
+                    # Process
+                    for file in find_keyboard_c(keyboard):
+                        try:
+                            ret = find_led_config(file, cols, rows)
+                            if ret:
+                                info_data[feature] = info_data.get(feature, {})
+                                info_data[feature]['layout'] = ret
+                        except Exception as e:
+                            _log_warning(info_data, f'led_config: {file.name}: {e}')
+                    else:
+                        _log_warning(info_data, 'led_config: matrix size required to parse g_led_config')
 
             if info_data[feature].get('layout', None) and not info_data[feature].get('led_count', None):
                 info_data[feature]['led_count'] = len(info_data[feature]['layout'])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Resurrecting #23941.

While its true this error should generally not happen to valid keyboards, users are constantly tripped up by the python stack trace that is otherwise spat out. This stack trace is output even if the board is not attempting to support RGB/LED matrix. 

This wall of text leads them down paths that are irrelevant to their issue. Worse is when reaching out for help, they then post the stack trace (usually as a screenshot...), and not the full output that shows the _actual_ error that triggered `matrix_size` to be undefined.


Before:
```
make clean  handwired/zeropad:default
QMK Firmware 0.27.1
Deleting .build/ ... done.
☒ Not including data from file: keyboards/handwired/zeropad/keyboard.json
☒ 	matrix_pins: Additional properties are not allowed ('encoder' was unexpected)
☒ 'matrix_size'
Traceback (most recent call last):
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.12/lib/python3.12/site-packages/milc/milc.py", line 606, in __call__
    return self.__call__()
           ^^^^^^^^^^^^^^^
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.12/lib/python3.12/site-packages/milc/milc.py", line 611, in __call__
    return self._subcommand(self)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/decorators.py", line 38, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/cli/list/layouts.py", line 21, in list_layouts
    info_data = info_json(cli.config.list_layouts.keyboard)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/info.py", line 258, in info_json
    info_data = _extract_led_config(info_data, str(keyboard))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/info.py", line 776, in _extract_led_config
    cols = info_data['matrix_size']['cols']
           ~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'matrix_size'
Making handwired/zeropad with keymap default
```

After:
```
$ make clean  handwired/zeropad:default
QMK Firmware 0.27.1
Deleting .build/ ... done.
☒ Not including data from file: keyboards/handwired/zeropad/keyboard.json
☒ 	matrix_pins: Additional properties are not allowed ('encoder' was unexpected)
☒ handwired/zeropad: No LAYOUTs defined! Need at least one layout defined in info.json.
Making handwired/zeropad with keymap default
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
