### PR TITLE
Add battery changed callbacks

### DIFF
--- a/docs/drivers/battery.md
+++ b/docs/drivers/battery.md
@@ -49,3 +49,25 @@ Sample battery level.
 #### Return Value {#api-battery-get-percent-return}
 
 The battery percentage, in the range 0-100.
+
+## Callbacks
+
+### `void battery_percent_changed_user(uint8_t level)` {#api-battery-percent-changed-user}
+
+User hook called when battery level changed.
+
+### Arguments {#api-battery-percent-changed-user-arguments}
+
+ - `uint8_t level`  
+   The battery percentage, in the range 0-100.
+
+---
+
+### `void battery_percent_changed_kb(uint8_t level)` {#api-battery-percent-changed-kb}
+
+Keyboard hook called when battery level changed.
+
+### Arguments {#api-battery-percent-changed-kb-arguments}
+
+ - `uint8_t level`  
+   The battery percentage, in the range 0-100.

--- a/drivers/battery/battery.c
+++ b/drivers/battery/battery.c
@@ -17,10 +17,20 @@ void battery_init(void) {
     last_bat_level = battery_driver_sample_percent();
 }
 
+__attribute__((weak)) void battery_percent_changed_user(uint8_t level) {}
+__attribute__((weak)) void battery_percent_changed_kb(uint8_t level) {}
+
+static void handle_percent_changed(void) {
+    battery_percent_changed_user(last_bat_level);
+    battery_percent_changed_kb(last_bat_level);
+}
+
 void battery_task(void) {
     static uint32_t bat_timer = 0;
     if (timer_elapsed32(bat_timer) > BATTERY_SAMPLE_INTERVAL) {
         last_bat_level = battery_driver_sample_percent();
+
+        handle_percent_changed();
 
         bat_timer = timer_read32();
     }

--- a/drivers/battery/battery.h
+++ b/drivers/battery/battery.h
@@ -31,4 +31,16 @@ void battery_task(void);
  */
 uint8_t battery_get_percent(void);
 
+/**
+ * \brief user hook called when battery level changed.
+ *
+ */
+void battery_percent_changed_user(uint8_t level);
+
+/**
+ * \brief keyboard hook called when battery level changed.
+ *
+ */
+void battery_percent_changed_kb(uint8_t level);
+
 /** \} */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Avoids the following sort of code block:
```c
void housekeeping_task_kb(void) {
  static uint16_t bat_timer = 0;
  static uint8_t last_bat_level = UINT8_MAX;

  if (timer_elapsed(bat_timer) > 5000) {
    uint8_t level = battery_get_percent();
    if (level != last_bat_level) {
      // do something

      last_bat_level = level;
    }
  }
}
```

Where the caching of value within `battery_get_percent` might not align with when the timer is checked.

This can now be reduced to:
```c
void battery_percent_changed_kb(uint8_t level) {
  // do something
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
