### PR TITLE
[Bug][Core] Fix for Chordal Hold: stuck mods when mod-taps are pressed in a stuttered sequence.

### DIFF
--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -736,7 +736,7 @@ static void waiting_buffer_chordal_hold_taps_until(keypos_t key) {
     while (waiting_buffer_tail != waiting_buffer_head) {
         keyrecord_t *record = &waiting_buffer[waiting_buffer_tail];
         ac_dprintf("waiting_buffer_chordal_hold_taps_until: processing [%u]\n", waiting_buffer_tail);
-        if (is_tap_record(record)) {
+        if (record->event.pressed && is_tap_record(record)) {
             record->tap.count = 1;
             registered_taps_add(record->event.key);
         }

--- a/tests/tap_hold_configurations/chordal_hold/hold_on_other_key_press/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/chordal_hold/hold_on_other_key_press/test_tap_hold.cpp
@@ -805,3 +805,46 @@ TEST_F(ChordalHoldHoldOnOtherKeyPress, roll_layer_tap_key_with_regular_key) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
+
+TEST_F(ChordalHoldHoldOnOtherKeyPress, two_mod_tap_keys_stuttered_press) {
+    TestDriver driver;
+    InSequence s;
+
+    auto mod_tap_key1 = KeymapKey(0, 1, 0, LSFT_T(KC_A));
+    auto mod_tap_key2 = KeymapKey(0, 2, 0, LCTL_T(KC_B));
+
+    set_keymap({mod_tap_key1, mod_tap_key2});
+
+    // Hold first mod-tap key until the tapping term.
+    EXPECT_REPORT(driver, (KC_LSFT));
+    mod_tap_key1.press();
+    idle_for(TAPPING_TERM + 1);
+    VERIFY_AND_CLEAR(driver);
+
+    // Press the second mod-tap key, then quickly release and press the first.
+    EXPECT_NO_REPORT(driver);
+    mod_tap_key2.press();
+    run_one_scan_loop();
+    mod_tap_key1.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LSFT, KC_B));
+    EXPECT_REPORT(driver, (KC_B));
+    EXPECT_REPORT(driver, (KC_B, KC_A));
+    mod_tap_key1.press();
+    run_one_scan_loop();
+    EXPECT_EQ(get_mods(), 0); // Verify that Shift was released.
+    VERIFY_AND_CLEAR(driver);
+
+    // Release both keys.
+    EXPECT_REPORT(driver, (KC_A));
+    mod_tap_key2.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_key1.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/tap_hold_configurations/chordal_hold/permissive_hold/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/chordal_hold/permissive_hold/test_tap_hold.cpp
@@ -877,6 +877,7 @@ TEST_F(ChordalHoldPermissiveHold, roll_layer_tap_key_with_regular_key) {
     VERIFY_AND_CLEAR(driver);
 
     // Press regular key.
+    EXPECT_NO_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
@@ -885,7 +886,6 @@ TEST_F(ChordalHoldPermissiveHold, roll_layer_tap_key_with_regular_key) {
     EXPECT_REPORT(driver, (KC_P));
     EXPECT_REPORT(driver, (KC_P, KC_A));
     EXPECT_REPORT(driver, (KC_A));
-    EXPECT_NO_REPORT(driver);
     layer_tap_hold_key.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
@@ -893,6 +893,49 @@ TEST_F(ChordalHoldPermissiveHold, roll_layer_tap_key_with_regular_key) {
     // Release regular key.
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ChordalHoldPermissiveHold, two_mod_tap_keys_stuttered_press) {
+    TestDriver driver;
+    InSequence s;
+
+    auto mod_tap_key1 = KeymapKey(0, 1, 0, LSFT_T(KC_A));
+    auto mod_tap_key2 = KeymapKey(0, 2, 0, LCTL_T(KC_B));
+
+    set_keymap({mod_tap_key1, mod_tap_key2});
+
+    // Hold first mod-tap key until the tapping term.
+    EXPECT_REPORT(driver, (KC_LSFT));
+    mod_tap_key1.press();
+    idle_for(TAPPING_TERM + 1);
+    VERIFY_AND_CLEAR(driver);
+
+    // Press the second mod-tap key, then quickly release and press the first.
+    EXPECT_NO_REPORT(driver);
+    mod_tap_key2.press();
+    run_one_scan_loop();
+    mod_tap_key1.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LSFT, KC_B));
+    EXPECT_REPORT(driver, (KC_B));
+    EXPECT_REPORT(driver, (KC_B, KC_A));
+    mod_tap_key1.press();
+    run_one_scan_loop();
+    EXPECT_EQ(get_mods(), 0); // Verify that Shift was released.
+    VERIFY_AND_CLEAR(driver);
+
+    // Release both keys.
+    EXPECT_REPORT(driver, (KC_A));
+    mod_tap_key2.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    mod_tap_key1.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }


### PR DESCRIPTION
I discovered an input sequence where Chordal Hold (https://github.com/qmk/qmk_firmware/pull/24560) leaves a mod in a stuck state.

## Description

**Repro example:** Suppose keys `LSFT_T(KC_A)` and `LCTL_T(KC_B)` are on the same hand, and the following input is made:

1. `LSFT_T(KC_A)` down
2. Wait unit the tapping term (Shift is now active)
3. `LCTL_T(KC_B)` down
4. `LSFT_T(KC_A)` up
5. `LSFT_T(KC_A)` down
6. `LCTL_T(KC_B)` up
7. `LSFT_T(KC_A)` up

where steps 3-5 are done quickly, within the tapping term. Then even after all keys are released, the Shift mod is stuck. The bug happens similarly with layer-tap keys or a mix of a mod-tap and a layer-tap key.

**Fix:** Handling goes wrong on step 5 of the example above, in the code `waiting_buffer_chordal_hold_taps_until()`. This function marks buffered events as tapped. The problem is that this inappropriately marks the `LSFT_T(KC_A)`-up event from step 4 as tapped, mismatching that the key was considered held on step 1. I realized that in this function it only makes sense to mark buffered press events as tapped. The fix amounts to adding an "`if (record->event.pressed)`."

To verify, I've added a "two_mod_taps_keys_stuttered_press" unit test simulating the repro example. This test fails before this PR and is fixed after.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
