### PR TITLE
[tzarc/djinn] Include community modules in RGB naming.

### DIFF
--- a/keyboards/1upkeyboards/pi50/pi50.c
+++ b/keyboards/1upkeyboards/pi50/pi50.c
@@ -33,6 +33,9 @@ enum {
 #ifdef RGB_MATRIX_CUSTOM_USER
 #    include "rgb_matrix_user.inc"
 #endif
+#if defined(COMMUNITY_MODULES_ENABLE) && __has_include("rgb_matrix_community_modules.inc")
+#    include "rgb_matrix_community_modules.inc"
+#endif
 };
 
 #define RGB_MATRIX_EFFECT(x)    \
@@ -49,6 +52,9 @@ const char* rgb_matrix_name(uint8_t effect) {
 #endif
 #ifdef RGB_MATRIX_CUSTOM_USER
 #    include "rgb_matrix_user.inc"
+#endif
+#if defined(COMMUNITY_MODULES_ENABLE) && __has_include("rgb_matrix_community_modules.inc")
+#    include "rgb_matrix_community_modules.inc"
 #endif
         default:
             return "UNKNOWN";

--- a/keyboards/tzarc/djinn/graphics/theme_djinn_default.c
+++ b/keyboards/tzarc/djinn/graphics/theme_djinn_default.c
@@ -49,6 +49,9 @@ enum {
 #    ifdef RGB_MATRIX_CUSTOM_USER
 #        include "rgb_matrix_user.inc"
 #    endif
+#    if defined(COMMUNITY_MODULES_ENABLE) && __has_include("rgb_matrix_community_modules.inc")
+#        include "rgb_matrix_community_modules.inc"
+#    endif
 #    undef RGB_MATRIX_EFFECT
 };
 
@@ -65,6 +68,9 @@ const char *rgb_matrix_name(uint8_t effect) {
 #    endif
 #    ifdef RGB_MATRIX_CUSTOM_USER
 #        include "rgb_matrix_user.inc"
+#    endif
+#    if defined(COMMUNITY_MODULES_ENABLE) && __has_include("rgb_matrix_community_modules.inc")
+#        include "rgb_matrix_community_modules.inc"
 #    endif
 #    undef RGB_MATRIX_EFFECT
         default:


### PR DESCRIPTION
## Description

Bugfix; community module names were showing up as `Unknown`.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
