### PR TITLE
Fix installation of clang in gentoo install script

### DIFF
--- a/util/install/gentoo.sh
+++ b/util/install/gentoo.sh
@@ -22,7 +22,7 @@ _qmk_install() {
     echo "sys-devel/gcc multilib\ncross-arm-none-eabi/newlib nano" | sudo tee --append /etc/portage/package.use/qmkfirmware >/dev/null
     sudo emerge -auN sys-devel/gcc
     sudo emerge -au --noreplace \
-        app-arch/unzip app-arch/zip net-misc/wget sys-devel/clang \
+        app-arch/unzip app-arch/zip net-misc/wget llvm-core/clang \
         sys-devel/crossdev \>=dev-lang/python-3.7 dev-embedded/avrdude \
         dev-embedded/dfu-programmer app-mobilephone/dfu-util sys-apps/hwloc \
         dev-libs/hidapi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
I tried to install the dependencies using the `qmk setup` script and it failed on my machine. While digging into the install script, I noticed that there is an old name of the clang dependency, which recently changed, see here: https://github.com/gentoo/gentoo/commit/1f9f1999cdc8ccb94054dec2d2951c7e486aa996.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
