### PR TITLE
Fix buggy switch statement in quantum.c

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -461,8 +461,8 @@ bool process_record_quantum(keyrecord_t *record) {
                 } else {
                     print("DEBUG: disabled.\n");
                 }
-#endif
                 return false;
+#endif
             case QK_CLEAR_EEPROM:
 #ifdef NO_RESET
                 eeconfig_init();
@@ -479,17 +479,16 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifndef NO_ACTION_ONESHOT
             case QK_ONE_SHOT_TOGGLE:
                 oneshot_toggle();
-                break;
+                return false;
             case QK_ONE_SHOT_ON:
                 oneshot_enable();
-                break;
+                return false;
             case QK_ONE_SHOT_OFF:
                 oneshot_disable();
-                break;
+                return false;
 #endif
 #ifdef ENABLE_COMPILE_KEYCODE
             case QK_MAKE: // Compiles the firmware, and adds the flash command based on keyboard bootloader
-            {
 #    ifdef NO_ACTION_ONESHOT
                 const uint8_t temp_mod = mod_config(get_mods());
 #    else
@@ -512,7 +511,7 @@ bool process_record_quantum(keyrecord_t *record) {
                 if (temp_mod & MOD_MASK_SHIFT && temp_mod & MOD_MASK_CTRL) {
                     reset_keyboard();
                 }
-            }
+                return false;
 #endif
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fix bugs found when inspecting a case statement in quantum.c

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* The `return` statement for the `QK_DEBUG_TOGGLE` case should be inside the `NO_DEBUG preprocessor directive.  Before this change, if both `NO_RESET` and `NO_DEBUG` were set the switch statement would be invalid after the preprocessor runs.
* The `NO_ACTION_ONESHOT` cases should `return false;` rather than `break;` to prevent `process_action_kb(record)` which comes after the switch statement from running.
* The `QK_MAKE` case should have a `return`  statement ` to prevent `process_action_kb(record)` which comes after the switch statement from running.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
