### PR TITLE
Avoid duplication in generated community modules `rules.mk`

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -251,6 +251,9 @@ generated-files: $(INTERMEDIATE_OUTPUT)/src/config.h $(INTERMEDIATE_OUTPUT)/src/
 endif
 
 # Community modules
+COMMUNITY_RULES_MK = $(shell $(QMK_BIN) generate-community-modules-rules-mk -kb $(KEYBOARD) --quiet --escape --output $(INTERMEDIATE_OUTPUT)/src/community_rules.mk $(KEYMAP_JSON))
+include $(COMMUNITY_RULES_MK)
+
 $(INTERMEDIATE_OUTPUT)/src/community_modules.h: $(KEYMAP_JSON) $(DD_CONFIG_FILES)
 	@$(SILENT) || printf "$(MSG_GENERATING) $@" | $(AWK_CMD)
 	$(eval CMD=$(QMK_BIN) generate-community-modules-h -kb $(KEYBOARD) --quiet --output $(INTERMEDIATE_OUTPUT)/src/community_modules.h $(KEYMAP_JSON))

--- a/lib/python/qmk/cli/generate/rules_mk.py
+++ b/lib/python/qmk/cli/generate/rules_mk.py
@@ -6,13 +6,12 @@ from dotty_dict import dotty
 from argcomplete.completers import FilesCompleter
 from milc import cli
 
-from qmk.info import info_json, get_modules
+from qmk.info import info_json
 from qmk.json_schema import json_load
 from qmk.keyboard import keyboard_completer, keyboard_folder
 from qmk.commands import dump_lines, parse_configurator_json
-from qmk.path import normpath, unix_style_path, FileType
+from qmk.path import normpath, FileType
 from qmk.constants import GPL2_HEADER_SH_LIKE, GENERATED_HEADER_SH_LIKE
-from qmk.community_modules import find_module_path, load_module_jsons
 
 
 def generate_rule(rules_key, rules_value):
@@ -53,35 +52,6 @@ def generate_features_rules(features_dict):
         feature = feature.upper()
         enabled = 'yes' if enabled else 'no'
         lines.append(generate_rule(f'{feature}_ENABLE', enabled))
-    return lines
-
-
-def generate_modules_rules(keyboard, filename):
-    lines = []
-    modules = get_modules(keyboard, filename)
-    if len(modules) > 0:
-        lines.append('')
-        lines.append('OPT_DEFS += -DCOMMUNITY_MODULES_ENABLE=TRUE')
-        for module in modules:
-            module_path = unix_style_path(find_module_path(module))
-            if not module_path:
-                raise FileNotFoundError(f"Module '{module}' not found.")
-            lines.append('')
-            lines.append(f'COMMUNITY_MODULES += {module_path.name}')  # use module_path here instead of module as it may be a subdirectory
-            lines.append(f'OPT_DEFS += -DCOMMUNITY_MODULE_{module_path.name.upper()}_ENABLE=TRUE')
-            lines.append(f'COMMUNITY_MODULE_PATHS += {module_path}')
-            lines.append(f'VPATH += {module_path}')
-            lines.append(f'SRC += $(wildcard {module_path}/{module_path.name}.c)')
-            lines.append(f'MODULE_NAME_{module_path.name.upper()} := {module_path.name}')
-            lines.append(f'MODULE_PATH_{module_path.name.upper()} := {module_path}')
-            lines.append(f'-include {module_path}/rules.mk')
-
-        module_jsons = load_module_jsons(modules)
-        for module_json in module_jsons:
-            if 'features' in module_json:
-                lines.append('')
-                lines.append(f'# Module: {module_json["module_name"]}')
-                lines.extend(generate_features_rules(module_json['features']))
     return lines
 
 
@@ -134,8 +104,6 @@ def generate_rules_mk(cli):
 
     if converter:
         rules_mk_lines.append(generate_rule('CONVERT_TO', converter))
-
-    rules_mk_lines.extend(generate_modules_rules(cli.args.keyboard, cli.args.filename))
 
     # Show the results
     dump_lines(cli.args.output, rules_mk_lines)

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -1066,23 +1066,13 @@ def get_modules(keyboard, keymap_filename):
     """
     modules = []
 
+    kb_info_json = info_json(keyboard)
+    modules.extend(kb_info_json.get('modules', []))
+
     if keymap_filename:
         keymap_json = parse_configurator_json(keymap_filename)
 
         if keymap_json:
-            kb = keymap_json.get('keyboard', None)
-            if not kb:
-                kb = keyboard
-
-            if kb:
-                kb_info_json = info_json(kb)
-                if kb_info_json:
-                    modules.extend(kb_info_json.get('modules', []))
-
             modules.extend(keymap_json.get('modules', []))
-
-    elif keyboard:
-        kb_info_json = info_json(keyboard)
-        modules.extend(kb_info_json.get('modules', []))
 
     return list(dict.fromkeys(modules))  # remove dupes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Due to the way the content was previously generated, the moving of module config to slightly later does not change the effective order.

Also avoids the scenario where `keymap.json` "keyboard` field has a different value to the currently comping keyboard. This can happen when a keymap is shared across multiple revisions (or just set to a completely incorrect value).
```
keyboards/test/rev1/keyboard.json - include module A
keyboards/test/rev2/keyboard.json - include module B
keyboards/test/keymaps/default/keymap.json - include module C sets keyboard field to "test/rev1"
```

If you then compile `test/rev2:default` it will incorrectly pull in modules A, B and C

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
