### PR TITLE
Consolidate send_string implementations.

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -635,6 +635,10 @@ ifeq ($(strip $(VIA_ENABLE)), yes)
     TRI_LAYER_ENABLE := yes
 endif
 
+ifeq ($(strip $(DYNAMIC_KEYMAP_ENABLE)), yes)
+    SEND_STRING_ENABLE := yes
+endif
+
 VALID_CUSTOM_MATRIX_TYPES:= yes lite no
 
 CUSTOM_MATRIX ?= no

--- a/quantum/send_string/send_string.c
+++ b/quantum/send_string/send_string.c
@@ -150,46 +150,63 @@ void send_string(const char *string) {
     send_string_with_delay(string, TAP_CODE_DELAY);
 }
 
-void send_string_with_delay(const char *string, uint8_t interval) {
+void send_string_with_delay_impl(char (*getter)(void *), void *arg, uint8_t interval) {
     while (1) {
-        char ascii_code = *string;
+        char ascii_code = getter(arg);
         if (!ascii_code) break;
         if (ascii_code == SS_QMK_PREFIX) {
-            ascii_code = *(++string);
+            ascii_code = getter(arg);
 
             if (ascii_code == SS_TAP_CODE) {
                 // tap
-                uint8_t keycode = *(++string);
+                uint8_t keycode = getter(arg);
                 tap_code(keycode);
             } else if (ascii_code == SS_DOWN_CODE) {
                 // down
-                uint8_t keycode = *(++string);
+                uint8_t keycode = getter(arg);
                 register_code(keycode);
             } else if (ascii_code == SS_UP_CODE) {
                 // up
-                uint8_t keycode = *(++string);
+                uint8_t keycode = getter(arg);
                 unregister_code(keycode);
             } else if (ascii_code == SS_DELAY_CODE) {
                 // delay
-                int     ms      = 0;
-                uint8_t keycode = *(++string);
+                int ms     = 0;
+                ascii_code = getter(arg);
 
-                while (isdigit(keycode)) {
+                while (isdigit(ascii_code)) {
                     ms *= 10;
-                    ms += keycode - '0';
-                    keycode = *(++string);
+                    ms += ascii_code - '0';
+                    ascii_code = getter(arg);
                 }
 
                 wait_ms(ms);
             }
 
             wait_ms(interval);
+
+            // if we had a delay that terminated with a null, we're done
+            if (ascii_code == 0) break;
         } else {
             send_char_with_delay(ascii_code, interval);
         }
-
-        ++string;
     }
+}
+
+typedef struct send_string_memory_state_t {
+    const char *string;
+} send_string_memory_state_t;
+
+char send_string_get_next_ram(void *arg) {
+    send_string_memory_state_t *state = (send_string_memory_state_t *)arg;
+    char                        ret   = *state->string;
+    state->string++;
+    return ret;
+}
+
+void send_string_with_delay(const char *string, uint8_t interval) {
+    send_string_memory_state_t state = {string};
+    send_string_with_delay_impl(send_string_get_next_ram, &state, interval);
 }
 
 void send_char(char ascii_code) {
@@ -297,42 +314,15 @@ void send_string_P(const char *string) {
     send_string_with_delay_P(string, TAP_CODE_DELAY);
 }
 
+char send_string_get_next_progmem(void *arg) {
+    send_string_memory_state_t *state = (send_string_memory_state_t *)arg;
+    char                        ret   = pgm_read_byte(state->string);
+    state->string++;
+    return ret;
+}
+
 void send_string_with_delay_P(const char *string, uint8_t interval) {
-    while (1) {
-        char ascii_code = pgm_read_byte(string);
-        if (!ascii_code) break;
-        if (ascii_code == SS_QMK_PREFIX) {
-            ascii_code = pgm_read_byte(++string);
-
-            if (ascii_code == SS_TAP_CODE) {
-                // tap
-                uint8_t keycode = pgm_read_byte(++string);
-                tap_code(keycode);
-            } else if (ascii_code == SS_DOWN_CODE) {
-                // down
-                uint8_t keycode = pgm_read_byte(++string);
-                register_code(keycode);
-            } else if (ascii_code == SS_UP_CODE) {
-                // up
-                uint8_t keycode = pgm_read_byte(++string);
-                unregister_code(keycode);
-            } else if (ascii_code == SS_DELAY_CODE) {
-                // delay
-                int     ms      = 0;
-                uint8_t keycode = pgm_read_byte(++string);
-
-                while (isdigit(keycode)) {
-                    ms *= 10;
-                    ms += keycode - '0';
-                    keycode = pgm_read_byte(++string);
-                }
-                wait_ms(ms);
-            }
-        } else {
-            send_char_with_delay(ascii_code, interval);
-        }
-
-        ++string;
-    }
+    send_string_memory_state_t state = {string};
+    send_string_with_delay_impl(send_string_get_next_progmem, &state, interval);
 }
 #endif

--- a/quantum/send_string/send_string.h
+++ b/quantum/send_string/send_string.h
@@ -161,4 +161,12 @@ void send_string_with_delay_P(const char *string, uint8_t interval);
  */
 #define SEND_STRING_DELAY(string, interval) send_string_with_delay_P(PSTR(string), interval)
 
+/**
+ * \brief Actual implementation function that iterates and sends the string returned by the getter function.
+ *
+ * The getter assumes that the next byte is available to be read, and returns it. `arg` is passed in and can be whatever
+ * makes most sense for the getter -- each invocation of `getter` must advance its position in the source.
+ */
+void send_string_with_delay_impl(char (*getter)(void *), void *arg, uint8_t interval);
+
 /** \} */


### PR DESCRIPTION
## Description

Consolidates handling of `send_string` et.al. such that the embedded commands using `SS_QMK_PREFIX` are consistently handled.

Tested on an AVR board, with string resident in RAM and PROGMEM. Tested with VIA and its use of `dynamic_keymap`.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
