### PR TITLE
Extend lint checks to reject duplication of defaults

### DIFF
--- a/data/mappings/info_defaults.hjson
+++ b/data/mappings/info_defaults.hjson
@@ -1,0 +1,73 @@
+{
+    "bootmagic": {
+        "matrix": [0, 0]
+    },
+    "backlight": {
+        "default": {
+            "on": true
+        },
+        "breathing_period": 6,
+        "levels": 3,
+        "on_state": 1
+    },
+    "features": {
+        "command": false,
+        "console": false
+    },
+    "indicators": {
+        "on_state": 1
+    },
+    "led_matrix": {
+        "default": {
+            "animation": "solid",
+            "on": true,
+            "val": 255,
+            "speed": 128
+        },
+        "led_flush_limit": 16,
+        "max_brightness": 255,
+        "sleep": false,
+        "speed_steps": 16,
+        "val_steps": 16
+    },
+    "rgblight": {
+        "default": {
+            "animation": "static_light",
+            "on": true,
+            "hue": 0,
+            "sat": 255,
+            "val": 255,
+            "speed": 0
+        },
+        "brightness_steps": 17,
+        "hue_steps": 8,
+        "max_brightness": 255,
+        "saturation_steps": 17,
+        "sleep": false
+    },
+    "rgb_matrix": {
+        "default": {
+            "animation": "cycle_left_right",
+            "on": true,
+            "hue": 0,
+            "sat": 255,
+            "val": 255,
+            "speed": 128
+        },
+        "hue_steps": 8,
+        "led_flush_limit": 16,
+        "max_brightness": 255,
+        "sat_steps": 16,
+        "sleep": false,
+        "speed_steps": 16,
+        "val_steps": 16
+    },
+    "split": {
+        "serial": {
+            "driver": "bitbang"
+        }
+    },
+    "ws2812": {
+        "driver": "bitbang"
+    }
+}

--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -1,5 +1,6 @@
 """Command to look over a keyboard/keymap and check for common mistakes.
 """
+from dotty_dict import dotty
 from pathlib import Path
 
 from milc import cli
@@ -11,6 +12,7 @@ from qmk.keymap import locate_keymap, list_keymaps
 from qmk.path import keyboard
 from qmk.git import git_get_ignored_files
 from qmk.c_parse import c_source_files, preprocess_c_file
+from qmk.json_schema import json_load
 
 CHIBIOS_CONF_CHECKS = ['chconf.h', 'halconf.h', 'mcuconf.h', 'board.h']
 INVALID_KB_FEATURES = set(['encoder_map', 'dip_switch_map', 'combo', 'tap_dance', 'via'])
@@ -214,6 +216,32 @@ def _rules_mk_assignment_only(rules_mk):
     return errors
 
 
+def _handle_duplicating_code_defaults(kb, info):
+    def _collect_dotted_output(kb_info_json, prefix=''):
+        """Print the info.json in a plain text format with dot-joined keys.
+        """
+        for key in sorted(kb_info_json):
+            new_prefix = f'{prefix}.{key}' if prefix else key
+
+            if isinstance(kb_info_json[key], dict):
+                yield from _collect_dotted_output(kb_info_json[key], new_prefix)
+            elif isinstance(kb_info_json[key], list):
+                # TODO: handle non primitives?
+                yield (new_prefix, kb_info_json[key])
+            else:
+                yield (new_prefix, kb_info_json[key])
+
+    defaults_map = json_load(Path('data/mappings/info_defaults.hjson'))
+    dotty_info = dotty(info)
+
+    for key, v_default in _collect_dotted_output(defaults_map):
+        v_info = dotty_info.get(key)
+        if v_default == v_info:
+            cli.log.warning(f'{kb}: Option "{key}" duplicates default value of "{v_default}"')
+
+    return True
+
+
 def keymap_check(kb, km):
     """Perform the keymap level checks.
     """
@@ -264,6 +292,9 @@ def keyboard_check(kb):  # noqa C901
         ok = False
 
     if not _handle_invalid_config(kb, kb_info):
+        ok = False
+
+    if not _handle_duplicating_code_defaults(kb, kb_info):
         ok = False
 
     invalid_files = git_get_ignored_files(f'keyboards/{kb}/')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Example output:
```
qmk lint -kb all 2>&1 | grep "duplicates default value" | grep -v features.console | grep -v features.command
☒ cipulot/ec_980c: Option "rgb_matrix.max_brightness" duplicates default value of "255"
☒ custommk/evo70_r2: Option "backlight.breathing_period" duplicates default value of "6"
☒ darmoshark/k3: Option "indicators.on_state" duplicates default value of "1"
☒ dnworks/frltkl: Option "indicators.on_state" duplicates default value of "1"
☒ dnworks/sbl: Option "indicators.on_state" duplicates default value of "1"
☒ dnworks/tkl87: Option "indicators.on_state" duplicates default value of "1"
☒ ebastler/e80_1800: Option "backlight.on_state" duplicates default value of "1"
☒ handwired/daskeyboard/daskeyboard4: Option "indicators.on_state" duplicates default value of "1"
☒ kbdfans/odin75: Option "indicators.on_state" duplicates default value of "1"
☒ kbdfans/tiger80: Option "indicators.on_state" duplicates default value of "1"
☒ meetlab/kafkasplit: Option "indicators.on_state" duplicates default value of "1"
☒ studiokestra/fairholme: Option "indicators.on_state" duplicates default value of "1"
☒ studiokestra/line_friends_tkl: Option "indicators.on_state" duplicates default value of "1"
☒ yandrstudio/transition80: Option "indicators.on_state" duplicates default value of "1"
☒ zeix/eden: Option "indicators.on_state" duplicates default value of "1"
```

First pass covers some of the common requests on PRs. The scope has been limited for now, with future passes planned for the next develop cycles, including promoting the warnings to errors.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
