### PR TITLE
Adding ability to use more than one Cirque Pinnacle via SPI

### DIFF
--- a/docs/features/pointing_device.md
+++ b/docs/features/pointing_device.md
@@ -217,6 +217,11 @@ Default Scaling is 1024. Actual CPI depends on trackpad diameter.
 
 Also see the `POINTING_DEVICE_TASK_THROTTLE_MS`, which defaults to 10ms when using Cirque Pinnacle, which matches the internal update rate of the position registers (in standard configuration). Advanced configuration for pen/stylus usage might require lower values.
 
+
+#### Multiple devices
+
+If you wish to use more than one Cirque Pinnacle via SPI, you will need to share the common SPI pins and provide a different CS pin for each device.  Then implement `cirque_pinnacle_spi_get_cs_pin` and change the pin prior to making any device calls (e.g. `cirque_pinnacle_init` or `cirque_pinnacle_read_data`).
+
 #### Absolute mode settings
 
 | Setting                                 | Description                                                             | Default     |

--- a/drivers/sensors/cirque_pinnacle_spi.c
+++ b/drivers/sensors/cirque_pinnacle_spi.c
@@ -9,12 +9,15 @@
 
 extern bool touchpad_init;
 
+
+__attribute__((weak)) uint8_t cirque_pinnacle_spi_get_cs_pin(void) { return CIRQUE_PINNACLE_SPI_CS_PIN; }
+
 /*  RAP Functions */
 // Reads <count> Pinnacle registers starting at <address>
 void RAP_ReadBytes(uint8_t address, uint8_t* data, uint8_t count) {
     uint8_t cmdByte = READ_MASK | address; // Form the READ command byte
     if (touchpad_init) {
-        if (spi_start(CIRQUE_PINNACLE_SPI_CS_PIN, CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
+        if (spi_start(cirque_pinnacle_spi_get_cs_pin(), CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
             spi_write(cmdByte);     // write command byte, receive filler
             spi_write(FILLER_BYTE); // write & receive filler
             spi_write(FILLER_BYTE); // write & receive filler
@@ -34,7 +37,7 @@ void RAP_Write(uint8_t address, uint8_t data) {
     uint8_t cmdByte = WRITE_MASK | address; // Form the WRITE command byte
 
     if (touchpad_init) {
-        if (spi_start(CIRQUE_PINNACLE_SPI_CS_PIN, CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
+        if (spi_start(cirque_pinnacle_spi_get_cs_pin(), CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
             spi_write(cmdByte);
             spi_write(data);
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

There is now a callback to get the current SPI CS pin when operations are being used.  Implement cirque_pinnacle_spi_get_cs_pin to set the pin to be used.  If this function is not implemented, the weak method will use the legacy method of CIRQUE_PINNACLE_SPI_CS_PIN.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [-] I have added tests to cover my changes.
- [-] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
