### PR TITLE
Remove more USB only branches from NKRO handling

### DIFF
--- a/tmk_core/protocol/report.c
+++ b/tmk_core/protocol/report.c
@@ -32,7 +32,7 @@ uint8_t has_anykey(void) {
     uint8_t* p   = keyboard_report->keys;
     uint8_t  lp  = sizeof(keyboard_report->keys);
 #ifdef NKRO_ENABLE
-    if (usb_device_state_get_protocol() == USB_PROTOCOL_REPORT && keymap_config.nkro) {
+    if (host_can_send_nkro() && keymap_config.nkro) {
         p  = nkro_report->bits;
         lp = sizeof(nkro_report->bits);
     }
@@ -49,7 +49,7 @@ uint8_t has_anykey(void) {
  */
 uint8_t get_first_key(void) {
 #ifdef NKRO_ENABLE
-    if (usb_device_state_get_protocol() == USB_PROTOCOL_REPORT && keymap_config.nkro) {
+    if (host_can_send_nkro() && keymap_config.nkro) {
         uint8_t i = 0;
         for (; i < NKRO_REPORT_BITS && !nkro_report->bits[i]; i++)
             ;
@@ -69,7 +69,7 @@ bool is_key_pressed(uint8_t key) {
         return false;
     }
 #ifdef NKRO_ENABLE
-    if (usb_device_state_get_protocol() == USB_PROTOCOL_REPORT && keymap_config.nkro) {
+    if (host_can_send_nkro() && keymap_config.nkro) {
         if ((key >> 3) < NKRO_REPORT_BITS) {
             return nkro_report->bits[key >> 3] & 1 << (key & 7);
         } else {
@@ -151,7 +151,7 @@ void del_key_bit(report_nkro_t* nkro_report, uint8_t code) {
  */
 void add_key_to_report(uint8_t key) {
 #ifdef NKRO_ENABLE
-    if (usb_device_state_get_protocol() == USB_PROTOCOL_REPORT && keymap_config.nkro) {
+    if (host_can_send_nkro() && keymap_config.nkro) {
         add_key_bit(nkro_report, key);
         return;
     }
@@ -165,7 +165,7 @@ void add_key_to_report(uint8_t key) {
  */
 void del_key_from_report(uint8_t key) {
 #ifdef NKRO_ENABLE
-    if (usb_device_state_get_protocol() == USB_PROTOCOL_REPORT && keymap_config.nkro) {
+    if (host_can_send_nkro() && keymap_config.nkro) {
         del_key_bit(nkro_report, key);
         return;
     }
@@ -180,7 +180,7 @@ void del_key_from_report(uint8_t key) {
 void clear_keys_from_report(void) {
     // not clear mods
 #ifdef NKRO_ENABLE
-    if (usb_device_state_get_protocol() == USB_PROTOCOL_REPORT && keymap_config.nkro) {
+    if (host_can_send_nkro() && keymap_config.nkro) {
         memset(nkro_report->bits, 0, sizeof(nkro_report->bits));
         return;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Only checking `usb_device_state_get_protocol` blocks other host drivers from correctly implementing NKRO.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
