### PR TITLE
Fix OSM modifiers only send keydown when held after tap

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -463,7 +463,7 @@ void process_action(keyrecord_t *record, action_t action) {
                     } else {
                         if (event.pressed) {
                             if (tap_count == 0) {
-                                // Not a tap, but a hold: register the held mod
+                                // Not a tap, but a hold: register the mods, replacing the oneshots
                                 ac_dprintf("MODS_TAP: Oneshot: 0\n");
                                 register_mods(mods);
                                 del_oneshot_mods(mods);

--- a/quantum/action.c
+++ b/quantum/action.c
@@ -466,6 +466,8 @@ void process_action(keyrecord_t *record, action_t action) {
                                 // Not a tap, but a hold: register the held mod
                                 ac_dprintf("MODS_TAP: Oneshot: 0\n");
                                 register_mods(mods);
+                                del_oneshot_mods(mods);
+                                del_oneshot_locked_mods(mods);
                             } else if (tap_count == 1) {
                                 ac_dprintf("MODS_TAP: Oneshot: start\n");
                                 add_oneshot_mods(mods);

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -267,8 +267,9 @@ static uint8_t get_mods_for_report(void) {
             clear_oneshot_mods();
         }
 #    endif
-        mods |= oneshot_mods;
         if (has_anykey()) {
+            // only send oneshots to host if used with a real key
+            mods |= oneshot_mods;
             clear_oneshot_mods();
         }
     }

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -267,9 +267,8 @@ static uint8_t get_mods_for_report(void) {
             clear_oneshot_mods();
         }
 #    endif
+        mods |= oneshot_mods;
         if (has_anykey()) {
-            // only send oneshots to host if used with a real key
-            mods |= oneshot_mods;
             clear_oneshot_mods();
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

(seems related to https://github.com/qmk/qmk_firmware/issues/3963)

Currently, one shot modifiers have weird behavior on windows (and maybe others). After a OSM(MOD_XXX) key is tapped and then held and released, **there is a key down even registered for that key but no key up**. Additionally, according to QMK the mod is not considered active. So for the host, the modifier is active but for QMK it's not. This seems like a bug.

This PR fixes the problem by only sending one shot modifiers to the host if there is in fact a relevant key pressed, i.e. no one shots. This allows the user to deactivate one shots by holding and releasing past COMBO_TERM.

**Replicate**:

1. Set up a `OSM(MOD_GUI)` key (or another OSM modifier)
2. Tap the the key -> one shot mod becomes active
3. Hold the key -> key down registered
4. Release the key -> key down still registered, one shot mod inactive

### Example debug output with bug

```
# tap a normal key (this seems necessary to exhibit the behaviour)
> ---- action_exec: start -----
> EVENT: 0201d(6189)
> ACTION: ACT_LMODS[0:04] layer_state: 00000000(0) default_layer_state: 00000001(0)
> keyboard_report: 00 | 04 00 00 00 00 00 
> processed: 0201d(6189):0 
> 
> 
> ---- action_exec: start -----
> EVENT: 0201u(6269)
> ACTION: ACT_LMODS[0:04] layer_state: 00000000(0) default_layer_state: 00000001(0)
> keyboard_report: 00 | 00 00 00 00 00 00 
> processed: 0201u(6269):0 
> 
> 
# tap OSM(MOD_GUI)
> ---- action_exec: start -----
> EVENT: 0403d(16164)
> Tapping: Start(Press tap key).
> TAPPING_KEY=0403d(16164):0 
> processed: 0403d(16164):0 
> 
> 
> ---- action_exec: start -----
> EVENT: 0403u(16215)
> Tapping: First tap(0->1).
> TAPPING_KEY=0403d(16164):1 
> ACTION: ACT_LMODS_TAP[1:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> MODS_TAP: Oneshot: start
> waiting_buffer_enq: { [0]=0403u(16215):1  }
> ---- action_exec: process waiting_buffer -----
> Tapping: key event while last tap(>0).
> ACTION: ACT_LMODS_TAP[1:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> processed: waiting_buffer[0] =0403u(16215):1 
> 
> 
> 
# hold and release OSM(MOD_GUI)
# note that the keyboard report for keydown is emitted; but the keyup report is not
> ---- action_exec: start -----
> EVENT: 0403d(18176)
> Tapping: Start while last timeout tap(1).
> TAPPING_KEY=0403d(18176):0 
> processed: 0403d(18176):0 
> 
> Tapping: End. Timeout. Not tap(0): 0000u(18366)
> ACTION: ACT_LMODS_TAP[1:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> MODS_TAP: Oneshot: 0
> keyboard_report: 01 | 00 00 00 00 00 00 
> TAPPING_KEY=0000u(0):0 
> 
> ---- action_exec: start -----
> EVENT: 0403u(19454)
> ACTION: ACT_LMODS_TAP[1:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> processed: 0403u(19454):0 
> 
> 
# hold and release again, and now the report is correctly emitted for keyup
> ---- action_exec: start -----
> EVENT: 0403d(32197)
> Tapping: Start(Press tap key).
> TAPPING_KEY=0403d(32197):0 
> processed: 0403d(32197):0 
> 
> Tapping: End. Timeout. Not tap(0): 0000u(32387)
> ACTION: ACT_LMODS_TAP[1:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> MODS_TAP: Oneshot: 0
> TAPPING_KEY=0000u(0):0 
> 
> ---- action_exec: start -----
> EVENT: 0403u(32962)
> ACTION: ACT_LMODS_TAP[1:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> keyboard_report: 00 | 00 00 00 00 00 00 
> processed: 0403u(32962):0 
> 
```

### Example debug output with this new PR

```
# tap a normal key
> ---- action_exec: start -----
> EVENT: 0201d(3953)
> ACTION: ACT_LMODS[0:04] layer_state: 00000000(0) default_layer_state: 00000001(0)
> keyboard_report: 00 | 04 00 00 00 00 00 
> processed: 0201d(3953):0 
> 
> 
> ---- action_exec: start -----
> EVENT: 0201u(4007)
> ACTION: ACT_LMODS[0:04] layer_state: 00000000(0) default_layer_state: 00000001(0)
> keyboard_report: 00 | 00 00 00 00 00 00 
> processed: 0201u(4007):0 
> 
> 
# tap OSM(MOD_GUI)
> ---- action_exec: start -----
> EVENT: 0402d(4919)
> Tapping: Start(Press tap key).
> TAPPING_KEY=0402d(4919):0 
> processed: 0402d(4919):0 
> 
> 
> ---- action_exec: start -----
> EVENT: 0402u(4976)
> Tapping: First tap(0->1).
> TAPPING_KEY=0402d(4919):1 
> ACTION: ACT_LMODS_TAP[4:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> MODS_TAP: Oneshot: start
> waiting_buffer_enq: { [0]=0402u(4976):1  }
> ---- action_exec: process waiting_buffer -----
> Tapping: Tap release(1)
> ACTION: ACT_LMODS_TAP[4:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> TAPPING_KEY=0402u(4976):1 
> processed: waiting_buffer[0] =0402u(4976):1 
> 
> 
> Tapping: End(Timeout after releasing last tap): 0000u(5166)
> TAPPING_KEY=0000u(0):0 
> 
# hold and release OSM(MOD_GUI) and now the keyup event is correctly emitted.
> ---- action_exec: start -----
> EVENT: 0402d(6775)
> Tapping: Start(Press tap key).
> TAPPING_KEY=0402d(6775):0 
> processed: 0402d(6775):0 
> 
> Tapping: End. Timeout. Not tap(0): 0000u(6965)
> ACTION: ACT_LMODS_TAP[4:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> MODS_TAP: Oneshot: 0
> keyboard_report: 04 | 00 00 00 00 00 00 
> TAPPING_KEY=0000u(0):0 
> 
> ---- action_exec: start -----
> EVENT: 0402u(7529)
> ACTION: ACT_LMODS_TAP[4:00] layer_state: 00000000(0) default_layer_state: 00000001(0)
> keyboard_report: 00 | 00 00 00 00 00 00 
> processed: 0402u(7529):0 
> 
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
