### PR TITLE
Remove preprocessor sanity check for STM32L0/L1 now that it relies on types in C.

### DIFF
--- a/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.h
+++ b/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.h
@@ -27,7 +27,3 @@
 #        define STM32_ONBOARD_EEPROM_SIZE (((EECONFIG_SIZE + 3) / 4) * 4) // based off eeconfig's current usage, aligned to 4-byte sizes, to deal with LTO and EEPROM page sizing
 #    endif
 #endif
-
-#if STM32_ONBOARD_EEPROM_SIZE > 128
-#    pragma message("Please note: resetting EEPROM using an STM32L0/L1 device takes up to 1 second for every 1kB of internal EEPROM used.")
-#endif


### PR DESCRIPTION
## Description

`EECONFIG_SIZE` is now dependent on datatypes in code, and thus isn't usable from preprocessor.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
