### PR TITLE
Add core handling for pointing device failures.

### DIFF
--- a/drivers/sensors/adns5050.c
+++ b/drivers/sensors/adns5050.c
@@ -55,7 +55,7 @@ const pointing_device_driver_t adns5050_pointing_device_driver = {
 
 static bool powered_down = false;
 
-void adns5050_init(void) {
+bool adns5050_init(void) {
     // Initialize the ADNS serial pins.
     gpio_set_pin_output(ADNS5050_SCLK_PIN);
     gpio_set_pin_output(ADNS5050_SDIO_PIN);
@@ -75,6 +75,9 @@ void adns5050_init(void) {
     // gets the adns ready for write commands
     // (for example, setting the dpi).
     adns5050_read_burst();
+
+    // TODO: Perform a real check
+    return true;
 }
 
 // Perform a synchronization with the ADNS.

--- a/drivers/sensors/adns5050.h
+++ b/drivers/sensors/adns5050.h
@@ -75,7 +75,7 @@ const pointing_device_driver_t adns5050_pointing_device_driver;
 // A bunch of functions to implement the ADNS5050-specific serial protocol.
 // Note that the "serial.h" driver is insufficient, because it does not
 // manually manipulate a serial clock signal.
-void              adns5050_init(void);
+bool              adns5050_init(void);
 void              adns5050_sync(void);
 uint8_t           adns5050_serial_read(void);
 void              adns5050_serial_write(uint8_t data);

--- a/drivers/sensors/adns9800.c
+++ b/drivers/sensors/adns9800.c
@@ -115,7 +115,7 @@ uint8_t adns9800_read(uint8_t reg_addr) {
     return data;
 }
 
-void adns9800_init(void) {
+bool adns9800_init(void) {
     gpio_set_pin_output(ADNS9800_CS_PIN);
 
     spi_init();
@@ -178,6 +178,9 @@ void adns9800_init(void) {
     adns9800_write(REG_LASER_CTRL0, laser_ctrl0 & 0xf0);
 
     adns9800_set_cpi(ADNS9800_CPI);
+
+    // TODO: Perform a real check
+    return true;
 }
 
 config_adns9800_t adns9800_get_config(void) {

--- a/drivers/sensors/adns9800.h
+++ b/drivers/sensors/adns9800.h
@@ -63,7 +63,7 @@ typedef struct {
 
 const pointing_device_driver_t adns9800_pointing_device_driver;
 
-void              adns9800_init(void);
+bool              adns9800_init(void);
 config_adns9800_t adns9800_get_config(void);
 void              adns9800_set_config(config_adns9800_t);
 uint16_t          adns9800_get_cpi(void);

--- a/drivers/sensors/analog_joystick.c
+++ b/drivers/sensors/analog_joystick.c
@@ -135,7 +135,7 @@ report_analog_joystick_t analog_joystick_read(void) {
     return report;
 }
 
-void analog_joystick_init(void) {
+bool analog_joystick_init(void) {
     gpio_set_pin_input_high(ANALOG_JOYSTICK_X_AXIS_PIN);
     gpio_set_pin_input_high(ANALOG_JOYSTICK_Y_AXIS_PIN);
 
@@ -152,6 +152,8 @@ void analog_joystick_init(void) {
     maxAxisValues[0] = xOrigin + 100;
     maxAxisValues[1] = yOrigin + 100;
 #endif
+
+    return true;
 }
 
 report_mouse_t analog_joystick_get_report(report_mouse_t mouse_report) {

--- a/drivers/sensors/analog_joystick.h
+++ b/drivers/sensors/analog_joystick.h
@@ -51,5 +51,5 @@ typedef struct {
     bool   button;
 } report_analog_joystick_t;
 report_analog_joystick_t analog_joystick_read(void);
-void                     analog_joystick_init(void);
+bool                     analog_joystick_init(void);
 report_mouse_t           analog_joystick_get_report(report_mouse_t mouse_report);

--- a/drivers/sensors/azoteq_iqs5xx.h
+++ b/drivers/sensors/azoteq_iqs5xx.h
@@ -180,7 +180,7 @@ typedef struct {
 
 const pointing_device_driver_t azoteq_iqs5xx_pointing_device_driver;
 
-void           azoteq_iqs5xx_init(void);
+bool           azoteq_iqs5xx_init(void);
 i2c_status_t   azoteq_iqs5xx_wake(void);
 report_mouse_t azoteq_iqs5xx_get_report(report_mouse_t mouse_report);
 i2c_status_t   azoteq_iqs5xx_get_report_rate(azoteq_iqs5xx_report_rate_t *report_rate, azoteq_iqs5xx_charging_modes_t mode, bool end_session);

--- a/drivers/sensors/cirque_pinnacle.c
+++ b/drivers/sensors/cirque_pinnacle.c
@@ -18,7 +18,6 @@
 #    endif
 #endif
 
-bool     touchpad_init;
 uint16_t scale_data = CIRQUE_PINNACLE_DEFAULT_SCALE;
 
 void cirque_pinnacle_clear_flags(void);
@@ -232,14 +231,14 @@ bool cirque_pinnacle_connected(void) {
 }
 
 /*  Pinnacle-based TM040040/TM035035/TM023023 Functions  */
-void cirque_pinnacle_init(void) {
+bool cirque_pinnacle_init(void) {
 #if defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_spi)
     spi_init();
 #elif defined(POINTING_DEVICE_DRIVER_cirque_pinnacle_i2c)
     i2c_init();
 #endif
 
-    touchpad_init = true;
+    bool touchpad_init = true;
 
     // send a RESET command now, in case QMK had a soft-reset without a power cycle
     RAP_Write(HOSTREG__SYSCONFIG1, HOSTREG__SYSCONFIG1__RESET);
@@ -293,6 +292,8 @@ void cirque_pinnacle_init(void) {
 #ifndef CIRQUE_PINNACLE_SKIP_SENSOR_CHECK
     touchpad_init = cirque_pinnacle_connected();
 #endif
+
+    return touchpad_init;
 }
 
 pinnacle_data_t cirque_pinnacle_read_data(void) {
@@ -476,9 +477,9 @@ report_mouse_t cirque_pinnacle_get_report(report_mouse_t mouse_report) {
 
     if (touchData.valid) {
         mouse_report.buttons = touchData.buttons;
-        mouse_report.x = CONSTRAIN_HID_XY(touchData.xDelta);
-        mouse_report.y = CONSTRAIN_HID_XY(touchData.yDelta);
-        mouse_report.v = touchData.wheelCount;
+        mouse_report.x       = CONSTRAIN_HID_XY(touchData.xDelta);
+        mouse_report.y       = CONSTRAIN_HID_XY(touchData.yDelta);
+        mouse_report.v       = touchData.wheelCount;
     }
     return mouse_report;
 }

--- a/drivers/sensors/cirque_pinnacle.h
+++ b/drivers/sensors/cirque_pinnacle.h
@@ -114,7 +114,7 @@ typedef struct {
 #define cirque_pinnacle_spi_pointing_device_driver cirque_pinnacle_pointing_device_driver
 const pointing_device_driver_t cirque_pinnacle_pointing_device_driver;
 
-void            cirque_pinnacle_init(void);
+bool            cirque_pinnacle_init(void);
 void            cirque_pinnacle_calibrate(void);
 void            cirque_pinnacle_cursor_smoothing(bool enable);
 pinnacle_data_t cirque_pinnacle_read_data(void);

--- a/drivers/sensors/cirque_pinnacle_i2c.c
+++ b/drivers/sensors/cirque_pinnacle_i2c.c
@@ -7,29 +7,22 @@
 #define WRITE_MASK 0x80
 #define READ_MASK 0xA0
 
-extern bool touchpad_init;
-
 /*  RAP Functions */
 // Reads <count> Pinnacle registers starting at <address>
 void RAP_ReadBytes(uint8_t address, uint8_t* data, uint8_t count) {
     uint8_t cmdByte = READ_MASK | address; // Form the READ command byte
-    if (touchpad_init) {
-        i2c_write_register(CIRQUE_PINNACLE_ADDR << 1, cmdByte, NULL, 0, CIRQUE_PINNACLE_TIMEOUT);
-        if (i2c_read_register(CIRQUE_PINNACLE_ADDR << 1, cmdByte, data, count, CIRQUE_PINNACLE_TIMEOUT) != I2C_STATUS_SUCCESS) {
-            pd_dprintf("error cirque_pinnacle i2c_read_register\n");
-            touchpad_init = false;
-        }
+    i2c_write_register(CIRQUE_PINNACLE_ADDR << 1, cmdByte, NULL, 0, CIRQUE_PINNACLE_TIMEOUT);
+    if (i2c_read_register(CIRQUE_PINNACLE_ADDR << 1, cmdByte, data, count, CIRQUE_PINNACLE_TIMEOUT) != I2C_STATUS_SUCCESS) {
+        pd_dprintf("error cirque_pinnacle i2c_read_register\n");
+        pointing_device_set_status(POINTING_DEVICE_STATUS_FAILED);
     }
 }
 
 // Writes single-byte <data> to <address>
 void RAP_Write(uint8_t address, uint8_t data) {
     uint8_t cmdByte = WRITE_MASK | address; // Form the WRITE command byte
-
-    if (touchpad_init) {
-        if (i2c_write_register(CIRQUE_PINNACLE_ADDR << 1, cmdByte, &data, sizeof(data), CIRQUE_PINNACLE_TIMEOUT) != I2C_STATUS_SUCCESS) {
-            pd_dprintf("error cirque_pinnacle i2c_write_register\n");
-            touchpad_init = false;
-        }
+    if (i2c_write_register(CIRQUE_PINNACLE_ADDR << 1, cmdByte, &data, sizeof(data), CIRQUE_PINNACLE_TIMEOUT) != I2C_STATUS_SUCCESS) {
+        pd_dprintf("error cirque_pinnacle i2c_write_register\n");
+        pointing_device_set_status(POINTING_DEVICE_STATUS_FAILED);
     }
 }

--- a/drivers/sensors/cirque_pinnacle_spi.c
+++ b/drivers/sensors/cirque_pinnacle_spi.c
@@ -7,40 +7,35 @@
 #define READ_MASK 0xA0
 #define FILLER_BYTE 0xFC
 
-extern bool touchpad_init;
-
 /*  RAP Functions */
 // Reads <count> Pinnacle registers starting at <address>
 void RAP_ReadBytes(uint8_t address, uint8_t* data, uint8_t count) {
     uint8_t cmdByte = READ_MASK | address; // Form the READ command byte
-    if (touchpad_init) {
-        if (spi_start(CIRQUE_PINNACLE_SPI_CS_PIN, CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
-            spi_write(cmdByte);     // write command byte, receive filler
-            spi_write(FILLER_BYTE); // write & receive filler
-            spi_write(FILLER_BYTE); // write & receive filler
-            for (uint8_t i = 0; i < count; i++) {
-                data[i] = spi_write(FILLER_BYTE); // write filler, receive data on the third filler send
-            }
-        } else {
-            pd_dprintf("error cirque_pinnacle spi_start read\n");
-            touchpad_init = false;
+
+    if (spi_start(CIRQUE_PINNACLE_SPI_CS_PIN, CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
+        spi_write(cmdByte);     // write command byte, receive filler
+        spi_write(FILLER_BYTE); // write & receive filler
+        spi_write(FILLER_BYTE); // write & receive filler
+        for (uint8_t i = 0; i < count; i++) {
+            data[i] = spi_write(FILLER_BYTE); // write filler, receive data on the third filler send
         }
-        spi_stop();
+    } else {
+        pd_dprintf("error cirque_pinnacle spi_start read\n");
+        pointing_device_set_status(POINTING_DEVICE_STATUS_FAILED);
     }
+    spi_stop();
 }
 
 // Writes single-byte <data> to <address>
 void RAP_Write(uint8_t address, uint8_t data) {
     uint8_t cmdByte = WRITE_MASK | address; // Form the WRITE command byte
 
-    if (touchpad_init) {
-        if (spi_start(CIRQUE_PINNACLE_SPI_CS_PIN, CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
-            spi_write(cmdByte);
-            spi_write(data);
-        } else {
-            pd_dprintf("error cirque_pinnacle spi_start write\n");
-            touchpad_init = false;
-        }
-        spi_stop();
+    if (spi_start(CIRQUE_PINNACLE_SPI_CS_PIN, CIRQUE_PINNACLE_SPI_LSBFIRST, CIRQUE_PINNACLE_SPI_MODE, CIRQUE_PINNACLE_SPI_DIVISOR)) {
+        spi_write(cmdByte);
+        spi_write(data);
+    } else {
+        pd_dprintf("error cirque_pinnacle spi_start write\n");
+        pointing_device_set_status(POINTING_DEVICE_STATUS_FAILED);
     }
+    spi_stop();
 }

--- a/drivers/sensors/paw3204.c
+++ b/drivers/sensors/paw3204.c
@@ -58,7 +58,7 @@ const pointing_device_driver_t paw3204_pointing_device_driver = {
     .get_cpi    = paw3204_get_cpi,
 };
 
-void paw3204_init(void) {
+bool paw3204_init(void) {
     gpio_set_pin_output(PAW3204_SCLK_PIN);     // setclockpin to output
     gpio_set_pin_input_high(PAW3204_SDIO_PIN); // set datapin input high
 
@@ -69,6 +69,9 @@ void paw3204_init(void) {
     paw3204_read_reg(0x01); // read id2
     // PAW3204_write_reg(REG_SETUP,0x06);  // dont reset sensor and set cpi 1600
     paw3204_write_reg(REG_IMGTRASH, 0x32); // write image trashhold
+
+    // TODO: Perform a real check
+    return true;
 }
 
 uint8_t paw3204_serial_read(void) {

--- a/drivers/sensors/paw3204.h
+++ b/drivers/sensors/paw3204.h
@@ -50,7 +50,7 @@ const pointing_device_driver_t paw3204_pointing_device_driver;
  * @return true Initialization was a success
  * @return false Initialization failed, do not proceed operation
  */
-void paw3204_init(void);
+bool paw3204_init(void);
 
 /**
  * @brief Reads and clears the current delta, and motion register values on the

--- a/drivers/sensors/pimoroni_trackball.c
+++ b/drivers/sensors/pimoroni_trackball.c
@@ -82,9 +82,12 @@ i2c_status_t read_pimoroni_trackball(pimoroni_data_t *data) {
     return status;
 }
 
-__attribute__((weak)) void pimoroni_trackball_device_init(void) {
+__attribute__((weak)) bool pimoroni_trackball_device_init(void) {
     i2c_init();
-    pimoroni_trackball_set_rgbw(0x00, 0x00, 0x00, 0x00);
+    uint8_t      rgbw_data[4] = {0};
+    i2c_status_t status       = i2c_write_register(PIMORONI_TRACKBALL_ADDRESS << 1, PIMORONI_TRACKBALL_REG_LED_RED, rgbw_data, sizeof(rgbw_data), PIMORONI_TRACKBALL_TIMEOUT);
+
+    return (status == I2C_STATUS_SUCCESS);
 }
 
 int16_t pimoroni_trackball_get_offsets(uint8_t negative_dir, uint8_t positive_dir, uint8_t scale) {

--- a/drivers/sensors/pimoroni_trackball.h
+++ b/drivers/sensors/pimoroni_trackball.h
@@ -52,7 +52,7 @@ typedef struct {
 
 const pointing_device_driver_t pimoroni_trackball_pointing_device_driver;
 
-void           pimoroni_trackball_device_init(void);
+bool           pimoroni_trackball_device_init(void);
 void           pimoroni_trackball_set_rgbw(uint8_t red, uint8_t green, uint8_t blue, uint8_t white);
 int16_t        pimoroni_trackball_get_offsets(uint8_t negative_dir, uint8_t positive_dir, uint8_t scale);
 uint16_t       pimoroni_trackball_get_cpi(void);

--- a/drivers/sensors/pmw3320.c
+++ b/drivers/sensors/pmw3320.c
@@ -30,7 +30,7 @@ const pointing_device_driver_t pmw3320_pointing_device_drivera = {
     .get_cpi    = pmw3320_get_cpi,
 };
 
-void pmw3320_init(void) {
+bool pmw3320_init(void) {
     // Initialize sensor serial pins.
     gpio_set_pin_output(PMW3320_SCLK_PIN);
     gpio_set_pin_output(PMW3320_SDIO_PIN);
@@ -56,6 +56,9 @@ void pmw3320_init(void) {
     pmw3320_write_reg(REG_Led_Control, 0x4);
     // Disable rest mode
     pmw3320_write_reg(REG_Performance, 0x80);
+
+    // TODO: Perform a real check
+    return true;
 }
 
 // Perform a synchronization with sensor.

--- a/drivers/sensors/pmw3320.h
+++ b/drivers/sensors/pmw3320.h
@@ -61,7 +61,7 @@ const pointing_device_driver_t pmw3320_pointing_device_driver;
 // Mostly taken from ADNS5050 driver.
 // Note that the "serial.h" driver is insufficient, because it does not
 // manually manipulate a serial clock signal.
-void             pmw3320_init(void);
+bool             pmw3320_init(void);
 void             pmw3320_sync(void);
 uint8_t          pmw3320_serial_read(void);
 void             pmw3320_serial_write(uint8_t data);

--- a/drivers/sensors/pmw33xx_common.c
+++ b/drivers/sensors/pmw33xx_common.c
@@ -102,7 +102,7 @@ uint8_t pmw33xx_read(uint8_t sensor, uint8_t reg_addr) {
     return data;
 }
 
-bool pmw33xx_check_signature(uint8_t sensor) {
+__attribute__((weak)) bool pmw33xx_check_signature(uint8_t sensor) {
     uint8_t signature_dump[2] = {
         pmw33xx_read(sensor, REG_Product_ID),
         pmw33xx_read(sensor, REG_Inverse_Product_ID),
@@ -236,8 +236,8 @@ pmw33xx_report_t pmw33xx_read_burst(uint8_t sensor) {
     return report;
 }
 
-void pmw33xx_init_wrapper(void) {
-    pmw33xx_init(0);
+__attribute__((weak)) bool pmw33xx_init_wrapper(void) {
+    return pmw33xx_init(0);
 }
 
 void pmw33xx_set_cpi_wrapper(uint16_t cpi) {

--- a/drivers/sensors/pmw33xx_common.h
+++ b/drivers/sensors/pmw33xx_common.h
@@ -72,14 +72,12 @@ STATIC_ASSERT(sizeof((pmw33xx_report_t){0}.motion) == 1, "pmw33xx_report_t.motio
 #    ifndef PMW33XX_CS_PIN
 #        ifdef POINTING_DEVICE_CS_PIN
 #            define PMW33XX_CS_PIN POINTING_DEVICE_CS_PIN
-#            define PMW33XX_CS_PINS \
-                { PMW33XX_CS_PIN }
+#            define PMW33XX_CS_PINS {PMW33XX_CS_PIN}
 #        else
 #            error "No chip select pin defined -- missing PMW33XX_CS_PIN or PMW33XX_CS_PINS"
 #        endif
 #    else
-#        define PMW33XX_CS_PINS \
-            { PMW33XX_CS_PIN }
+#        define PMW33XX_CS_PINS {PMW33XX_CS_PIN}
 #    endif
 #endif
 
@@ -88,8 +86,7 @@ STATIC_ASSERT(sizeof((pmw33xx_report_t){0}.motion) == 1, "pmw33xx_report_t.motio
 #    if !defined(PMW33XX_CS_PIN_RIGHT)
 #        define PMW33XX_CS_PIN_RIGHT PMW33XX_CS_PIN
 #    endif
-#    define PMW33XX_CS_PINS_RIGHT \
-        { PMW33XX_CS_PIN_RIGHT }
+#    define PMW33XX_CS_PINS_RIGHT {PMW33XX_CS_PIN_RIGHT}
 #endif
 
 // Defines so the old variable names are swapped by the appropiate value on each half
@@ -177,7 +174,7 @@ uint8_t pmw33xx_read(uint8_t sensor, uint8_t reg_addr);
  */
 bool pmw33xx_write(uint8_t sensor, uint8_t reg_addr, uint8_t data);
 
-void           pmw33xx_init_wrapper(void);
+bool           pmw33xx_init_wrapper(void);
 void           pmw33xx_set_cpi_wrapper(uint16_t cpi);
 uint16_t       pmw33xx_get_cpi_wrapper(void);
 report_mouse_t pmw33xx_get_report(report_mouse_t mouse_report);

--- a/quantum/pointing_device/pointing_device.h
+++ b/quantum/pointing_device/pointing_device.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "report.h"
 
 typedef struct {
-    void (*init)(void);
+    bool (*init)(void);
     report_mouse_t (*get_report)(report_mouse_t mouse_report);
     void (*set_cpi)(uint16_t);
     uint16_t (*get_cpi)(void);
@@ -75,7 +75,7 @@ typedef struct {
 #    include "drivers/sensors/pmw33xx_common.h"
 #    define POINTING_DEVICE_MOTION_PIN_ACTIVE_LOW
 #else
-void           pointing_device_driver_init(void);
+bool           pointing_device_driver_init(void);
 report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report);
 uint16_t       pointing_device_driver_get_cpi(void);
 void           pointing_device_driver_set_cpi(uint16_t cpi);
@@ -92,6 +92,13 @@ typedef enum {
     POINTING_DEVICE_BUTTON8,
 } pointing_device_buttons_t;
 
+typedef enum {
+    POINTING_DEVICE_STATUS_UNKNOWN,
+    POINTING_DEVICE_STATUS_INIT_FAILED,
+    POINTING_DEVICE_STATUS_FAILED,
+    POINTING_DEVICE_STATUS_SUCCESS,
+} pointing_device_status_t;
+
 #ifdef MOUSE_EXTENDED_REPORT
 typedef int32_t xy_clamp_range_t;
 #else
@@ -107,13 +114,15 @@ typedef int16_t hv_clamp_range_t;
 #define CONSTRAIN_HID(amt) ((amt) < INT8_MIN ? INT8_MIN : ((amt) > INT8_MAX ? INT8_MAX : (amt)))
 #define CONSTRAIN_HID_XY(amt) ((amt) < MOUSE_REPORT_XY_MIN ? MOUSE_REPORT_XY_MIN : ((amt) > MOUSE_REPORT_XY_MAX ? MOUSE_REPORT_XY_MAX : (amt)))
 
-void           pointing_device_init(void);
-bool           pointing_device_task(void);
-bool           pointing_device_send(void);
-report_mouse_t pointing_device_get_report(void);
-void           pointing_device_set_report(report_mouse_t mouse_report);
-uint16_t       pointing_device_get_cpi(void);
-void           pointing_device_set_cpi(uint16_t cpi);
+void                     pointing_device_init(void);
+bool                     pointing_device_task(void);
+bool                     pointing_device_send(void);
+report_mouse_t           pointing_device_get_report(void);
+void                     pointing_device_set_report(report_mouse_t mouse_report);
+uint16_t                 pointing_device_get_cpi(void);
+void                     pointing_device_set_cpi(uint16_t cpi);
+pointing_device_status_t pointing_device_get_status(void);
+void                     pointing_device_set_status(pointing_device_status_t status);
 
 void           pointing_device_init_kb(void);
 void           pointing_device_init_user(void);

--- a/tests/pointing/test_pointing.cpp
+++ b/tests/pointing/test_pointing.cpp
@@ -12,6 +12,26 @@ using testing::_;
 class Pointing : public TestFixture {};
 class PointingButtonsViaMousekeysParametrized : public ::testing::WithParamInterface<std::pair<KeymapKey, uint8_t>>, public Pointing {};
 
+TEST_F(Pointing, NoMovementOnInitFailure) {
+    TestDriver driver;
+
+    pointing_device_set_status(POINTING_DEVICE_STATUS_INIT_FAILED);
+    pd_set_x(-50);
+    pd_set_y(100);
+    EXPECT_NO_MOUSE_REPORT(driver);
+    run_one_scan_loop();
+
+    pointing_device_set_status(POINTING_DEVICE_STATUS_SUCCESS);
+    EXPECT_MOUSE_REPORT(driver, (-50, 100, 0, 0, 0));
+    run_one_scan_loop();
+
+    pd_clear_movement();
+    // EXPECT_EMPTY_MOUSE_REPORT(driver);
+    run_one_scan_loop();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
 TEST_F(Pointing, SendMouseIsNotCalledWithNoInput) {
     TestDriver driver;
     EXPECT_NO_MOUSE_REPORT(driver);

--- a/tests/test_common/pointing_device_driver.c
+++ b/tests/test_common/pointing_device_driver.c
@@ -22,8 +22,9 @@ typedef struct {
 
 static pd_config_t pd_config = {0};
 
-void pointing_device_driver_init(void) {
+bool pointing_device_driver_init(void) {
     pd_set_init(true);
+    return pd_config.initiated;
 }
 
 report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The intention is to allow a pointing device driver to be enabled by default firmware without a downside if the user doesn't fit the device. This will also have the benefit of less random behaviour from incorrectly fitted SPI devices.

I decided against any retry logic, this can be handled in user code if required as the status is available using the `pointing_device_get_status` function. 

This strips out init failure handling from a couple of drivers, implements proper checks on a couple of others. There's a few devices that need a real check implementing as they currently just return true. I don't think this required for this to go in?

This needs testing on a few more devices, particular the drivers with checks. I've only checked with my charybdis (pmw3360) so far.

TODO: Docs

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
