### PR TITLE
Resolve keyboard_aliases when processing keyboard make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,29 @@ endef
 # Make it easier to call TRY_TO_MATCH_RULE_FROM_LIST
 TRY_TO_MATCH_RULE_FROM_LIST = $(eval $(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER,$1))$(RULE_FOUND)
 
+# As TRY_TO_MATCH_RULE_FROM_LIST_HELPER, but with additional
+# resolution of DEFAULT_FOLDER and keyboard_aliases.hjson for provided rule 
+define TRY_TO_MATCH_RULE_FROM_LIST_HELPER_KB
+    # Split on ":", padding with empty strings to avoid indexing issues
+    TOKEN1:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[0])" $$(RULE))
+    TOKENr:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[1])" $$(RULE))
+
+    TOKEN1:=$$(shell $(QMK_BIN) resolve-alias --allow-unknown $$(TOKEN1))
+
+    FOUNDx:=$$(shell echo $1 | tr " " "\n" | grep -Fx $$(TOKEN1))
+    ifneq ($$(FOUNDx),)
+        RULE := $$(TOKENr)
+        RULE_FOUND := true
+        MATCHED_ITEM := $$(TOKEN1)
+    else
+        RULE_FOUND := false
+        MATCHED_ITEM :=
+    endif
+endef
+
+# Make it easier to call TRY_TO_MATCH_RULE_FROM_LIST_KB
+TRY_TO_MATCH_RULE_FROM_LIST_KB = $(eval $(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER_KB,$1))$(RULE_FOUND)
+
 define ALL_IN_LIST_LOOP
     OLD_RULE$1 := $$(RULE)
     $$(eval $$(call $1,$$(ITEM$1)))
@@ -138,7 +161,7 @@ define PARSE_RULE
         $$(eval $$(call PARSE_TEST))
     # If the rule starts with the name of a known keyboard, then continue
     # the parsing from PARSE_KEYBOARD
-    else ifeq ($$(call TRY_TO_MATCH_RULE_FROM_LIST,$$(shell $(QMK_BIN) list-keyboards --no-resolve-defaults)),true)
+    else ifeq ($$(call TRY_TO_MATCH_RULE_FROM_LIST_KB,$$(shell $(QMK_BIN) list-keyboards)),true)
         KEYBOARD_RULE=$$(MATCHED_ITEM)
         $$(eval $$(call PARSE_KEYBOARD,$$(MATCHED_ITEM)))
     else
@@ -169,17 +192,6 @@ define PARSE_KEYBOARD
     # If we want to compile the default subproject, then we need to
     # include the correct makefile to determine the actual name of it
     CURRENT_KB := $1
-
-    # KEYBOARD_FOLDERS := $$(subst /, , $(CURRENT_KB))
-
-    DEFAULT_FOLDER := $$(CURRENT_KB)
-
-    # We assume that every rules.mk will contain the full default value
-    $$(eval include $(ROOT_DIR)/keyboards/$$(CURRENT_KB)/rules.mk)
-    ifneq ($$(DEFAULT_FOLDER),$$(CURRENT_KB))
-        $$(eval include $(ROOT_DIR)/keyboards/$$(DEFAULT_FOLDER)/rules.mk)
-    endif
-    CURRENT_KB := $$(DEFAULT_FOLDER)
 
     # 5/4/3/2/1
     KEYBOARD_FOLDER_PATH_1 := $$(CURRENT_KB)

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -82,6 +82,7 @@ subcommands = [
     'qmk.cli.new.keymap',
     'qmk.cli.painter',
     'qmk.cli.pytest',
+    'qmk.cli.resolve_alias',
     'qmk.cli.test.c',
     'qmk.cli.userspace.add',
     'qmk.cli.userspace.compile',

--- a/lib/python/qmk/cli/resolve_alias.py
+++ b/lib/python/qmk/cli/resolve_alias.py
@@ -1,0 +1,16 @@
+from qmk.keyboard import keyboard_folder
+
+from milc import cli
+
+
+@cli.argument('--allow-unknown', arg_only=True, action='store_true', help="Return original if rule is not a valid keyboard.")
+@cli.argument('keyboard', arg_only=True, help='The keyboard\'s name')
+@cli.subcommand('Resolve DEFAULT_FOLDER and any keyboard_aliases for provided rule')
+def resolve_alias(cli):
+    try:
+        print(keyboard_folder(cli.args.keyboard))
+    except ValueError:
+        if cli.args.allow_unknown:
+            print(cli.args.keyboard)
+        else:
+            raise


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The aim is to minimise disruption to end users while we continue the deprecation process of `DEFAULT_FOLDER`.

Implementation is somewhat less than ideal, but hopefully its only temporary while `DEFAULT_FOLDER` handling still exists.

Enabled keyboard_aliases.hjson values to be used, for example
```
make 2_milk:default
```

While still allowing keyboards with `DEFAULT_FOLDER` to compile as before
```
make yosino58:default
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
