### PR TITLE
Add Printronics Mectechpad 3x3 RP2040 macropad with VIA support

### DIFF
--- a/keyboards/mectechpad/config.h
+++ b/keyboards/mectechpad/config.h
@@ -1,0 +1,18 @@
+// Copyright 2025 Jack Sachinidhs (@jacksaxi)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+/* Key matrix size */
+#define MATRIX_ROWS 3
+#define MATRIX_COLS 3
+
+/* LED pin definitions */
+#define LED_PIN_LAYER1 GP12
+#define LED_PIN_LAYER2 GP11
+#define LED_PIN_LAYER3 GP10
+#define LED_PIN_LAYER4 GP9
+
+/* Pin for the layer change button */
+#define LAYER_CHANGE_PIN GP13
+
+/* Debounce time in milliseconds */
+#define DEBOUNCE 15

--- a/keyboards/mectechpad/keyboard.json
+++ b/keyboards/mectechpad/keyboard.json
@@ -1,0 +1,40 @@
+{
+    "manufacturer": "Printronics",
+    "keyboard_name": "Mectechpad",
+    "maintainer": "jacksaxi",
+    "bootloader": "rp2040",
+    "diode_direction": "ROW2COL",
+    "features": {
+        "bootmagic": true,
+        "command": true,
+        "console": true,
+        "extrakey": true,
+        "mousekey": true
+    },
+    "matrix_pins": {
+        "rows": ["GP26", "GP15", "GP14"],
+        "cols": ["GP29", "GP28", "GP27"]
+    },
+    "processor": "RP2040",
+    "url": "printronics.gr",
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x1A2B",
+        "vid": "0x3C4D"
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0}, 
+                {"matrix": [0, 1], "x": 1, "y": 0}, 
+                {"matrix": [0, 2], "x": 2, "y": 0},  
+                {"matrix": [1, 0], "x": 0, "y": 1}, 
+                {"matrix": [1, 1], "x": 1, "y": 1}, 
+                {"matrix": [1, 2], "x": 2, "y": 1},  
+                {"matrix": [2, 0], "x": 0, "y": 2}, 
+                {"matrix": [2, 1], "x": 1, "y": 2}, 
+                {"matrix": [2, 2], "x": 2, "y": 2}
+            ]
+        }
+    }
+}

--- a/keyboards/mectechpad/keymaps/default/keymap.c
+++ b/keyboards/mectechpad/keymaps/default/keymap.c
@@ -1,0 +1,87 @@
+// Copyright 2025 Jack Sachinidhs (@jacksaxi)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include QMK_KEYBOARD_H
+#include "mectechpad.h" // or whatever the correct file is
+
+enum layers {
+    _LAYER1,
+    _LAYER2,
+    _LAYER3,
+    _LAYER4
+};
+
+// Define the pin for the layer change button
+#define LAYER_CHANGE_PIN GP13
+#define DEBOUNCE_DELAY 10 // Debounce time in milliseconds
+
+// Update LEDs based on the current layer
+void set_layer_indicator(uint8_t layer) {
+    writePin(LED_PIN_LAYER1, layer == _LAYER1);
+    writePin(LED_PIN_LAYER2, layer == _LAYER2);
+    writePin(LED_PIN_LAYER3, layer == _LAYER3);
+    writePin(LED_PIN_LAYER4, layer == _LAYER4);
+}
+
+// Initialize pins
+void keyboard_post_init_user(void) {
+    setPinOutput(LED_PIN_LAYER1);
+    setPinOutput(LED_PIN_LAYER2);
+    setPinOutput(LED_PIN_LAYER3);
+    setPinOutput(LED_PIN_LAYER4);
+
+    // Initialize the layer change button pin
+    setPinInputHigh(LAYER_CHANGE_PIN);
+
+    set_layer_indicator(_LAYER1);
+}
+
+// Cycle through layers based on the layer change button state
+void matrix_scan_user(void) {
+    static bool last_button_state = false;
+    static uint16_t last_debounce_time = 0;
+
+    // Read the current state of the button (active low)
+    bool current_button_state = !readPin(LAYER_CHANGE_PIN);
+
+    // Check if the button state has changed and debounce time has passed
+    if (current_button_state != last_button_state) {
+        if (timer_elapsed(last_debounce_time) > DEBOUNCE_DELAY) {
+            last_debounce_time = timer_read(); // Reset debounce timer
+
+            if (current_button_state) {
+                // Button was just pressed, move to the next layer
+                uint8_t current_layer = get_highest_layer(layer_state);
+                uint8_t next_layer = (current_layer + 1) % 4; // Cycle to the next layer
+                layer_move(next_layer);
+                set_layer_indicator(next_layer);
+            }
+        }
+    }
+
+    // Update the last known button state
+    last_button_state = current_button_state;
+}
+
+// Define the keymap
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_LAYER1] = LAYOUT(
+        KC_1, KC_2, KC_3,
+        KC_4, KC_5, KC_6,
+        KC_7, KC_8, KC_9
+    ),
+    [_LAYER2] = LAYOUT(
+        KC_Q, KC_W, KC_E,
+        KC_R, KC_T, KC_Y,
+        KC_U, KC_I, KC_O
+    ),
+    [_LAYER3] = LAYOUT(
+        KC_A, KC_S, KC_D,
+        KC_F, KC_G, KC_H,
+        KC_J, KC_K, KC_L
+    ),
+    [_LAYER4] = LAYOUT(
+        KC_Z, KC_X, KC_C,
+        KC_V, KC_B, KC_N,
+        KC_M, KC_COMM, KC_DOT
+    ),
+};

