### PR TITLE
DZ60 layout name corrections

### DIFF
--- a/keyboards/dz60/keyboard.json
+++ b/keyboards/dz60/keyboard.json
@@ -67,10 +67,14 @@
         "60_ansi_tsangan_split_bs_rshift",
         "60_hhkb",
         "60_iso",
-        "60_abnt2"
+        "60_iso_arrow",
+        "60_abnt2",
+        "64_iso"
     ],
     "layout_aliases": {
-        "LAYOUT_60_tsangan_hhkb": "LAYOUT_60_ansi_tsangan_split_bs_rshift"
+        "LAYOUT_60_tsangan_hhkb": "LAYOUT_60_ansi_tsangan_split_bs_rshift",
+        "LAYOUT_60_iso_arrow_one_bksp": "LAYOUT_60_iso_arrow",
+        "LAYOUT_60_iso_4th_row_all_1u": "LAYOUT_64_iso"
     },
     "layouts": {
         "LAYOUT": {
@@ -863,7 +867,7 @@
                 {"matrix": [4, 14], "x": 13.75, "y": 4, "w": 1.25}
             ]
         },
-        "LAYOUT_60_iso_arrow_one_bksp": {
+        "LAYOUT_60_iso_arrow": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},
@@ -1941,7 +1945,7 @@
                 {"matrix": [4, 14], "x": 13.75, "y": 4, "w": 1.25}
             ]
         },
-        "LAYOUT_60_iso_4th_row_all_1u": {
+        "LAYOUT_64_iso": {
             "layout": [
                 {"matrix": [0, 0], "x": 0, "y": 0},
                 {"matrix": [0, 1], "x": 1, "y": 0},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
- renamed layouts to match corresponding Community Layout:
  - `60_iso_arrow_one_bksp` to `60_iso_arrow`
  - `60_iso_4th_row_all_1u` to `64_iso`
- `layouts_aliases` and `community_layouts` appended accordingly
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
