### PR TITLE
In `qmk doctor`, elaborate error message when essential binaries are not found in the path.

### DIFF
--- a/lib/python/qmk/cli/doctor/check.py
+++ b/lib/python/qmk/cli/doctor/check.py
@@ -142,15 +142,23 @@ def check_binaries():
     """Iterates through ESSENTIAL_BINARIES and tests them.
     """
     ok = CheckStatus.OK
+    missing_from_path = []
 
     for binary in sorted(ESSENTIAL_BINARIES):
         try:
-            if not is_executable(binary):
+            if not is_in_path(binary):
+                ok = CheckStatus.ERROR
+                missing_from_path.append(binary)
+            elif not is_executable(binary):
                 ok = CheckStatus.ERROR
         except TimeoutExpired:
             cli.log.debug('Timeout checking %s', binary)
             if ok != CheckStatus.ERROR:
                 ok = CheckStatus.WARNING
+
+    if missing_from_path:
+        location_noun = 'its location' if len(missing_from_path) == 1 else 'their locations'
+        cli.log.error('{fg_red}' + ', '.join(missing_from_path) + f' may need to be installed, or {location_noun} added to your path.')
 
     return ok
 
@@ -190,15 +198,18 @@ def check_submodules():
     return CheckStatus.OK
 
 
-def is_executable(command):
-    """Returns True if command exists and can be executed.
+def is_in_path(command):
+    """Returns True if command is found in the path.
     """
-    # Make sure the command is in the path.
-    res = shutil.which(command)
-    if res is None:
+    if shutil.which(command) is None:
         cli.log.error("{fg_red}Can't find %s in your path.", command)
         return False
+    return True
 
+
+def is_executable(command):
+    """Returns True if command can be executed.
+    """
     # Make sure the command can be executed
     version_arg = ESSENTIAL_BINARIES[command].get('version_arg', '--version')
     check = cli.run([command, version_arg], combined_output=True, stdin=DEVNULL, timeout=5)


### PR DESCRIPTION
This adds a clarifying message like "`☒ avr-gcc: may need to be installed, or its location added to your path.`"

## Description

When an essential binary is missing, `qmk doctor` prints a message like

```
☒ Can't find avr-gcc in your path.
```

While this is accurate, users who are less familiar with the shell might not understand what the "path" is or what they should do.

This PR adds an additional message below the existing one to suggest how to fix it:

```
☒ avr-gcc may need to be installed, or its location added to your path.
```

If multiple essential binaries are missing, the new message appears just once.

The doctor tool might offer to install the missing binaries after this point ("`Would you like to install dependencies? [Y/n]`"), obviating the added error message. However, I don't know if there are cases where the tool doesn't offer to install them (is this OS dependent?). Or maybe installing the dependencies fails. Perhaps the added error message helps in covering such gaps.

I'm open to suggestions on how to improve this. Thanks!


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
