### PR TITLE
Update onekey example for nucleo f446re

### DIFF
--- a/keyboards/handwired/onekey/nucleo_f446re/config.h
+++ b/keyboards/handwired/onekey/nucleo_f446re/config.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #pragma once
 
-#define ADC_PIN A0
+#define ADC_PIN A5
 
 #define SOLENOID_PINS { B12, B13, B14, B15 }
 #define SOLENOID_PINS_ACTIVE_STATE { high, high, low }

--- a/keyboards/handwired/onekey/nucleo_f446re/keyboard.json
+++ b/keyboards/handwired/onekey/nucleo_f446re/keyboard.json
@@ -10,10 +10,10 @@
         "pin": "B8"
     },
     "ws2812": {
-        "pin": "A2"
+        "pin": "A4"
     },
     "apa102": {
-        "data_pin": "A2",
+        "data_pin": "A4",
         "clock_pin": "B13"
     }
 }

--- a/keyboards/handwired/onekey/nucleo_f446re/keyboard.json
+++ b/keyboards/handwired/onekey/nucleo_f446re/keyboard.json
@@ -3,7 +3,7 @@
     "processor": "STM32F446",
     "bootloader": "stm32-dfu",
     "matrix_pins": {
-        "cols": ["A2"],
+        "cols": ["A0"],
         "rows": ["A1"]
     },
     "backlight": {

--- a/keyboards/handwired/onekey/nucleo_f446re/keyboard.json
+++ b/keyboards/handwired/onekey/nucleo_f446re/keyboard.json
@@ -10,10 +10,10 @@
         "pin": "B8"
     },
     "ws2812": {
-        "pin": "A0"
+        "pin": "A2"
     },
     "apa102": {
-        "data_pin": "A0",
+        "data_pin": "A2",
         "clock_pin": "B13"
     }
 }

--- a/keyboards/handwired/onekey/nucleo_f446re/readme.md
+++ b/keyboards/handwired/onekey/nucleo_f446re/readme.md
@@ -1,5 +1,5 @@
 # STM32 Nucleo-L432 onekey
 
-To trigger keypress, short together pins *A1* and *A2*.
+To trigger keypress, short together pins *A0* and *A1*. Note that the pin numbering is relative to the MCU, so that A0 and A1 refer to PA0 and PA1 on the MCU (which are also labelled A0 and A1 on the board, but this isn't true for the other PAx pins). 
 
 You'll also need to connect `VIN`, `GND`, USB `D+` to `PA12`/`D2`, and USB `D-` to `PA11`/`D10`.


### PR DESCRIPTION
The onekey example for the nucleo f446re board doesn't work: this PR updates the example. 

## Description

The onekey example for the nucleo f446re board doesn't work as it relies on pin A2, which by default isn't connected to a pin header but to USART (see the schematic available at [the ST website](https://www.st.com/en/evaluation-tools/nucleo-f446re.html#cad-resources)). This PR updates the pin assignments to use A0 and A1 which are both accessible on the standard board pin headers. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
