### PR TITLE
[Fix] lib8tion: enable fixed scale8 and blend functions

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -722,6 +722,7 @@ ifeq ($(strip $(LIB8TION_ENABLE)), yes)
         # ATmegaxxU2 does not have hardware MUL instruction - lib8tion must be told to use software multiplication routines
         OPT_DEFS += -DLIB8_ATTINY
     endif
+    OPT_DEFS += -DFASTLED_SCALE8_FIXED=1 -DFASTLED_BLEND_FIXED=1
     SRC += $(LIB_PATH)/lib8tion/lib8tion.c
 endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

These FastLED derived lib8tion functions have been fixed and enabled by default in FastLED. QMK just never set these defines, there is no reason to keep the buggy implementation. It is assumed that nobody relied on the buggy behavior.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
