### PR TITLE
Include `math.h` where necessary.

### DIFF
--- a/keyboards/rubi/lib/calc.c
+++ b/keyboards/rubi/lib/calc.c
@@ -13,6 +13,7 @@ This is the modified version of [calculator by MWWorks](https://github.com/MWWor
    Feel free to fix it! I think it needs to detect the precision of the two operands and then figure out what the precision of the result should be
 
 */
+#include <math.h>
 #include "rubi.h"
 
 static uint8_t calc_current_operand = 0;

--- a/keyboards/terrazzo/terrazzo.c
+++ b/keyboards/terrazzo/terrazzo.c
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <math.h>
 #include "terrazzo.h"
 
 #ifdef LED_MATRIX_ENABLE


### PR DESCRIPTION
## Description

As per title.

These boards apparently relied on an implicit `math.h` inclusion somewhere, which seemingly no longer exists on the new toolchains.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
