### PR TITLE
Remove duplication of RGB Matrix defaults

### DIFF
--- a/keyboards/adm42/rev4/keyboard.json
+++ b/keyboards/adm42/rev4/keyboard.json
@@ -82,7 +82,6 @@
             {"matrix": [0, 10], "x": 194, "y": 13, "flags": 4},
             {"matrix": [0, 11], "x": 210, "y": 11, "flags": 4}
         ],
-        "led_flush_limit": 16,
         "led_process_limit": 21,
         "max_brightness": 170,
         "sat_steps": 24,

--- a/keyboards/ashwing66/keyboard.json
+++ b/keyboards/ashwing66/keyboard.json
@@ -75,7 +75,6 @@
             {"matrix": [0, 14], "x": 206, "y": 1, "flags": 4},
             {"matrix": [0, 15], "x": 223, "y": 0, "flags": 4}
         ],
-        "led_flush_limit": 16,
         "led_process_limit": 5,
         "max_brightness": 125,
         "sleep": true

--- a/keyboards/eek/info.json
+++ b/keyboards/eek/info.json
@@ -13,7 +13,6 @@
             "val": 150
         },
         "driver": "ws2812",
-        "led_flush_limit": 16,
         "max_brightness": 200
     },
     "features": {

--- a/keyboards/ein_60/keyboard.json
+++ b/keyboards/ein_60/keyboard.json
@@ -13,7 +13,6 @@
             "val": 150
         },
         "driver": "ws2812",
-        "led_flush_limit": 16,
         "max_brightness": 200
     },
     "rgblight": {

--- a/keyboards/fs_streampad/keyboard.json
+++ b/keyboards/fs_streampad/keyboard.json
@@ -76,9 +76,6 @@
             "pixel_flow": true,
             "pixel_rain": true
         },
-        "default": {
-            "animation": "cycle_left_right"
-        },
         "sleep": true,
         "layout": [
             {"matrix": [0, 0], "flags": 4, "x": 0,   "y": 0 },

--- a/keyboards/geekboards/macropad_v2/keyboard.json
+++ b/keyboards/geekboards/macropad_v2/keyboard.json
@@ -47,7 +47,6 @@
     },
     "default": {
       "animation": "cycle_up_down",
-      "sat": 255,
       "speed": 30,
       "val": 192
     },

--- a/keyboards/handwired/hnah40rgb/keyboard.json
+++ b/keyboards/handwired/hnah40rgb/keyboard.json
@@ -61,7 +61,6 @@
             "animation": "cycle_pinwheel"
         },
         "driver": "ws2812",
-        "led_flush_limit": 16,
         "max_brightness": 200,
         "react_on_keyup": true
     },

--- a/keyboards/marcopad/keyboard.json
+++ b/keyboards/marcopad/keyboard.json
@@ -34,8 +34,7 @@
             "animation": "splash",
             "hue": 132,
             "sat": 102,
-            "speed": 80,
-            "val": 255
+            "speed": 80
         },
         "driver": "ws2812",
         "layout": [

--- a/keyboards/mechboards/crkbd/pro/keyboard.json
+++ b/keyboards/mechboards/crkbd/pro/keyboard.json
@@ -30,9 +30,6 @@
         "animations": {
             "cycle_left_right": true
         },
-        "default": {
-            "animation": "cycle_left_right"
-        },
         "driver": "ws2812",
         "layout": [
             {"x": 85, "y": 16, "flags": 2},

--- a/keyboards/mechboards/lily58/pro/keyboard.json
+++ b/keyboards/mechboards/lily58/pro/keyboard.json
@@ -30,9 +30,6 @@
         "animations": {
             "cycle_left_right": true
         },
-        "default": {
-            "animation": "cycle_left_right"
-        },
         "driver": "ws2812",
         "layout": [
             {"matrix": [0, 5], "x": 72, "y": 4, "flags": 4},

--- a/keyboards/mechboards/sofle/pro/keyboard.json
+++ b/keyboards/mechboards/sofle/pro/keyboard.json
@@ -30,9 +30,6 @@
         "animations": {
             "cycle_left_right": true
         },
-        "default": {
-            "animation": "cycle_left_right"
-        },
         "driver": "ws2812",
         "layout": [
             {"matrix": [4, 0], "x": 32, "y": 57, "flags": 4},

--- a/keyboards/momokai/aurora/keyboard.json
+++ b/keyboards/momokai/aurora/keyboard.json
@@ -45,7 +45,6 @@
     "rgb_matrix": {
         "default": {
             "animation": "solid_color",
-            "hue": 0,
             "sat": 0,
             "val": 200
         },

--- a/keyboards/momokai/tap_duo/keyboard.json
+++ b/keyboards/momokai/tap_duo/keyboard.json
@@ -14,7 +14,6 @@
     "rgb_matrix": {
         "default": {
             "animation": "solid_color",
-            "hue": 0,
             "sat": 0,
             "val": 200
         },

--- a/keyboards/momokai/tap_trio/keyboard.json
+++ b/keyboards/momokai/tap_trio/keyboard.json
@@ -14,7 +14,6 @@
     "rgb_matrix": {
         "default": {
             "animation": "solid_color",
-            "hue": 0,
             "sat": 0,
             "val": 200
         },

--- a/keyboards/rot13labs/veilid_sao/keyboard.json
+++ b/keyboards/rot13labs/veilid_sao/keyboard.json
@@ -31,9 +31,6 @@
             "cycle_left_right": true
         },
         "driver": "ws2812",
-        "default": {
-            "animation": "cycle_left_right"
-        },
         "layout": [
             {"flags": 4, "matrix": [0, 0], "x": 0,   "y": 0}
         ],

--- a/keyboards/splitkb/halcyon/kyria/rev4/keyboard.json
+++ b/keyboards/splitkb/halcyon/kyria/rev4/keyboard.json
@@ -139,9 +139,6 @@
     },
     "split": {
         "enabled": true,
-        "handedness": {
-            "pin": "GP24"
-        },
         "matrix_pins": {
             "right": {
                 "cols": ["GP5", "GP10", "GP9", "GP4", "GP25", "GP20", "GP19"],

--- a/keyboards/splitkb/halcyon/kyria/rev4/keyboard.json
+++ b/keyboards/splitkb/halcyon/kyria/rev4/keyboard.json
@@ -65,9 +65,6 @@
             "splash": true,
             "typing_heatmap": true
         },
-        "default": {
-            "animation": "cycle_left_right"
-        },
         "driver": "ws2812",
         "layout": [
             {"x": 75, "y": 2, "flags": 2},
@@ -139,6 +136,9 @@
     },
     "split": {
         "enabled": true,
+        "handedness": {
+            "pin": "GP24"
+        },
         "matrix_pins": {
             "right": {
                 "cols": ["GP5", "GP10", "GP9", "GP4", "GP25", "GP20", "GP19"],

--- a/keyboards/system76/launch_1/keyboard.json
+++ b/keyboards/system76/launch_1/keyboard.json
@@ -44,9 +44,7 @@
         },
         "default": {
             "animation": "rainbow_moving_chevron",
-            "hue": 142,
-            "sat": 255,
-            "speed": 127
+            "hue": 142
         },
         "driver": "ws2812",
         "max_brightness": 176,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Removed config options where they are duplicating defaults while implementing 25149.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
