### PR TITLE
[Core] Add dirty chunk checking for all RGB and LED drivers

### DIFF
--- a/drivers/led/apa102.c
+++ b/drivers/led/apa102.c
@@ -55,6 +55,7 @@
 
 rgb_t   apa102_leds[APA102_LED_COUNT];
 uint8_t apa102_led_brightness = APA102_DEFAULT_BRIGHTNESS;
+bool    apa102_dirty          = false;
 
 static void apa102_send_byte(uint8_t byte) {
     APA102_SEND_BIT(byte, 7);
@@ -126,6 +127,7 @@ void apa102_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     apa102_leds[index].r = red;
     apa102_leds[index].g = green;
     apa102_leds[index].b = blue;
+    apa102_dirty         = true;
 }
 
 void apa102_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
@@ -135,6 +137,7 @@ void apa102_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void apa102_flush(void) {
+    if (!apa102_dirty) return;
     apa102_start_frame();
     for (uint8_t i = 0; i < APA102_LED_COUNT; i++) {
         apa102_send_frame(apa102_leds[i].r, apa102_leds[i].g, apa102_leds[i].b, apa102_led_brightness);

--- a/drivers/led/issi/is31fl3729-mono.c
+++ b/drivers/led/issi/is31fl3729-mono.c
@@ -175,7 +175,7 @@ void is31fl3729_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                            = value;
         driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3729_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }

--- a/drivers/led/issi/is31fl3729-mono.c
+++ b/drivers/led/issi/is31fl3729-mono.c
@@ -64,6 +64,9 @@
 #    define IS31FL3729_PWM_FREQUENCY IS31FL3729_PWM_FREQUENCY_32K_HZ
 #endif
 
+#define IS31FL3729_PWM_REGISTERS_PER_CHUNK 13
+#define IS31FL3729_CHUNK_COUNT (IS31FL3729_PWM_REGISTER_COUNT / IS31FL3729_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3729_DRIVER_COUNT] = {
     IS31FL3729_I2C_ADDRESS_1,
 #ifdef IS31FL3729_I2C_ADDRESS_2
@@ -81,14 +84,14 @@ const uint8_t i2c_addresses[IS31FL3729_DRIVER_COUNT] = {
 // Storing them like this is optimal for I2C transfers to the registers.
 typedef struct is31fl3729_driver_t {
     uint8_t pwm_buffer[IS31FL3729_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3729_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3729_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3729_driver_t;
 
 is31fl3729_driver_t driver_buffers[IS31FL3729_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -107,13 +110,21 @@ void is31fl3729_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 11 transfers of 13 bytes.
 
     // Iterate over the pwm_buffer contents at 13 byte intervals.
-    for (uint8_t i = 0; i <= IS31FL3729_PWM_REGISTER_COUNT; i += 13) {
+    for (uint8_t i = 0; i <= IS31FL3729_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3729_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3729_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3729_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 13, IS31FL3729_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3729_PWM_REGISTERS_PER_CHUNK, IS31FL3729_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 13, IS31FL3729_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3729_PWM_REGISTERS_PER_CHUNK, IS31FL3729_I2C_TIMEOUT);
 #endif
     }
 }
@@ -165,7 +176,7 @@ void is31fl3729_set_value(int index, uint8_t value) {
         }
 
         driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3729_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -189,10 +200,13 @@ void is31fl3729_set_scaling_register(uint8_t index, uint8_t value) {
 }
 
 void is31fl3729_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3729_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3729_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3729_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3729.c
+++ b/drivers/led/issi/is31fl3729.c
@@ -64,6 +64,9 @@
 #    define IS31FL3729_PWM_FREQUENCY IS31FL3729_PWM_FREQUENCY_32K_HZ
 #endif
 
+#define IS31FL3729_PWM_REGISTERS_PER_CHUNK 13
+#define IS31FL3729_CHUNK_COUNT (IS31FL3729_PWM_REGISTER_COUNT / IS31FL3729_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3729_DRIVER_COUNT] = {
     IS31FL3729_I2C_ADDRESS_1,
 #ifdef IS31FL3729_I2C_ADDRESS_2
@@ -81,14 +84,14 @@ const uint8_t i2c_addresses[IS31FL3729_DRIVER_COUNT] = {
 // Storing them like this is optimal for I2C transfers to the registers.
 typedef struct is31fl3729_driver_t {
     uint8_t pwm_buffer[IS31FL3729_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3729_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3729_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3729_driver_t;
 
 is31fl3729_driver_t driver_buffers[IS31FL3729_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -107,13 +110,21 @@ void is31fl3729_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 11 transfers of 13 bytes.
 
     // Iterate over the pwm_buffer contents at 13 byte intervals.
-    for (uint8_t i = 0; i <= IS31FL3729_PWM_REGISTER_COUNT; i += 13) {
+    for (uint8_t i = 0; i <= IS31FL3729_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3729_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3729_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3729_I2C_PERSISTENCE; j++) {
             if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 13, IS31FL3729_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 13, IS31FL3729_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3729_PWM_REGISTERS_PER_CHUNK, IS31FL3729_I2C_TIMEOUT);
 #endif
     }
 }
@@ -167,7 +178,10 @@ void is31fl3729_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         driver_buffers[led.driver].pwm_buffer[led.r] = red;
         driver_buffers[led.driver].pwm_buffer[led.g] = green;
         driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3729_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3729_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3729_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -195,10 +209,13 @@ void is31fl3729_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, 
 }
 
 void is31fl3729_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3729_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3729_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3729_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3729.c
+++ b/drivers/led/issi/is31fl3729.c
@@ -121,7 +121,7 @@ void is31fl3729_write_pwm_buffer(uint8_t index) {
 
 #if IS31FL3729_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3729_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 13, IS31FL3729_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3729_PWM_REGISTERS_PER_CHUNK, IS31FL3729_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3729_PWM_REGISTERS_PER_CHUNK, IS31FL3729_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3731-mono.c
+++ b/drivers/led/issi/is31fl3731-mono.c
@@ -33,6 +33,9 @@
 #    define IS31FL3731_I2C_PERSISTENCE 0
 #endif
 
+#define IS31FL3731_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3731_CHUNK_COUNT (IS31FL3731_PWM_REGISTER_COUNT / IS31FL3731_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3731_DRIVER_COUNT] = {
     IS31FL3731_I2C_ADDRESS_1,
 #ifdef IS31FL3731_I2C_ADDRESS_2
@@ -53,14 +56,14 @@ const uint8_t i2c_addresses[IS31FL3731_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct is31fl3731_driver_t {
     uint8_t pwm_buffer[IS31FL3731_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3731_CHUNK_COUNT];
     uint8_t led_control_buffer[IS31FL3731_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED is31fl3731_driver_t;
 
 is31fl3731_driver_t driver_buffers[IS31FL3731_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -84,13 +87,21 @@ void is31fl3731_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 9 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3731_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
             if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3731_PWM_REGISTERS_PER_CHUNK, IS31FL3731_I2C_TIMEOUT);
 #endif
     }
 }
@@ -178,8 +189,8 @@ void is31fl3731_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                            = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3731_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -206,10 +217,13 @@ void is31fl3731_set_led_control_register(uint8_t index, bool value) {
 }
 
 void is31fl3731_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3731_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3731_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3731_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3731-mono.c
+++ b/drivers/led/issi/is31fl3731-mono.c
@@ -98,7 +98,7 @@ void is31fl3731_write_pwm_buffer(uint8_t index) {
 
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3731_PWM_REGISTERS_PER_CHUNK, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3731_PWM_REGISTERS_PER_CHUNK, IS31FL3731_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -32,6 +32,9 @@
 #    define IS31FL3731_I2C_PERSISTENCE 0
 #endif
 
+#define IS31FL3731_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3731_CHUNK_COUNT (IS31FL3731_PWM_REGISTER_COUNT / IS31FL3731_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3731_DRIVER_COUNT] = {
     IS31FL3731_I2C_ADDRESS_1,
 #ifdef IS31FL3731_I2C_ADDRESS_2
@@ -51,15 +54,15 @@ const uint8_t i2c_addresses[IS31FL3731_DRIVER_COUNT] = {
 // buffers and the transfers in is31fl3731_write_pwm_buffer() but it's
 // probably not worth the extra complexity.
 typedef struct is31fl3731_driver_t {
-    uint8_t pwm_buffer[IS31FL3731_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
-    uint8_t led_control_buffer[IS31FL3731_LED_CONTROL_REGISTER_COUNT];
-    bool    led_control_buffer_dirty;
+    uint8_t    pwm_buffer[IS31FL3731_PWM_REGISTER_COUNT];
+    bool       pwm_buffer_dirty[IS31FL3731_CHUNK_COUNT];
+    uint8_t    led_control_buffer[IS31FL3731_LED_CONTROL_REGISTER_COUNT];
+    bool       led_control_buffer_dirty;
 } PACKED is31fl3731_driver_t;
 
 is31fl3731_driver_t driver_buffers[IS31FL3731_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -83,13 +86,21 @@ void is31fl3731_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 9 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3731_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3731_CHUNK_COUNT; i ++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3731_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
             if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3731_PWM_REGISTERS_PER_CHUNK, IS31FL3731_I2C_TIMEOUT);
 #endif
     }
 }
@@ -180,7 +191,11 @@ void is31fl3731_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         driver_buffers[led.driver].pwm_buffer[led.r] = red;
         driver_buffers[led.driver].pwm_buffer[led.g] = green;
         driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+
+        // update the dirty bitfield for the PWM registers
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3731_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3731_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3731_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -221,10 +236,13 @@ void is31fl3731_set_led_control_register(uint8_t index, bool red, bool green, bo
 }
 
 void is31fl3731_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3731_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3731_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3731_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -97,7 +97,7 @@ void is31fl3731_write_pwm_buffer(uint8_t index) {
 
 #if IS31FL3731_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3731_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3731_PWM_REGISTERS_PER_CHUNK, IS31FL3731_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
         i2c_write_register(i2c_addresses[index] << 1, IS31FL3731_FRAME_REG_PWM + offset, driver_buffers[index].pwm_buffer + offset, IS31FL3731_PWM_REGISTERS_PER_CHUNK, IS31FL3731_I2C_TIMEOUT);

--- a/drivers/led/issi/is31fl3731.c
+++ b/drivers/led/issi/is31fl3731.c
@@ -54,10 +54,10 @@ const uint8_t i2c_addresses[IS31FL3731_DRIVER_COUNT] = {
 // buffers and the transfers in is31fl3731_write_pwm_buffer() but it's
 // probably not worth the extra complexity.
 typedef struct is31fl3731_driver_t {
-    uint8_t    pwm_buffer[IS31FL3731_PWM_REGISTER_COUNT];
-    bool       pwm_buffer_dirty[IS31FL3731_CHUNK_COUNT];
-    uint8_t    led_control_buffer[IS31FL3731_LED_CONTROL_REGISTER_COUNT];
-    bool       led_control_buffer_dirty;
+    uint8_t pwm_buffer[IS31FL3731_PWM_REGISTER_COUNT];
+    bool    pwm_buffer_dirty[IS31FL3731_CHUNK_COUNT];
+    uint8_t led_control_buffer[IS31FL3731_LED_CONTROL_REGISTER_COUNT];
+    bool    led_control_buffer_dirty;
 } PACKED is31fl3731_driver_t;
 
 is31fl3731_driver_t driver_buffers[IS31FL3731_DRIVER_COUNT] = {{
@@ -86,7 +86,7 @@ void is31fl3731_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 9 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3731_CHUNK_COUNT; i ++) {
+    for (uint8_t i = 0; i < IS31FL3731_CHUNK_COUNT; i++) {
         if (!driver_buffers[index].pwm_buffer_dirty[i]) {
             continue;
         }

--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -63,6 +63,9 @@
 #    define IS31FL3733_SYNC_4 IS31FL3733_SYNC_NONE
 #endif
 
+#define IS31FL3733_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3733_CHUNK_COUNT (IS31FL3733_PWM_REGISTER_COUNT / IS31FL3733_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3733_DRIVER_COUNT] = {
     IS31FL3733_I2C_ADDRESS_1,
 #ifdef IS31FL3733_I2C_ADDRESS_2
@@ -97,14 +100,14 @@ const uint8_t driver_sync[IS31FL3733_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct is31fl3733_driver_t {
     uint8_t pwm_buffer[IS31FL3733_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3733_CHUNK_COUNT];
     uint8_t led_control_buffer[IS31FL3733_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED is31fl3733_driver_t;
 
 is31fl3733_driver_t driver_buffers[IS31FL3733_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -129,13 +132,21 @@ void is31fl3733_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3733_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3733_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3733_PWM_REGISTERS_PER_CHUNK, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3733_PWM_REGISTERS_PER_CHUNK, IS31FL3733_I2C_TIMEOUT);
 #endif
     }
 }
@@ -210,7 +221,7 @@ void is31fl3733_set_value(int index, uint8_t value) {
         }
 
         driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3733_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -237,12 +248,14 @@ void is31fl3733_set_led_control_register(uint8_t index, bool value) {
 }
 
 void is31fl3733_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3733_select_page(index, IS31FL3733_COMMAND_PWM);
-
-        is31fl3733_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3733_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3733_select_page(index, IS31FL3733_COMMAND_PWM);
+            is31fl3733_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3733-mono.c
+++ b/drivers/led/issi/is31fl3733-mono.c
@@ -220,7 +220,7 @@ void is31fl3733_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                            = value;
         driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3733_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }

--- a/drivers/led/issi/is31fl3733.c
+++ b/drivers/led/issi/is31fl3733.c
@@ -21,6 +21,7 @@
 #include "i2c_master.h"
 #include "gpio.h"
 #include "wait.h"
+#include "bit_array.h"
 
 #define IS31FL3733_PWM_REGISTER_COUNT 192
 #define IS31FL3733_LED_CONTROL_REGISTER_COUNT 24
@@ -62,6 +63,9 @@
 #    define IS31FL3733_SYNC_4 IS31FL3733_SYNC_NONE
 #endif
 
+#define IS31FL3733_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3733_CHUNK_COUNT (IS31FL3733_PWM_REGISTER_COUNT / IS31FL3733_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3733_DRIVER_COUNT] = {
     IS31FL3733_I2C_ADDRESS_1,
 #ifdef IS31FL3733_I2C_ADDRESS_2
@@ -96,16 +100,17 @@ const uint8_t driver_sync[IS31FL3733_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct is31fl3733_driver_t {
     uint8_t pwm_buffer[IS31FL3733_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3733_CHUNK_COUNT];
     uint8_t led_control_buffer[IS31FL3733_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED is31fl3733_driver_t;
 
 is31fl3733_driver_t driver_buffers[IS31FL3733_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
+    .led_control_bitfield     = {0},
 }};
 
 void is31fl3733_write_register(uint8_t index, uint8_t reg, uint8_t data) {
@@ -128,13 +133,21 @@ void is31fl3733_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3733_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3733_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3733_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3733_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3733_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3733_PWM_REGISTERS_PER_CHUNK, IS31FL3733_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3733_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3733_PWM_REGISTERS_PER_CHUNK, IS31FL3733_I2C_TIMEOUT);
 #endif
     }
 }
@@ -211,7 +224,10 @@ void is31fl3733_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         driver_buffers[led.driver].pwm_buffer[led.r] = red;
         driver_buffers[led.driver].pwm_buffer[led.g] = green;
         driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3733_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3733_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3733_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -252,12 +268,14 @@ void is31fl3733_set_led_control_register(uint8_t index, bool red, bool green, bo
 }
 
 void is31fl3733_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3733_select_page(index, IS31FL3733_COMMAND_PWM);
-
-        is31fl3733_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3733_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3733_select_page(index, IS31FL3733_COMMAND_PWM);
+            is31fl3733_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3736-mono.c
+++ b/drivers/led/issi/is31fl3736-mono.c
@@ -47,6 +47,9 @@
 #    define IS31FL3736_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3736_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3736_CHUNK_COUNT (IS31FL3736_PWM_REGISTER_COUNT / IS31FL3736_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3736_DRIVER_COUNT] = {
     IS31FL3736_I2C_ADDRESS_1,
 #ifdef IS31FL3736_I2C_ADDRESS_2
@@ -68,14 +71,14 @@ const uint8_t i2c_addresses[IS31FL3736_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct is31fl3736_driver_t {
     uint8_t pwm_buffer[IS31FL3736_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3736_CHUNK_COUNT];
     uint8_t led_control_buffer[IS31FL3736_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED is31fl3736_driver_t;
 
 is31fl3736_driver_t driver_buffers[IS31FL3736_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -100,13 +103,21 @@ void is31fl3736_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3736_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3736_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3736_PWM_REGISTERS_PER_CHUNK, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3736_PWM_REGISTERS_PER_CHUNK, IS31FL3736_I2C_TIMEOUT);
 #endif
     }
 }
@@ -178,8 +189,8 @@ void is31fl3736_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                            = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3736_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -212,12 +223,14 @@ void is31fl3736_set_led_control_register(uint8_t index, bool value) {
 }
 
 void is31fl3736_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
-
-        is31fl3736_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3736_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
+            is31fl3736_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3736.c
+++ b/drivers/led/issi/is31fl3736.c
@@ -47,6 +47,9 @@
 #    define IS31FL3736_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3736_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3736_CHUNK_COUNT (IS31FL3736_PWM_REGISTER_COUNT / IS31FL3736_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3736_DRIVER_COUNT] = {
     IS31FL3736_I2C_ADDRESS_1,
 #ifdef IS31FL3736_I2C_ADDRESS_2
@@ -68,14 +71,14 @@ const uint8_t i2c_addresses[IS31FL3736_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct is31fl3736_driver_t {
     uint8_t pwm_buffer[IS31FL3736_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3736_CHUNK_COUNT];
     uint8_t led_control_buffer[IS31FL3736_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED is31fl3736_driver_t;
 
 is31fl3736_driver_t driver_buffers[IS31FL3736_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -100,13 +103,21 @@ void is31fl3736_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3736_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3736_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3736_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3736_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3736_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3736_PWM_REGISTERS_PER_CHUNK, IS31FL3736_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3736_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3736_PWM_REGISTERS_PER_CHUNK, IS31FL3736_I2C_TIMEOUT);
 #endif
     }
 }
@@ -178,10 +189,12 @@ void is31fl3736_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.r] = red;
-        driver_buffers[led.driver].pwm_buffer[led.g] = green;
-        driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.r]                                            = red;
+        driver_buffers[led.driver].pwm_buffer[led.g]                                            = green;
+        driver_buffers[led.driver].pwm_buffer[led.b]                                            = blue;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3736_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3736_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3736_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -229,12 +242,14 @@ void is31fl3736_set_led_control_register(uint8_t index, bool red, bool green, bo
 }
 
 void is31fl3736_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
-
-        is31fl3736_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3736_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3736_select_page(index, IS31FL3736_COMMAND_PWM);
+            is31fl3736_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3737-mono.c
+++ b/drivers/led/issi/is31fl3737-mono.c
@@ -49,6 +49,9 @@
 #    define IS31FL3737_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3737_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3737_CHUNK_COUNT (IS31FL3737_PWM_REGISTER_COUNT / IS31FL3737_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3737_DRIVER_COUNT] = {
     IS31FL3737_I2C_ADDRESS_1,
 #ifdef IS31FL3737_I2C_ADDRESS_2
@@ -70,7 +73,7 @@ const uint8_t i2c_addresses[IS31FL3737_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct is31fl3737_driver_t {
     uint8_t pwm_buffer[IS31FL3737_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3737_CHUNK_COUNT];
     uint8_t led_control_buffer[IS31FL3737_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED is31fl3737_driver_t;
@@ -102,13 +105,21 @@ void is31fl3737_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3737_CHUNK_COUNT; i += 16) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3737_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3737_PWM_REGISTERS_PER_CHUNK, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3737_PWM_REGISTERS_PER_CHUNK, IS31FL3737_I2C_TIMEOUT);
 #endif
     }
 }
@@ -180,8 +191,8 @@ void is31fl3737_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                            = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3737_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -208,12 +219,14 @@ void is31fl3737_set_led_control_register(uint8_t index, bool value) {
 }
 
 void is31fl3737_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
-
-        is31fl3737_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3737_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
+            is31fl3737_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3737.c
+++ b/drivers/led/issi/is31fl3737.c
@@ -49,6 +49,9 @@
 #    define IS31FL3737_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3737_PWM_REGISTERS_PER_CHUNK 16
+#define IS31FL3737_CHUNK_COUNT (IS31FL3737_PWM_REGISTER_COUNT / IS31FL3737_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3737_DRIVER_COUNT] = {
     IS31FL3737_I2C_ADDRESS_1,
 #ifdef IS31FL3737_I2C_ADDRESS_2
@@ -70,14 +73,14 @@ const uint8_t i2c_addresses[IS31FL3737_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct is31fl3737_driver_t {
     uint8_t pwm_buffer[IS31FL3737_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3737_CHUNK_COUNT];
     uint8_t led_control_buffer[IS31FL3737_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED is31fl3737_driver_t;
 
 is31fl3737_driver_t driver_buffers[IS31FL3737_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -102,13 +105,21 @@ void is31fl3737_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3737_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < IS31FL3737_CHUNK_COUNT; i += 16) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3737_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3737_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3737_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3737_PWM_REGISTERS_PER_CHUNK, IS31FL3737_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, IS31FL3737_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3737_PWM_REGISTERS_PER_CHUNK, IS31FL3737_I2C_TIMEOUT);
 #endif
     }
 }
@@ -183,7 +194,10 @@ void is31fl3737_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         driver_buffers[led.driver].pwm_buffer[led.r] = red;
         driver_buffers[led.driver].pwm_buffer[led.g] = green;
         driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3737_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3737_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3737_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -224,12 +238,14 @@ void is31fl3737_set_led_control_register(uint8_t index, bool red, bool green, bo
 }
 
 void is31fl3737_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
-
-        is31fl3737_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3737_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3737_select_page(index, IS31FL3737_COMMAND_PWM);
+            is31fl3737_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3741-mono.c
+++ b/drivers/led/issi/is31fl3741-mono.c
@@ -55,6 +55,11 @@
 #    define IS31FL3741_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3741_PWM_0_REGISTERS_PER_CHUNK 30
+#define IS31FL3741_PWM_1_REGISTERS_PER_CHUNK 19
+#define IS31FL3741_PAGE_0_CHUNK_COUNT (IS31FL3741_PWM_0_REGISTER_COUNT / IS31FL3741_PWM_0_REGISTERS_PER_CHUNK)
+#define IS31FL3741_PAGE_1_CHUNK_COUNT (IS31FL3741_PWM_1_REGISTER_COUNT / IS31FL3741_PWM_1_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3741_DRIVER_COUNT] = {
     IS31FL3741_I2C_ADDRESS_1,
 #ifdef IS31FL3741_I2C_ADDRESS_2
@@ -77,19 +82,21 @@ const uint8_t i2c_addresses[IS31FL3741_DRIVER_COUNT] = {
 typedef struct is31fl3741_driver_t {
     uint8_t pwm_buffer_0[IS31FL3741_PWM_0_REGISTER_COUNT];
     uint8_t pwm_buffer_1[IS31FL3741_PWM_1_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
     uint8_t scaling_buffer_0[IS31FL3741_SCALING_0_REGISTER_COUNT];
     uint8_t scaling_buffer_1[IS31FL3741_SCALING_1_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
+    bool    pwm_buffer_0_dirty[IS31FL3741_PAGE_0_CHUNK_COUNT];
+    bool    pwm_buffer_1_dirty[IS31FL3741_PAGE_1_CHUNK_COUNT];
 } PACKED is31fl3741_driver_t;
 
 is31fl3741_driver_t driver_buffers[IS31FL3741_DRIVER_COUNT] = {{
     .pwm_buffer_0         = {0},
     .pwm_buffer_1         = {0},
-    .pwm_buffer_dirty     = false,
     .scaling_buffer_0     = {0},
     .scaling_buffer_1     = {0},
     .scaling_buffer_dirty = false,
+    .pwm_buffer_0_dirty   = {0},
+    .pwm_buffer_1_dirty   = {0},
 }};
 
 void is31fl3741_write_register(uint8_t index, uint8_t reg, uint8_t data) {
@@ -113,13 +120,21 @@ void is31fl3741_write_pwm_buffer(uint8_t index) {
     // Transmit PWM0 registers in 6 transfers of 30 bytes.
 
     // Iterate over the pwm_buffer_0 contents at 30 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3741_PWM_0_REGISTER_COUNT; i += 30) {
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_0_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_0_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_0_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3741_PWM_0_REGISTERS_PER_CHUNK;
+
 #if IS31FL3741_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3741_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_0 + i, 30, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_0 + offset, IS31FL3741_PWM_0_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_0 + i, 30, IS31FL3741_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer_0 + offset, IS31FL3741_PWM_0_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT);
 #endif
     }
 
@@ -128,13 +143,21 @@ void is31fl3741_write_pwm_buffer(uint8_t index) {
     // Transmit PWM1 registers in 9 transfers of 19 bytes.
 
     // Iterate over the pwm_buffer_1 contents at 19 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3741_PWM_1_REGISTER_COUNT; i += 19) {
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_1_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_1_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_1_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3741_PWM_1_REGISTERS_PER_CHUNK;
+
 #if IS31FL3741_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_1 + i, 19, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_1 + offset, IS31FL3741_PWM_1_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_1 + i, 19, IS31FL3741_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer_1 + offset, IS31FL3741_PWM_1_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT);
 #endif
     }
 }
@@ -201,6 +224,14 @@ void set_pwm_value(uint8_t driver, uint16_t reg, uint8_t value) {
     }
 }
 
+void dirty_bitfield_set(uint8_t driver, uint16_t reg) {
+    if (reg & 0x100) {
+        driver_buffers[driver].pwm_buffer_1_dirty[(reg & 0xFF) / IS31FL3741_PWM_1_REGISTERS_PER_CHUNK] = true;
+    } else {
+        driver_buffers[driver].pwm_buffer_0_dirty[reg / IS31FL3741_PWM_0_REGISTERS_PER_CHUNK] = true;
+    }
+}
+
 void is31fl3741_set_value(int index, uint8_t value) {
     is31fl3741_led_t led;
 
@@ -212,7 +243,7 @@ void is31fl3741_set_value(int index, uint8_t value) {
         }
 
         set_pwm_value(led.driver, led.v, value);
-        driver_buffers[led.driver].pwm_buffer_dirty = true;
+        dirty_bitfield_set(led.driver, led.v);
     }
 }
 
@@ -240,10 +271,20 @@ void is31fl3741_set_led_control_register(uint8_t index, bool value) {
 }
 
 void is31fl3741_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3741_write_pwm_buffer(index);
+    // Check if any of the PWM buffers are dirty.
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_0_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_0_dirty[i]) {
+            is31fl3741_write_pwm_buffer(index);
+            // return since we update both pages at the same time
+            return;
+        }
+    }
 
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_1_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_1_dirty[i]) {
+            is31fl3741_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -55,6 +55,11 @@
 #    define IS31FL3741_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3741_PWM_0_REGISTERS_PER_CHUNK 30
+#define IS31FL3741_PWM_1_REGISTERS_PER_CHUNK 19
+#define IS31FL3741_PAGE_0_CHUNK_COUNT (IS31FL3741_PWM_0_REGISTER_COUNT / IS31FL3741_PWM_0_REGISTERS_PER_CHUNK)
+#define IS31FL3741_PAGE_1_CHUNK_COUNT (IS31FL3741_PWM_1_REGISTER_COUNT / IS31FL3741_PWM_1_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3741_DRIVER_COUNT] = {
     IS31FL3741_I2C_ADDRESS_1,
 #ifdef IS31FL3741_I2C_ADDRESS_2
@@ -77,19 +82,21 @@ const uint8_t i2c_addresses[IS31FL3741_DRIVER_COUNT] = {
 typedef struct is31fl3741_driver_t {
     uint8_t pwm_buffer_0[IS31FL3741_PWM_0_REGISTER_COUNT];
     uint8_t pwm_buffer_1[IS31FL3741_PWM_1_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
     uint8_t scaling_buffer_0[IS31FL3741_SCALING_0_REGISTER_COUNT];
     uint8_t scaling_buffer_1[IS31FL3741_SCALING_1_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
+    bool    pwm_buffer_0_dirty[IS31FL3741_PAGE_0_CHUNK_COUNT];
+    bool    pwm_buffer_1_dirty[IS31FL3741_PAGE_1_CHUNK_COUNT];
 } PACKED is31fl3741_driver_t;
 
 is31fl3741_driver_t driver_buffers[IS31FL3741_DRIVER_COUNT] = {{
     .pwm_buffer_0         = {0},
     .pwm_buffer_1         = {0},
-    .pwm_buffer_dirty     = false,
     .scaling_buffer_0     = {0},
     .scaling_buffer_1     = {0},
     .scaling_buffer_dirty = false,
+    .pwm_buffer_0_dirty   = {0},
+    .pwm_buffer_1_dirty   = {0},
 }};
 
 void is31fl3741_write_register(uint8_t index, uint8_t reg, uint8_t data) {
@@ -113,13 +120,21 @@ void is31fl3741_write_pwm_buffer(uint8_t index) {
     // Transmit PWM0 registers in 6 transfers of 30 bytes.
 
     // Iterate over the pwm_buffer_0 contents at 30 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3741_PWM_0_REGISTER_COUNT; i += 30) {
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_0_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_0_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_0_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3741_PWM_0_REGISTERS_PER_CHUNK;
+
 #if IS31FL3741_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3741_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_0 + i, 30, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_0 + offset, IS31FL3741_PWM_0_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_0 + i, 30, IS31FL3741_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer_0 + offset, IS31FL3741_PWM_0_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT);
 #endif
     }
 
@@ -128,13 +143,21 @@ void is31fl3741_write_pwm_buffer(uint8_t index) {
     // Transmit PWM1 registers in 9 transfers of 19 bytes.
 
     // Iterate over the pwm_buffer_1 contents at 19 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3741_PWM_1_REGISTER_COUNT; i += 19) {
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_1_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_1_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_1_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3741_PWM_1_REGISTERS_PER_CHUNK;
+
 #if IS31FL3741_I2C_PERSISTENCE > 0
         for (uint8_t i = 0; i < IS31FL3741_I2C_PERSISTENCE; i++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_1 + i, 19, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_1 + offset, IS31FL3741_PWM_1_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer_1 + i, 19, IS31FL3741_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer_1 + offset, IS31FL3741_PWM_1_REGISTERS_PER_CHUNK, IS31FL3741_I2C_TIMEOUT);
 #endif
     }
 }
@@ -201,6 +224,14 @@ void set_pwm_value(uint8_t driver, uint16_t reg, uint8_t value) {
     }
 }
 
+void dirty_bitfield_set_bit(uint8_t driver, uint16_t reg) {
+    if (reg & 0x100) {
+        driver_buffers[driver].pwm_buffer_1_dirty[(reg & 0xFF) / IS31FL3741_PWM_1_REGISTERS_PER_CHUNK] = true;
+    } else {
+        driver_buffers[driver].pwm_buffer_0_dirty[reg / IS31FL3741_PWM_0_REGISTERS_PER_CHUNK] = true;
+    }
+}
+
 void is31fl3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     is31fl3741_led_t led;
 
@@ -214,7 +245,10 @@ void is31fl3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         set_pwm_value(led.driver, led.r, red);
         set_pwm_value(led.driver, led.g, green);
         set_pwm_value(led.driver, led.b, blue);
-        driver_buffers[led.driver].pwm_buffer_dirty = true;
+
+        dirty_bitfield_set_bit(led.driver, led.r);
+        dirty_bitfield_set_bit(led.driver, led.g);
+        dirty_bitfield_set_bit(led.driver, led.b);
     }
 }
 
@@ -244,10 +278,20 @@ void is31fl3741_set_led_control_register(uint8_t index, bool red, bool green, bo
 }
 
 void is31fl3741_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3741_write_pwm_buffer(index);
+    // Check if any of the PWM buffers are dirty.
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_0_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_0_dirty[i]) {
+            is31fl3741_write_pwm_buffer(index);
+            // return since we update both pages at the same time
+            return;
+        }
+    }
 
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3741_PAGE_1_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_1_dirty[i]) {
+            is31fl3741_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 
@@ -255,7 +299,10 @@ void is31fl3741_set_pwm_buffer(const is31fl3741_led_t *pled, uint8_t red, uint8_
     set_pwm_value(pled->driver, pled->r, red);
     set_pwm_value(pled->driver, pled->g, green);
     set_pwm_value(pled->driver, pled->b, blue);
-    driver_buffers[pled->driver].pwm_buffer_dirty = true;
+
+    dirty_bitfield_set_bit(pled->driver, pled->r);
+    dirty_bitfield_set_bit(pled->driver, pled->g);
+    dirty_bitfield_set_bit(pled->driver, pled->b);
 }
 
 void is31fl3741_update_led_control_registers(uint8_t index) {

--- a/drivers/led/issi/is31fl3741.c
+++ b/drivers/led/issi/is31fl3741.c
@@ -224,7 +224,7 @@ void set_pwm_value(uint8_t driver, uint16_t reg, uint8_t value) {
     }
 }
 
-void dirty_bitfield_set_bit(uint8_t driver, uint16_t reg) {
+void dirty_bitfield_set(uint8_t driver, uint16_t reg) {
     if (reg & 0x100) {
         driver_buffers[driver].pwm_buffer_1_dirty[(reg & 0xFF) / IS31FL3741_PWM_1_REGISTERS_PER_CHUNK] = true;
     } else {
@@ -246,9 +246,9 @@ void is31fl3741_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
         set_pwm_value(led.driver, led.g, green);
         set_pwm_value(led.driver, led.b, blue);
 
-        dirty_bitfield_set_bit(led.driver, led.r);
-        dirty_bitfield_set_bit(led.driver, led.g);
-        dirty_bitfield_set_bit(led.driver, led.b);
+        dirty_bitfield_set(led.driver, led.r);
+        dirty_bitfield_set(led.driver, led.g);
+        dirty_bitfield_set(led.driver, led.b);
     }
 }
 

--- a/drivers/led/issi/is31fl3742a-mono.c
+++ b/drivers/led/issi/is31fl3742a-mono.c
@@ -54,6 +54,9 @@
 #    define IS31FL3742A_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3742A_PWM_REGISTERS_PER_CHUNK 30
+#define IS31FL3742A_CHUNK_COUNT (IS31FL3742A_PWM_REGISTER_COUNT / IS31FL3742A_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3742A_DRIVER_COUNT] = {
     IS31FL3742A_I2C_ADDRESS_1,
 #ifdef IS31FL3742A_I2C_ADDRESS_2
@@ -69,14 +72,14 @@ const uint8_t i2c_addresses[IS31FL3742A_DRIVER_COUNT] = {
 
 typedef struct is31fl3742a_driver_t {
     uint8_t pwm_buffer[IS31FL3742A_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3742A_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3742A_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3742a_driver_t;
 
 is31fl3742a_driver_t driver_buffers[IS31FL3742A_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -101,13 +104,21 @@ void is31fl3742a_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 6 transfers of 30 bytes.
 
     // Iterate over the pwm_buffer contents at 30 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
+    for (uint8_t i = 0; i < IS31FL3742A_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3742A_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3742A_PWM_REGISTERS_PER_CHUNK, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3742A_PWM_REGISTERS_PER_CHUNK, IS31FL3742A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -173,8 +184,8 @@ void is31fl3742a_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                             = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3742A_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -193,12 +204,14 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t value) {
 }
 
 void is31fl3742a_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
-
-        is31fl3742a_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3742A_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
+            is31fl3742a_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3742a.c
+++ b/drivers/led/issi/is31fl3742a.c
@@ -54,6 +54,9 @@
 #    define IS31FL3742A_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3742A_PWM_REGISTERS_PER_CHUNK 30
+#define IS31FL3742A_CHUNK_COUNT (IS31FL3742A_PWM_REGISTER_COUNT / IS31FL3742A_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3742A_DRIVER_COUNT] = {
     IS31FL3742A_I2C_ADDRESS_1,
 #ifdef IS31FL3742A_I2C_ADDRESS_2
@@ -69,14 +72,14 @@ const uint8_t i2c_addresses[IS31FL3742A_DRIVER_COUNT] = {
 
 typedef struct is31fl3742a_driver_t {
     uint8_t pwm_buffer[IS31FL3742A_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3742A_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3742A_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3742a_driver_t;
 
 is31fl3742a_driver_t driver_buffers[IS31FL3742A_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -101,13 +104,21 @@ void is31fl3742a_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 6 transfers of 30 bytes.
 
     // Iterate over the pwm_buffer contents at 30 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3742A_PWM_REGISTER_COUNT; i += 30) {
+    for (uint8_t i = 0; i < IS31FL3742A_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3742A_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3742A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3742A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3742A_PWM_REGISTERS_PER_CHUNK, IS31FL3742A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 30, IS31FL3742A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, IS31FL3742A_PWM_REGISTERS_PER_CHUNK, IS31FL3742A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -173,10 +184,12 @@ void is31fl3742a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) 
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.r] = red;
-        driver_buffers[led.driver].pwm_buffer[led.g] = green;
-        driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.r]                                             = red;
+        driver_buffers[led.driver].pwm_buffer[led.g]                                             = green;
+        driver_buffers[led.driver].pwm_buffer[led.b]                                             = blue;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3742A_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3742A_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3742A_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -197,12 +210,14 @@ void is31fl3742a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
 }
 
 void is31fl3742a_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
-
-        is31fl3742a_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3742A_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3742a_select_page(index, IS31FL3742A_COMMAND_PWM);
+            is31fl3742a_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3743a-mono.c
+++ b/drivers/led/issi/is31fl3743a-mono.c
@@ -63,6 +63,9 @@
 #    define IS31FL3743A_SYNC_4 IS31FL3743A_SYNC_NONE
 #endif
 
+#define IS31FL3743A_PWM_REGISTERS_PER_CHUNK 18
+#define IS31FL3743A_CHUNK_COUNT (IS31FL3743A_PWM_REGISTER_COUNT / IS31FL3743A_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3743A_DRIVER_COUNT] = {
     IS31FL3743A_I2C_ADDRESS_1,
 #ifdef IS31FL3743A_I2C_ADDRESS_2
@@ -91,14 +94,14 @@ const uint8_t driver_sync[IS31FL3743A_DRIVER_COUNT] = {
 
 typedef struct is31fl3743a_driver_t {
     uint8_t pwm_buffer[IS31FL3743A_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3743A_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3743A_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3743a_driver_t;
 
 is31fl3743a_driver_t driver_buffers[IS31FL3743A_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -123,13 +126,21 @@ void is31fl3743a_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 11 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3743A_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3743A_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3743A_PWM_REGISTERS_PER_CHUNK, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3743A_PWM_REGISTERS_PER_CHUNK, IS31FL3743A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -197,8 +208,8 @@ void is31fl3743a_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                             = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3743A_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -217,12 +228,14 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t value) {
 }
 
 void is31fl3743a_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
-
-        is31fl3743a_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3743A_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
+            is31fl3743a_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3743a.c
+++ b/drivers/led/issi/is31fl3743a.c
@@ -63,6 +63,9 @@
 #    define IS31FL3743A_SYNC_4 IS31FL3743A_SYNC_NONE
 #endif
 
+#define IS31FL3743A_PWM_REGISTERS_PER_CHUNK 18
+#define IS31FL3743A_CHUNK_COUNT (IS31FL3743A_PWM_REGISTER_COUNT / IS31FL3743A_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3743A_DRIVER_COUNT] = {
     IS31FL3743A_I2C_ADDRESS_1,
 #ifdef IS31FL3743A_I2C_ADDRESS_2
@@ -91,14 +94,14 @@ const uint8_t driver_sync[IS31FL3743A_DRIVER_COUNT] = {
 
 typedef struct is31fl3743a_driver_t {
     uint8_t pwm_buffer[IS31FL3743A_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3743A_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3743A_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3743a_driver_t;
 
 is31fl3743a_driver_t driver_buffers[IS31FL3743A_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -123,13 +126,21 @@ void is31fl3743a_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 11 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3743A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3743A_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3743A_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3743A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3743A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3743A_PWM_REGISTERS_PER_CHUNK, IS31FL3743A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3743A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3743A_PWM_REGISTERS_PER_CHUNK, IS31FL3743A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -197,10 +208,12 @@ void is31fl3743a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) 
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.r] = red;
-        driver_buffers[led.driver].pwm_buffer[led.g] = green;
-        driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.r]                                             = red;
+        driver_buffers[led.driver].pwm_buffer[led.g]                                             = green;
+        driver_buffers[led.driver].pwm_buffer[led.b]                                             = blue;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3743A_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3743A_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3743A_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -221,12 +234,14 @@ void is31fl3743a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
 }
 
 void is31fl3743a_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
-
-        is31fl3743a_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3743A_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3743a_select_page(index, IS31FL3743A_COMMAND_PWM);
+            is31fl3743a_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3745-mono.c
+++ b/drivers/led/issi/is31fl3745-mono.c
@@ -63,6 +63,9 @@
 #    define IS31FL3745_SYNC_4 IS31FL3745_SYNC_NONE
 #endif
 
+#define IS31FL3745_PWM_REGISTERS_PER_CHUNK 18
+#define IS31FL3745_CHUNK_COUNT (IS31FL3745_PWM_REGISTER_COUNT / IS31FL3745_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3745_DRIVER_COUNT] = {
     IS31FL3745_I2C_ADDRESS_1,
 #ifdef IS31FL3745_I2C_ADDRESS_2
@@ -91,14 +94,14 @@ const uint8_t driver_sync[IS31FL3745_DRIVER_COUNT] = {
 
 typedef struct is31fl3745_driver_t {
     uint8_t pwm_buffer[IS31FL3745_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3745_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3745_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3745_driver_t;
 
 is31fl3745_driver_t driver_buffers[IS31FL3745_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -123,13 +126,21 @@ void is31fl3745_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 8 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3745_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3745_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3745_PWM_REGISTERS_PER_CHUNK, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3745_PWM_REGISTERS_PER_CHUNK, IS31FL3745_I2C_TIMEOUT);
 #endif
     }
 }
@@ -197,8 +208,8 @@ void is31fl3745_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                            = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3745_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -217,12 +228,14 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t value) {
 }
 
 void is31fl3745_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3745_select_page(index, IS31FL3745_COMMAND_PWM);
-
-        is31fl3745_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3745_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3745a_select_page(index, IS31FL3745_COMMAND_PWM);
+            is31fl3745a_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3745.c
+++ b/drivers/led/issi/is31fl3745.c
@@ -63,6 +63,9 @@
 #    define IS31FL3745_SYNC_4 IS31FL3745_SYNC_NONE
 #endif
 
+#define IS31FL3745_PWM_REGISTERS_PER_CHUNK 18
+#define IS31FL3745_CHUNK_COUNT (IS31FL3745_PWM_REGISTER_COUNT / IS31FL3745_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3745_DRIVER_COUNT] = {
     IS31FL3745_I2C_ADDRESS_1,
 #ifdef IS31FL3745_I2C_ADDRESS_2
@@ -91,14 +94,14 @@ const uint8_t driver_sync[IS31FL3745_DRIVER_COUNT] = {
 
 typedef struct is31fl3745_driver_t {
     uint8_t pwm_buffer[IS31FL3745_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3745_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3745_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3745_driver_t;
 
 is31fl3745_driver_t driver_buffers[IS31FL3745_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -123,13 +126,21 @@ void is31fl3745_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 8 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3745_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3745_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3745_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3745_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3745_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3745_PWM_REGISTERS_PER_CHUNK, IS31FL3745_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3745_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3745_PWM_REGISTERS_PER_CHUNK, IS31FL3745_I2C_TIMEOUT);
 #endif
     }
 }
@@ -197,10 +208,12 @@ void is31fl3745_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.r] = red;
-        driver_buffers[led.driver].pwm_buffer[led.g] = green;
-        driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.r]                                            = red;
+        driver_buffers[led.driver].pwm_buffer[led.g]                                            = green;
+        driver_buffers[led.driver].pwm_buffer[led.b]                                            = blue;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3745_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3745_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3745_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -221,12 +234,14 @@ void is31fl3745_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, 
 }
 
 void is31fl3745_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3745_select_page(index, IS31FL3745_COMMAND_PWM);
-
-        is31fl3745_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3745_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3745_select_page(index, IS31FL3745_COMMAND_PWM);
+            is31fl3745_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3746a-mono.c
+++ b/drivers/led/issi/is31fl3746a-mono.c
@@ -54,6 +54,9 @@
 #    define IS31FL3746A_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3746A_PWM_REGISTERS_PER_CHUNK 18
+#define IS31FL3746A_CHUNK_COUNT (IS31FL3746A_PWM_REGISTER_COUNT / IS31FL3746A_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3746A_DRIVER_COUNT] = {
     IS31FL3746A_I2C_ADDRESS_1,
 #ifdef IS31FL3746A_I2C_ADDRESS_2
@@ -69,14 +72,14 @@ const uint8_t i2c_addresses[IS31FL3746A_DRIVER_COUNT] = {
 
 typedef struct is31fl3746a_driver_t {
     uint8_t pwm_buffer[IS31FL3746A_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3746A_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3746A_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3746a_driver_t;
 
 is31fl3746a_driver_t driver_buffers[IS31FL3746A_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -101,13 +104,21 @@ void is31fl3746a_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 4 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3746A_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3746A_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3746A_PWM_REGISTERS_PER_CHUNK, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3746A_PWM_REGISTERS_PER_CHUNK, IS31FL3746A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -174,8 +185,8 @@ void is31fl3746a_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                             = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / IS31FL3746A_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -194,12 +205,14 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t value) {
 }
 
 void is31fl3746a_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
-
-        is31fl3746a_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3746A_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
+            is31fl3746a_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/issi/is31fl3746a.c
+++ b/drivers/led/issi/is31fl3746a.c
@@ -54,6 +54,9 @@
 #    define IS31FL3746A_GLOBAL_CURRENT 0xFF
 #endif
 
+#define IS31FL3746A_PWM_REGISTERS_PER_CHUNK 18
+#define IS31FL3746A_CHUNK_COUNT (IS31FL3746A_PWM_REGISTER_COUNT / IS31FL3746A_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[IS31FL3746A_DRIVER_COUNT] = {
     IS31FL3746A_I2C_ADDRESS_1,
 #ifdef IS31FL3746A_I2C_ADDRESS_2
@@ -69,14 +72,14 @@ const uint8_t i2c_addresses[IS31FL3746A_DRIVER_COUNT] = {
 
 typedef struct is31fl3746a_driver_t {
     uint8_t pwm_buffer[IS31FL3746A_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[IS31FL3746A_CHUNK_COUNT];
     uint8_t scaling_buffer[IS31FL3746A_SCALING_REGISTER_COUNT];
     bool    scaling_buffer_dirty;
 } PACKED is31fl3746a_driver_t;
 
 is31fl3746a_driver_t driver_buffers[IS31FL3746A_DRIVER_COUNT] = {{
     .pwm_buffer           = {0},
-    .pwm_buffer_dirty     = false,
+    .pwm_buffer_dirty     = {0},
     .scaling_buffer       = {0},
     .scaling_buffer_dirty = false,
 }};
@@ -101,13 +104,21 @@ void is31fl3746a_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 4 transfers of 18 bytes.
 
     // Iterate over the pwm_buffer contents at 18 byte intervals.
-    for (uint8_t i = 0; i < IS31FL3746A_PWM_REGISTER_COUNT; i += 18) {
+    for (uint8_t i = 0; i < IS31FL3746A_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * IS31FL3746A_PWM_REGISTERS_PER_CHUNK;
+
 #if IS31FL3746A_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3746A_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3746A_PWM_REGISTERS_PER_CHUNK, IS31FL3746A_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i + 1, driver_buffers[index].pwm_buffer + i, 18, IS31FL3746A_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset + 1, driver_buffers[index].pwm_buffer + offset, IS31FL3746A_PWM_REGISTERS_PER_CHUNK, IS31FL3746A_I2C_TIMEOUT);
 #endif
     }
 }
@@ -174,10 +185,12 @@ void is31fl3746a_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) 
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.r] = red;
-        driver_buffers[led.driver].pwm_buffer[led.g] = green;
-        driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.r]                                             = red;
+        driver_buffers[led.driver].pwm_buffer[led.g]                                             = green;
+        driver_buffers[led.driver].pwm_buffer[led.b]                                             = blue;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / IS31FL3746A_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / IS31FL3746A_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / IS31FL3746A_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -198,12 +211,14 @@ void is31fl3746a_set_scaling_register(uint8_t index, uint8_t red, uint8_t green,
 }
 
 void is31fl3746a_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
-
-        is31fl3746a_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < IS31FL3746A_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            is31fl3746a_select_page(index, IS31FL3746A_COMMAND_PWM);
+            is31fl3746a_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/snled27351-mono.c
+++ b/drivers/led/snled27351-mono.c
@@ -38,6 +38,9 @@
         { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
 #endif
 
+#define SNLED27351_PWM_REGISTERS_PER_CHUNK 16
+#define SNLED27351_CHUNK_COUNT (SNLED27351_PWM_REGISTER_COUNT / SNLED27351_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[SNLED27351_DRIVER_COUNT] = {
     SNLED27351_I2C_ADDRESS_1,
 #ifdef SNLED27351_I2C_ADDRESS_2
@@ -59,14 +62,14 @@ const uint8_t i2c_addresses[SNLED27351_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct snled27351_driver_t {
     uint8_t pwm_buffer[SNLED27351_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[SNLED27351_CHUNK_COUNT];
     uint8_t led_control_buffer[SNLED27351_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED snled27351_driver_t;
 
 snled27351_driver_t driver_buffers[SNLED27351_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -90,13 +93,21 @@ void snled27351_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < SNLED27351_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * SNLED27351_PWM_REGISTERS_PER_CHUNK;
+
 #if SNLED27351_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < SNLED27351_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, SNLED27351_PWM_REGISTERS_PER_CHUNK, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, SNLED27351_PWM_REGISTERS_PER_CHUNK, SNLED27351_I2C_TIMEOUT);
 #endif
     }
 }
@@ -178,8 +189,8 @@ void snled27351_set_value(int index, uint8_t value) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.v] = value;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.v]                                            = value;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.v / SNLED27351_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -206,12 +217,14 @@ void snled27351_set_led_control_register(uint8_t index, bool value) {
 }
 
 void snled27351_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        snled27351_select_page(index, SNLED27351_COMMAND_PWM);
-
-        snled27351_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < SNLED27351_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            snled27351_select_page(index, SNLED27351_COMMAND_PWM);
+            snled27351_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/drivers/led/snled27351.c
+++ b/drivers/led/snled27351.c
@@ -38,6 +38,9 @@
         { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
 #endif
 
+#define SNLED27351_PWM_REGISTERS_PER_CHUNK 16
+#define SNLED27351_CHUNK_COUNT (SNLED27351_PWM_REGISTER_COUNT / SNLED27351_PWM_REGISTERS_PER_CHUNK)
+
 const uint8_t i2c_addresses[SNLED27351_DRIVER_COUNT] = {
     SNLED27351_I2C_ADDRESS_1,
 #ifdef SNLED27351_I2C_ADDRESS_2
@@ -59,14 +62,14 @@ const uint8_t i2c_addresses[SNLED27351_DRIVER_COUNT] = {
 // probably not worth the extra complexity.
 typedef struct snled27351_driver_t {
     uint8_t pwm_buffer[SNLED27351_PWM_REGISTER_COUNT];
-    bool    pwm_buffer_dirty;
+    bool    pwm_buffer_dirty[SNLED27351_CHUNK_COUNT];
     uint8_t led_control_buffer[SNLED27351_LED_CONTROL_REGISTER_COUNT];
     bool    led_control_buffer_dirty;
 } PACKED snled27351_driver_t;
 
 snled27351_driver_t driver_buffers[SNLED27351_DRIVER_COUNT] = {{
     .pwm_buffer               = {0},
-    .pwm_buffer_dirty         = false,
+    .pwm_buffer_dirty         = {0},
     .led_control_buffer       = {0},
     .led_control_buffer_dirty = false,
 }};
@@ -90,13 +93,21 @@ void snled27351_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 12 transfers of 16 bytes.
 
     // Iterate over the pwm_buffer contents at 16 byte intervals.
-    for (uint8_t i = 0; i < SNLED27351_PWM_REGISTER_COUNT; i += 16) {
+    for (uint8_t i = 0; i < SNLED27351_CHUNK_COUNT; i++) {
+        if (!driver_buffers[index].pwm_buffer_dirty[i]) {
+            continue;
+        }
+
+        driver_buffers[index].pwm_buffer_dirty[i] = false;
+
+        uint8_t offset = i * SNLED27351_PWM_REGISTERS_PER_CHUNK;
+
 #if SNLED27351_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < SNLED27351_I2C_PERSISTENCE; j++) {
-            if (i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
+            if (i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, SNLED27351_PWM_REGISTERS_PER_CHUNK, SNLED27351_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
         }
 #else
-        i2c_write_register(i2c_addresses[index] << 1, i, driver_buffers[index].pwm_buffer + i, 16, SNLED27351_I2C_TIMEOUT);
+        i2c_write_register(i2c_addresses[index] << 1, offset, driver_buffers[index].pwm_buffer + offset, SNLED27351_PWM_REGISTERS_PER_CHUNK, SNLED27351_I2C_TIMEOUT);
 #endif
     }
 }
@@ -178,10 +189,12 @@ void snled27351_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
             return;
         }
 
-        driver_buffers[led.driver].pwm_buffer[led.r] = red;
-        driver_buffers[led.driver].pwm_buffer[led.g] = green;
-        driver_buffers[led.driver].pwm_buffer[led.b] = blue;
-        driver_buffers[led.driver].pwm_buffer_dirty  = true;
+        driver_buffers[led.driver].pwm_buffer[led.r]                                            = red;
+        driver_buffers[led.driver].pwm_buffer[led.g]                                            = green;
+        driver_buffers[led.driver].pwm_buffer[led.b]                                            = blue;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.r / SNLED27351_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.g / SNLED27351_PWM_REGISTERS_PER_CHUNK] = true;
+        driver_buffers[led.driver].pwm_buffer_dirty[led.b / SNLED27351_PWM_REGISTERS_PER_CHUNK] = true;
     }
 }
 
@@ -222,12 +235,14 @@ void snled27351_set_led_control_register(uint8_t index, bool red, bool green, bo
 }
 
 void snled27351_update_pwm_buffers(uint8_t index) {
-    if (driver_buffers[index].pwm_buffer_dirty) {
-        snled27351_select_page(index, SNLED27351_COMMAND_PWM);
-
-        snled27351_write_pwm_buffer(index);
-
-        driver_buffers[index].pwm_buffer_dirty = false;
+    for (uint8_t i = 0; i < SNLED27351_CHUNK_COUNT; i++) {
+        if (driver_buffers[index].pwm_buffer_dirty[i]) {
+            // if any of these are true then write PWM buffer
+            // then exit the loop
+            snled27351_select_page(index, SNLED27351_COMMAND_PWM);
+            snled27351_write_pwm_buffer(index);
+            return;
+        }
     }
 }
 

--- a/platforms/avr/drivers/ws2812_bitbang.c
+++ b/platforms/avr/drivers/ws2812_bitbang.c
@@ -152,7 +152,7 @@ static inline void ws2812_sendarray_mask(uint8_t *data, uint16_t datlen, uint8_t
 }
 
 ws2812_led_t ws2812_leds[WS2812_LED_COUNT];
-bool        ws2812_dirty = false;
+bool         ws2812_dirty = false;
 
 void ws2812_init(void) {
     DDRx_ADDRESS(WS2812_DI_PIN) |= pinmask(WS2812_DI_PIN);
@@ -176,6 +176,7 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 
 void ws2812_flush(void) {
     if (!ws2812_dirty) return;
+    ws2812_dirty = false;
     uint8_t masklo = ~(pinmask(WS2812_DI_PIN)) & PORTx_ADDRESS(WS2812_DI_PIN);
     uint8_t maskhi = pinmask(WS2812_DI_PIN) | PORTx_ADDRESS(WS2812_DI_PIN);
 

--- a/platforms/avr/drivers/ws2812_bitbang.c
+++ b/platforms/avr/drivers/ws2812_bitbang.c
@@ -152,6 +152,7 @@ static inline void ws2812_sendarray_mask(uint8_t *data, uint16_t datlen, uint8_t
 }
 
 ws2812_led_t ws2812_leds[WS2812_LED_COUNT];
+bool        ws2812_dirty = false;
 
 void ws2812_init(void) {
     DDRx_ADDRESS(WS2812_DI_PIN) |= pinmask(WS2812_DI_PIN);
@@ -161,6 +162,7 @@ void ws2812_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     ws2812_leds[index].r = red;
     ws2812_leds[index].g = green;
     ws2812_leds[index].b = blue;
+    ws2812_dirty         = true;
 #if defined(WS2812_RGBW)
     ws2812_rgb_to_rgbw(&ws2812_leds[index]);
 #endif
@@ -173,6 +175,7 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void ws2812_flush(void) {
+    if (!ws2812_dirty) return;
     uint8_t masklo = ~(pinmask(WS2812_DI_PIN)) & PORTx_ADDRESS(WS2812_DI_PIN);
     uint8_t maskhi = pinmask(WS2812_DI_PIN) | PORTx_ADDRESS(WS2812_DI_PIN);
 

--- a/platforms/avr/drivers/ws2812_i2c.c
+++ b/platforms/avr/drivers/ws2812_i2c.c
@@ -17,6 +17,7 @@
 #endif
 
 ws2812_led_t ws2812_leds[WS2812_LED_COUNT];
+bool         ws2812_dirty = false;
 
 void ws2812_init(void) {
     i2c_init();
@@ -26,6 +27,7 @@ void ws2812_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     ws2812_leds[index].r = red;
     ws2812_leds[index].g = green;
     ws2812_leds[index].b = blue;
+    ws2812_dirty         = true;
 }
 
 void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
@@ -35,5 +37,6 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void ws2812_flush(void) {
+    if (!ws2812_dirty) return;
     i2c_transmit(WS2812_I2C_ADDRESS, (uint8_t *)ws2812_leds, WS2812_LED_COUNT * sizeof(ws2812_led_t), WS2812_I2C_TIMEOUT);
 }

--- a/platforms/avr/drivers/ws2812_i2c.c
+++ b/platforms/avr/drivers/ws2812_i2c.c
@@ -38,5 +38,6 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 
 void ws2812_flush(void) {
     if (!ws2812_dirty) return;
+    ws2812_dirty = false;
     i2c_transmit(WS2812_I2C_ADDRESS, (uint8_t *)ws2812_leds, WS2812_LED_COUNT * sizeof(ws2812_led_t), WS2812_I2C_TIMEOUT);
 }

--- a/platforms/chibios/drivers/ws2812_bitbang.c
+++ b/platforms/chibios/drivers/ws2812_bitbang.c
@@ -101,6 +101,7 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 
 void ws2812_flush(void) {
     if (!ws2812_dirty) return;
+    ws2812_dirty = false;
     // this code is very time dependent, so we need to disable interrupts
     chSysLock();
 

--- a/platforms/chibios/drivers/ws2812_bitbang.c
+++ b/platforms/chibios/drivers/ws2812_bitbang.c
@@ -77,6 +77,7 @@ void sendByte(uint8_t byte) {
 }
 
 ws2812_led_t ws2812_leds[WS2812_LED_COUNT];
+bool         ws2812_dirty = false;
 
 void ws2812_init(void) {
     palSetLineMode(WS2812_DI_PIN, WS2812_OUTPUT_MODE);
@@ -86,6 +87,7 @@ void ws2812_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     ws2812_leds[index].r = red;
     ws2812_leds[index].g = green;
     ws2812_leds[index].b = blue;
+    ws2812_dirty         = true;
 #if defined(WS2812_RGBW)
     ws2812_rgb_to_rgbw(&ws2812_leds[index]);
 #endif
@@ -98,6 +100,7 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void ws2812_flush(void) {
+    if (!ws2812_dirty) return;
     // this code is very time dependent, so we need to disable interrupts
     chSysLock();
 

--- a/platforms/chibios/drivers/ws2812_pwm.c
+++ b/platforms/chibios/drivers/ws2812_pwm.c
@@ -291,6 +291,7 @@ typedef uint8_t ws2812_buffer_t;
 #endif
 
 static ws2812_buffer_t ws2812_frame_buffer[WS2812_BIT_N + 1]; /**< Buffer for a frame */
+bool                   ws2812_dirty = false;
 
 /* --- PUBLIC FUNCTIONS ----------------------------------------------------- */
 /*
@@ -310,7 +311,7 @@ void ws2812_init(void) {
     palSetLineMode(WS2812_DI_PIN, WS2812_OUTPUT_MODE);
 
     // PWM Configuration
-    //#pragma GCC diagnostic ignored "-Woverride-init"  // Turn off override-init warning for this struct. We use the overriding ability to set a "default" channel config
+    // #pragma GCC diagnostic ignored "-Woverride-init"  // Turn off override-init warning for this struct. We use the overriding ability to set a "default" channel config
     static const PWMConfig ws2812_pwm_config = {
         .frequency = WS2812_PWM_TICK_FREQUENCY,
         .period    = WS2812_PWM_PERIOD, // Mit dieser Periode wird UDE-Event erzeugt und ein neuer Wert (Länge WS2812_BIT_N) vom DMA ins CCR geschrieben
@@ -328,7 +329,7 @@ void ws2812_init(void) {
         .dier = TIM_DIER_UDE, // DMA on update event for next period
 #endif
     };
-    //#pragma GCC diagnostic pop  // Restore command-line warning options
+    // #pragma GCC diagnostic pop  // Restore command-line warning options
 
     // Configure DMA
     // dmaInit(); // Joe added this
@@ -398,6 +399,7 @@ void ws2812_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
     ws2812_leds[index].r = red;
     ws2812_leds[index].g = green;
     ws2812_leds[index].b = blue;
+    ws2812_dirty         = true;
 #if defined(WS2812_RGBW)
     ws2812_rgb_to_rgbw(&ws2812_leds[index]);
 #endif
@@ -410,6 +412,8 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void ws2812_flush(void) {
+    if (!ws2812_dirty) return;
+    ws2812_dirty = false;
     for (int i = 0; i < WS2812_LED_COUNT; i++) {
 #if defined(WS2812_RGBW)
         ws2812_write_led_rgbw(i, ws2812_leds[i].r, ws2812_leds[i].g, ws2812_leds[i].b, ws2812_leds[i].w);

--- a/platforms/chibios/drivers/ws2812_spi.c
+++ b/platforms/chibios/drivers/ws2812_spi.c
@@ -241,6 +241,9 @@ void ws2812_set_color_all(uint8_t red, uint8_t green, uint8_t blue) {
 }
 
 void ws2812_flush(void) {
+    if (!ws2812_dirty) return;
+    ws2812_dirty = false;
+
     for (int i = 0; i < WS2812_LED_COUNT; i++) {
         set_led_color_rgb(ws2812_leds[i], i);
     }
@@ -249,7 +252,6 @@ void ws2812_flush(void) {
     // Instead spiSend can be used to send synchronously (or the thread logic can be added back).
 #ifndef WS2812_SPI_USE_CIRCULAR_BUFFER
 #    ifdef WS2812_SPI_SYNC
-    if (!ws2812_dirty) return;
     spiSend(&WS2812_SPI_DRIVER, ARRAY_SIZE(txbuf), txbuf);
 #    else
     spiStartSend(&WS2812_SPI_DRIVER, ARRAY_SIZE(txbuf), txbuf);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Replaces #23625 

Should this require additional documentation and require an additional `#define` to enable this?
The file size of increase is only about 100 bytes on AVR

Tested on Pachi RGB Rev2 and Dawn60 Rev1_QMK

## Types of Changes
- Update all ws2812 drivers to not update if there are no LED updates. There is a single bool check because all of them in the chain are required to be updated.
- All ISSI drivers updated if they are sent in chunks
- All other led drivers updated it they are sent in chunks
- Did not update the AW20216S as that is SPI and sends the entire buffer

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Adds double buffering and helps with scan rate when indicators are on for most RGB effects

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
