### PR TITLE
Fixed print statement after enabling 32-bit layers

### DIFF
--- a/quantum/command.c
+++ b/quantum/command.c
@@ -243,7 +243,7 @@ static void print_status(void) {
 
 #if !defined(NO_PRINT) && !defined(USER_PRINT)
 static void print_eeconfig(void) {
-    xprintf("eeconfig:\ndefault_layer: %"PRIu32"\n", (uint32_t)eeconfig_read_default_layer());
+    xprintf("eeconfig:\ndefault_layer: %" PRIu32 "\n", (uint32_t)eeconfig_read_default_layer());
 
     debug_config_t dc;
     dc.raw = eeconfig_read_debug();

--- a/quantum/command.c
+++ b/quantum/command.c
@@ -243,7 +243,7 @@ static void print_status(void) {
 
 #if !defined(NO_PRINT) && !defined(USER_PRINT)
 static void print_eeconfig(void) {
-    xprintf("eeconfig:\ndefault_layer: %u\n", eeconfig_read_default_layer());
+    xprintf("eeconfig:\ndefault_layer: %"PRIu32"\n", (uint32_t)eeconfig_read_default_layer());
 
     debug_config_t dc;
     dc.raw = eeconfig_read_debug();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Enabling both LAYER_STATE_32BIT and CONSOLE_ENABLE currently causes QMK not to compile due to a mismatch in the types expected in a print statement in quantum/command.c.

## Description

I simply added a definition check around the print statement and handled both print statments independently.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #25026

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
