### PR TITLE
Add ArteryTek AT32 dfu to udev rules

### DIFF
--- a/util/udev/50-qmk.rules
+++ b/util/udev/50-qmk.rules
@@ -84,3 +84,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", TAG+="uacc
 
 # WB32 DFU
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="342d", ATTRS{idProduct}=="dfa0", TAG+="uaccess"
+
+# AT32 DFU
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", TAG+="uaccess"


### PR DESCRIPTION

## Description

Noticed this when re-setting up system, at32 dfu bootloader was missed from the udev rules in #23445

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* missing udev rule

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
