### PR TITLE
[Bug] Minimise force-included files

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -267,18 +267,22 @@ ifneq ($(strip $(WEAR_LEVELING_DRIVER)),none)
     ifeq ($(strip $(WEAR_LEVELING_DRIVER)), embedded_flash)
       OPT_DEFS += -DHAL_USE_EFL
       SRC += wear_leveling_efl.c
-      POST_CONFIG_H += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/wear_leveling/wear_leveling_efl_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_efl.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_efl_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_efl_config.h
     else ifeq ($(strip $(WEAR_LEVELING_DRIVER)), spi_flash)
       FLASH_DRIVER := spi
       SRC += wear_leveling_flash_spi.c
-      POST_CONFIG_H += $(DRIVER_PATH)/wear_leveling/wear_leveling_flash_spi_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_flash_spi.o: INIT_HOOK_CFLAGS += -include $(DRIVER_PATH)/wear_leveling/wear_leveling_flash_spi_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(DRIVER_PATH)/wear_leveling/wear_leveling_flash_spi_config.h
     else ifeq ($(strip $(WEAR_LEVELING_DRIVER)), rp2040_flash)
       SRC += wear_leveling_rp2040_flash.c
-      POST_CONFIG_H += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_rp2040_flash_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_rp2040_flash.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_rp2040_flash_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_rp2040_flash_config.h
     else ifeq ($(strip $(WEAR_LEVELING_DRIVER)), legacy)
       COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/flash
       SRC += legacy_flash_ops.c wear_leveling_legacy.c
-      POST_CONFIG_H += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/wear_leveling/wear_leveling_legacy_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_legacy.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_legacy_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_legacy_config.h
     endif
   endif
 endif

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -267,22 +267,22 @@ ifneq ($(strip $(WEAR_LEVELING_DRIVER)),none)
     ifeq ($(strip $(WEAR_LEVELING_DRIVER)), embedded_flash)
       OPT_DEFS += -DHAL_USE_EFL
       SRC += wear_leveling_efl.c
-      $(INTERMEDIATE_OUTPUT)/wear_leveling_efl.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_efl_config.h
-      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_efl_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_efl.o: FILE_SPECIFIC_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_efl_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: FILE_SPECIFIC_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_efl_config.h
     else ifeq ($(strip $(WEAR_LEVELING_DRIVER)), spi_flash)
       FLASH_DRIVER := spi
       SRC += wear_leveling_flash_spi.c
-      $(INTERMEDIATE_OUTPUT)/wear_leveling_flash_spi.o: INIT_HOOK_CFLAGS += -include $(DRIVER_PATH)/wear_leveling/wear_leveling_flash_spi_config.h
-      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(DRIVER_PATH)/wear_leveling/wear_leveling_flash_spi_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_flash_spi.o: FILE_SPECIFIC_CFLAGS += -include $(DRIVER_PATH)/wear_leveling/wear_leveling_flash_spi_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: FILE_SPECIFIC_CFLAGS += -include $(DRIVER_PATH)/wear_leveling/wear_leveling_flash_spi_config.h
     else ifeq ($(strip $(WEAR_LEVELING_DRIVER)), rp2040_flash)
       SRC += wear_leveling_rp2040_flash.c
-      $(INTERMEDIATE_OUTPUT)/wear_leveling_rp2040_flash.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_rp2040_flash_config.h
-      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_rp2040_flash_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_rp2040_flash.o: FILE_SPECIFIC_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_rp2040_flash_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: FILE_SPECIFIC_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_rp2040_flash_config.h
     else ifeq ($(strip $(WEAR_LEVELING_DRIVER)), legacy)
       COMMON_VPATH += $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_DIR)/flash
       SRC += legacy_flash_ops.c wear_leveling_legacy.c
-      $(INTERMEDIATE_OUTPUT)/wear_leveling_legacy.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_legacy_config.h
-      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: INIT_HOOK_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_legacy_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling_legacy.o: FILE_SPECIFIC_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_legacy_config.h
+      $(INTERMEDIATE_OUTPUT)/wear_leveling.o: FILE_SPECIFIC_CFLAGS += -include $(PLATFORM_PATH)/$(PLATFORM_KEY)/$(DRIVER_PATH)/wear_leveling/wear_leveling_legacy_config.h
     endif
   endif
 endif

