### PR TITLE
Fix deletion of oneshot locked modifiers (#25106)

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -472,22 +472,22 @@ void process_action(keyrecord_t *record, action_t action) {
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == ONESHOT_TAP_TOGGLE) {
                                 ac_dprintf("MODS_TAP: Toggling oneshot");
-                                register_mods(mods);
                                 del_oneshot_mods(mods);
                                 add_oneshot_locked_mods(mods);
+                                register_mods(mods);
 #        endif
                             }
                         } else {
                             if (tap_count == 0) {
                                 // Release hold: unregister the held mod and its variants
-                                unregister_mods(mods);
                                 del_oneshot_mods(mods);
                                 del_oneshot_locked_mods(mods);
+                                unregister_mods(mods);
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == 1 && (mods & get_mods())) {
-                                unregister_mods(mods);
                                 del_oneshot_mods(mods);
                                 del_oneshot_locked_mods(mods);
+                                unregister_mods(mods);
 #        endif
                             }
                         }


### PR DESCRIPTION
## Description

Fixed a deletion of oneshot locked modifiers by changing the order of instructions in `process_action` function.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #25106 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
