### PR TITLE
Add dragscroll combo option for Ploopy devices.

### DIFF
--- a/keyboards/ploopyco/readme.md
+++ b/keyboards/ploopyco/readme.md
@@ -43,3 +43,4 @@ Nothing needs to be enabled to use this functionality.  Just add the `DRAG_SCROL
 * `#define PLOOPY_DRAGSCROLL_DIVISOR_H 8.0` - Sets the horizontal movement divisor to use when drag scroll is enabled.
 * `#define PLOOPY_DRAGSCROLL_DIVISOR_V 8.0` - Sets the vertical movement divisor to use when drag scroll is enabled.
 * `#define PLOOPY_DRAGSCROLL_INVERT` - This reverses the direction that the scroll is performed.
+* `#define PLOOPY_DRAGSCROLL_COMBO` - Makes the key into a momentary key when held and scrolled, but toggle when pressed without scrolling.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR adds an option for Ploopy devices with the `DRAG_SCROLL` key to allow it to be both held or toggled (combining both momentary and toggled scroll).

The way it can be used is by tapping the key for toggling drag scroll or holding it for momentary drag scroll.

This can be enabled by setting `#define PLOOPY_DRAGSCROLL_COMBO` (defaults to not defined), the threshold can be customized by setting `#define PLOOPY_DRAGSCROLL_COMBO_THRESHOLD <float value>` (defaults to `0.5` if `PLOOPY_DRAGSCROLL_COMBO` is defined).

It works by checking if the user has exceeded the threshold while the key is being held:
* If the threshold is exceeded, we cancel the toggle, but keep drag scrolling until the key is lifted.
* Otherwise we toggle drag scrolling until the key is pressed again.

I have also included a short description of `PLOOPY_DRAGSCROLL_COMBO` in `keyboards/ploopyco/readme.md` following the style of the existing documentation.

I have worked on and tested this with my Ploopy Adept/Madromys, it seems to work well for my needs. I was directly inspired by [this repo](https://github.com/erikhoggard/adept-combo-scroll), but that was unmergeable so I chose to reimplement it on the latest `master` branch.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
