### PR TITLE
Fixup eeconfig lighting reset.

### DIFF
--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -103,8 +103,8 @@ void eeconfig_init_quantum(void) {
 #endif // AUDIO_ENABLE
 
 #ifdef RGBLIGHT_ENABLE
-    rgblight_config_t rgblight_config = {0};
-    eeconfig_update_rgblight(&rgblight_config);
+    extern void eeconfig_update_rgblight_default(void);
+    eeconfig_update_rgblight_default();
 #endif // RGBLIGHT_ENABLE
 
 #ifdef UNICODE_COMMON_ENABLE
@@ -117,13 +117,13 @@ void eeconfig_init_quantum(void) {
 #endif // STENO_ENABLE
 
 #ifdef RGB_MATRIX_ENABLE
-    rgb_config_t rgb_matrix_config = {0};
-    eeconfig_update_rgb_matrix(&rgb_matrix_config);
+    extern void eeconfig_update_rgb_matrix_default(void);
+    eeconfig_update_rgb_matrix_default();
 #endif
 
 #ifdef LED_MATRIX_ENABLE
-    led_eeconfig_t led_matrix_config = {0};
-    eeconfig_update_led_matrix(&led_matrix_config);
+    extern void eeconfig_update_led_matrix_default(void);
+    eeconfig_update_led_matrix_default();
 #endif // LED_MATRIX_ENABLE
 
 #ifdef HAPTIC_ENABLE
@@ -150,6 +150,15 @@ void eeconfig_init_quantum(void) {
 #endif
 
     eeconfig_init_kb();
+
+#ifdef RGB_MATRIX_ENABLE
+    extern void eeconfig_force_flush_rgb_matrix(void);
+    eeconfig_force_flush_rgb_matrix();
+#endif // RGB_MATRIX_ENABLE
+#ifdef LED_MATRIX_ENABLE
+    extern void eeconfig_force_flush_led_matrix(void);
+    eeconfig_force_flush_led_matrix();
+#endif // LED_MATRIX_ENABLE
 }
 
 void eeconfig_init(void) {


### PR DESCRIPTION
## Description

Lighting wasn't being reset correctly after an `EE_CLR`. The initial write of zero's to the lighting would effectively turn the subsystems off, and as such would disregard any attempts to update values within the configuration as all the APIs are guarded by an `if (!xxx_matrix.enabled) { return; }` or equivalent.

Basically, the example in the docs ([here, down the bottom](https://docs.qmk.fm/feature_eeprom#example-implementation)) was non-functional.

This change forces defaults to be written rather than zero's, but also in the case of rgb_matrix / led_matrix flushes the eeprom once the kb/user eeconfig hooks have been invoked. This ensures any changes those hooks made are actually saved.

Happy to rebase onto `master` if we think it's worth fixing there.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
