### PR TITLE
chore: Allow disabling underglow on Work Louder devices (#25123)

### DIFF
--- a/keyboards/work_louder/rgb_functions.c
+++ b/keyboards/work_louder/rgb_functions.c
@@ -17,7 +17,6 @@
 #ifdef RGBLIGHT_ENABLE
 
 #include "rgblight.h"
-#include "rgb_matrix.h"
 
 #undef WS2812_DI_PIN
 #define WS2812_DI_PIN RGBLIGHT_DI_PIN

--- a/keyboards/work_louder/rgb_functions.c
+++ b/keyboards/work_louder/rgb_functions.c
@@ -14,10 +14,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef RGBLIGHT_ENABLE
+
 #include "rgblight.h"
 #include "rgb_matrix.h"
 
-#ifdef RGBLIGHT_ENABLE
 #undef WS2812_DI_PIN
 #define WS2812_DI_PIN RGBLIGHT_DI_PIN
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Allows disabling Underglow on Work Louder devices by using `RGBLIGHT_ENABLE = no` on rules.mk. Reduces firmware size to allow using other features. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #25123 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
