### PR TITLE
Fix missing wait.h include in Dip Switch Map

### DIFF
--- a/quantum/dip_switch.c
+++ b/quantum/dip_switch.c
@@ -64,6 +64,7 @@ __attribute__((weak)) bool dip_switch_update_mask_kb(uint32_t state) {
 #ifdef DIP_SWITCH_MAP_ENABLE
 #    include "keymap_introspection.h"
 #    include "action.h"
+#    include "wait.h"
 
 #    ifndef DIP_SWITCH_MAP_KEY_DELAY
 #        define DIP_SWITCH_MAP_KEY_DELAY TAP_CODE_DELAY


### PR DESCRIPTION
## Description

While playing with test board, ran into "implicit definition of wait_ms" when dip switch map is enabled and `TAP_CODE_ENABLE` or `DIP_SWITCH_MAP_KEY_DELAY` is configured.

Considering it hasn't come up before now....

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

* compilation issue

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
