### PR TITLE
Update faq_debug.md: Add newline to print examples

### DIFF
--- a/docs/faq_debug.md
+++ b/docs/faq_debug.md
@@ -42,10 +42,10 @@ Sometimes it's useful to print debug messages from within your [custom code](cus
 
 After that you can use a few different print functions:
 
-* `print("string")`: Print a simple string.
-* `uprintf("%s string", var)`: Print a formatted string
-* `dprint("string")` Print a simple string, but only when debug mode is enabled
-* `dprintf("%s string", var)`: Print a formatted string, but only when debug mode is enabled
+* `print("string\n")`: Print a simple string.
+* `uprintf("%s string\n", var)`: Print a formatted string
+* `dprint("string\n")` Print a simple string, but only when debug mode is enabled
+* `dprintf("%s string\n", var)`: Print a formatted string, but only when debug mode is enabled
 
 ## Debug Examples
 


### PR DESCRIPTION
Add newline to print statements messages so that it actually prints something.

Given CONSOLE_ENABLE = yes, when you want to print `print("stuff \n"); `something, you also have to include a newline so that it actually shows up on the hid console.

## Description

I was trying to find out what's going wrong for longer than I'd like to admit. It turns out the doc's example print statements dont actually print anything, because they dont end with a newline. I added these newlines to the docs so that the examples are complete and actually print something to console when pasted into ones own custom QMK code.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
