### PR TITLE
Disable CORTEX_ENABLE_WFI_IDLE for kinesis/kint41.

### DIFF
--- a/keyboards/kinesis/kint41/config.h
+++ b/keyboards/kinesis/kint41/config.h
@@ -16,6 +16,10 @@
 
 #pragma once
 
+/* Low-power sleep mode for the ChibiOS idle thread does not work on the  
+ * Teensy 4.0. */
+#define CORTEX_ENABLE_WFI_IDLE FALSE
+
 /* We use the i.MX RT1060 high-speed GPIOs (GPIO6-9) which are connected to the
  * AHB bus (AHB_CLK_ROOT), which runs at the same speed as the ARM Core Clock,
  * i.e. 600 MHz. See MIMXRT1062, page 949, 12.1 Chip-specific GPIO information.


### PR DESCRIPTION
Fix for #24865.
CORTEX_ENABLE_WFI_IDLE was globally enabled for all keyboards in 416af0171c6433a7ecb198386dd2c3ac70d4cbd2. This breaks the Teensy 4.0. This change explicitly disables WFI idle for kinesis/kint41.

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
