### PR TITLE
Invoke `process_record_via` after `_user`/`_kb` have a chance to handle it.

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -329,13 +329,13 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef HAPTIC_ENABLE
             process_haptic(keycode, record) &&
 #endif
-#if defined(VIA_ENABLE)
-            process_record_via(keycode, record) &&
-#endif
 #if defined(POINTING_DEVICE_ENABLE) && defined(POINTING_DEVICE_AUTO_MOUSE_ENABLE)
             process_auto_mouse(keycode, record) &&
 #endif
             process_record_kb(keycode, record) &&
+#if defined(VIA_ENABLE)
+            process_record_via(keycode, record) &&
+#endif
 #if defined(SECURE_ENABLE)
             process_secure(keycode, record) &&
 #endif


### PR DESCRIPTION
## Description

`process_record_via` completely takes over the functionality of `QK_MACRO`...`QK_MACRO_MAX`. As it's run before `process_record_kb`, there's no opportunity for keyboard- or user-level code to override.

This PR relocates the invocation of `process_record_via` after the equivalent `_kb` call, as VIA keymaps won't have these keycodes implemented in their keymap.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
