### PR TITLE
Update franky36 pid and vid

### DIFF
--- a/keyboards/handwired/franky36/keyboard.json
+++ b/keyboards/handwired/franky36/keyboard.json
@@ -23,8 +23,8 @@
     "url": "https://github.com/avdyushin/franky36",
     "usb": {
         "device_version": "0.2.0",
-        "pid": "0x0001",
-        "vid": "0xFEED"
+        "pid": "0x1337",
+        "vid": "0x1209"
     },
     "community_layouts": ["split_3x5_3"],
     "layouts": {

--- a/keyboards/handwired/franky36/keyboard.json
+++ b/keyboards/handwired/franky36/keyboard.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/avdyushin/franky36",
     "usb": {
         "device_version": "0.2.0",
-        "pid": "0x1337",
+        "pid": "0x3336",
         "vid": "0x1209"
     },
     "community_layouts": ["split_3x5_3"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Changed VID and PID for handwired franky36 keyboard.
I think this values are available for open source projects.

This should resolve conflicts with keyboards that uses same `0x0001` pid and `0xFEED` vid

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
