### PR TITLE
[Bug] Fix `usb_endpoint_interface_lut` multiple def compile err

### DIFF
--- a/tmk_core/protocol/chibios/usb_endpoints.h
+++ b/tmk_core/protocol/chibios/usb_endpoints.h
@@ -121,7 +121,7 @@ typedef enum {
 
 #define IS_VALID_USB_ENDPOINT_IN_LUT(i) ((i) >= 0 && (i) < USB_ENDPOINT_IN_COUNT)
 
-usb_endpoint_in_lut_t usb_endpoint_interface_lut[TOTAL_INTERFACES];
+extern usb_endpoint_in_lut_t usb_endpoint_interface_lut[TOTAL_INTERFACES];
 
 typedef enum {
 #if defined(RAW_ENABLE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I hit this error when playing with the `OPT_DEFS` to increase performance.

Tested on STM32F405 with
```
OPT_DEFS += -Ofast -flto -ffast-math -funroll-loops \
            -fno-tree-vectorize -fno-signed-zeros -fno-math-errno \
            -fno-common -fomit-frame-pointer -falign-functions=16 \
            -falign-loops=16 -falign-jumps=16 -fno-exceptions -fno-unwind-tables
```

```
Linking: .build/xelus_valor_he_default.elf                                                          [ERRORS]
 |
 | /usr/bin/qmk_toolchain/bin/../lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: .build/obj_xelus_valor_he_default/protocol/chibios/chibios.o (symbol from plugin): in function `early_hardware_init_pre':
 | (.text+0x0): multiple definition of `usb_endpoint_interface_lut'; .build/obj_xelus_valor_he_default/protocol/chibios/usb_main.o (symbol from plugin):(.text+0x0): first defined here
 | /usr/bin/qmk_toolchain/bin/../lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: .build/obj_xelus_valor_he_default/protocol/chibios/usb_endpoints.o (symbol from plugin): in function `usb_endpoints_out':
 | (.text+0x0): multiple definition of `usb_endpoint_interface_lut'; .build/obj_xelus_valor_he_default/protocol/chibios/usb_main.o (symbol from plugin):(.text+0x0): first defined here
 | /usr/bin/qmk_toolchain/bin/../lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: .build/obj_xelus_valor_he_default/protocol/chibios/usb_report_handling.o (symbol from plugin): in function `usb_set_report':
 | (.text+0x0): multiple definition of `usb_endpoint_interface_lut'; .build/obj_xelus_valor_he_default/protocol/chibios/usb_main.o (symbol from plugin):(.text+0x0): first defined here
 | /usr/bin/qmk_toolchain/bin/../lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: .build/obj_xelus_valor_he_default/protocol/chibios/usb_util.o (symbol from plugin): in function `usb_disconnect':
 | (.text+0x0): multiple definition of `usb_endpoint_interface_lut'; .build/obj_xelus_valor_he_default/protocol/chibios/usb_main.o (symbol from plugin):(.text+0x0): first defined here
 | lto-wrapper: warning: using serial compilation of 2 LTRANS jobs
 | lto-wrapper: note: see the '-flto' option documentation for more information
 | collect2: error: ld returned 1 exit status
 |
gmake: *** [builddefs/common_rules.mk:269: .build/xelus_valor_he_default.elf] Error 1
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes multiple definition of `usb_endpoint_interface_lut`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
