### PR TITLE
fix swapped encoder pins on ploopy thumb rev1_001 

### DIFF
--- a/keyboards/ploopyco/trackball_thumb/rev1_001/config.h
+++ b/keyboards/ploopyco/trackball_thumb/rev1_001/config.h
@@ -26,5 +26,5 @@
 /* PMW33XX Settings */
 #define PMW33XX_CS_PIN B0
 
-#define ENCODER_A_PINS { F0 }
-#define ENCODER_B_PINS { F4 }
+#define ENCODER_A_PINS { F4 }
+#define ENCODER_B_PINS { F0 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
PR #24880, has swapped encoder pins on ploopyco/trackball_thumb/rev1_001 
This seems to have been in error, reversing scroll direction.
Previous pin defs from old `keyboards/ploopyco/trackball_thumb/config.h` re-instated to current `keyboards/ploopyco/trackball_thumb/rev1_001/config.h` 

https://github.com/qmk/qmk_firmware/pull/24880/files
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
