### PR TITLE
Fix Aurora sweep default keymap configuration

### DIFF
--- a/keyboards/splitkb/aurora/sweep/keymaps/default/keymap.json
+++ b/keyboards/splitkb/aurora/sweep/keymaps/default/keymap.json
@@ -54,20 +54,6 @@
         ]
     ],
     "config": {
-        "features": {
-            "oled": true,
-            "rgb_matrix": true,
-            "rgblight": false
-        },
-        "encoder": {
-            "enabled": true
-        },
-        "rgblight": {
-            "hue_steps": 8,
-            "saturation_steps": 8,
-            "brightness_steps": 8,
-            "sleep": true
-        },
         "mousekey": {
             "interval": 16,
             "time_to_max": 40,

--- a/keyboards/splitkb/aurora/sweep/keymaps/default/keymap.json
+++ b/keyboards/splitkb/aurora/sweep/keymaps/default/keymap.json
@@ -67,18 +67,17 @@
             "saturation_steps": 8,
             "brightness_steps": 8,
             "sleep": true
+        },
+        "mousekey": {
+            "interval": 16,
+            "time_to_max": 40,
+            "delay": 100,
+            "wheel_delay": 100
+        },
+        "tapping": {
+            "term": 200,
+            "permissive_hold": true,
+            "force_hold": true
         }
-    },
-    "mouse_key": {
-        "enabled": true,
-        "interval": 16,
-        "time_to_max": 40,
-        "delay": 100,
-        "wheel_delay": 100
-    },
-    "tapping": {
-        "term": 200,
-        "permissive_hold": true,
-        "force_hold": true
     }
 }


### PR DESCRIPTION
## Description

Aurora sweep default keymap had some invalid configuration for the mouse keys and tapping. Duplicate items which were already set in the `keyboard.json` have also been removed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
