### PR TITLE
Fix flash wear leveling sector calculation

### DIFF
--- a/platforms/chibios/drivers/wear_leveling/wear_leveling_efl.c
+++ b/platforms/chibios/drivers/wear_leveling/wear_leveling_efl.c
@@ -84,12 +84,14 @@ bool backing_store_init(void) {
 
     // Work out how many sectors we want to use, working backwards from the end of the flash
     flash_sector_t last_sector = desc->sectors_count - WEAR_LEVELING_EFL_OMIT_LAST_SECTOR_COUNT;
+
+    // skip sectors that are past the actual flash size
+    while (flashGetSectorOffset(flash, last_sector) >= flash_size) {
+        last_sector--;
+    }
+
     for (flash_sector_t i = 0; i < last_sector; ++i) {
         first_sector = last_sector - i - 1;
-        if (flashGetSectorOffset(flash, first_sector) >= flash_size) {
-            last_sector = first_sector;
-            continue;
-        }
         counter += flashGetSectorSize(flash, first_sector);
         if (counter >= (WEAR_LEVELING_BACKING_SIZE)) {
             sector_count = last_sector - first_sector;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently the calculation of the last usable flash sector doesn't work properly if `last_sector` starts beyond the end of the actual flash size:
https://github.com/qmk/qmk_firmware/blob/172c3496756fb5468c778c2536b4334f25eb883b/platforms/chibios/drivers/wear_leveling/wear_leveling_efl.c#L87-L92
Here the `last_sector` is calculated from the `first_sector` but also `i` is included in the calculation. But `i` is incremented in each loop iteration and thus an increasing offset is added.
The solution here is to first calculate the number of the last usable sector and then use another loop to calculate the first sector.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