--- a/keyboards/mectechpad/mectechpad.h
+++ b/keyboards/mectechpad/mectechpad.h
@@ -1,0 +1,5 @@
+// Copyright 2025 Jack Sachinidhs (@jacksaxi)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include "quantum.h"

--- a/keyboards/mectechpad/mectechpad_via.json
+++ b/keyboards/mectechpad/mectechpad_via.json
@@ -1,0 +1,16 @@
+{
+    "name": "Printronics Mectechpad",
+    "productId": "0x1A2B",
+    "vendorId": "0x3C4D",
+    "matrix": {
+    "rows": 3,
+    "cols": 3
+  },
+  "layouts": {
+    "keymap": [
+        ["0,0","0,1","0,2"],
+        ["1,0","1,1","1,2"],
+        ["2,0","2,1","2,2"]
+    ]
+  }
+}

--- a/keyboards/mectechpad/readme.md
+++ b/keyboards/mectechpad/readme.md
@@ -1,0 +1,42 @@
+# MECTECHPAD
+
+A 3x3 custom macropad designed by [Printronics](https://printronics.gr), powered by the RP2040 MCU, and fully compatible with VIA for real-time key remapping.
+
+## Features
+
+- **3x3 matrix** (9 keys)
+- RP2040 microcontroller
+- VIA support for easy key remapping
+- 4 programmable layers, with hardware-based layer switching via dedicated button
+- Layer indicator LEDs (one per layer)
+- Designed for makers, productivity, and automation
+
+## Matrix and Pinout
+
+| Row Pins     | Col Pins     |
+|--------------|--------------|
+| GP26, GP15, GP14 | GP29, GP28, GP27 |
+
+**Diode Direction:** ROW2COL
+
+## Layer Switch & LEDs
+
+- Dedicated layer change button: **GP13**
+- Layer indicator LEDs: *specify your pins here* (e.g. GP2, GP3, GP4, GP5)
+
+## How to Flash
+
+1. Hold the **BOOTSEL** button and plug the board into USB.
+2. Copy the generated `.uf2` firmware file to the new drive ("RPI-RP2").
+3. The board will reboot automatically.
+
+## VIA Support
+
+- Use [VIA](https://usevia.app/) for live key remapping.
+- If VIA doesn’t auto-detect, drag and drop `mectechpad_via.json` into VIA’s design tab.
+
+## Maintainer
+
+[jacksaxi](https://github.com/jacksaxi)
+
+---

--- a/keyboards/mectechpad/rules.mk
+++ b/keyboards/mectechpad/rules.mk
@@ -1,0 +1,8 @@
+# MCU type for RP2040
+MCU = RP2040
+
+# Enable VIA support
+VIA_ENABLE = yes
+
+# Bootloader type for RP2040 boards
+BOOTLOADER = rp2040


### PR DESCRIPTION
## Keyboard: Printronics Mectechpad

- Custom 3x3 RP2040 macropad designed for productivity and automation
- Fully compatible with VIA (`mectechpad_via.json` included)
- 4 hardware-selectable layers with dedicated LED indicators
- Clean QMK structure (`config.h`, `rules.mk`, `keymaps`, `keyboard.json`, `readme.md`)
- Matrix: 3x3 (Rows: GP26, GP15, GP14; Cols: GP29, GP28, GP27), Diode Direction: ROW2COL
- Layer change button: GP13
- All files included as per QMK guidelines

Tested and working. Let me know if anything needs adjustment!

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*None*

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
