### PR TITLE
Remove duplicate of SPI default config from keyboards

### DIFF
--- a/docs/drivers/spi.md
+++ b/docs/drivers/spi.md
@@ -39,8 +39,6 @@ To enable SPI, modify your board's `halconf.h` to enable SPI, then modify your b
 #pragma once
 
 #define HAL_USE_SPI TRUE // [!code focus]
-#define SPI_USE_WAIT TRUE // [!code focus]
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD // [!code focus]
 
 #include_next <halconf.h>
 ```

--- a/keyboards/adafruit/macropad/halconf.h
+++ b/keyboards/adafruit/macropad/halconf.h
@@ -16,16 +16,7 @@
 
 #pragma once
 
-#include_next <halconf.h>
-
-#undef HAL_USE_SPI
 #define HAL_USE_SPI TRUE
-
-#undef SPI_USE_WAIT
-#define SPI_USE_WAIT TRUE
-
-#undef SPI_SELECT_MODE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-
-#undef HAL_USE_PWM
 #define HAL_USE_PWM TRUE
+
+#include_next <halconf.h>

--- a/keyboards/akko/5087/halconf.h
+++ b/keyboards/akko/5087/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/akko/5108/halconf.h
+++ b/keyboards/akko/5108/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/akko/acr87/halconf.h
+++ b/keyboards/akko/acr87/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/akko/top40/halconf.h
+++ b/keyboards/akko/top40/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/annepro2/halconf.h
+++ b/keyboards/annepro2/halconf.h
@@ -26,7 +26,5 @@
 #define SERIAL_USB_BUFFERS_SIZE 256
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/bastardkb/charybdis/3x5/blackpill/halconf.h
+++ b/keyboards/bastardkb/charybdis/3x5/blackpill/halconf.h
@@ -21,7 +21,5 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_SERIAL TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/bastardkb/charybdis/3x6/blackpill/halconf.h
+++ b/keyboards/bastardkb/charybdis/3x6/blackpill/halconf.h
@@ -21,7 +21,5 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_SERIAL TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/bastardkb/charybdis/4x6/blackpill/halconf.h
+++ b/keyboards/bastardkb/charybdis/4x6/blackpill/halconf.h
@@ -21,7 +21,5 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_SERIAL TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/bastardkb/scylla/blackpill/halconf.h
+++ b/keyboards/bastardkb/scylla/blackpill/halconf.h
@@ -21,7 +21,5 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_SERIAL TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/bastardkb/skeletyl/blackpill/halconf.h
+++ b/keyboards/bastardkb/skeletyl/blackpill/halconf.h
@@ -21,7 +21,5 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_SERIAL TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/bastardkb/tbkmini/blackpill/halconf.h
+++ b/keyboards/bastardkb/tbkmini/blackpill/halconf.h
@@ -21,7 +21,5 @@
 #define HAL_USE_PWM TRUE
 #define HAL_USE_SERIAL TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/chosfox/cf81/halconf.h
+++ b/keyboards/chosfox/cf81/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/custommk/cmk11/halconf.h
+++ b/keyboards/custommk/cmk11/halconf.h
@@ -20,11 +20,6 @@
 
 #define HAL_USE_SPI TRUE
 
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-
 #define SERIAL_BUFFERS_SIZE 256
-
-// This enables interrupt-driven mode
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/custommk/elysian/halconf.h
+++ b/keyboards/custommk/elysian/halconf.h
@@ -5,10 +5,6 @@
 
 #define HAL_USE_SPI TRUE
 
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-
 #define SERIAL_BUFFERS_SIZE 256
-
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/custommk/ergostrafer/halconf.h
+++ b/keyboards/custommk/ergostrafer/halconf.h
@@ -20,11 +20,6 @@
 
 #define HAL_USE_SPI TRUE
 
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-
 #define SERIAL_BUFFERS_SIZE 256
-
-// This enables interrupt-driven mode
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/custommk/ergostrafer_rgb/halconf.h
+++ b/keyboards/custommk/ergostrafer_rgb/halconf.h
@@ -20,11 +20,6 @@
 
 #define HAL_USE_SPI TRUE
 
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-
 #define SERIAL_BUFFERS_SIZE 256
-
-// This enables interrupt-driven mode
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/custommk/evo70_r2/halconf.h
+++ b/keyboards/custommk/evo70_r2/halconf.h
@@ -26,11 +26,6 @@
 
 #define HAL_USE_GPT TRUE
 
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-
 #define SERIAL_BUFFERS_SIZE 256
-
-// This enables interrupt-driven mode
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/darkproject/kd83a_bfg_edition/halconf.h
+++ b/keyboards/darkproject/kd83a_bfg_edition/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/darkproject/kd87a_bfg_edition/halconf.h
+++ b/keyboards/darkproject/kd87a_bfg_edition/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/darmoshark/k3/halconf.h
+++ b/keyboards/darmoshark/k3/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/edi/hardlight/mk2/halconf.h
+++ b/keyboards/edi/hardlight/mk2/halconf.h
@@ -25,8 +25,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Activate Serial Peripheral Interface
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-
 
 #include_next <halconf.h>

--- a/keyboards/gmmk/gmmk2/p65/halconf.h
+++ b/keyboards/gmmk/gmmk2/p65/halconf.h
@@ -22,8 +22,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>
-

--- a/keyboards/gmmk/gmmk2/p96/halconf.h
+++ b/keyboards/gmmk/gmmk2/p96/halconf.h
@@ -22,8 +22,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>
-

--- a/keyboards/gmmk/numpad/halconf.h
+++ b/keyboards/gmmk/numpad/halconf.h
@@ -18,9 +18,6 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 #define HAL_USE_ADC TRUE
-
 
 #include_next <halconf.h>

--- a/keyboards/gmmk/pro/rev1/halconf.h
+++ b/keyboards/gmmk/pro/rev1/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/gmmk/pro/rev2/halconf.h
+++ b/keyboards/gmmk/pro/rev2/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/handwired/onekey/at_start_f415/halconf.h
+++ b/keyboards/handwired/onekey/at_start_f415/halconf.h
@@ -11,6 +11,5 @@
 #define HAL_USE_PWM TRUE
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/handwired/onekey/kb2040/halconf.h
+++ b/keyboards/handwired/onekey/kb2040/halconf.h
@@ -17,6 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/handwired/onekey/rp2040/halconf.h
+++ b/keyboards/handwired/onekey/rp2040/halconf.h
@@ -10,6 +10,5 @@
 #define HAL_USE_ADC TRUE
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
 
 #include_next <halconf.h>

--- a/keyboards/handwired/tractyl_manuform/5x6_right/f303/halconf.h
+++ b/keyboards/handwired/tractyl_manuform/5x6_right/f303/halconf.h
@@ -21,7 +21,5 @@
 #define HAL_USE_SPI     TRUE
 #define HAL_USE_GPT     TRUE
 #define HAL_USE_DAC     TRUE
-#define SPI_USE_WAIT    TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/handwired/tractyl_manuform/5x6_right/f405/halconf.h
+++ b/keyboards/handwired/tractyl_manuform/5x6_right/f405/halconf.h
@@ -22,11 +22,6 @@
 #    define HAL_USE_PWM TRUE
 #endif // defined(WS2812_PWM) || defined(BACKLIGHT_PWM)
 
-#if HAL_USE_SPI == TRUE
-#    define SPI_USE_WAIT TRUE
-#    define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
-#endif
-
 #ifdef AUDIO_DRIVER_DAC
 #    define HAL_USE_GPT TRUE
 #    define HAL_USE_DAC TRUE

--- a/keyboards/handwired/tractyl_manuform/5x6_right/f411/halconf.h
+++ b/keyboards/handwired/tractyl_manuform/5x6_right/f411/halconf.h
@@ -19,7 +19,5 @@
 #define HAL_USE_SERIAL  TRUE
 #define HAL_USE_I2C     TRUE
 #define HAL_USE_SPI     TRUE
-#define SPI_USE_WAIT    TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/hazel/bad_wings/halconf.h
+++ b/keyboards/hazel/bad_wings/halconf.h
@@ -6,7 +6,5 @@
 #define HAL_USE_SPI     TRUE
 #define HAL_USE_I2C     TRUE
 #define HAL_USE_PWM     TRUE
-#define SPI_USE_WAIT    TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/hazel/bad_wings_v2/halconf.h
+++ b/keyboards/hazel/bad_wings_v2/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/hfdkb/ac001/halconf.h
+++ b/keyboards/hfdkb/ac001/halconf.h
@@ -16,7 +16,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/horrortroll/handwired_k552/halconf.h
+++ b/keyboards/horrortroll/handwired_k552/halconf.h
@@ -22,9 +22,6 @@
 #pragma once
 
 #define HAL_USE_I2C TRUE
-
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/inland/kb83/halconf.h
+++ b/keyboards/inland/kb83/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/inland/mk47/halconf.h
+++ b/keyboards/inland/mk47/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/inland/v83p/halconf.h
+++ b/keyboards/inland/v83p/halconf.h
@@ -5,7 +5,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/jidohun/km113/halconf.h
+++ b/keyboards/jidohun/km113/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/jukaie/jk01/halconf.h
+++ b/keyboards/jukaie/jk01/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/kbdfans/odin75/halconf.h
+++ b/keyboards/kbdfans/odin75/halconf.h
@@ -16,13 +16,6 @@
 
 #pragma once
 
-#include_next <halconf.h>
-
-#undef HAL_USE_SPI
 #define HAL_USE_SPI TRUE
 
-#undef SPI_USE_WAIT
-#define SPI_USE_WAIT TRUE
-
-#undef SPI_SELECT_MODE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
+#include_next <halconf.h>

--- a/keyboards/mechwild/puckbuddy/halconf.h
+++ b/keyboards/mechwild/puckbuddy/halconf.h
@@ -5,9 +5,6 @@
 #pragma once
 
 #define HAL_USE_I2C TRUE
-
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/mechwild/sugarglider/halconf.h
+++ b/keyboards/mechwild/sugarglider/halconf.h
@@ -4,9 +4,6 @@
 #pragma once
 
 #define HAL_USE_I2C TRUE
-
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/moky/moky67/halconf.h
+++ b/keyboards/moky/moky67/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/moky/moky88/halconf.h
+++ b/keyboards/moky/moky88/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/monsgeek/m1/halconf.h
+++ b/keyboards/monsgeek/m1/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/monsgeek/m3/halconf.h
+++ b/keyboards/monsgeek/m3/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/monsgeek/m5/halconf.h
+++ b/keyboards/monsgeek/m5/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/monsgeek/m6/halconf.h
+++ b/keyboards/monsgeek/m6/halconf.h
@@ -17,7 +17,5 @@
 
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/phentech/rpk_001/halconf.h
+++ b/keyboards/phentech/rpk_001/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/projectd/65/projectd_65_ansi/halconf.h
+++ b/keyboards/projectd/65/projectd_65_ansi/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/projectd/75/ansi/halconf.h
+++ b/keyboards/projectd/75/ansi/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/projectd/75/iso/halconf.h
+++ b/keyboards/projectd/75/iso/halconf.h
@@ -17,7 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/sawnsprojects/okayu/halconf.h
+++ b/keyboards/sawnsprojects/okayu/halconf.h
@@ -4,6 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
+
 #include_next <halconf.h>

--- a/keyboards/sharkoon/skiller_sgk50_s2/halconf.h
+++ b/keyboards/sharkoon/skiller_sgk50_s2/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/sharkoon/skiller_sgk50_s3/halconf.h
+++ b/keyboards/sharkoon/skiller_sgk50_s3/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/sharkoon/skiller_sgk50_s4/halconf.h
+++ b/keyboards/sharkoon/skiller_sgk50_s4/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/splitkb/elora/rev1/halconf.h
+++ b/keyboards/splitkb/elora/rev1/halconf.h
@@ -6,8 +6,6 @@
 #define HAL_USE_SIO TRUE
 #define HAL_USE_I2C TRUE
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 #define HAL_USE_ADC TRUE
 
 #include_next <halconf.h>

--- a/keyboards/splitkb/halcyon/elora/rev2/halconf.h
+++ b/keyboards/splitkb/halcyon/elora/rev2/halconf.h
@@ -6,9 +6,6 @@
 //// VIK
 
 #define HAL_USE_I2C TRUE
-
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/splitkb/halcyon/kyria/rev4/halconf.h
+++ b/keyboards/splitkb/halcyon/kyria/rev4/halconf.h
@@ -6,9 +6,6 @@
 //// VIK
 
 #define HAL_USE_I2C TRUE
-
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/tacworks/tac_k1/halconf.h
+++ b/keyboards/tacworks/tac_k1/halconf.h
@@ -4,7 +4,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
 
 #include_next <halconf.h>

--- a/keyboards/trnthsn/s6xty5neor2/halconf.h
+++ b/keyboards/trnthsn/s6xty5neor2/halconf.h
@@ -17,6 +17,5 @@
 #pragma once
 
 #define HAL_USE_SPI TRUE
-#define SPI_USE_WAIT TRUE
-#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
+
 #include_next <halconf.h>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The docs suggestion of adding the following,
```c
#define SPI_USE_WAIT TRUE
#define SPI_SELECT_MODE SPI_SELECT_MODE_PAD
```
adds no value as these are already the defaults.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
