### PR TITLE
Require 'x'/'y' properties for LED/RGB Matrix layout

### DIFF
--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -554,6 +554,7 @@
                     "items": {
                         "type": "object",
                         "additionalProperties": false,
+                        "required": ["x", "y"],
                         "properties": {
                             "matrix": {
                                 "type": "array",
@@ -640,6 +641,7 @@
                     "items": {
                         "type": "object",
                         "additionalProperties": false,
+                        "required": ["x", "y"],
                         "properties": {
                             "matrix": {
                                 "type": "array",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Spotted on 24994,

```json
            {"matrix": [5, 4], "x": 44, "y": 32, "flags": 1},
            {"flags": 1}
```

Note: `flags` has not been made mandatory as we have existing keyboards which do not specify the property.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
