### PR TITLE
Allow for disabling EEPROM subsystem entirely.

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -169,12 +169,12 @@ ifeq ($(strip $(QUANTUM_PAINTER_ENABLE)), yes)
     include $(QUANTUM_DIR)/painter/rules.mk
 endif
 
-VALID_EEPROM_DRIVER_TYPES := none vendor custom transient i2c spi wear_leveling legacy_stm32_flash
+VALID_EEPROM_DRIVER_TYPES := vendor custom transient i2c spi wear_leveling legacy_stm32_flash
 EEPROM_DRIVER ?= vendor
-ifeq ($(filter $(EEPROM_DRIVER),$(VALID_EEPROM_DRIVER_TYPES)),)
+ifneq ($(strip $(EEPROM_DRIVER)),none)
+  ifeq ($(filter $(EEPROM_DRIVER),$(VALID_EEPROM_DRIVER_TYPES)),)
   $(call CATASTROPHIC_ERROR,Invalid EEPROM_DRIVER,EEPROM_DRIVER="$(EEPROM_DRIVER)" is not a valid EEPROM driver)
-else
-  ifneq ($(strip $(EEPROM_DRIVER)),none)
+  else
     OPT_DEFS += -DEEPROM_ENABLE
     COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/eeprom
     COMMON_VPATH += $(DRIVER_PATH)/eeprom

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -169,82 +169,84 @@ ifeq ($(strip $(QUANTUM_PAINTER_ENABLE)), yes)
     include $(QUANTUM_DIR)/painter/rules.mk
 endif
 
-VALID_EEPROM_DRIVER_TYPES := vendor custom transient i2c spi wear_leveling legacy_stm32_flash
+VALID_EEPROM_DRIVER_TYPES := none vendor custom transient i2c spi wear_leveling legacy_stm32_flash
 EEPROM_DRIVER ?= vendor
 ifeq ($(filter $(EEPROM_DRIVER),$(VALID_EEPROM_DRIVER_TYPES)),)
   $(call CATASTROPHIC_ERROR,Invalid EEPROM_DRIVER,EEPROM_DRIVER="$(EEPROM_DRIVER)" is not a valid EEPROM driver)
 else
