### PR TITLE
Fix path typo related RP2040

### DIFF
--- a/platforms/chibios/vendors/RP/RP2040.mk
+++ b/platforms/chibios/vendors/RP/RP2040.mk
@@ -78,7 +78,7 @@ PICOSDKINTRINSICSSRC =  $(PICOSDKROOT)/src/rp2_common/pico_divider/divider.S \
                         $(PICOSDKROOT)/src/rp2_common/pico_int64_ops/pico_int64_ops_aeabi.S
 
 PICOSDKINTRINSICSINC =  $(PICOSDKROOT)/src/common/pico_base/include \
-                        $(PICOSDKROOT)/src/rp2_common/pico_platfrom/include \
+                        $(PICOSDKROOT)/src/rp2_common/pico_platform/include \
                         $(PICOSDKROOT)/src/rp2_common/hardware_divider/include
 
 # integer division intrinsics utilizing the RP2040 hardware divider

--- a/quantum/bits.h
+++ b/quantum/bits.h
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 
-/* Remove these once we transitioned to C23 across all platfroms */
+/* Remove these once we transitioned to C23 across all platforms */
 #define UINT32_WIDTH 32
 #define UINT64_WIDTH 64
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Fix path typo: `platfrom` → `platform` (RP2040-related).
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
