### PR TITLE
Fixed oled raise/lower layer order and added adjust layer text to ole…

### DIFF
--- a/keyboards/sofle/sofle.c
+++ b/keyboards/sofle/sofle.c
@@ -85,10 +85,13 @@ void print_status_narrow(void) {
             oled_write_P(PSTR("Base\n"), false);
             break;
         case 2:
-            oled_write_P(PSTR("Raise"), false);
+            oled_write_P(PSTR("Lower"), false);
             break;
         case 3:
-            oled_write_P(PSTR("Lower"), false);
+            oled_write_P(PSTR("Raise"), false);
+            break;
+        case 4:
+            oled_write_P(PSTR("Adjust"), false);
             break;
         default:
             oled_write_ln_P(PSTR("Undef"), false);


### PR DESCRIPTION
…d display

<!--- Provide a general summary of your changes in the title above. -->

The raise and lower text are backwards. When you put lower key, the raise text will display. I have also added the "adjust layer text so that when tri layer is activated, it will display "adjust" on the OLED.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