--- a/builddefs/common_rules.mk
+++ b/builddefs/common_rules.mk
@@ -168,7 +168,7 @@ MOVE_DEP = mv -f $(patsubst %.o,%.td,$@) $(patsubst %.o,%.d,$@)
 
 # For a ChibiOS build, ensure that the board files have the hook overrides injected
 define BOARDSRC_INJECT_HOOKS
-$(INTERMEDIATE_OUTPUT)/$(patsubst %.c,%.o,$(patsubst ./%,%,$1)): INIT_HOOK_CFLAGS += -include $(TOP_DIR)/tmk_core/protocol/chibios/init_hooks.h
+$(INTERMEDIATE_OUTPUT)/$(patsubst %.c,%.o,$(patsubst ./%,%,$1)): FILE_SPECIFIC_CFLAGS += -include $(TOP_DIR)/tmk_core/protocol/chibios/init_hooks.h
 endef
 $(foreach LOBJ, $(BOARDSRC), $(eval $(call BOARDSRC_INJECT_HOOKS,$(LOBJ))))
 
@@ -289,10 +289,10 @@ $1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
     ifneq ($$(VERBOSE_C_INCLUDE),)
 	$$(if $$(filter $$(notdir $$(VERBOSE_C_INCLUDE)),$$(notdir $$<)),$$(eval CC_EXEC += -H))
     endif
-	$$(eval CMD := $$(CC_EXEC) -c $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
+	$$(eval CMD := $$(CC_EXEC) -c $$($1_CFLAGS) $$(FILE_SPECIFIC_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
     ifneq ($$(DUMP_C_MACROS),)
-	$$(eval CMD := $$(CC) -E -dM $$($1_CFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$<)
+	$$(eval CMD := $$(CC) -E -dM $$($1_CFLAGS) $$(FILE_SPECIFIC_CFLAGS) $$(GENDEPFLAGS) $$<)
 	@$$(if $$(filter $$(notdir $$(DUMP_C_MACROS)),$$(notdir $$<)),$$(BUILD_CMD))
     endif
 
@@ -300,13 +300,13 @@ $1/%.o : %.c $1/%.d $1/cflags.txt $1/compiler.txt | $(BEGIN)
 $1/%.o : %.cpp $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING_CXX) $$<" | $$(AWK_CMD)
-	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
+	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(FILE_SPECIFIC_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
 $1/%.o : %.cc $1/%.d $1/cxxflags.txt $1/compiler.txt | $(BEGIN)
 	@mkdir -p $$(@D)
 	@$$(SILENT) || printf "$$(MSG_COMPILING_CXX) $$<" | $$(AWK_CMD)
-	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(INIT_HOOK_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
+	$$(eval CMD=$$(CC) -c $$($1_CXXFLAGS) $$(FILE_SPECIFIC_CFLAGS) $$(GENDEPFLAGS) $$< -o $$@ && $$(MOVE_DEP))
 	@$$(BUILD_CMD)
 
 # Assemble: create object files from assembler source files.

--- a/keyboards/stront/stront.h
+++ b/keyboards/stront/stront.h
@@ -3,4 +3,6 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 bool is_display_enabled(void);

--- a/platforms/chibios/bootloaders/uf2boot.c
+++ b/platforms/chibios/bootloaders/uf2boot.c
@@ -1,6 +1,8 @@
 // Copyright 2023 QMK
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <stdint.h>
+#include <hal.h>
 #include "bootloader.h"
 
 // From mmoskal/uf2-stm32f103's backup.c


### PR DESCRIPTION
## Description

When writing a module which included lua, naming collisions were occurring with `panic` and the like due to `POST_CONFIG_H` inclusions pulling in the pico-sdk for every compiled file, resulting in conflicting function signatures with the name of the one in lua itself.

This limits the `POST_CONFIG_H` inclusions to where they're required, setting up file-specific forced inclusions instead. Leverages the same plumbing as the ChibiOS init hook overrides for the board files, renaming the variable to something a bit more generic in the process.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
