### PR TITLE
[Bug] Fix Underglow keycode processing

### DIFF
--- a/quantum/process_keycode/process_underglow.c
+++ b/quantum/process_keycode/process_underglow.c
@@ -16,7 +16,9 @@
 
 bool process_underglow(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
-        __attribute__((unused)) const uint8_t shifted = get_mods() & MOD_MASK_SHIFT;
+#if defined(RGBLIGHT_ENABLE) || (defined(RGB_MATRIX_ENABLE) && !defined(RGB_MATRIX_DISABLE_SHARED_KEYCODES))
+        const uint8_t shifted = get_mods() & MOD_MASK_SHIFT;
+#endif
 
         switch (keycode) {
             case QK_UNDERGLOW_TOGGLE:

--- a/quantum/process_keycode/process_underglow.c
+++ b/quantum/process_keycode/process_underglow.c
@@ -16,7 +16,8 @@
 
 bool process_underglow(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
-        uint8_t shifted = get_mods() & MOD_MASK_SHIFT;
+        __attribute__((unused)) const uint8_t shifted = get_mods() & MOD_MASK_SHIFT;
+
         switch (keycode) {
             case QK_UNDERGLOW_TOGGLE:
 #if defined(RGBLIGHT_ENABLE)


### PR DESCRIPTION

## Description

If RGB Matrix is enabled and `RGB_MATRIX_DISABLE_SHARED_KEYCODES` is defined, `shifted` is set but never used, causing unused variable errors. 

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* Fixes #24792

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
