### PR TITLE
Cater for use of `__errno_r()` in ChibiOS syscalls.c in newer picolibc revisions

### DIFF
--- a/platforms/chibios/errno.h
+++ b/platforms/chibios/errno.h
@@ -1,0 +1,13 @@
+// Copyright 2025 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+#include_next <errno.h>
+
+// Newer versions of picolibc don't seem to provide `__errno_r(r)` in the header file, but is used by ChibiOS.
+#ifndef __errno_r
+#    ifdef __REENT_ERRNO
+#        define __errno_r(r) _REENT_ERRNO(r)
+#    else
+#        define __errno_r(r) (errno)
+#    endif
+#endif


### PR DESCRIPTION
## Description

As per the title.

Struck this when doing `qmk mass-compile` with bootstrapped toolchain.

Seems newer picolibc revisions don't include `__errno_r()`, and ChibiOS uses it.

Only newer toolchain affected by this currently, and limited to the single riscv32 target.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