-  OPT_DEFS += -DEEPROM_ENABLE
-  COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/eeprom
-  COMMON_VPATH += $(DRIVER_PATH)/eeprom
-  COMMON_VPATH += $(PLATFORM_COMMON_DIR)
-  ifeq ($(strip $(EEPROM_DRIVER)), custom)
-    # Custom EEPROM implementation -- only needs to implement init/erase/read_block/write_block
-    OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_CUSTOM
-    SRC += eeprom_driver.c
-  else ifeq ($(strip $(EEPROM_DRIVER)), wear_leveling)
-    # Wear-leveling EEPROM implementation
-    OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_WEAR_LEVELING
-    SRC += eeprom_driver.c eeprom_wear_leveling.c
-  else ifeq ($(strip $(EEPROM_DRIVER)), i2c)
-    # External I2C EEPROM implementation
-    OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_I2C
-    I2C_DRIVER_REQUIRED = yes
-    SRC += eeprom_driver.c eeprom_i2c.c
-  else ifeq ($(strip $(EEPROM_DRIVER)), spi)
-    # External SPI EEPROM implementation
-    OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_SPI
-    SPI_DRIVER_REQUIRED = yes
-    SRC += eeprom_driver.c eeprom_spi.c
-  else ifeq ($(strip $(EEPROM_DRIVER)), legacy_stm32_flash)
-    # STM32 Emulated EEPROM, backed by MCU flash (soon to be deprecated)
-    OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_LEGACY_EMULATED_FLASH
-    COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/flash
-    COMMON_VPATH += $(DRIVER_PATH)/flash
-    SRC += eeprom_driver.c eeprom_legacy_emulated_flash.c legacy_flash_ops.c
-  else ifeq ($(strip $(EEPROM_DRIVER)), transient)
-    # Transient EEPROM implementation -- no data storage but provides runtime area for it
-    OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_TRANSIENT
-    SRC += eeprom_driver.c eeprom_transient.c
-  else ifeq ($(strip $(EEPROM_DRIVER)), vendor)
-    # Vendor-implemented EEPROM
-    OPT_DEFS += -DEEPROM_VENDOR
-    ifeq ($(PLATFORM),AVR)
-      # Automatically provided by avr-libc, nothing required
-    else ifeq ($(PLATFORM),CHIBIOS)
-      ifneq ($(filter %_STM32F072xB %_STM32F042x6, $(MCU_SERIES)_$(MCU_LDSCRIPT)),)
-        # STM32 Emulated EEPROM, backed by MCU flash (soon to be deprecated)
-        OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_LEGACY_EMULATED_FLASH
-        COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/flash
-        COMMON_VPATH += $(DRIVER_PATH)/flash
-        SRC += eeprom_driver.c eeprom_legacy_emulated_flash.c legacy_flash_ops.c
-      else ifneq ($(filter $(MCU_SERIES),STM32F1xx STM32F3xx STM32F4xx STM32L4xx STM32G4xx WB32F3G71xx WB32FQ95xx AT32F415 GD32VF103),)
-        # Wear-leveling EEPROM implementation, backed by MCU flash
-        OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_WEAR_LEVELING
-        SRC += eeprom_driver.c eeprom_wear_leveling.c
-        WEAR_LEVELING_DRIVER ?= embedded_flash
-      else ifneq ($(filter $(MCU_SERIES),STM32L0xx STM32L1xx),)
-        # True EEPROM on STM32L0xx, L1xx
-        OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_STM32_L0_L1
-        SRC += eeprom_driver.c eeprom_stm32_L0_L1.c
-      else ifneq ($(filter $(MCU_SERIES),RP2040),)
-        # Wear-leveling EEPROM implementation, backed by RP2040 flash
-        OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_WEAR_LEVELING
-        SRC += eeprom_driver.c eeprom_wear_leveling.c
-        WEAR_LEVELING_DRIVER ?= rp2040_flash
-      else ifneq ($(filter $(MCU_SERIES),KL2x K20x),)
-        # Teensy EEPROM implementations
-        OPT_DEFS += -DEEPROM_KINETIS_FLEXRAM
-        SRC += eeprom_kinetis_flexram.c
-      else
-        # Fall back to transient, i.e. non-persistent
-        OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_TRANSIENT
-        SRC += eeprom_driver.c eeprom_transient.c
+  ifneq ($(strip $(EEPROM_DRIVER)),none)
+    OPT_DEFS += -DEEPROM_ENABLE
+    COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/eeprom
+    COMMON_VPATH += $(DRIVER_PATH)/eeprom
+    COMMON_VPATH += $(PLATFORM_COMMON_DIR)
+    ifeq ($(strip $(EEPROM_DRIVER)), custom)
+      # Custom EEPROM implementation -- only needs to implement init/erase/read_block/write_block
+      OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_CUSTOM
+      SRC += eeprom_driver.c
+    else ifeq ($(strip $(EEPROM_DRIVER)), wear_leveling)
+      # Wear-leveling EEPROM implementation
+      OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_WEAR_LEVELING
+      SRC += eeprom_driver.c eeprom_wear_leveling.c
+    else ifeq ($(strip $(EEPROM_DRIVER)), i2c)
+      # External I2C EEPROM implementation
+      OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_I2C
+      I2C_DRIVER_REQUIRED = yes
+      SRC += eeprom_driver.c eeprom_i2c.c
+    else ifeq ($(strip $(EEPROM_DRIVER)), spi)
+      # External SPI EEPROM implementation
+      OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_SPI
+      SPI_DRIVER_REQUIRED = yes
+      SRC += eeprom_driver.c eeprom_spi.c
+    else ifeq ($(strip $(EEPROM_DRIVER)), legacy_stm32_flash)
+      # STM32 Emulated EEPROM, backed by MCU flash (soon to be deprecated)
+      OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_LEGACY_EMULATED_FLASH
+      COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/flash
+      COMMON_VPATH += $(DRIVER_PATH)/flash
+      SRC += eeprom_driver.c eeprom_legacy_emulated_flash.c legacy_flash_ops.c
+    else ifeq ($(strip $(EEPROM_DRIVER)), transient)
+      # Transient EEPROM implementation -- no data storage but provides runtime area for it
+      OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_TRANSIENT
+      SRC += eeprom_driver.c eeprom_transient.c
+    else ifeq ($(strip $(EEPROM_DRIVER)), vendor)
+      # Vendor-implemented EEPROM
+      OPT_DEFS += -DEEPROM_VENDOR
+      ifeq ($(PLATFORM),AVR)
+        # Automatically provided by avr-libc, nothing required
+      else ifeq ($(PLATFORM),CHIBIOS)
+        ifneq ($(filter %_STM32F072xB %_STM32F042x6, $(MCU_SERIES)_$(MCU_LDSCRIPT)),)
+          # STM32 Emulated EEPROM, backed by MCU flash (soon to be deprecated)
+          OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_LEGACY_EMULATED_FLASH
+          COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/flash
+          COMMON_VPATH += $(DRIVER_PATH)/flash
+          SRC += eeprom_driver.c eeprom_legacy_emulated_flash.c legacy_flash_ops.c
+        else ifneq ($(filter $(MCU_SERIES),STM32F1xx STM32F3xx STM32F4xx STM32L4xx STM32G4xx WB32F3G71xx WB32FQ95xx AT32F415 GD32VF103),)
+          # Wear-leveling EEPROM implementation, backed by MCU flash
+          OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_WEAR_LEVELING
+          SRC += eeprom_driver.c eeprom_wear_leveling.c
+          WEAR_LEVELING_DRIVER ?= embedded_flash
+        else ifneq ($(filter $(MCU_SERIES),STM32L0xx STM32L1xx),)
+          # True EEPROM on STM32L0xx, L1xx
+          OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_STM32_L0_L1
+          SRC += eeprom_driver.c eeprom_stm32_L0_L1.c
+        else ifneq ($(filter $(MCU_SERIES),RP2040),)
+          # Wear-leveling EEPROM implementation, backed by RP2040 flash
+          OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_WEAR_LEVELING
+          SRC += eeprom_driver.c eeprom_wear_leveling.c
+          WEAR_LEVELING_DRIVER ?= rp2040_flash
+        else ifneq ($(filter $(MCU_SERIES),KL2x K20x),)
+          # Teensy EEPROM implementations
+          OPT_DEFS += -DEEPROM_KINETIS_FLEXRAM
+          SRC += eeprom_kinetis_flexram.c
+        else
+          # Fall back to transient, i.e. non-persistent
+          OPT_DEFS += -DEEPROM_DRIVER -DEEPROM_TRANSIENT
+          SRC += eeprom_driver.c eeprom_transient.c
+        endif
+      else ifeq ($(PLATFORM),TEST)
+        # Test harness "EEPROM"
+        OPT_DEFS += -DEEPROM_TEST_HARNESS
+        SRC += eeprom.c
       endif
