### PR TITLE
Fix OS_DETECTION_KEYBOARD_RESET

### DIFF
--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -70,11 +70,11 @@ static volatile struct usb_device_state maxprev_usb_device_state = {.configure_s
 
 // to reset the keyboard on USB state change
 #ifdef OS_DETECTION_KEYBOARD_RESET
-#   ifndef OS_DETECTION_RESET_DEBOUNCE
-#   define OS_DETECTION_RESET_DEBOUNCE OS_DETECTION_DEBOUNCE
-#   endif
+#    ifndef OS_DETECTION_RESET_DEBOUNCE
+#        define OS_DETECTION_RESET_DEBOUNCE OS_DETECTION_DEBOUNCE
+#    endif
 static volatile fast_timer_t configured_since = 0;
-static volatile bool         reset_pending = false;
+static volatile bool         reset_pending    = false;
 #endif
 
 // the OS detection might be unstable for a while, "debounce" it

--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -68,6 +68,15 @@ static volatile bool first_report = true;
 static volatile struct usb_device_state current_usb_device_state = {.configure_state = USB_DEVICE_STATE_NO_INIT};
 static volatile struct usb_device_state maxprev_usb_device_state = {.configure_state = USB_DEVICE_STATE_NO_INIT};
 
+// to reset the keyboard on USB state change
+#ifdef OS_DETECTION_KEYBOARD_RESET
+#   ifndef OS_DETECTION_RESET_DEBOUNCE
+#   define OS_DETECTION_RESET_DEBOUNCE OS_DETECTION_DEBOUNCE
+#   endif
+static volatile fast_timer_t configured_since = 0;
+static volatile bool         reset_pending = false;
+#endif
+
 // the OS detection might be unstable for a while, "debounce" it
 static volatile bool         debouncing = false;
 static volatile fast_timer_t last_time  = 0;
@@ -77,7 +86,10 @@ bool process_detected_host_os_modules(os_variant_t os);
 void os_detection_task(void) {
 #ifdef OS_DETECTION_KEYBOARD_RESET
     // resetting the keyboard on the USB device state change callback results in instability, so delegate that to this task
-    // only take action if it's been stable at least once, to avoid issues with some KVMs
+    if (reset_pending) {
+        soft_reset_keyboard();
+    }
+    // reset the keyboard if it is stuck in the init state for longer than debounce duration, which can happen with some KVMs
     if (current_usb_device_state.configure_state <= USB_DEVICE_STATE_INIT && maxprev_usb_device_state.configure_state >= USB_DEVICE_STATE_CONFIGURED) {
         if (debouncing && timer_elapsed_fast(last_time) >= OS_DETECTION_DEBOUNCE) {
             soft_reset_keyboard();
@@ -187,6 +199,18 @@ void os_detection_notify_usb_device_state_change(struct usb_device_state usb_dev
     current_usb_device_state = usb_device_state;
     last_time                = timer_read_fast();
     debouncing               = true;
+
+#ifdef OS_DETECTION_KEYBOARD_RESET
+    if (configured_since == 0 && current_usb_device_state.configure_state == USB_DEVICE_STATE_CONFIGURED) {
+        configured_since = timer_read_fast();
+    } else if (current_usb_device_state.configure_state == USB_DEVICE_STATE_INIT) {
+        // reset the keyboard only if it's been stable for at least debounce duration, to avoid issues with some KVMs
+        if (configured_since > 0 && timer_elapsed_fast(configured_since) >= OS_DETECTION_RESET_DEBOUNCE) {
+            reset_pending = true;
+        }
+        configured_since = 0;
+    }
+#endif
 }
 
 #if defined(SPLIT_KEYBOARD) && defined(SPLIT_DETECTED_OS_ENABLE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
In #24379 the OS_DETECTION_KEYBOARD_RESET logic got inadvertently changed to only reset if the keyboard ends up stuck in the INIT phase, which was apparently an issue with some KVMs, but this means that it no longer does what it originally was meant to do.

This PR leaves that functionality, but also resets the keyboard on USB device reinitilization again, as long as it had been stable for debounce duration before that. The debounce time used for reset is by default the same as for the detection, but it can be tuned with the undocumented `OS_DETECTION_RESET_DEBOUNCE` setting.

We set the debounce timer in the USB device change callback, because reacting to state changes in the main task loop feels racy. Actual reset still happens in `os_detection_task`, because some MCUs seem not to like it if they are being immediately reset on USB state change.

Fixes #24920.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #24920

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
