### PR TITLE
CXT Studio 12E3: Fix encoder resolutions not applying

### DIFF
--- a/keyboards/cxt_studio/12e3/keyboard.json
+++ b/keyboards/cxt_studio/12e3/keyboard.json
@@ -21,8 +21,8 @@
     },
     "encoder": {
         "rotary": [
-            {"pin_a": "F5", "pin_b": "F6"},
-            {"pin_a": "E6", "pin_b": "F0"},
+            {"pin_a": "F5", "pin_b": "F6", "resolution": 4},
+            {"pin_a": "E6", "pin_b": "F0", "resolution": 4},
             {"pin_a": "B3", "pin_b": "B2", "resolution": 2}
         ]
     },

--- a/keyboards/cxt_studio/12e3/keymaps/default/keymap.c
+++ b/keyboards/cxt_studio/12e3/keymaps/default/keymap.c
@@ -12,7 +12,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     [_BASE] = LAYOUT(
         KC_ESC, C(KC_X), C(KC_C), C(KC_V),  MS_BTN3, RM_TOGG,
-        KC_PSCR,KC_UNDO, KC_CALC, KC_MNXT,     KC_MPLY,
+        KC_PSCR,C(KC_Z), KC_CALC, KC_MNXT,     KC_MPLY,
         MO(1), KC_LGUI, KC_DEL, KC_APP
     ),
 

--- a/keyboards/cxt_studio/12e3/keymaps/default/keymap.c
+++ b/keyboards/cxt_studio/12e3/keymaps/default/keymap.c
@@ -11,14 +11,14 @@ enum my_layers {
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     [_BASE] = LAYOUT(
-        KC_PSCR, KC_CUT, KC_COPY, KC_PSTE,  MS_BTN3, RM_TOGG,
-        KC_CALC, KC_UNDO, KC_MPLY, KC_MNXT,     KC_MUTE,
+        KC_ESC, C(KC_X), C(KC_C), C(KC_V),  MS_BTN3, RM_TOGG,
+        KC_PSCR,KC_UNDO, KC_CALC, KC_MNXT,     KC_MPLY,
         MO(1), KC_LGUI, KC_DEL, KC_APP
     ),
 
     [_RGBL] = LAYOUT(
-        RM_NEXT, RM_SATU, KC_INS, KC_DEL,   _______, _______,
-        RM_PREV, RM_SATD, KC_PGUP, KC_HOME,     _______,
+        RM_NEXT, RM_SATU, KC_INS,  KC_DEL,   _______, _______,
+        RM_PREV, RM_SATD, KC_PGUP, KC_HOME,     KC_MUTE,
         _______, QK_BOOT, KC_PGDN, KC_END
     ),
 };


### PR DESCRIPTION
## Description

Added resolutions to keyboard.json encoders so they apply properly.
Also took the opportunity to tweak the default keymap layout slightly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
