### PR TITLE
fix EEPROM driver for STM32L0/1 cat.1 devices

### DIFF
--- a/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.c
+++ b/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.c
@@ -62,12 +62,16 @@ void eeprom_driver_erase(void) {
     STM32_L0_L1_EEPROM_Unlock();
 
     for (size_t offset = 0; offset < STM32_ONBOARD_EEPROM_SIZE; offset += sizeof(uint32_t)) {
+#ifdef QMK_MCU_SERIES_STM32L0XX
         FLASH->PECR |= FLASH_PECR_ERASE | FLASH_PECR_DATA;
+#endif
 
         *(__IO uint32_t *)EEPROM_ADDR(offset) = (uint32_t)0;
 
         STM32_L0_L1_EEPROM_WaitNotBusy();
+#ifdef QMK_MCU_SERIES_STM32L0XX
         FLASH->PECR &= ~(FLASH_PECR_ERASE | FLASH_PECR_DATA);
+#endif
     }
 
     STM32_L0_L1_EEPROM_Lock();

--- a/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.c
+++ b/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.c
@@ -25,6 +25,7 @@
 #define EEPROM_ADDR(offset) (EEPROM_BASE_ADDR + (offset))
 #define EEPROM_PTR(offset) ((__IO uint8_t *)EEPROM_ADDR(offset))
 #define EEPROM_BYTE(location, offset) (*(EEPROM_PTR(((uint32_t)location) + ((uint32_t)offset))))
+#define EEPROM_WORD(location) (*(__IO uint32_t *)EEPROM_PTR(location))
 
 #define BUFFER_BYTE(buffer, offset) (*(((uint8_t *)buffer) + offset))
 
@@ -66,7 +67,7 @@ void eeprom_driver_erase(void) {
         FLASH->PECR |= FLASH_PECR_ERASE | FLASH_PECR_DATA;
 #endif
 
-        *(__IO uint32_t *)EEPROM_ADDR(offset) = (uint32_t)0;
+        EEPROM_WORD(offset) = (uint32_t)0;
 
         STM32_L0_L1_EEPROM_WaitNotBusy();
 #ifdef QMK_MCU_SERIES_STM32L0XX
@@ -106,7 +107,7 @@ void eeprom_write_block(const void *buf, void *addr, size_t len) {
 
     STM32_L0_L1_EEPROM_Unlock();
     for (uint32_t word_addr = aligned_start; word_addr < aligned_end; word_addr += 4) {
-        uint32_t existing_word = *(__IO uint32_t *)EEPROM_PTR(word_addr);
+        uint32_t existing_word = EEPROM_WORD(word_addr);
         uint32_t new_word      = existing_word;
 
         // Update the relevant bytes in the word
@@ -121,7 +122,7 @@ void eeprom_write_block(const void *buf, void *addr, size_t len) {
         // Only write if the word has changed
         if (new_word != existing_word) {
             STM32_L0_L1_EEPROM_WaitNotBusy();
-            *(__IO uint32_t *)EEPROM_PTR(word_addr) = new_word;
+            EEPROM_WORD(word_addr) = new_word;
         }
     }
     STM32_L0_L1_EEPROM_Lock();

--- a/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.c
+++ b/platforms/chibios/drivers/eeprom/eeprom_stm32_L0_L1.c
@@ -86,17 +86,39 @@ void eeprom_read_block(void *buf, const void *addr, size_t len) {
 }
 
 void eeprom_write_block(const void *buf, void *addr, size_t len) {
-    STM32_L0_L1_EEPROM_Unlock();
+    // use word-aligned write to overcome issues with writing null bytes
+    uint32_t start_addr = (uint32_t)addr;
+    if (start_addr >= (STM32_ONBOARD_EEPROM_SIZE)) {
+        return;
+    }
+    uint32_t max_len = (STM32_ONBOARD_EEPROM_SIZE)-start_addr;
+    if (len > max_len) {
+        len = max_len;
+    }
+    uint32_t end_addr = start_addr + len;
 
-    for (size_t offset = 0; offset < len; ++offset) {
-        // Drop out if we've hit the limit of the EEPROM
-        if ((((uint32_t)addr) + offset) >= STM32_ONBOARD_EEPROM_SIZE) {
-            break;
+    uint32_t aligned_start = start_addr & ~0x3;
+    uint32_t aligned_end   = (end_addr + 3) & ~0x3;
+
+    STM32_L0_L1_EEPROM_Unlock();
+    for (uint32_t word_addr = aligned_start; word_addr < aligned_end; word_addr += 4) {
+        uint32_t existing_word = *(__IO uint32_t *)EEPROM_PTR(word_addr);
+        uint32_t new_word      = existing_word;
+
+        // Update the relevant bytes in the word
+        for (int i = 0; i < 4; i++) {
+            uint32_t byte_addr = word_addr + i;
+            if (byte_addr >= start_addr && byte_addr < end_addr) {
+                uint8_t new_byte = BUFFER_BYTE(buf, byte_addr - start_addr);
+                new_word         = (new_word & ~(0xFFU << (i * 8))) | ((uint32_t)new_byte << (i * 8));
+            }
         }
 
-        STM32_L0_L1_EEPROM_WaitNotBusy();
-        EEPROM_BYTE(addr, offset) = BUFFER_BYTE(buf, offset);
+        // Only write if the word has changed
+        if (new_word != existing_word) {
+            STM32_L0_L1_EEPROM_WaitNotBusy();
+            *(__IO uint32_t *)EEPROM_PTR(word_addr) = new_word;
+        }
     }
-
     STM32_L0_L1_EEPROM_Lock();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This fixes the STM32L0/1 driver for devices which only support writing null (all 0s) for full and double word writes.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Per [RM0038](https://www.st.com/resource/en/reference_manual/rm0038-stm32l100xx-stm32l151xx-stm32l152xx-and-stm32l162xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) section 3.4.3:
>  Data EEPROM Byte Write
This operation is used to write a NON NULL (This restriction applies only for Cat.1 devices) byte to the data EEPROM whatever the
previous value of the word to be written to. The time taken for this is 1 or 2 tprog, depending
on the FTDW bit (see Table 20 on page 77 for more details).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Required by https://github.com/qmk/qmk_firmware/pull/24916

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
