### PR TITLE
[Keyboard] Add Binepad KN01

### DIFF
--- a/keyboards/binepad/kn01/keyboard.json
+++ b/keyboards/binepad/kn01/keyboard.json
@@ -1,0 +1,58 @@
+{
+    "manufacturer": "Binepad",
+    "keyboard_name": "KN01",
+    "maintainer": "Binpad",
+    "bootloader": "stm32duino",
+    "processor": "STM32F103",
+    "diode_direction": "COL2ROW",
+    "debounce": 5,
+    "features": {
+        "bootmagic": true,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": false,
+        "encoder": true
+    },
+    "url": "http://binepad.com",
+    "usb": {
+        "vid": "0x4249",
+        "pid": "0x4040",
+        "device_version": "1.0.0"
+    },
+    "matrix_pins": {
+        "cols": [
+            "A15"
+        ],
+        "rows": [
+            "A8"
+        ]
+    },
+    "encoder": {
+        "enabled": true,
+        "rotary": [
+            {
+                "pin_a": "B3",
+                "pin_b": "B4"
+            }
+        ]
+    },
+    "community_layouts": [
+        "ortho_1x1"
+    ],
+    "layouts": {
+        "LAYOUT_ortho_1x1": {
+            "layout": [
+                {
+                    "matrix": [
+                        0,
+                        0
+                    ],
+                    "x": 0,
+                    "y": 0,
+                    "w": 2,
+                    "h": 2
+                }
+            ]
+        }
+    }
+}

--- a/keyboards/binepad/kn01/keyboard.json
+++ b/keyboards/binepad/kn01/keyboard.json
@@ -3,55 +3,34 @@
     "keyboard_name": "KN01",
     "maintainer": "Binpad",
     "bootloader": "stm32duino",
-    "processor": "STM32F103",
     "diode_direction": "COL2ROW",
-    "debounce": 5,
+    "encoder": {
+        "rotary": [
+            {"pin_a": "B3", "pin_b": "B4"}
+        ]
+    },
     "features": {
         "bootmagic": true,
+        "encoder": true,
         "extrakey": true,
-        "mousekey": true,
-        "nkro": false,
-        "encoder": true
-    },
-    "url": "http://binepad.com",
-    "usb": {
-        "vid": "0x4249",
-        "pid": "0x4040",
-        "device_version": "1.0.0"
+        "mousekey": true
     },
     "matrix_pins": {
-        "cols": [
-            "A15"
-        ],
-        "rows": [
-            "A8"
-        ]
+        "cols": ["A15"],
+        "rows": ["A8"]
     },
-    "encoder": {
-        "enabled": true,
-        "rotary": [
-            {
-                "pin_a": "B3",
-                "pin_b": "B4"
-            }
-        ]
+    "processor": "STM32F103",
+    "url": "http://binepad.com",
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x4040",
+        "vid": "0x4249"
     },
-    "community_layouts": [
-        "ortho_1x1"
-    ],
+    "community_layouts": ["ortho_1x1"],
     "layouts": {
         "LAYOUT_ortho_1x1": {
             "layout": [
-                {
-                    "matrix": [
-                        0,
-                        0
-                    ],
-                    "x": 0,
-                    "y": 0,
-                    "w": 2,
-                    "h": 2
-                }
+                {"matrix": [0, 0], "x": 0, "y": 0, "w": 2, "h": 2}
             ]
         }
     }

--- a/keyboards/binepad/kn01/keymaps/default/keymap.json
+++ b/keyboards/binepad/kn01/keymaps/default/keymap.json
@@ -1,16 +1,4 @@
 {
-    "keyboard": "binepad/kn01",
-    "keymap": "default",
-    "version": 1,
-    "layout": "LAYOUT_ortho_1x1",
-    "layers": [
-        [
-            "LT(1, KC_MUTE)"
-        ],
-        [
-            "_______"
-        ]
-    ],
     "config": {
         "features": {
             "encoder_map": true
@@ -29,5 +17,13 @@
                 "cw": "KC_MS_WH_UP"
             }
         ]
-    ]
+    ],
+    "keyboard": "binepad/kn01",
+    "keymap": "default",
+    "layers": [
+        ["LT(1, KC_MUTE)"],
+        ["_______"]
+    ],
+    "layout": "LAYOUT_ortho_1x1",
+    "version": 1
 }

