### PR TITLE
Fix coban pad9a wrong layout in keyboard.json

### DIFF
--- a/keyboards/coban/pad9a/keyboard.json
+++ b/keyboards/coban/pad9a/keyboard.json
@@ -69,7 +69,7 @@
                 {"label": "key_3", "matrix": [0, 4], "x": 2, "y": 1},
                 {"label": "key_4", "matrix": [0, 5], "x": 0, "y": 2},
                 {"label": "key_5", "matrix": [0, 6], "x": 1, "y": 2},
-                {"label": "key_6", "matrix": [0, 7], "x": 2, "y": 3}
+                {"label": "key_6", "matrix": [0, 7], "x": 2, "y": 2}
             ]
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

coban pad9a show wrong layout

Current:

https://config.qmk.fm/#/coban/pad9a/LAYOUT

<img width="456" alt="image" src="https://github.com/user-attachments/assets/eb8b4cb5-e9f4-4699-92bc-1b17df753b17" />

Expect:

![image](https://github.com/user-attachments/assets/6b7e5b7e-2a66-4887-af47-ad274a165b50)

<!--- Describe your changes in detail here. -->

I change location of key_6 from [2, 3] to [2, 2]

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
