### PR TITLE
Add lint warning for empty url

### DIFF
--- a/lib/python/qmk/cli/lint.py
+++ b/lib/python/qmk/cli/lint.py
@@ -171,6 +171,14 @@ def _handle_invalid_features(kb, info):
     return ok
 
 
+def _handle_invalid_config(kb, info):
+    """Check for invalid keyboard level config
+    """
+    if info.get('url') == "":
+        cli.log.warning(f'{kb}: Invalid keyboard level config detected - Optional field "url" should not be empty.')
+    return True
+
+
 def _chibios_conf_includenext_check(target):
     """Check the ChibiOS conf.h for the correct inclusion of the next conf.h
     """
@@ -253,6 +261,9 @@ def keyboard_check(kb):  # noqa C901
 
     # Additional checks
     if not _handle_invalid_features(kb, kb_info):
+        ok = False
+
+    if not _handle_invalid_config(kb, kb_info):
         ok = False
 
     invalid_files = git_get_ignored_files(f'keyboards/{kb}/')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Empty "url" fields serve no value for the repo.

This PR adds a lint warning so that we can begin to require this, without breaking anything. Next cycle we can then promote this to an error.

```
qmk lint -kb handwired/ziyoulang_k3_mod
⚠ handwired/ziyoulang_k3_mod: Invalid keyboard level config detected - Optional field "url" should not be empty.
Ψ Lint check passed!
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
