### PR TITLE
fixed reference to wrong layer when LM used with right modifiers

### DIFF
--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -156,7 +156,7 @@ action_t action_for_keycode(uint16_t keycode) {
         case QK_LAYER_MOD ... QK_LAYER_MOD_MAX:
             mod          = mod_config(QK_LAYER_MOD_GET_MODS(keycode));
             action_layer = QK_LAYER_MOD_GET_LAYER(keycode);
-            action.code  = ACTION_LAYER_MODS(action_layer, (mod & 0x10) ? mod << 4 : mod);
+            action.code  = ACTION_LAYER_MODS(action_layer, (mod & 0x10) ? (mod & 0xF) << 4 : mod);
             break;
 #endif // NO_ACTION_LAYER
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:


### PR DESCRIPTION
when `LM()` used with right modifiers and references even layer it leads to use referenced layer + 1. The problem is right modifiers contains 5-th bit and converting it to `mods_8bit` without masking this bit leads to overlap layer bits and modifier bits in `action.code`.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  #25301

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
