### PR TITLE
Fix Spleeb compile when pointing device is enabled

### DIFF
--- a/keyboards/spleeb/rules.mk
+++ b/keyboards/spleeb/rules.mk
@@ -1,0 +1,1 @@
+POINTING_DEVICE_DRIVER = cirque_pinnacle_i2c

--- a/keyboards/spleeb/spleeb.c
+++ b/keyboards/spleeb/spleeb.c
@@ -8,6 +8,10 @@
 #    include "print.h"
 #endif // CONSOLE_ENABLE
 
+#ifdef POINTING_DEVICE_ENABLE
+#    include "drivers/sensors/cirque_pinnacle_gestures.h"
+#endif // POINTING_DEVICE_ENABLE
+
 #if defined(POINTING_DEVICE_ENABLE) || defined(SPLEEB_ENCODER_MODE_MAP_ENABLE)
 typedef union {
     uint16_t raw;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

spleeb.c relied on changing the glide setting at runtime and the `cirque_pinnacle_enable_cursor_glide` was no longer being included and was producing build errors. 

This change explicitly includes `drivers/sensors/cirque_pinnacle_gestures.h` to address this. 

If there is a "more correct" approach here I am happy to adjust the code as needed. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
