### PR TITLE
`ferris/0_1`: update I2C API usage

### DIFF
--- a/keyboards/ferris/0_2/matrix.c
+++ b/keyboards/ferris/0_2/matrix.c
@@ -30,8 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 extern i2c_status_t mcp23017_status;
 #define MCP23017_I2C_TIMEOUT 1000
-#define I2C_WRITE 0x00
-#define I2C_READ 0x01
+
 // For a better understanding of the i2c protocol, this is a good read:
 // https://www.robot-electronics.co.uk/i2c-tutorial
 

--- a/platforms/avr/drivers/i2c_master.h
+++ b/platforms/avr/drivers/i2c_master.h
@@ -21,9 +21,6 @@
 
 #include <stdint.h>
 
-#define I2C_READ 0x01
-#define I2C_WRITE 0x00
-
 typedef int16_t i2c_status_t;
 
 #define I2C_STATUS_SUCCESS (0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

These `I2C_READ` and `I2C_WRITE` defines don't need to exist.

The custom matrix code for `ferris/0_1` has been updated to align more closely with `0_2` by using `i2c_read/write_register()` instead. This was actually already done for `0_2` in #21273, but not `0_1` for some reason. They could possibly be completely identical but I mainly just wanted to clean up the `i2c_master` header.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
