### PR TITLE
Disable `qmk lint` acting on userspace by default.

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -359,10 +359,12 @@ Checks over a keyboard and/or keymap and highlights common errors, problems, and
 **Usage**:
 
 ```
-qmk lint [-km KEYMAP] [-kb KEYBOARD] [--strict]
+qmk lint [-km KEYMAP] [-kb KEYBOARD] [--strict] [--all-keymaps]
 ```
 
 This command is directory aware. It will automatically fill in KEYBOARD and/or KEYMAP if you are in a keyboard or keymap directory.
+
+When using `--all-keymaps`, any external userspace will also be considered for lint checking.
 
 **Examples**:
 

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -14,7 +14,7 @@ from qmk.c_parse import c_source_files, preprocess_c_file
 
 CHIBIOS_CONF_CHECKS = ['chconf.h', 'halconf.h', 'mcuconf.h', 'board.h']
 INVALID_KB_FEATURES = set(['encoder_map', 'dip_switch_map', 'combo', 'tap_dance', 'via'])
-INVALID_KM_NAMES = ['via', 'vial', 'tzarc']
+INVALID_KM_NAMES = ['via', 'vial']
 
 
 def _list_defaultish_keymaps(kb):


### PR DESCRIPTION
## Description

Skips running lint checks against userspace keymaps by default. Can still opt-in through using `--all-keymaps` as a new argument.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #24676 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
