### PR TITLE
More compiledb fixes.

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -25,4 +25,9 @@ CompileFlags:
     Compiler: clang
 Diagnostics:
     UnusedIncludes: None
-    Suppress: [asm_invalid_output_constraint, asm_invalid_input_constraint]
+    Suppress:
+        [
+            asm_invalid_output_constraint,
+            asm_invalid_input_constraint,
+            invalid_asm_value_for_constraint,
+        ]

--- a/.clangd
+++ b/.clangd
@@ -1,7 +1,28 @@
 CompileFlags:
-  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast, -Wno-int-to-void-pointer-cast, -DPROGMEM=, -D__builtin_avr_delay_cycles(x)=_delay_us(1)]
-  Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*, -mlra]
-  Compiler: clang
+    Add:
+        [
+            -Wno-unknown-attributes,
+            -Wno-maybe-uninitialized,
+            -Wno-unknown-warning-option,
+            -Wno-pointer-to-int-cast,
+            -Wno-int-to-void-pointer-cast,
+            -DPROGMEM=,
+            -D__builtin_avr_delay_cycles(x)=_delay_us(1),
+        ]
+    Remove:
+        [
+            -W*,
+            -mmcu=*,
+            -mcpu=*,
+            -mfpu=*,
+            -mfloat-abi=*,
+            -mno-unaligned-access,
+            -mno-thumb-interwork,
+            -mcall-prologues,
+            -D__has_include*,
+            -mlra,
+        ]
+    Compiler: clang
 Diagnostics:
-  UnusedIncludes: None
-  Suppress: [asm_invalid_output_constraint, asm_invalid_input_constraint]
+    UnusedIncludes: None
+    Suppress: [asm_invalid_output_constraint, asm_invalid_input_constraint]

--- a/.clangd
+++ b/.clangd
@@ -30,4 +30,5 @@ Diagnostics:
             asm_invalid_output_constraint,
             asm_invalid_input_constraint,
             invalid_asm_value_for_constraint,
+            anyx86_interrupt_attribute,
         ]

--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,5 @@
 CompileFlags:
-  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option]
+  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast]
   Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*, -mlra]
   Compiler: clang
 Diagnostics:

--- a/.clangd
+++ b/.clangd
@@ -4,4 +4,4 @@ CompileFlags:
   Compiler: clang
 Diagnostics:
   UnusedIncludes: None
-  Suppress: [asm_invalid_output_constraint]
+  Suppress: [asm_invalid_output_constraint, asm_invalid_input_constraint]

--- a/.clangd
+++ b/.clangd
@@ -4,3 +4,4 @@ CompileFlags:
   Compiler: clang
 Diagnostics:
   UnusedIncludes: None
+  Suppress: [asm_invalid_output_constraint]

--- a/.clangd
+++ b/.clangd
@@ -7,7 +7,6 @@ CompileFlags:
             -Wno-pointer-to-int-cast,
             -Wno-int-to-void-pointer-cast,
             -DPROGMEM=,
-            -D__builtin_avr_delay_cycles(x)=_delay_us(1),
         ]
     Remove:
         [

--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,5 @@
 CompileFlags:
-  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast, -Wno-int-to-void-pointer-cast]
+  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast, -Wno-int-to-void-pointer-cast, -DPROGMEM=]
   Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*, -mlra]
   Compiler: clang
 Diagnostics:

--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,5 @@
 CompileFlags:
-  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast]
+  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast, -Wno-int-to-void-pointer-cast]
   Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*, -mlra]
   Compiler: clang
 Diagnostics:

--- a/.clangd
+++ b/.clangd
@@ -1,6 +1,6 @@
 CompileFlags:
   Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option]
-  Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*]
+  Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*, -mlra]
   Compiler: clang
 Diagnostics:
   UnusedIncludes: None

--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,5 @@
 CompileFlags:
-  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast, -Wno-int-to-void-pointer-cast, -DPROGMEM=]
+  Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option, -Wno-pointer-to-int-cast, -Wno-int-to-void-pointer-cast, -DPROGMEM=, -D__builtin_avr_delay_cycles(x)=_delay_us(1)]
   Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*, -mlra]
   Compiler: clang
 Diagnostics:

--- a/.clangd
+++ b/.clangd
@@ -2,3 +2,5 @@ CompileFlags:
   Add: [-Wno-unknown-attributes, -Wno-maybe-uninitialized, -Wno-unknown-warning-option]
   Remove: [-W*, -mmcu=*, -mcpu=*, -mfpu=*, -mfloat-abi=*, -mno-unaligned-access, -mno-thumb-interwork, -mcall-prologues, -D__has_include*]
   Compiler: clang
+Diagnostics:
+  UnusedIncludes: None

--- a/lib/python/qmk/compilation_database.py
+++ b/lib/python/qmk/compilation_database.py
@@ -55,7 +55,9 @@ def cpu_defines(binary: str, compiler_args: str) -> List[str]:
             elif len(line_args) == 2 and line_args[0] == '#define':
                 define_args.append(f'-D{line_args[1]}')
 
