### PR TITLE
Enable mouse key feature and disable leader key on Maxr1998/Phoebe

### DIFF
--- a/keyboards/maxr1998/phoebe/keyboard.json
+++ b/keyboards/maxr1998/phoebe/keyboard.json
@@ -9,10 +9,10 @@
     "diode_direction": "COL2ROW",
     "features": {
         "bootmagic": true,
-        "nkro": true,
-        "rgblight": true,
         "key_lock": true,
-        "leader": true
+        "mousekey": true,
+        "nkro": true,
+        "rgblight": true
     },
     "qmk": {
         "locking": {

--- a/keyboards/maxr1998/phoebe/keymaps/default/config.h
+++ b/keyboards/maxr1998/phoebe/keymaps/default/config.h
@@ -1,3 +1,18 @@
+/* Copyright 2019 Max Rumpf (@Maxr1998)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #pragma once
 
 #define RSPC_KEYS KC_RSFT, KC_RALT, KC_7

--- a/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
+++ b/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
@@ -35,7 +35,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_GRV,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
   KC_TAB,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    DE_PLUS, KC_ENT,
   KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_UP,   SC_RSPC,
-  KC_LCTL, KC_LGUI, KC_LALT, QK_LEAD, KC_SC,       KC_SPC,       KC_ALGR, KC_FN,   KC_LEFT, KC_DOWN, KC_RGHT
+  KC_LCTL, KC_LGUI, KC_LALT, KC_BTN1, KC_SC,       KC_SPC,       KC_ALGR, KC_FN,   KC_LEFT, KC_DOWN, KC_RGHT
 ),
 
 /* Special characters
@@ -77,7 +77,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   _______, _______, _______, _______, _______, _______, _______, DE_UDIA, KC_F9,   DE_ODIA, KC_PSCR, KC_DEL,
   QK_LOCK, DE_ADIA, DE_SS,   _______, _______, G_1,     _______, RGB_M_P, RGB_M_SW,RGB_M_SN,_______, _______,
   _______, _______, _______, _______, _______, _______, _______, UG_HUED, UG_TOGG, UG_HUEU, KC_PGUP, _______,
-  XXXXXXX, _______, XXXXXXX, XXXXXXX, XXXXXXX,      _______,     XXXXXXX, XXXXXXX, KC_HOME, KC_PGDN, KC_END
+  XXXXXXX, _______, XXXXXXX, KC_BTN2, XXXXXXX,      _______,     XXXXXXX, XXXXXXX, KC_HOME, KC_PGDN, KC_END
 ),
 
 /* Gaming
@@ -128,13 +128,4 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             break;
     }
     return true;
-};
-
-void leader_end_user(void) {
-    if (leader_sequence_two_keys(KC_G, KC_P)) {
-        SEND_STRING("git push");
-    }
-    if (leader_sequence_three_keys(KC_G, KC_F, KC_P)) {
-        SEND_STRING("git push --force-with-lease");
-    }
 }

--- a/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
+++ b/keyboards/maxr1998/phoebe/keymaps/default/keymap.c
@@ -1,3 +1,18 @@
+/* Copyright 2019 Max Rumpf (@Maxr1998)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include QMK_KEYBOARD_H
 
 #include "keymap_german.h"

--- a/keyboards/maxr1998/phoebe/phoebe.c
+++ b/keyboards/maxr1998/phoebe/phoebe.c
@@ -1,3 +1,18 @@
+/* Copyright 2019 Max Rumpf (@Maxr1998)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "quantum.h"
 
 const uint8_t RGBLED_SNAKE_INTERVALS[] PROGMEM = {50, 50, 50};


### PR DESCRIPTION
## Description

Updating the default keymap of Phoebe to remove complex leader key support and include the more useful mouse key support instead. This is also to move towards a more pristine default keymap. Nonetheless, the default keymap of this board is still targeted towards German QWERTZ users, requiring various layers and macros to support all special characters.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
