### PR TITLE
Fix durgod k3x0 docs

### DIFF
--- a/keyboards/durgod/k310/readme.md
+++ b/keyboards/durgod/k310/readme.md
@@ -6,7 +6,7 @@ This is a standard off-the-shelf Durgod Taurus K310 full-sized 104/105-key
 keyboard without backlight.  This supports both the ANSI and ISO variants.
 
 * Keyboard Maintainers: [dkjer](https://github.com/dkjer) and [tylert](https://github.com/tylert)
-* Hardware Supported: [Durgod Taurus K310 board with STM32F070RBT6](https://www.durgod.com/page9?product_id=53&_l=en "Durgod.com Product Page")
+* Hardware Supported: [Durgod Taurus K310 board with STM32F070RBT6](https://www.durgod.com/product/k310-space-gray/)
 * Hardware Availability: [Amazon.com](https://www.amazon.com/Durgod-Taurus-K310-Mechanical-Keyboard/dp/B07TXB4XF3)
 
 ## Instructions

--- a/keyboards/durgod/k320/readme.md
+++ b/keyboards/durgod/k320/readme.md
@@ -6,7 +6,7 @@ This is a standard off-the-shelf Durgod Taurus K320 TKL (87/88-key)
 keyboard without backlight.  This supports both the ANSI and ISO variants.
 
 * Keyboard Maintainers: [dkjer](https://github.com/dkjer) and [tylert](https://github.com/tylert)
-* Hardware Supported: [Durgod Taurus K320 board with STM32F070RBT6](https://www.durgod.com/page9?product_id=47&_l=en "Durgod.com Product Page")
+* Hardware Supported: [Durgod Taurus K320 board with STM32F070RBT6](https://www.durgod.com/product/k320-space-gray/)
 * Hardware Availability: [Amazon.com](https://www.amazon.com/Durgod-Taurus-Corona-Mechanical-Keyboard/dp/B078H3WPHM)
 
 ## Instructions
@@ -15,11 +15,11 @@ keyboard without backlight.  This supports both the ANSI and ISO variants.
 
 Make command example for this keyboard (after setting up your build environment):
 
-    make durgod/k3x0/k320/base:default
+    make durgod/k320/base:default
 
 Flashing example for this keyboard:
 
-    make durgod/k3x0/k320/base:default:flash
+    make durgod/k320/base:default:flash
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 

--- a/keyboards/durgod/k3x0/readme.md
+++ b/keyboards/durgod/k3x0/readme.md
@@ -5,8 +5,8 @@ K310 full-sized 104/105-key and K320 TKL 87/88-key keyboards.
 
 * Keyboard Maintainers: [dkjer](https://github.com/dkjer) and [tylert](https://github.com/tylert)
 * Hardware Supported:
-  * [Durgod Taurus K310 with STM32F070RBT6](https://www.durgod.com/page9?product_id=53&_l=en "Taurus K310 Product Page | Durgod.com")
-  * [Durgod Taurus K320 with STM32F070RBT6](https://www.durgod.com/page9?product_id=47&_l=en "Taurus K320 Product Page | Durgod.com")
+  * [Durgod Taurus K310 with STM32F070RBT6](https://www.durgod.com/product/k310-space-gray/)
+  * [Durgod Taurus K320 with STM32F070RBT6](https://www.durgod.com/product/k320-space-gray/)
 * Hardware Availability:
   * [K310 on Amazon.com](https://www.amazon.com/Durgod-Taurus-K310-Mechanical-Keyboard/dp/B07TXB4XF3)
   * [K320 on Amazon.com](https://www.amazon.com/Durgod-Taurus-Corona-Mechanical-Keyboard/dp/B078H3WPHM)
@@ -16,8 +16,8 @@ K310 full-sized 104/105-key and K320 TKL 87/88-key keyboards.
 ### Build
 
 Instructions for building the K310 and K320 firmware can be found here:
-* [K310](k310/readme.md)
-* [K320](k320/readme.md)
+* [K310](../k310/readme.md)
+* [K320](../k320/readme.md)
 
 ### Initial Flash
 
@@ -67,10 +67,10 @@ dfu-util -a 0 -d 0483:DF11 -s 0x08000000 -U k3x0_original.bin
 
 ```bash
 # k310
-qmk flash -kb durgod/k3x0/k310 -km default
+qmk flash -kb durgod/k310 -km default
 
 # k320
-qmk flash -kb durgod/k3x0/k320 -km default
+qmk flash -kb durgod/k320 -km default
 ```
 
 ### Subsequent Flashing


### PR DESCRIPTION
## Description

As I was flashing my K320 I noticed that the links to the manufacture's websites were broken, and the flashing instructions were incorrect (`k310`/`k320` apparently used to reside below the `k3x0` folder, which is no longer the case).

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
