### PR TITLE
Consolidate timer_elapsed implementations

### DIFF
--- a/platforms/avr/timer.c
+++ b/platforms/avr/timer.c
@@ -125,34 +125,6 @@ inline uint32_t timer_read32(void) {
     return t;
 }
 
-/** \brief timer elapsed
- *
- * FIXME: needs doc
- */
-inline uint16_t timer_elapsed(uint16_t last) {
-    uint32_t t;
-
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        t = timer_count;
-    }
-
-    return TIMER_DIFF_16((t & 0xFFFF), last);
-}
-
-/** \brief timer elapsed32
- *
- * FIXME: needs doc
- */
-inline uint32_t timer_elapsed32(uint32_t last) {
-    uint32_t t;
-
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        t = timer_count;
-    }
-
-    return TIMER_DIFF_32(t, last);
-}
-
 // excecuted once per 1ms.(excess for just timer count?)
 #ifndef __AVR_ATmega32A__
 #    define TIMER_INTERRUPT_VECTOR TIMER0_COMPA_vect

--- a/platforms/chibios/timer.c
+++ b/platforms/chibios/timer.c
@@ -118,11 +118,3 @@ uint32_t timer_read32(void) {
 
     return (uint32_t)TIME_I2MS(ticks) + ms_offset_copy;
 }
-
-uint16_t timer_elapsed(uint16_t last) {
-    return TIMER_DIFF_16(timer_read(), last);
-}
-
-uint32_t timer_elapsed32(uint32_t last) {
-    return TIMER_DIFF_32(timer_read32(), last);
-}

--- a/platforms/test/timer.c
+++ b/platforms/test/timer.c
@@ -60,14 +60,6 @@ uint32_t timer_read32(void) {
     return current_time;
 }
 
-uint16_t timer_elapsed(uint16_t last) {
-    return TIMER_DIFF_16(timer_read(), last);
-}
-
-uint32_t timer_elapsed32(uint32_t last) {
-    return TIMER_DIFF_32(timer_read32(), last);
-}
-
 void set_time(uint32_t t) {
     current_time   = t;
     access_counter = 0;

--- a/platforms/timer.c
+++ b/platforms/timer.c
@@ -6,3 +6,11 @@
 // Generate out-of-line copies for inline functions defined in timer.h.
 extern inline fast_timer_t timer_read_fast(void);
 extern inline fast_timer_t timer_elapsed_fast(fast_timer_t last);
+
+uint16_t timer_elapsed(uint16_t last) {
+    return TIMER_DIFF_16(timer_read(), last);
+}
+
+uint32_t timer_elapsed32(uint32_t last) {
+    return TIMER_DIFF_32(timer_read32(), last);
+}

--- a/quantum/debounce/tests/rules.mk
+++ b/quantum/debounce/tests/rules.mk
@@ -16,6 +16,7 @@
 DEBOUNCE_COMMON_DEFS := -DMATRIX_ROWS=4 -DMATRIX_COLS=10 -DDEBOUNCE=5
 
 DEBOUNCE_COMMON_SRC := $(QUANTUM_PATH)/debounce/tests/debounce_test_common.cpp \
+	$(PLATFORM_PATH)/timer.c \
 	$(PLATFORM_PATH)/$(PLATFORM_KEY)/timer.c
 
 debounce_none_DEFS := $(DEBOUNCE_COMMON_DEFS)

--- a/quantum/os_detection/tests/rules.mk
+++ b/quantum/os_detection/tests/rules.mk
@@ -4,4 +4,5 @@ os_detection_DEFS += -DOS_DETECTION_DEBOUNCE=50
 os_detection_SRC := \
     $(QUANTUM_PATH)/os_detection/tests/os_detection.cpp \
     $(QUANTUM_PATH)/os_detection.c \
+    $(PLATFORM_PATH)/timer.c \
     $(PLATFORM_PATH)/$(PLATFORM_KEY)/timer.c

--- a/quantum/sequencer/tests/rules.mk
+++ b/quantum/sequencer/tests/rules.mk
@@ -8,4 +8,5 @@ sequencer_SRC := \
 	$(QUANTUM_PATH)/sequencer/tests/midi_mock.c \
 	$(QUANTUM_PATH)/sequencer/tests/sequencer_tests.cpp \
 	$(QUANTUM_PATH)/sequencer/sequencer.c \
+	$(PLATFORM_PATH)/timer.c \
 	$(PLATFORM_PATH)/$(PLATFORM_KEY)/timer.c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Saves a whole 20 bytes on AVR builds, and one less thing to implement on the RIOT port.

(Implementing as a define like timer_expired performs 22 bytes worse) 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
