### PR TITLE
digitizer: set physical size

### DIFF
--- a/docs/features/digitizer.md
+++ b/docs/features/digitizer.md
@@ -41,6 +41,14 @@ digitizer_flush();
 
 `digitizer_state` is a struct of type `digitizer_t`.
 
+## Configuration
+
+By default the digitizer is presented as a 10x10 inch device. You can redefine the physical dimensions in a `config.h`:
+
+```c
+#define DIGITIZER_PHYSICAL_INCHES_X 6.3
+#define DIGITIZER_PHYSICAL_INCHES_Y 3.9
+```
 
 ## API {#api}
 

--- a/quantum/digitizer.h
+++ b/quantum/digitizer.h
@@ -18,6 +18,15 @@
 
 #include <stdbool.h>
 
+#ifndef DIGITIZER_PHYSICAL_INCHES_X
+#    define DIGITIZER_PHYSICAL_INCHES_X 10.0
+#endif
+#ifndef DIGITIZER_PHYSICAL_INCHES_Y
+#    define DIGITIZER_PHYSICAL_INCHES_Y 10.0
+#endif
+#define DIGITIZER_X (int16_t)(DIGITIZER_PHYSICAL_INCHES_X * 100.0)
+#define DIGITIZER_Y (int16_t)(DIGITIZER_PHYSICAL_INCHES_Y * 100.0)
+
 /**
  * \file
  *

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -49,6 +49,10 @@
 #    include "os_detection.h"
 #endif
 
+#ifdef DIGITIZER_ENABLE
+#    include "digitizer.h"
+#endif
+
 #if defined(SERIAL_NUMBER) || (defined(SERIAL_NUMBER_USE_HARDWARE_ID) && SERIAL_NUMBER_USE_HARDWARE_ID == TRUE)
 
 #    define HAS_SERIAL_NUMBER
@@ -318,9 +322,21 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
             // X/Y Position (4 bytes)
             HID_RI_USAGE_PAGE(8, 0x01),    // Generic Desktop
             HID_RI_USAGE(8, 0x30),         // X
-            HID_RI_USAGE(8, 0x31),         // Y
+            HID_RI_LOGICAL_MINIMUM(8, 0x0),
             HID_RI_LOGICAL_MAXIMUM(16, 0x7FFF),
-            HID_RI_REPORT_COUNT(8, 0x02),
+            HID_RI_PHYSICAL_MINIMUM(8, 0),
+            HID_RI_PHYSICAL_MAXIMUM(16, DIGITIZER_X),
+            HID_RI_REPORT_COUNT(8, 0x01),
+            HID_RI_REPORT_SIZE(8, 0x10),
+            HID_RI_UNIT(8, 0x13),          // Inch, English Linear
+            HID_RI_UNIT_EXPONENT(8, 0x0E), // -2
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+            HID_RI_USAGE(8, 0x31),         // Y
+            HID_RI_LOGICAL_MINIMUM(8, 0x0),
+            HID_RI_LOGICAL_MAXIMUM(16, 0x7FFF),
+            HID_RI_PHYSICAL_MINIMUM(8, 0),
+            HID_RI_PHYSICAL_MAXIMUM(16, DIGITIZER_Y),
+            HID_RI_REPORT_COUNT(8, 0x01),
             HID_RI_REPORT_SIZE(8, 0x10),
             HID_RI_UNIT(8, 0x13),          // Inch, English Linear
             HID_RI_UNIT_EXPONENT(8, 0x0E), // -2

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -49,6 +49,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    include "os_detection.h"
 #endif
 
+#ifdef DIGITIZER_ENABLE
+#    include "digitizer.h"
+#endif
+
 /*
  * Interface indexes
  */
@@ -680,17 +684,29 @@ const PROGMEM uchar shared_hid_report[] = {
     0x81, 0x03, //     Input (Constant)
 
     // X/Y Position (4 bytes)
-    0x05, 0x01,       //     Usage Page (Generic Desktop)
-    0x09, 0x30,       //     Usage (X)
-    0x09, 0x31,       //     Usage (Y)
-    0x26, 0xFF, 0x7F, //     Logical Maximum (32767)
-    0x95, 0x02,       //     Report Count (2)
-    0x75, 0x10,       //     Report Size (16)
-    0x65, 0x13,       //     Unit (Inch, English Linear)
-    0x55, 0x0E,       //     Unit Exponent (-2)
-    0x81, 0x02,       //     Input (Data, Variable, Absolute)
-    0xC0,             //   End Collection
-    0xC0,             // End Collection
+    0x05, 0x01,                      //     Usage Page (Generic Desktop)
+    0x09, 0x30,                      //     Usage (X)
+    0x15, 0x00,                      //     Logical Minimum (0)
+    0x26, 0xFF, 0x7F,                //     Logical Maximum (32767)
+    0x35, 0x00,                      //     Physical Minimum (0)
+    0x46, HID_VALUE_16(DIGITIZER_X), // Physical Maximum
+    0x95, 0x01,                      //     Report Count (1)
+    0x75, 0x10,                      //     Report Size (16)
+    0x65, 0x13,                      //     Unit (Inch, English Linear)
+    0x55, 0x0E,                      //     Unit Exponent (-2)
+    0x81, 0x02,                      //     Input (Data, Variable, Absolute)
+    0x09, 0x31,                      //     Usage (Y)
+    0x15, 0x00,                      //     Logical Minimum (0)
+    0x26, 0xFF, 0x7F,                //     Logical Maximum (32767)
+    0x35, 0x00,                      //     Physical Minimum (0)
+    0x46, HID_VALUE_16(DIGITIZER_Y), // Physical Maximum
+    0x95, 0x01,                      //     Report Count (1)
+    0x75, 0x10,                      //     Report Size (16)
+    0x65, 0x13,                      //     Unit (Inch, English Linear)
+    0x55, 0x0E,                      //     Unit Exponent (-2)
+    0x81, 0x02,                      //     Input (Data, Variable, Absolute)
+    0xC0,                            //   End Collection
+    0xC0,                            // End Collection
 #endif
 
 #ifdef PROGRAMMABLE_BUTTON_ENABLE


### PR DESCRIPTION
Fix digitizer cursor movements on platforms that require a physical maximum value.

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

At least on linux with X11, without a physical size set the cursor does not move. Setting the maximum phyiscal value to anything non-zero seems to work equally well, so setting it to 1024 which I think should imply a ~10 inch physical touchpad size.

I assume this works as-is on other OSs, so it would probably be wise to try to test this to make sure it does not cause a regression on some other platform. I've tested on a an Ubuntu laptop with X11 (broken before change, fixed after the change) and on a Windows laptop and a Chromebook (both working both before and after the change). I don't have an Apple laptop to test on.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

I haven't filed an issue, but happy to add one if you think one is needed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
