### PR TITLE
Fix single key combos activating only once

### DIFF
--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -347,6 +347,10 @@ void apply_combo(uint16_t combo_index, combo_t *combo) {
             qrecord->combo_index = combo_index;
             ACTIVATE_COMBO(combo);
 
+            if (key_count == 1) {
+                release_combo(combo_index, combo);
+            }
+
             break;
         } else {
             // key was part of the combo but not the last one, "disable" it

--- a/tests/combo/test_combo.cpp
+++ b/tests/combo/test_combo.cpp
@@ -54,3 +54,18 @@ TEST_F(Combo, combo_osmshift_tapped) {
     tap_key(key_i);
     VERIFY_AND_CLEAR(driver);
 }
+
+TEST_F(Combo, combo_single_key_twice) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 1, KC_A);
+    set_keymap({key_a});
+
+    EXPECT_REPORT(driver, (KC_B));
+    tap_combo({key_a});
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a});
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/combo/test_combos.c
+++ b/tests/combo/test_combos.c
@@ -4,14 +4,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "quantum.h"
 
-enum combos { modtest, osmshift };
+enum combos { modtest, osmshift, single_key };
 
 uint16_t const modtest_combo[]  = {KC_Y, KC_U, COMBO_END};
 uint16_t const osmshift_combo[] = {KC_Z, KC_X, COMBO_END};
+uint16_t const single_key_combo[] = {KC_A, COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {
     [modtest]  = COMBO(modtest_combo, RSFT_T(KC_SPACE)),
-    [osmshift] = COMBO(osmshift_combo, OSM(MOD_LSFT))
+    [osmshift] = COMBO(osmshift_combo, OSM(MOD_LSFT)),
+    [single_key] = COMBO(single_key_combo, KC_B),
 };
 // clang-format on


### PR DESCRIPTION
## Description

This PR fixes single key combos activating only once as described in #25197.
The bug is fixed by releasing the combo immediately upon sending if it consists of a single key.

I also added a unit test demonstrating the bug which runs successful after applying the fix.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #25197 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
