### PR TITLE
Add keycode aliases for Japanese JIS kana input (#24921)

### DIFF
--- a/data/constants/keycodes/extras/keycodes_japanese_jis_kana_0.0.1.hjson
+++ b/data/constants/keycodes/extras/keycodes_japanese_jis_kana_0.0.1.hjson
@@ -1,0 +1,370 @@
+{
+    "aliases": {
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+ * │   │ぬ │ふ │あ │う │え │お │や │ゆ │よ │わ │ほ │へ │ー │   │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┤
+ * │     │た │て │い │す │か │ん │な │に │ら │せ │゛ │゜ │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │ち │と │し │は │き │く │ま |の │り │け │れ │む │    │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────┤
+ * │        │つ │さ │そ │ひ │こ │み │も │ね │る │め │ろ │      │
+ * ├─────┬──┴┬──┴──┬┴───┴┬──┴───┴──┬┴───┴┬──┴┬──┴┬──┴┬──┴┬─────┤
+ * │     │   │     │Muhen│         │ Hen │K↔H│   │   │   │     │
+ * └─────┴───┴─────┴─────┴─────────┴─────┴───┴───┴───┴───┴─────┘
+ */
+        "KC_GRV": {
+            "key": "JP_ZKHK",
+            "label": "Zenkaku ↔ Hankaku ↔ Kanji (半角 ↔ 全角 ↔ 漢字)",
+        }
+        "KC_1": {
+            "key": "JK_NU",
+            "label": "ぬ",
+        }
+        "KC_2": {
+            "key": "JK_FU",
+            "label": "ふ",
+            "aliases": [
+                "JK_HU"
+            ]
+        }
+        "KC_3": {
+            "key": "JK_A",
+            "label": "あ",
+        }
+        "KC_4": {
+            "key": "JK_U",
+            "label": "う",
+        }
+        "KC_5": {
+            "key": "JK_E",
+            "label": "え",
+        }
+        "KC_6": {
+            "key": "JK_O",
+            "label": "お",
+        }
+        "KC_7": {
+            "key": "JK_YA",
+            "label": "や",
+        }
+        "KC_8": {
+            "key": "JK_YU",
+            "label": "ゆ",
+        }
+        "KC_9": {
+            "key": "JK_YO",
+            "label": "よ",
+        }
+        "KC_0": {
+            "key": "JK_WA",
+            "label": "わ",
+        }
+        "KC_MINS": {
+            "key": "JK_HO",
+            "label": "ほ",
+        }
+        "KC_EQL": {
+            "key": "JK_HE",
+            "label": "へ",
+        }
+        "KC_INT3": {
+            "key": "JK_LONG",
+            "label": "ー",
+        }
+        "KC_Q": {
+            "key": "JK_TA",
+            "label": "た",
+        }
+        "KC_W": {
+            "key": "JK_TE",
+            "label": "て",
+        }
+        "KC_E": {
+            "key": "JK_I",
+            "label": "い",
+        }
+        "KC_R": {
+            "key": "JK_SU",
+            "label": "す",
+        }
+        "KC_T": {
+            "key": "JK_KA",
+            "label": "か",
+        }
+        "KC_Y": {
+            "key": "JK_N",
+            "label": "ん",
+            "aliases": [
+                "JK_NN"
+            ]
+        }
+        "KC_U": {
+            "key": "JK_NA",
+            "label": "な",
+        }
+        "KC_I": {
+            "key": "JK_NI",
+            "label": "に",
+        }
+        "KC_O": {
+            "key": "JK_RA",
+            "label": "ら",
+        }
+        "KC_P": {
+            "key": "JK_SE",
+            "label": "せ",
+        }
+        "KC_LBRC": {
+            "key": "JK_VOICE",
+            "label": "゛(濁点)",
+            "aliases": [
+                "JK_DAKU",
+                "JK_DAKUTEN"
+            ]
+        }
+        "KC_RBRC": {
+            "key": "JK_SEMI_VOICE",
+            "label": "゜(半濁点)",
+            "aliases": [
+                "JK_HANDAKU",
+                "JK_HANDAKUTEN"
+            ]
+        }
+        "KC_CAPS": {
+            "key": "JK_EISU",
+            "label": "Eisū (英数)",
+        }
+        "KC_A": {
+            "key": "JK_CHI",
+            "label": "ち",
+            "aliases": [
+                "JK_TI"
+            ]
+        }
+        "KC_S": {
+            "key": "JK_TO",
+            "label": "と",
+        }
+        "KC_D": {
+            "key": "JK_SHI",
+            "label": "し",
+            "aliases": [
+                "JK_SI"
+            ]
+        }
+        "KC_F": {
+            "key": "JK_HA",
+            "label": "は",
+        }
+        "KC_G": {
+            "key": "JK_KI",
+            "label": "き",
+        }
+        "KC_H": {
+            "key": "JK_KU",
+            "label": "く",
+        }
+        "KC_J": {
+            "key": "JK_MA",
+            "label": "ま",
+        }
+        "KC_K": {
+            "key": "JK_NO",
+            "label": "の",
+        }
+        "KC_L": {
+            "key": "JK_RI",
+            "label": "り",
+        }
+        "KC_SCLN": {
+            "key": "JK_RE",
+            "label": "れ",
+        }
+        "KC_QUOT": {
+            "key": "JK_KE",
+            "label": "け",
+        }
+        "KC_NUHS": {
+            "key": "JK_MU",
+            "label": "む",
+        }
+        "KC_Z": {
+            "key": "JK_TSU",
+            "label": "つ",
+            "aliases": [
+                "JK_TU"
+            ]
+        }
+        "KC_X": {
+            "key": "JK_SA",
+            "label": "さ",
+        }
+        "KC_C": {
+            "key": "JK_SO",
+            "label": "そ",
+        }
+        "KC_V": {
+            "key": "JK_HI",
+            "label": "ひ",
+        }
+        "KC_B": {
+            "key": "JK_KO",
+            "label": "こ",
+        }
+        "KC_N": {
+            "key": "JK_MI",
+            "label": "み",
+        }
+        "KC_M": {
+            "key": "JK_MO",
+            "label": "も",
+        }
+        "KC_COMM": {
+            "key": "JK_NE",
+            "label": "ね",
+        }
+        "KC_DOT": {
+            "key": "JK_RU",
+            "label": "る",
+        }
+        "KC_SLSH": {
+            "key": "JK_ME",
+            "label": "め",
+        }
+        "KC_INT1": {
+            "key": "JK_RO",
+            "label": "ろ",
+        }
+        "KC_INT5": {
+            "key": "JK_MHEN",
+            "label": "Muhenkan (無変換)",
+            "aliases": [
+                "JK_MUHENKAN"
+            ]
+        }
+        "KC_INT4": {
+            "key": "JK_HENK",
+            "label": "Henkan (変換)",
+            "aliases": [
+                "JK_HENKAN"
+            ]
+        }
+        "KC_INT2": {
+            "key": "JK_KANA",
+            "label": "Katakana ↔ Hiragana ↔ Rōmaji (カタカナ ↔ ひらがな ↔ ローマ字)",
+        }
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+ * │   │   │   │ぁ │ぅ │ぇ │ぉ │ゃ │ゅ │ょ │を │   │   │   │   │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┤
+ * │     │   │   │ぃ │   │   │   │   │   │   │   │   │「 │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │ Caps │   │   │   │   │   │   │   │   │   │   │   │」 │    │
+ * ├──────┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴────┤
+ * │        │っ │   │   │   │   │   │   │、 │。 │・ │   │      │
+ * ├─────┬──┴┬──┴──┬┴───┴┬──┴───┴──┬┴───┴┬──┴┬──┴┬──┴┬──┴┬─────┤
+ * │     │   │     │     │         │     │   │   │   │   │     │
+ * └─────┴───┴─────┴─────┴─────────┴─────┴───┴───┴───┴───┴─────┘
+ */
+        "S(KC_3)": {
+            "key": "JK_LA",
+            "label": "ぁ",
+            "aliases": [
+                "JK_XA",
+                "JK_SMALL_A"
+            ]
+        }
+        "S(KC_4)": {
+            "key": "JK_LU",
+            "label": "ぅ",
+            "aliases": [
+                "JK_XU",
+                "JK_SMALL_U"
+            ]
+        }
+        "S(KC_5)": {
+            "key": "JK_LE",
+            "label": "ぇ",
+            "aliases": [
+                "JK_XE",
+                "JK_SMALL_E"
+            ]
+        }
+        "S(KC_6)": {
+            "key": "JK_LO",
+            "label": "ぉ",
+            "aliases": [
+                "JK_XO",
+                "JK_SMALL_O"
+            ]
+        }
+        "S(KC_7)": {
+            "key": "JK_LYA",
+            "label": "ゃ",
+            "aliases": [
+                "JK_XYA",
+                "JK_SMALL_YA"
+            ]
+        }
+        "S(KC_8)": {
+            "key": "JK_LYU",
+            "label": "ゅ",
+            "aliases": [
+                "JK_XYU",
+                "JK_SMALL_YU"
+            ]
+        }
+        "S(KC_9)": {
+            "key": "JK_LYO",
+            "label": "ょ",
+            "aliases": [
+                "JK_XYO",
+                "JK_SMALL_YO"
+            ]
+        }
+        "S(KC_0)": {
+            "key": "JK_WO",
+            "label": "を",
+        }
+        "S(KC_E)": {
+            "key": "JK_LI",
+            "label": "ぃ",
+            "aliases": [
+                "JK_XI",
+                "JK_SMALL_I"
+            ]
+        }
+        "S(KC_RBRC)": {
+            "key": "JK_LEFT_KAGI",
+            "label": "「",
+            "aliases": [
+                "JK_LKAG"
+            ]
+        }
+        "S(KC_NUHS)": {
+            "key": "JK_RIGHT_KAGI",
+            "label": "」",
+            "aliases": [
+                "JK_RKAG"
+            ]
+        }
+        "S(KC_COMM)": {
+            "key": "JK_TEN",
+            "label": "、",
+            "aliases": [
+                "JK_COMMA",
+                "JK_COMM"
+            ]
+        }
+        "S(KC_DOT)": {
+            "key": "JK_MARU",
+            "label": "。",
+            "aliases": [
+                "JK_DOT",
+                "JK_PERIOD",
+                "JK_PROD"
+            ]
+        }
+    }
+}

--- a/quantum/keymap_extras/keymap_japanese_jis_kana.h
+++ b/quantum/keymap_extras/keymap_japanese_jis_kana.h
@@ -1,0 +1,131 @@
+// Copyright 2025 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*******************************************************************************
+  88888888888 888      d8b                .d888 d8b 888               d8b
+      888     888      Y8P               d88P"  Y8P 888               Y8P
+      888     888                        888        888
+      888     88888b.  888 .d8888b       888888 888 888  .d88b.       888 .d8888b
+      888     888 "88b 888 88K           888    888 888 d8P  Y8b      888 88K
+      888     888  888 888 "Y8888b.      888    888 888 88888888      888 "Y8888b.
+      888     888  888 888      X88      888    888 888 Y8b.          888      X88
+      888     888  888 888  88888P'      888    888 888  "Y8888       888  88888P'
+                                                        888                 888
+                                                        888                 888
+                                                        888                 888
+     .d88b.   .d88b.  88888b.   .d88b.  888d888 8888b.  888888 .d88b.   .d88888
+    d88P"88b d8P  Y8b 888 "88b d8P  Y8b 888P"      "88b 888   d8P  Y8b d88" 888
+    888  888 88888888 888  888 88888888 888    .d888888 888   88888888 888  888
+    Y88b 888 Y8b.     888  888 Y8b.     888    888  888 Y88b. Y8b.     Y88b 888
+     "Y88888  "Y8888  888  888  "Y8888  888    "Y888888  "Y888 "Y8888   "Y88888
+         888
+    Y8b d88P
+     "Y88P"
+*******************************************************************************/
+
+#pragma once
+#include "keycodes.h"
+// clang-format off
+
+// Aliases
+#define JP_ZKHK KC_GRV  // Zenkaku ↔ Hankaku ↔ Kanji (半角 ↔ 全角 ↔ 漢字)
+#define JK_NU   KC_1    // ぬ
+#define JK_FU   KC_2    // ふ
+#define JK_A    KC_3    // あ
+#define JK_U    KC_4    // う
+#define JK_E    KC_5    // え
+#define JK_O    KC_6    // お
+#define JK_YA   KC_7    // や
+#define JK_YU   KC_8    // ゆ
+#define JK_YO   KC_9    // よ
+#define JK_WA   KC_0    // わ
+#define JK_HO   KC_MINS // ほ
+#define JK_HE   KC_EQL  // へ
+#define JK_LONG KC_INT3 // ー
+#define JK_TA   KC_Q    // た
+#define JK_TE   KC_W    // て
+#define JK_I    KC_E    // い
+#define JK_SU   KC_R    // す
+#define JK_KA   KC_T    // か
+#define JK_N    KC_Y    // ん
+#define JK_NA   KC_U    // な
+#define JK_NI   KC_I    // に
+#define JK_RA   KC_O    // ら
+#define JK_SE   KC_P    // せ
+#define JK_VOICE KC_LBRC // ゛(濁点)
+#define JK_SEMI_VOICE KC_RBRC // ゜(半濁点)
+#define JK_EISU KC_CAPS // Eisū (英数)
+#define JK_CHI  KC_A    // ち
+#define JK_TO   KC_S    // と
+#define JK_SHI  KC_D    // し
+#define JK_HA   KC_F    // は
+#define JK_KI   KC_G    // き
+#define JK_KU   KC_H    // く
+#define JK_MA   KC_J    // ま
+#define JK_NO   KC_K    // の
+#define JK_RI   KC_L    // り
+#define JK_RE   KC_SCLN // れ
+#define JK_KE   KC_QUOT // け
+#define JK_MU   KC_NUHS // む
+#define JK_TSU  KC_Z    // つ
+#define JK_SA   KC_X    // さ
+#define JK_SO   KC_C    // そ
+#define JK_HI   KC_V    // ひ
+#define JK_KO   KC_B    // こ
+#define JK_MI   KC_N    // み
+#define JK_MO   KC_M    // も
+#define JK_NE   KC_COMM // ね
+#define JK_RU   KC_DOT  // る
+#define JK_ME   KC_SLSH // め
+#define JK_RO   KC_INT1 // ろ
+#define JK_MHEN KC_INT5 // Muhenkan (無変換)
+#define JK_HENK KC_INT4 // Henkan (変換)
+#define JK_KANA KC_INT2 // Katakana ↔ Hiragana ↔ Rōmaji (カタカナ ↔ ひらがな ↔ ローマ字)
+#define JK_LA   S(KC_3)    // ぁ
+#define JK_LU   S(KC_4)    // ぅ
+#define JK_LE   S(KC_5)    // ぇ
+#define JK_LO   S(KC_6)    // ぉ
+#define JK_LYA  S(KC_7)    // ゃ
+#define JK_LYU  S(KC_8)    // ゅ
+#define JK_LYO  S(KC_9)    // ょ
+#define JK_WO   S(KC_0)    // を
+#define JK_LI   S(KC_E)    // ぃ
+#define JK_LEFT_KAGI S(KC_RBRC) // 「
+#define JK_RIGHT_KAGI S(KC_NUHS) // 」
+#define JK_TEN  S(KC_COMM) // 、
+#define JK_MARU S(KC_DOT)  // 。
+
+#define JK_HU JK_FU
+#define JK_NN JK_N
+#define JK_DAKU JK_VOICE
+#define JK_DAKUTEN JK_VOICE
+#define JK_HANDAKU JK_SEMI_VOICE
+#define JK_HANDAKUTEN JK_SEMI_VOICE
+#define JK_TI JK_CHI
+#define JK_SI JK_SHI
+#define JK_TU JK_TSU
+#define JK_MUHENKAN JK_MHEN
+#define JK_HENKAN JK_HENK
+#define JK_XA JK_LA
+#define JK_SMALL_A JK_LA
+#define JK_XU JK_LU
+#define JK_SMALL_U JK_LU
+#define JK_XE JK_LE
+#define JK_SMALL_E JK_LE
+#define JK_XO JK_LO
+#define JK_SMALL_O JK_LO
+#define JK_XYA JK_LYA
+#define JK_SMALL_YA JK_LYA
+#define JK_XYU JK_LYU
+#define JK_SMALL_YU JK_LYU
+#define JK_XYO JK_LYO
+#define JK_SMALL_YO JK_LYO
+#define JK_XI JK_LI
+#define JK_SMALL_I JK_LI
+#define JK_LKAG JK_LEFT_KAGI
+#define JK_RKAG JK_RIGHT_KAGI
+#define JK_COMMA JK_TEN
+#define JK_COMM JK_TEN
+#define JK_DOT JK_MARU
+#define JK_PERIOD JK_MARU
+#define JK_PROD JK_MARU


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Defined the keycode aliases based on the Japanese JIS kana input (かな入力), whose keymap is shown below:

![Kana keymap without Shift](https://upload.wikimedia.org/wikipedia/commons/d/df/Jis_kana.png)
Kana keymap without Shift

![Kana keymap with Shift](https://upload.wikimedia.org/wikipedia/commons/f/f8/Jis_kanashift.png)
Kana keymap with Shift

Here are the examples of the keycode aliases. They starts with `JK_`.

| Letter | Alias | Keycode |
| ------ | ----- | -------- |
| あ (a) | JK_A | KC_3 |
| か (ka) | JK_KA | KC_T |
| ゛(voiced consonant mark) | JK_VOICE | KC_LBRC |

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #24921

## Checklist

I'm not sure if documentation changes of tests are required.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
