### PR TITLE
annepro2: Add BLE status handling

### DIFF
--- a/keyboards/annepro2/annepro2.h
+++ b/keyboards/annepro2/annepro2.h
@@ -21,10 +21,17 @@
 #include "ap2_led.h"
 
 typedef struct __attribute__((__packed__)) {
-    uint8_t _dummy[10];
-    bool    caps_lock;
-} ble_capslock_t;
-extern ble_capslock_t ble_capslock;
+    uint8_t _dummy[9];
+    uint8_t id;
+    uint8_t status;
+} ble_status_t;
+
+extern bool ble_capslock;
+
+enum {
+    BLE_STS_ID_CAPSLOCK = 0x07,
+    BLE_STS_ID_CONNECT = 0x0c,
+};
 
 enum AP2KeyCodes {
     KC_AP2_BT1 = QK_KB_0,

--- a/keyboards/annepro2/annepro2_ble.c
+++ b/keyboards/annepro2/annepro2_ble.c
@@ -127,7 +127,7 @@ static void ap2_ble_swtich_ble_driver(void) {
 }
 
 static uint8_t ap2_ble_leds(void) {
-    return 0;  // TODO: Figure out how to obtain LED status
+    return ble_capslock << 1;
 }
 
 static void ap2_ble_mouse(report_mouse_t *report) {}

--- a/keyboards/annepro2/ap2_led.c
+++ b/keyboards/annepro2/ap2_led.c
@@ -120,6 +120,11 @@ void ap2_led_blink(uint8_t row, uint8_t col, ap2_led_t color, uint8_t count, uin
     proto_tx(CMD_LED_KEY_BLINK, payload, sizeof(payload), 1);
 }
 
+void ap2_led_cancel_blink(void) {
+    uint8_t payload[] = {0};
+    proto_tx(CMD_LED_KEY_BLINK, payload, sizeof(payload), 1);
+}
+
 void ap2_led_set_foreground_color(uint8_t red, uint8_t green, uint8_t blue) {
     ap2_led_t color = {.p.red = red, .p.green = green, .p.blue = blue, .p.alpha = 0xff};
     ap2_led_mask_set_mono(color);

--- a/keyboards/annepro2/ap2_led.h
+++ b/keyboards/annepro2/ap2_led.h
@@ -79,6 +79,8 @@ void ap2_led_set_manual_control(uint8_t manual);
 
 /* Blink given key `count` times by masking it with a `color`. Blink takes `hundredths` of a second */
 void ap2_led_blink(uint8_t row, uint8_t col, ap2_led_t color, uint8_t count, uint8_t hundredths);
+/* Cancel any running blinking */
+void ap2_led_cancel_blink(void);
 
 /* Kept for compatibility, but implemented using masks */
 void ap2_led_set_foreground_color(uint8_t red, uint8_t green, uint8_t blue);


### PR DESCRIPTION
Add BLE handling for Anne Pro 2:
- Caps Lock LED
- Cancelling profile key blinking upon successful connection, selecting another slot, selecting USB or unpairing.

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Add code to manage the bluetooth Caps Lock status LED, and to cancel the bluetooth profile key blinking upon succesful connection,
unpairing or switching to USB mode.

I have not thoroughly reversed the BLE firmware protocol, but I observed that:
- When enabling capslock on BLE host, the BLE firmware sends a message ending with `07 0x` where x may be 0 if capslock is off, or 1 when capslock is on
- When switching profiles, as soon as the connection is established, a message of the same size ending in `0c 00` is received on the BLE UART, which I guess is the confirmation of connection. I use that to cancel any blinking.

I was not able to trigger any other messages on that UART so I didn't implement full protocol handling (not enough data anyway)

The capslock status is reset upon switching slots, as per Bluetooth HID profile specification 1.1, appendix F

Tested on a C18 variant of the board with BLE firmware v1.0.0

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/18435

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
