### PR TITLE
Remove force disable of NKRO when Bluetooth enabled

### DIFF
--- a/drivers/bluetooth/bluetooth.c
+++ b/drivers/bluetooth/bluetooth.c
@@ -11,6 +11,10 @@ __attribute__((weak)) bool bluetooth_is_connected(void) {
     return true;
 }
 
+__attribute__((weak)) bool bluetooth_can_send_nkro(void) {
+    return false;
+}
+
 __attribute__((weak)) uint8_t bluetooth_keyboard_leds(void) {
     return 0;
 }

--- a/drivers/bluetooth/bluetooth.h
+++ b/drivers/bluetooth/bluetooth.h
@@ -38,6 +38,11 @@ void bluetooth_task(void);
 bool bluetooth_is_connected(void);
 
 /**
+ * \brief Detects if `bluetooth_send_nkro` should be used over `bluetooth_send_keyboard`.
+ */
+bool bluetooth_can_send_nkro(void);
+
+/**
  * \brief Get current LED state.
  */
 uint8_t bluetooth_keyboard_leds(void);

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_layer.h"
 #include "timer.h"
 #include "keycode_config.h"
-#include "usb_device_state.h"
 #include <string.h>
 
 extern keymap_config_t keymap_config;
@@ -319,14 +318,12 @@ void send_nkro_report(void) {
  */
 void send_keyboard_report(void) {
 #ifdef NKRO_ENABLE
-    if (usb_device_state_get_protocol() == USB_PROTOCOL_REPORT && keymap_config.nkro) {
+    if (host_can_send_nkro() && keymap_config.nkro) {
         send_nkro_report();
-    } else {
-        send_6kro_report();
+        return;
     }
-#else
-    send_6kro_report();
 #endif
+    send_6kro_report();
 }
 
 /** \brief Get mods

--- a/tmk_core/protocol.mk
+++ b/tmk_core/protocol.mk
@@ -46,12 +46,8 @@ else
 endif
 
 ifeq ($(strip $(NKRO_ENABLE)), yes)
-    ifeq ($(strip $(BLUETOOTH_ENABLE)), yes)
-        $(info NKRO is not currently supported with Bluetooth, and has been disabled.)
-    else
-        OPT_DEFS += -DNKRO_ENABLE
-        SHARED_EP_ENABLE = yes
-    endif
+    OPT_DEFS += -DNKRO_ENABLE
+    SHARED_EP_ENABLE = yes
 endif
 
 ifeq ($(strip $(NO_SUSPEND_POWER_DOWN)), yes)

--- a/tmk_core/protocol/host.c
+++ b/tmk_core/protocol/host.c
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "host.h"
 #include "util.h"
 #include "debug.h"
+#include "usb_device_state.h"
 
 #ifdef DIGITIZER_ENABLE
 #    include "digitizer.h"
@@ -88,6 +89,23 @@ static host_driver_t *host_get_active_driver(void) {
     }
 #endif
     return driver;
+}
+
+bool host_can_send_nkro(void) {
+#ifdef CONNECTION_ENABLE
+    switch (connection_get_host()) {
+#    ifdef BLUETOOTH_ENABLE
+        case CONNECTION_HOST_BLUETOOTH:
+            return bluetooth_can_send_nkro();
+#    endif
+        case CONNECTION_HOST_NONE:
+            return false;
+        default:
+            break;
+    }
+#endif
+
+    return usb_device_state_get_protocol() == USB_PROTOCOL_REPORT;
 }
 
 #ifdef SPLIT_KEYBOARD

--- a/tmk_core/protocol/host.h
+++ b/tmk_core/protocol/host.h
@@ -32,6 +32,7 @@ void           host_set_driver(host_driver_t *driver);
 host_driver_t *host_get_driver(void);
 
 /* host driver interface */
+bool    host_can_send_nkro(void);
 uint8_t host_keyboard_leds(void);
 led_t   host_keyboard_led_state(void);
 void    host_keyboard_send(report_keyboard_t *report);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Compiling Bluetooth enabled firmware currently produces the following:
> NKRO is not currently supported with Bluetooth, and has been disabled.

This is somewhat pointless, as the keyboard would still be perfectly capable of supporting NKRO over USB.

This PR removes USB only assumptions in `send_keyboard_report`, and adds a Bluetooth stub that maintains the existing behaviour. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
