### PR TITLE
Formally deprecate DEFAULT_FOLDER

### DIFF
--- a/data/mappings/info_rules.hjson
+++ b/data/mappings/info_rules.hjson
@@ -55,5 +55,6 @@
     // Items we want flagged in lint
     "CTPC": {"info_key": "_deprecated.ctpc", "deprecated": true, "replace_with": "CONVERT_TO=proton_c"},
     "CONVERT_TO_PROTON_C": {"info_key": "_deprecated.ctpc", "deprecated": true, "replace_with": "CONVERT_TO=proton_c"},
+    "DEFAULT_FOLDER": {"info_key": "_deprecated.default_folder", "deprecated": true},
     "VIAL_ENABLE": {"info_key": "_invalid.vial", "invalid": true}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Been on the radar internally for a while, figured it was time we start the process of its removal.

Example output
```sh
$ qmk lint -kb ploopyco/trackball
⚠ ploopyco/trackball/rev1_005: DEFAULT_FOLDER in rules.mk is deprecated and will be removed at a later date
⚠ ploopyco/trackball/rev1_005: DEFAULT_FOLDER in rules.mk is deprecated and will be removed at a later date
Ψ Lint check passed!
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
