### PR TITLE
[Modules] Provide access to current path in `rules.mk`.

### DIFF
--- a/lib/python/qmk/cli/generate/rules_mk.py
+++ b/lib/python/qmk/cli/generate/rules_mk.py
@@ -72,7 +72,11 @@ def generate_modules_rules(keyboard, filename):
             lines.append(f'COMMUNITY_MODULE_PATHS += {module_path}')
             lines.append(f'VPATH += {module_path}')
             lines.append(f'SRC += $(wildcard {module_path}/{module_path.name}.c)')
+            lines.append(f'CURRENT_MODULE_NAME := {module_path.name}')
+            lines.append(f'CURRENT_MODULE_PATH := {module_path}')
             lines.append(f'-include {module_path}/rules.mk')
+            lines.append('CURRENT_MODULE_NAME :=')
+            lines.append('CURRENT_MODULE_PATH :=')
 
         module_jsons = load_module_jsons(modules)
         for module_json in module_jsons:

--- a/lib/python/qmk/cli/generate/rules_mk.py
+++ b/lib/python/qmk/cli/generate/rules_mk.py
@@ -72,11 +72,9 @@ def generate_modules_rules(keyboard, filename):
             lines.append(f'COMMUNITY_MODULE_PATHS += {module_path}')
             lines.append(f'VPATH += {module_path}')
             lines.append(f'SRC += $(wildcard {module_path}/{module_path.name}.c)')
-            lines.append(f'CURRENT_MODULE_NAME := {module_path.name}')
-            lines.append(f'CURRENT_MODULE_PATH := {module_path}')
+            lines.append(f'MODULE_NAME_{module_path.name.upper()} := {module_path.name}')
+            lines.append(f'MODULE_PATH_{module_path.name.upper()} := {module_path}')
             lines.append(f'-include {module_path}/rules.mk')
-            lines.append('CURRENT_MODULE_NAME :=')
-            lines.append('CURRENT_MODULE_PATH :=')
 
         module_jsons = load_module_jsons(modules)
         for module_json in module_jsons:


### PR DESCRIPTION
## Description

Modules may need access to the current path, in order to add relative paths to say, `COMMON_VPATH`.
Refer https://github.com/tzarc/qmk_modules/blob/main/experimental/filesystem/rules.mk#L11-L12

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
