### PR TITLE
salicylic_acid3/getta25 - Fix oled keymap

### DIFF
--- a/keyboards/salicylic_acid3/getta25/keymaps/oled/config.h
+++ b/keyboards/salicylic_acid3/getta25/keymaps/oled/config.h
@@ -21,5 +21,5 @@
 #define QUICK_TAP_TERM 0
 #define TAPPING_TERM 180
 
-#define OLED_FONT_H "keyboards/getta25/keymaps/oled/glcdfont.c"
+#define OLED_FONT_H "keyboards/salicylic_acid3/getta25/keymaps/oled/glcdfont.c"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
[CI](https://github.com/qmk/qmk_firmware/pull/25293/checks?check_run_id=42806452897) produces the following error:
```
Compiling QMK Firmware for target: 'salicylic_acid3/getta25/rev1:oled'...
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/info_deps.d                            [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/community_modules.c                    [OK]
avr-gcc (GCC) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/community_modules.h                    [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/community_modules_introspection.c      [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/community_modules_introspection.h      [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/led_matrix_community_modules.inc       [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/rgb_matrix_community_modules.inc       [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/info_config.h                          [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/default_keyboard.c                     [OK]
Generating: .build/obj_salicylic_acid3_getta25_rev1_oled/src/default_keyboard.h                     [OK]
Compiling: platforms/avr/printf.c                                                                   [OK]
Compiling: quantum/process_keycode/process_underglow.c                                              [OK]
Compiling: quantum/color.c                                                                          [OK]
Compiling: quantum/rgblight/rgblight.c                                                              [OK]
Compiling: quantum/rgblight/rgblight_drivers.c                                                      [OK]
Compiling: quantum/led_tables.c                                                                     [OK]
Compiling: drivers/oled/oled_driver.c                                                              In file included from <command-line>:
./keyboards/salicylic_acid3/getta25/keymaps/oled/config.h:24:21: fatal error: keyboards/getta25/keymaps/oled/glcdfont.c: No such file or directory
 #define OLED_FONT_H "keyboards/getta25/keymaps/oled/glcdfont.c"
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
 [ERRORS]
 |
 |
 |
gmake[1]: *** [builddefs/common_rules.mk:358: .build/obj_salicylic_acid3_getta25_rev1_oled/oled_driver.o] Error 1
```
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
