### PR TITLE
Add forgotten Caps Lock Indicator for Keychron C3 Pro

### DIFF
--- a/keyboards/keychron/c3_pro/c3_pro.c
+++ b/keyboards/keychron/c3_pro/c3_pro.c
@@ -112,27 +112,28 @@ bool led_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
 #endif // LED_MATRIX_ENABLE && CAPS_LOCK_LED_INDEX
 
 void keyboard_post_init_kb(void) {
-    setPinOutputPushPull(LED_MAC_OS_PIN);
-    setPinOutputPushPull(LED_WIN_OS_PIN);
-    writePin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-    writePin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+    gpio_set_pin_output_push_pull(LED_MAC_OS_PIN);
+    gpio_set_pin_output_push_pull(LED_WIN_OS_PIN);
+    gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
+    gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+
     keyboard_post_init_user();
 }
 
 void housekeeping_task_kb(void) {
     if (default_layer_state == (1U << 0)) {
-        writePin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
-        writePin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+        gpio_write_pin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
+        gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
     }
     if (default_layer_state == (1U << 2)) {
-        writePin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
-        writePin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
+        gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
+        gpio_write_pin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
     }
-    housekeeping_task_user();
 }
-...
+
 void suspend_power_down_kb(void) {
-    writePin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
-    writePin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
+    gpio_write_pin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+    gpio_write_pin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
+
     suspend_power_down_user();
 }

--- a/keyboards/keychron/c3_pro/c3_pro.c
+++ b/keyboards/keychron/c3_pro/c3_pro.c
@@ -110,3 +110,29 @@ bool led_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
 }
 
 #endif // LED_MATRIX_ENABLE && CAPS_LOCK_LED_INDEX
+
+void keyboard_post_init_kb(void) {
+    setPinOutputPushPull(LED_MAC_OS_PIN);
+    setPinOutputPushPull(LED_WIN_OS_PIN);
+    writePin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
+    writePin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+    keyboard_post_init_user();
+}
+
+void housekeeping_task_kb(void) {
+    if (default_layer_state == (1U << 0)) {
+        writePin(LED_MAC_OS_PIN, LED_OS_PIN_ON_STATE);
+        writePin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+    }
+    if (default_layer_state == (1U << 2)) {
+        writePin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
+        writePin(LED_WIN_OS_PIN, LED_OS_PIN_ON_STATE);
+    }
+    housekeeping_task_user();
+}
+...
+void suspend_power_down_kb(void) {
+    writePin(LED_WIN_OS_PIN, !LED_OS_PIN_ON_STATE);
+    writePin(LED_MAC_OS_PIN, !LED_OS_PIN_ON_STATE);
+    suspend_power_down_user();
+}

--- a/keyboards/keychron/c3_pro/config.h
+++ b/keyboards/keychron/c3_pro/config.h
@@ -22,3 +22,5 @@
 #define I2C1_CLOCK_SPEED 400000
 #define I2C1_DUTY_CYCLE FAST_DUTY_CYCLE_2
 
+/* Caps Lock Indicator*/
+#define CAPS_LOCK_LED_INDEX 50


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

As title. Quickly checked `default_keyboard.c` after compiling for both variants to check their LED indexes for Caps Lock and they are the same for each other.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