-    else ifeq ($(PLATFORM),TEST)
-      # Test harness "EEPROM"
-      OPT_DEFS += -DEEPROM_TEST_HARNESS
-      SRC += eeprom.c
     endif
   endif
 endif

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -319,7 +319,7 @@
                     "properties": {
                         "driver": {
                             "type": "string",
-                            "enum": ["custom", "embedded_flash", "legacy", "rp2040_flash", "spi_flash"]
+                            "enum": ["none", "custom", "embedded_flash", "legacy", "rp2040_flash", "spi_flash"]
                         },
                         "backing_size": {"$ref": "qmk.definitions.v1#/unsigned_int"},
                         "logical_size": {"$ref": "qmk.definitions.v1#/unsigned_int"}

--- a/quantum/dynamic_keymap.c
+++ b/quantum/dynamic_keymap.c
@@ -18,8 +18,6 @@
 #include "dynamic_keymap.h"
 #include "keymap_introspection.h"
 #include "action.h"
-#include "eeprom.h"
-#include "progmem.h"
 #include "send_string.h"
 #include "keycodes.h"
 #include "nvm_dynamic_keymap.h"

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -7,11 +7,6 @@
 #include "nvm_eeconfig.h"
 #include "keycode_config.h"
 
-#ifdef EEPROM_DRIVER
-#    include "eeprom.h"
-#    include "eeprom_driver.h"
-#endif // EEPROM_DRIVER
-
 #ifdef BACKLIGHT_ENABLE
 #    include "backlight.h"
 #endif // BACKLIGHT_ENABLE

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -2,13 +2,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "debug.h"
-#include "eeprom.h"
 #include "eeconfig.h"
 #include "action_layer.h"
 #include "nvm_eeconfig.h"
 #include "keycode_config.h"
 
 #ifdef EEPROM_DRIVER
+#    include "eeprom.h"
 #    include "eeprom_driver.h"
 #endif // EEPROM_DRIVER
 

--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -19,7 +19,6 @@
 
 #include "led_matrix.h"
 #include "progmem.h"
-#include "eeprom.h"
 #include "eeconfig.h"
 #include "keyboard.h"
 #include "sync_timer.h"

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -18,7 +18,6 @@
 
 #include "rgb_matrix.h"
 #include "progmem.h"
-#include "eeprom.h"
 #include "eeconfig.h"
 #include "keyboard.h"
 #include "sync_timer.h"

--- a/quantum/unicode/unicode.c
+++ b/quantum/unicode/unicode.c
@@ -16,7 +16,6 @@
 
 #include "unicode.h"
 
-#include "eeprom.h"
 #include "eeconfig.h"
 #include "action.h"
 #include "action_util.h"

--- a/quantum/via.c
+++ b/quantum/via.c
@@ -26,7 +26,6 @@
 
 #include "raw_hid.h"
 #include "dynamic_keymap.h"
-#include "eeprom.h"
 #include "eeconfig.h"
 #include "matrix.h"
 #include "timer.h"


### PR DESCRIPTION
## Description

Allow for disabling the EEPROM subsystem entirely. NVM is now exposed to `eeconfig`, `via`, `dynamic_keymap` et.al. -- EEPROM is no longer necessary when NVM is implemented through other means.

Code diff is best viewed with whitespace disabled.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