--- a/keyboards/binepad/kn01/keymaps/default/keymap.json
+++ b/keyboards/binepad/kn01/keymaps/default/keymap.json
@@ -1,0 +1,33 @@
+{
+    "keyboard": "binepad/kn01",
+    "keymap": "default",
+    "version": 1,
+    "layout": "LAYOUT_ortho_1x1",
+    "layers": [
+        [
+            "LT(1, KC_MUTE)"
+        ],
+        [
+            "_______"
+        ]
+    ],
+    "config": {
+        "features": {
+            "encoder_map": true
+        }
+    },
+    "encoders": [
+        [
+            {
+                "ccw": "KC_VOLD",
+                "cw": "KC_VOLU"
+            }
+        ],
+        [
+            {
+                "ccw": "KC_MS_WH_DOWN",
+                "cw": "KC_MS_WH_UP"
+            }
+        ]
+    ]
+}

--- a/keyboards/binepad/kn01/readme.md
+++ b/keyboards/binepad/kn01/readme.md
@@ -1,0 +1,29 @@
+# BINEPAD NEOKNOB KN01
+
+![Binepad NeoKnob KN01](https://i.imgur.com/N8GXq7P.png)
+
+The KN01 is a multifunction knob, which can be rotated, pressed, and rotated while pressed.
+
+* Keyboard Maintainer: [Binpad](https://github.com/binepad)
+* Hardware Supported: **NEOKNOB KN01**
+* Hardware Availability: [Binepad.com](https://www.binepad.com/product-page/kn01)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make binepad/kn01:default
+
+Flashing example for this keyboard:
+
+    make binepad/kn01:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information.
+Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the knob while plugging in the keyboard's USB cable
+* **Physical reset button**: Briefly press the button on the underside of the PCB
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` *(or `RESET`)* if it is available

--- a/keyboards/binepad/kn01/readme.md
+++ b/keyboards/binepad/kn01/readme.md
@@ -6,7 +6,7 @@ The KN01 is a multifunction knob, which can be rotated, pressed, and rotated whi
 
 * Keyboard Maintainer: [Binpad](https://github.com/binepad)
 * Hardware Supported: **NEOKNOB KN01**
-* Hardware Availability: [Binepad.com](https://www.binepad.com/product-page/kn01)
+* Hardware Availability: [Binepad.com](https://www.binepad.com/products/kn01)
 
 Make example for this keyboard (after setting up your build environment):
 
@@ -26,4 +26,4 @@ Enter the bootloader in 3 ways:
 
 * **Bootmagic reset**: Hold down the knob while plugging in the keyboard's USB cable
 * **Physical reset button**: Briefly press the button on the underside of the PCB
-* **Keycode in layout**: Press the key mapped to `QK_BOOT` *(or `RESET`)* if it is available
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/binepad/kn01/rules.mk
+++ b/keyboards/binepad/kn01/rules.mk
@@ -1,4 +1,0 @@
-# This file only enables F103 low-power mode
-
-# Enter lower-power sleep mode when on the ChibiOS idle thread
-OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE

--- a/keyboards/binepad/kn01/rules.mk
+++ b/keyboards/binepad/kn01/rules.mk
@@ -1,0 +1,4 @@
+# This file only enables F103 low-power mode
+
+# Enter lower-power sleep mode when on the ChibiOS idle thread
+OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE


### PR DESCRIPTION
## Description

Addition of the Binepad NeoKnob KN01 rotary dial.

> This is an older model that was initially posted on Vial back in [March 2023](https://github.com/vial-kb/vial-qmk/commit/6c0ef5cbaedec62e0bd0e5936e0fbff8ea41ed80).

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* (n/a)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
