### PR TITLE
fix winry25tc lightsout keymap

### DIFF
--- a/keyboards/winry/winry25tc/keymaps/lightsout/keymap.c
+++ b/keyboards/winry/winry25tc/keymaps/lightsout/keymap.c
@@ -82,9 +82,9 @@ void refresh_leds(void) {
             uint8_t tile  = tiles[x][y];
             uint8_t index = (y * 5) + x;
             if (tile) {
-                setrgb(RGB_RED, &led[remap[index]]);
+                rgblight_setrgb_at(RGB_RED, remap[index]);
             } else {
-                setrgb(RGB_WHITE, &led[remap[index]]);
+                rgblight_setrgb_at(RGB_WHITE, remap[index]);
             }
         }
     }


### PR DESCRIPTION
## Description

fixes compilation errors in the `lightsout` keymap for winry25tc discovered when opening #25351 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #25352

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
