### PR TITLE
Fixed momentary mode of mouse keys resetting speed when it should not

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -618,11 +618,11 @@ void mousekey_off(uint8_t code) {
     else if (IS_MOUSEKEY_BUTTON(code))
         mouse_report.buttons &= ~(1 << (code - QK_MOUSE_BUTTON_1));
 #    ifdef MK_MOMENTARY_ACCEL
-    else if (code == QK_MOUSE_ACCELERATION_0)
+    else if (code == QK_MOUSE_ACCELERATION_0 && old_speed == mkspd_0)
         mk_speed = mkspd_DEFAULT;
-    else if (code == QK_MOUSE_ACCELERATION_1)
+    else if (code == QK_MOUSE_ACCELERATION_1 && old_speed == mkspd_1)
         mk_speed = mkspd_DEFAULT;
-    else if (code == QK_MOUSE_ACCELERATION_2)
+    else if (code == QK_MOUSE_ACCELERATION_2 && old_speed == mkspd_2)
         mk_speed = mkspd_DEFAULT;
     if (mk_speed != old_speed) adjust_speed();
 #    endif


### PR DESCRIPTION
Fixes mouse key momentary mode prematurely resetting 

## Description

This will prefer the most recently pressed acceleration profile, only reverting to unset if the button corresponding to the current mouse speed is released.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #5691 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
