### PR TITLE
Fixup MSYS + unix-style paths in Community Modules.

### DIFF
--- a/lib/python/qmk/cli/generate/rules_mk.py
+++ b/lib/python/qmk/cli/generate/rules_mk.py
@@ -10,7 +10,7 @@ from qmk.info import info_json, get_modules
 from qmk.json_schema import json_load
 from qmk.keyboard import keyboard_completer, keyboard_folder
 from qmk.commands import dump_lines, parse_configurator_json
-from qmk.path import normpath, FileType
+from qmk.path import normpath, unix_style_path, FileType
 from qmk.constants import GPL2_HEADER_SH_LIKE, GENERATED_HEADER_SH_LIKE
 from qmk.community_modules import find_module_path, load_module_jsons
 
@@ -63,7 +63,7 @@ def generate_modules_rules(keyboard, filename):
         lines.append('')
         lines.append('OPT_DEFS += -DCOMMUNITY_MODULES_ENABLE=TRUE')
         for module in modules:
-            module_path = find_module_path(module)
+            module_path = unix_style_path(find_module_path(module))
             if not module_path:
                 raise FileNotFoundError(f"Module '{module}' not found.")
             lines.append('')

--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import argparse
-from pathlib import Path
+from pathlib import Path, PureWindowsPath, PurePosixPath
 
 from qmk.constants import MAX_KEYBOARD_SUBFOLDERS, QMK_FIRMWARE, QMK_USERSPACE, HAS_QMK_USERSPACE
 from qmk.errors import NoSuchKeyboardError
@@ -144,6 +144,28 @@ def normpath(path):
         return path
 
     return Path(os.environ['ORIG_CWD']) / path
+
+
+def unix_style_path(path):
+    """Converts a Windows-style path with drive letter to a Unix path.
+
+    Path().as_posix() normally returns the path with drive letter and forward slashes, so is inappropriate for `Makefile` paths.
+
+    Passes through unadulterated if the path is not a Windows-style path.
+
+    Args:
+
+        path
+            The path to convert.
+
+    Returns:
+        The input path converted to Unix format.
+    """
+    if isinstance(path, PureWindowsPath):
+        p = list(path.parts)
+        p[0] = f'/{p[0][0].lower()}'  # convert from `X:/` to `/x`
+        path = PurePosixPath(*p)
+    return path
 
 
 class FileType(argparse.FileType):


### PR DESCRIPTION
## Description

Python was handing out Windows-style "posix" paths with drive letter but normal forward slashes. Generating the `rules.mk` caused issues with the output, so this fix adds a function similar to `cygpath` and swaps the drive letter to a unix-style rooted path.

Happy to entertain "better" suggestions as far as the conversion goes.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
