### PR TITLE
Remove invalid "effect_max" animation from keyboards

### DIFF
--- a/keyboards/keychron/c1_pro/ansi/white/keyboard.json
+++ b/keyboards/keychron/c1_pro/ansi/white/keyboard.json
@@ -119,8 +119,7 @@
             "solid_reactive_multinexus": true,
             "solid_splash": true,
             "wave_left_right": true,
-            "wave_up_down": true,
-            "effect_max": true
+            "wave_up_down": true
         },
         "layout": [
             {"matrix":[0, 0],  "flags":1, "x":0,   "y":0},

--- a/keyboards/keychron/c2_pro/ansi/white/keyboard.json
+++ b/keyboards/keychron/c2_pro/ansi/white/keyboard.json
@@ -136,8 +136,7 @@
             "solid_reactive_multinexus": true,
             "solid_splash": true,
             "wave_left_right": true,
-            "wave_up_down": true,
-            "effect_max": true
+            "wave_up_down": true
         },
         "layout": [
             {"matrix":[0, 0],  "flags":1, "x":0,   "y":0},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`effect_max` is not a valid animation so should never be specified.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
