### PR TITLE
Fix typo in docs: split_keyboard.md SPLIT_USB_DETECT ("theres's -> "there's")

### DIFF
--- a/docs/features/split_keyboard.md
+++ b/docs/features/split_keyboard.md
@@ -444,7 +444,7 @@ This setting implies that `RGBLIGHT_SPLIT` is enabled, and will forcibly enable 
 #define SPLIT_USB_DETECT
 ```
 
-Enabling this option changes the startup behavior to listen for an active USB communication to delegate which part is master and which is slave. With this option enabled and there's USB communication, then that half assumes it is the master, otherwise it assumes it is the slave.
+Enabling this option changes the startup behavior to listen for an active USB communication to delegate which part is master and which is slave. With this option enabled and active USB communication, then that half assumes it is the master, otherwise it assumes it is the slave.
 
 Without this option, the master is the half that can detect voltage on the physical USB connection (VBUS detection).
 

--- a/docs/features/split_keyboard.md
+++ b/docs/features/split_keyboard.md
@@ -444,7 +444,7 @@ This setting implies that `RGBLIGHT_SPLIT` is enabled, and will forcibly enable 
 #define SPLIT_USB_DETECT
 ```
 
-Enabling this option changes the startup behavior to listen for an active USB communication to delegate which part is master and which is slave. With this option enabled and theres's USB communication, then that half assumes it is the master, otherwise it assumes it is the slave.
+Enabling this option changes the startup behavior to listen for an active USB communication to delegate which part is master and which is slave. With this option enabled and there's USB communication, then that half assumes it is the master, otherwise it assumes it is the slave.
 
 Without this option, the master is the half that can detect voltage on the physical USB connection (VBUS detection).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fixes typo in the split keyboard section of the docs ("theres's -> "there's").

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* fixes #24983

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
