### PR TITLE
Ensure `qmk_userspace_paths` maintains detected order

### DIFF
--- a/lib/python/qmk/userspace.py
+++ b/lib/python/qmk/userspace.py
@@ -12,29 +12,30 @@ from qmk.json_encoders import UserspaceJSONEncoder
 
 
 def qmk_userspace_paths():
-    test_dirs = set()
+    test_dirs = []
 
     # If we're already in a directory with a qmk.json and a keyboards or layouts directory, interpret it as userspace
     if environ.get('ORIG_CWD') is not None:
         current_dir = Path(environ['ORIG_CWD'])
         while len(current_dir.parts) > 1:
             if (current_dir / 'qmk.json').is_file():
-                test_dirs.add(current_dir)
+                test_dirs.append(current_dir)
             current_dir = current_dir.parent
 
     # If we have a QMK_USERSPACE environment variable, use that
     if environ.get('QMK_USERSPACE') is not None:
         current_dir = Path(environ['QMK_USERSPACE']).expanduser()
         if current_dir.is_dir():
-            test_dirs.add(current_dir)
+            test_dirs.append(current_dir)
 
     # If someone has configured a directory, use that
     if cli.config.user.overlay_dir is not None:
         current_dir = Path(cli.config.user.overlay_dir).expanduser().resolve()
         if current_dir.is_dir():
-            test_dirs.add(current_dir)
+            test_dirs.append(current_dir)
 
-    return list(test_dirs)
+    # remove duplicates while maintaining the current order
+    return list(dict.fromkeys(test_dirs))
 
 
 def qmk_userspace_validate(path):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When `user.overlay_dir` is set, but current directory is inside a different `qmk_userspace` folder, the resolved order of the userspace directory resolves randomly. One compilation it can pick the "correct" directory, 30 seconds later the next invocation it can pick a different one.

This is due to the result of the `set -> list` not maintaining insertion order. Copied strat used by community modules to fix the issue.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
