### PR TITLE
[Docs] Fix wording in Mod Tap documentation

### DIFF
--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -2,7 +2,7 @@
 
 The Mod-Tap key `MT(mod, kc)` acts like a modifier when held, and a regular keycode when tapped. In other words, you can have a key that sends Escape when you tap it, but functions as a Control or Shift key when you hold it down.
 
-The modifiers this keycode and `OSM()` accept are prefixed with `MOD_`, not `KC_`:
+The modifiers (`mod`) argument to the `MT()` macro are prefixed with `MOD_`, not `KC_`:
 
 |Modifier  |Description                             |
 |----------|----------------------------------------|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Title. Removes mention of `OSM()` as it seems irrelevant on mod tap page.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Documentation

## Issues Fixed or Closed by This PR

Fixes #24795

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
