### PR TITLE
Add warning when deprecated 'promicro_rp2040' is used

### DIFF
--- a/platforms/chibios/converters/promicro_to_promicro_rp2040/pre_converter.mk
+++ b/platforms/chibios/converters/promicro_to_promicro_rp2040/pre_converter.mk
@@ -1,2 +1,8 @@
 CONVERTER:=platforms/chibios/converters/promicro_to_sparkfun_pm2040
 ACTIVE_CONVERTER:=sparkfun_pm2040
+
+$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
+$(info The 'CONVERT_TO=promicro_rp2040' option is now deprecated.)
+$(info Depending on hardware either 'CONVERT_TO=sparkfun_pm2040' or 'CONVERT_TO=rp2040_ce' should be used instead.)
+$(info See https://docs.qmk.fm/feature_converters#pro-micro documentation for more information.)
+$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
https://docs.qmk.fm/ChangeLog/20240825#sparkfun-pro-micro-rp2040-converter-renamed-24192

Converter was marked as deprecated and removed from docs, but nothing is currently being shoved in users faces to tell them what they are doing is incorrect.
 
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
