### PR TITLE
Add Super Alt-Tab macro example as module

### DIFF
--- a/modules/qmk/super_alt_tab/qmk_module.json
+++ b/modules/qmk/super_alt_tab/qmk_module.json
@@ -1,0 +1,10 @@
+{
+    "module_name": "Super Alt Tab",
+    "maintainer": "QMK Maintainers",
+    "keycodes": [
+        {
+            "key": "COMMUNITY_MODULE_SUPER_ALT_TAB",
+            "aliases": ["CM_S_AT"]
+        }
+    ]
+}

--- a/modules/qmk/super_alt_tab/super_alt_tab.c
+++ b/modules/qmk/super_alt_tab/super_alt_tab.c
@@ -1,0 +1,42 @@
+// Copyright 2025 Christopher Courtney, aka Drashna Jael're  (@drashna)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+#include "introspection.h"
+
+ASSERT_COMMUNITY_MODULES_MIN_API_VERSION(1, 0, 0);
+
+static bool     is_alt_tab_active = false; // ADD this near the beginning of keymap.c
+static uint16_t alt_tab_timer     = 0;     // we will be using them soon.
+
+bool process_record_super_alt_tab(uint16_t keycode, keyrecord_t *record) {
+    if (!process_record_super_alt_tab_kb(keycode, record)) {
+        return false;
+    }
+
+    switch (keycode) { // This will do most of the grunt work with the keycodes.
+        case COMMUNITY_MODULE_SUPER_ALT_TAB:
+            if (record->event.pressed) {
+                if (!is_alt_tab_active) {
+                    is_alt_tab_active = true;
+                    register_code(KC_LALT);
+                }
+                alt_tab_timer = timer_read();
+                register_code(KC_TAB);
+            } else {
+                unregister_code(KC_TAB);
+            }
+            break;
+    }
+    return true;
+}
+
+void housekeeping_task_super_alt_tab(void) {
+    if (is_alt_tab_active) {
+        if (timer_elapsed(alt_tab_timer) > 1000) {
+            unregister_code(KC_LALT);
+            is_alt_tab_active = false;
+        }
+    }
+}

--- a/modules/qmk/super_alt_tab/super_alt_tab.c
+++ b/modules/qmk/super_alt_tab/super_alt_tab.c
@@ -10,6 +10,16 @@ ASSERT_COMMUNITY_MODULES_MIN_API_VERSION(1, 0, 0);
 static bool     is_alt_tab_active = false; // ADD this near the beginning of keymap.c
 static uint16_t alt_tab_timer     = 0;     // we will be using them soon.
 
+#ifndef COMMUNITY_MODULE_SUPER_ALT_TAB_TIMEOUT
+#    define COMMUNITY_MODULE_SUPER_ALT_TAB_TIMEOUT 1000
+#endif // COMMUNITY_MODULE_SUPER_ALT_TAB_TIMEOUT
+#ifndef COMMUNITY_MODULE_SUPER_ALT_TAB_MODIFIER
+#    define COMMUNITY_MODULE_SUPER_ALT_TAB_MODIFIER MOD_LALT
+#endif // COMMUNITY_MODULE_SUPER_ALT_TAB_MODIFIER
+#ifndef COMMUNITY_MODULE_SUPER_ALT_TAB_KEY
+#    define COMMUNITY_MODULE_SUPER_ALT_TAB_KEY KC_TAB
+#endif // COMMUNITY_MODULE_SUPER_ALT_TAB_KEY
+
 bool process_record_super_alt_tab(uint16_t keycode, keyrecord_t *record) {
     if (!process_record_super_alt_tab_kb(keycode, record)) {
         return false;
@@ -20,12 +30,12 @@ bool process_record_super_alt_tab(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 if (!is_alt_tab_active) {
                     is_alt_tab_active = true;
-                    register_code(KC_LALT);
+                    register_mods(COMMUNITY_MODULE_SUPER_ALT_TAB_MODIFIER);
                 }
                 alt_tab_timer = timer_read();
-                register_code(KC_TAB);
+                register_code(COMMUNITY_MODULE_SUPER_ALT_TAB_KEY);
             } else {
-                unregister_code(KC_TAB);
+                unregister_code(COMMUNITY_MODULE_SUPER_ALT_TAB_KEY);
             }
             break;
     }
@@ -34,8 +44,8 @@ bool process_record_super_alt_tab(uint16_t keycode, keyrecord_t *record) {
 
 void housekeeping_task_super_alt_tab(void) {
     if (is_alt_tab_active) {
-        if (timer_elapsed(alt_tab_timer) > 1000) {
-            unregister_code(KC_LALT);
+        if (timer_elapsed(alt_tab_timer) > COMMUNITY_MODULE_SUPER_ALT_TAB_TIMEOUT) {
+            unregister_mods(COMMUNITY_MODULE_SUPER_ALT_TAB_MODIFIER);
             is_alt_tab_active = false;
         }
     }

--- a/modules/qmk/super_alt_tab/super_alt_tab.c
+++ b/modules/qmk/super_alt_tab/super_alt_tab.c
@@ -7,8 +7,8 @@
 
 ASSERT_COMMUNITY_MODULES_MIN_API_VERSION(1, 0, 0);
 
-static bool     is_alt_tab_active = false; // ADD this near the beginning of keymap.c
-static uint16_t alt_tab_timer     = 0;     // we will be using them soon.
+static bool     is_alt_tab_active = false;
+static uint16_t alt_tab_timer     = 0;
 
 #ifndef COMMUNITY_MODULE_SUPER_ALT_TAB_TIMEOUT
 #    define COMMUNITY_MODULE_SUPER_ALT_TAB_TIMEOUT 1000

--- a/modules/qmk/super_alt_tab/super_alt_tab.c
+++ b/modules/qmk/super_alt_tab/super_alt_tab.c
@@ -3,8 +3,6 @@
 
 #include QMK_KEYBOARD_H
 
-#include "introspection.h"
-
 ASSERT_COMMUNITY_MODULES_MIN_API_VERSION(1, 0, 0);
 
 static bool     is_alt_tab_active = false;


### PR DESCRIPTION
## Description

Adds the Super Alt-Tab behavior from the [macros example](https://docs.qmk.fm/feature_macros#super-alt%E2%86%AFtab) as a module, with some configurable options

Blame tzarc

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
