### PR TITLE
Add watchdog service to RGBKB Sol 3

### DIFF
--- a/keyboards/rgbkb/sol3/rev1/keyboard.json
+++ b/keyboards/rgbkb/sol3/rev1/keyboard.json
@@ -153,6 +153,8 @@
             "pin": "A9"
         },
         "transport": {
+            "watchdog": true,
+            "watchdog_timeout": 20000,
             "sync": {
                 "indicators": true,
                 "layer_state": true,


### PR DESCRIPTION
## Description

Due to power demands, the Sol 3 might get initially ignored or something by the attached device.

The solution is the enable watchdog, which would have the keyboard repoll the system to connect again.

I have been using watchdog for awhile, but given that the RGBKB developer never progressed #24279,
 I made this to add in the essential feature.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Should fix USB reconnect issues on power cycle for some users.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
