### PR TITLE
rmi_kb squishy* layout name corrections

### DIFF
--- a/keyboards/rmi_kb/squishy65/keyboard.json
+++ b/keyboards/rmi_kb/squishy65/keyboard.json
@@ -48,13 +48,13 @@
     "diode_direction": "COL2ROW",
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
-    "community_layouts": ["65_ansi_blocker", "65_iso_blocker"],
+    "community_layouts": ["65_ansi_blocker_split_bs", "65_iso_blocker"],
     "layout_aliases": {
-        "LAYOUT_ansi": "LAYOUT_65_ansi_blocker",
+        "LAYOUT_ansi": "LAYOUT_65_ansi_blocker_split_bs",
         "LAYOUT_iso": "LAYOUT_65_iso_blocker"
     },
     "layouts": {
-        "LAYOUT_65_ansi_blocker": {
+        "LAYOUT_65_ansi_blocker_split_bs": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/rmi_kb/squishy65/keyboard.json
+++ b/keyboards/rmi_kb/squishy65/keyboard.json
@@ -48,8 +48,13 @@
     "diode_direction": "COL2ROW",
     "processor": "STM32F072",
     "bootloader": "stm32-dfu",
+    "community_layouts": ["65_ansi_blocker", "65_iso_blocker"],
+    "layout_aliases": {
+        "LAYOUT_ansi": "LAYOUT_65_ansi_blocker",
+        "LAYOUT_iso": "LAYOUT_65_iso_blocker"
+    },
     "layouts": {
-        "LAYOUT_ansi": {
+        "LAYOUT_65_ansi_blocker": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},
@@ -126,7 +131,7 @@
                 {"matrix": [4, 15], "x": 15, "y": 4}
             ]
         },
-        "LAYOUT_iso": {
+        "LAYOUT_65_iso_blocker": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},

--- a/keyboards/rmi_kb/squishy65/keymaps/default/keymap.c
+++ b/keyboards/rmi_kb/squishy65/keymaps/default/keymap.c
@@ -18,14 +18,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT_ansi(
+  [0] = LAYOUT_65_ansi_blocker(
       KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSLS, KC_HOME,
       KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC,          KC_PGUP,
       KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,                    KC_PGDN,
       KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   KC_UP,   KC_END,
       KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                    KC_RALT, MO(1),                     KC_LEFT, KC_DOWN, KC_RGHT
   ),
-  [1] = LAYOUT_ansi(
+  [1] = LAYOUT_65_ansi_blocker(
       QK_BOOT, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______, UG_SATU,
       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_DEL,           UG_HUEU,
       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   UG_HUED,

--- a/keyboards/rmi_kb/squishy65/keymaps/default/keymap.c
+++ b/keyboards/rmi_kb/squishy65/keymaps/default/keymap.c
@@ -18,14 +18,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT_65_ansi_blocker(
+  [0] = LAYOUT_65_ansi_blocker_split_bs(
       KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_GRV,  KC_BSLS, KC_HOME,
       KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSPC,          KC_PGUP,
       KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,                    KC_PGDN,
       KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                   KC_UP,   KC_END,
       KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                    KC_RALT, MO(1),                     KC_LEFT, KC_DOWN, KC_RGHT
   ),
-  [1] = LAYOUT_65_ansi_blocker(
+  [1] = LAYOUT_65_ansi_blocker_split_bs(
       QK_BOOT, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  _______, _______, UG_SATU,
       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_DEL,           UG_HUEU,
       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   UG_HUED,

--- a/keyboards/rmi_kb/squishy65/keymaps/iso/keymap.c
+++ b/keyboards/rmi_kb/squishy65/keymaps/iso/keymap.c
@@ -18,14 +18,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT_iso(
+  [0] = LAYOUT_65_iso_blocker(
       KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,          KC_HOME,
       KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_ENT,           KC_PGUP,
       KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_NUHS,                   KC_PGDN,
       KC_LSFT, KC_NUBS, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_END,
       KC_LCTL, KC_LGUI, KC_LALT,                            KC_SPC,                    KC_RALT, MO(1),                     KC_LEFT, KC_DOWN, KC_RGHT
   ),
-  [1] = LAYOUT_iso(
+  [1] = LAYOUT_65_iso_blocker(
       QK_BOOT, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,           UG_SATU,
       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          UG_HUEU,
       _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,                   UG_HUED,

--- a/keyboards/rmi_kb/squishytkl/keyboard.json
+++ b/keyboards/rmi_kb/squishytkl/keyboard.json
@@ -54,8 +54,13 @@
     },
     "processor": "STM32F103",
     "bootloader": "stm32duino",
+    "community_layouts": ["tkl_f13_ansi", "tkl_f13_iso"],
+    "layout_aliases": {
+        "LAYOUT_ansi": "LAYOUT_tkl_f13_ansi",
+        "LAYOUT_iso": "LAYOUT_tkl_f13_iso"
+    },
     "layouts": {
-        "LAYOUT_ansi": {
+        "LAYOUT_tkl_f13_ansi": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
 
@@ -161,7 +166,7 @@
                 {"matrix": [7, 25], "x": 17.25, "y": 5.25}
             ]
         },
-        "LAYOUT_iso": {
+        "LAYOUT_tkl_f13_iso": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
 

--- a/keyboards/rmi_kb/squishytkl/keymaps/default/keymap.c
+++ b/keyboards/rmi_kb/squishytkl/keymaps/default/keymap.c
@@ -16,7 +16,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_ansi(
+    [0] = LAYOUT_tkl_f13_ansi(
         KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_MUTE, KC_PSCR, KC_SCRL, KC_PAUS,
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_DEL,  KC_END,  KC_PGDN,

--- a/keyboards/rmi_kb/squishytkl/keymaps/iso/keymap.c
+++ b/keyboards/rmi_kb/squishytkl/keymaps/iso/keymap.c
@@ -16,7 +16,7 @@
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [0] = LAYOUT_iso(
+    [0] = LAYOUT_tkl_f13_iso(
         KC_ESC,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_MUTE, KC_PSCR, KC_SCRL, KC_PAUS,
         KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_INS,  KC_HOME, KC_PGUP,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC,          KC_DEL,  KC_END,  KC_PGDN,


### PR DESCRIPTION
Amend layout names for rmi_kb's squishy series to matching Community Layouts
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
- rename layout names, in keyboard and keymap(s), to match community layout
- layout aliases added for backwards compatibility
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