-        type_filter = re.compile(r'^-D__(SIZE|INT|UINT|WINT|WCHAR|BYTE|SHRT|SIG|FLOAT|LONG|CHAR|SCHAR|DBL|FLT|LDBL|PTRDIFF|QQ|DQ|DA|HA|HQ|SA|SQ|TA|TQ|UDA|UDQ|UHA|UHQ|USQ|USA|UTQ|UTA|UQQ|UQA|ACCUM|FRACT|UACCUM|UFRACT|LACCUM|LFRACT|ULACCUM|ULFRACT|LLACCUM|LLFRACT|ULLACCUM|ULLFRACT|SACCUM|SFRACT|USACCUM|USFRACT)')
+        type_filter = re.compile(
+            r'^-D__(SIZE|INT|UINT|WINT|WCHAR|BYTE|SHRT|SIG|FLOAT|LONG|CHAR|SCHAR|DBL|FLT|LDBL|PTRDIFF|QQ|DQ|DA|HA|HQ|SA|SQ|TA|TQ|UDA|UDQ|UHA|UHQ|USQ|USA|UTQ|UTA|UQQ|UQA|ACCUM|FRACT|UACCUM|UFRACT|LACCUM|LFRACT|ULACCUM|ULFRACT|LLACCUM|LLFRACT|ULLACCUM|ULLFRACT|SACCUM|SFRACT|USACCUM|USFRACT)'
+        )
         return list(sorted(set(filter(lambda x: not type_filter.match(x), define_args))))
     return []
 

--- a/lib/python/qmk/compilation_database.py
+++ b/lib/python/qmk/compilation_database.py
@@ -44,8 +44,7 @@ def cpu_defines(binary: str, compiler_args: str) -> List[str]:
             invocation.extend(['-x', 'c', '-std=gnu11'])
         elif binary.endswith("g++"):
             invocation.extend(['-x', 'c++', '-std=gnu++14'])
-        compiler_args = shlex.split(compiler_args)
-        invocation.extend(compiler_args)
+        invocation.extend(shlex.split(compiler_args))
         invocation.append('-')
         result = cli.run(invocation, capture_output=True, check=True, stdin=None, input='\n')
         define_args = []
@@ -55,7 +54,9 @@ def cpu_defines(binary: str, compiler_args: str) -> List[str]:
                 define_args.append(f'-D{line_args[1]}={line_args[2]}')
             elif len(line_args) == 2 and line_args[0] == '#define':
                 define_args.append(f'-D{line_args[1]}')
-        return list(sorted(set(define_args)))
+
+        type_filter = re.compile(r'^-D__(SIZE|INT|UINT|WINT|WCHAR|BYTE|SHRT|SIG|FLOAT|LONG|CHAR|SCHAR|DBL|FLT|LDBL|PTRDIFF|QQ|DQ|DA|HA|HQ|SA|SQ|TA|TQ|UDA|UDQ|UHA|UHQ|USQ|USA|UTQ|UTA|UQQ|UQA|ACCUM|FRACT|UACCUM|UFRACT|LACCUM|LFRACT|ULACCUM|ULFRACT|LLACCUM|LLFRACT|ULLACCUM|ULLFRACT|SACCUM|SFRACT|USACCUM|USFRACT)')
+        return list(sorted(set(filter(lambda x: not type_filter.match(x), define_args))))
     return []
 
 
@@ -92,8 +93,8 @@ def parse_make_n(f: Iterator[str]) -> List[Dict[str, str]]:
                 for s in system_libs(binary):
                     args += ['-isystem', '%s' % s]
                 args.extend(cpu_defines(binary, ' '.join(shlex.quote(s) for s in compiler_args)))
-                new_cmd = ' '.join(shlex.quote(s) for s in args)
-                records.append({"directory": str(QMK_FIRMWARE.resolve()), "command": new_cmd, "file": this_file})
+                args[0] = binary
+                records.append({"arguments": args, "directory": str(QMK_FIRMWARE.resolve()), "file": this_file})
                 state = 'start'
 
     return records

--- a/platforms/avr/_wait.h
+++ b/platforms/avr/_wait.h
@@ -21,6 +21,8 @@
 #include <util/delay.h>
 #pragma GCC diagnostic pop
 
+extern void __builtin_avr_delay_cycles(uint32_t);
+
 // http://ww1.microchip.com/downloads/en/devicedoc/atmel-0856-avr-instruction-set-manual.pdf
 // page 22: Table 4-2. Arithmetic and Logic Instructions
 /*


### PR DESCRIPTION
## Description

The auto-detected compiler args were seemingly breaking clangd, overriding its own internal auto-detection routines:

* Updated `.clangd` to be multiline, so we can do proper diffs when the file changes in the future
* The executable is now changed to fully qualify the compiler path
	* The executable was the one on vscode/clangd's `$PATH`, not the one actually used by the QMK CLI -- this would affect any instance which deals with the environment, so using `direnv` or the bootstrap distribution would usually result in the system-provided `avr-gcc` or `arm-none-eabi-gcc` being used by `clangd`
* The compiler's integer defines -- specifying things like type widths -- seemed to conflict with the auto-detection within clangd itself
	* These are now stripped from the list of defines
* The `compile_commands.json` was using the "old" format with the entire command in one line
	* This has now been swapped to an `arguments` array instead
	* This now matches what `bear` and `compiledb` output
* clangd is now configured to ignore "unnecessary" includes
	* clangd's view of whether an include should be present is plain wrong, unless we decide to properly run through [IWYU](https://include-what-you-use.org/) -- which I'm not sure we have the appetite for
* clangd has no idea about AVR assembly constraints, so the diagnostic is suppressed
* clangd was still considering pointers as 8-byte for whatever reason, so disabled warnings casting to int
* clangd has no idea what `PROGMEM` is, so defined it to nothing/empty
* clangd had no idea about AVR-specific builtins, so the delay builtin now has a forward declaration

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
