### PR TITLE
Fix One Shot Modifiers getting stuck

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -112,7 +112,7 @@ void action_exec(keyevent_t event) {
         if (has_oneshot_layer_timed_out()) {
             clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
         }
-        if (has_oneshot_mods_timed_out()) {
+        if (has_oneshot_mods_timed_out() && !get_oneshot_mods_fired()) {
             clear_oneshot_mods();
         }
 #        ifdef SWAP_HANDS_ENABLE

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -46,8 +46,12 @@ extern inline void clear_keys(void);
 #ifndef NO_ACTION_ONESHOT
 static uint8_t oneshot_mods        = 0;
 static uint8_t oneshot_locked_mods = 0;
+static bool    oneshot_mods_fired  = false;
 uint8_t        get_oneshot_locked_mods(void) {
     return oneshot_locked_mods;
+}
+bool get_oneshot_mods_fired(void) {
+    return oneshot_mods_fired;
 }
 void add_oneshot_locked_mods(uint8_t mods) {
     if ((oneshot_locked_mods & mods) != mods) {
@@ -260,16 +264,15 @@ static uint8_t get_mods_for_report(void) {
 
 #ifndef NO_ACTION_ONESHOT
     if (oneshot_mods) {
-#    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
-        if (has_oneshot_mods_timed_out()) {
-            dprintf("Oneshot: timeout\n");
+        // Fire oneshots when other keys are pressed
+        // Release oneshots when everything else is released
+        if (has_anykey() || mods) {
+            oneshot_mods_fired = true;
+        } else if (oneshot_mods_fired) {
+            oneshot_mods_fired = false;
             clear_oneshot_mods();
         }
-#    endif
         mods |= oneshot_mods;
-        if (has_anykey()) {
-            clear_oneshot_mods();
-        }
     }
 #endif
 

--- a/quantum/action_util.h
+++ b/quantum/action_util.h
@@ -68,6 +68,7 @@ void    clear_oneshot_mods(void);
 bool    has_oneshot_mods_timed_out(void);
 
 uint8_t get_oneshot_locked_mods(void);
+bool    get_oneshot_mods_fired(void);
 void    add_oneshot_locked_mods(uint8_t mods);
 void    set_oneshot_locked_mods(uint8_t mods);
 void    clear_oneshot_locked_mods(void);

--- a/tests/basic/config.h
+++ b/tests/basic/config.h
@@ -17,3 +17,5 @@
 #pragma once
 
 #include "test_common.h"
+
+#define ONESHOT_TAP_TOGGLE 5

--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -254,7 +254,7 @@ TEST_F(OneShot, OSMHoldNotLockingOSMs) {
 
     /* Press and release regular key */
     EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code, regular_key.report_code)).Times(1);
-    EXPECT_REPORT(driver, (osm_key2.report_code)).Times(1);
+    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code)).Times(1);
     tap_key(regular_key);
     VERIFY_AND_CLEAR(driver);
 
@@ -274,6 +274,118 @@ TEST_F(OneShot, OSMHoldNotLockingOSMs) {
     EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(OneShot, OSMHoldRelease) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osm_key = KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT};
+
+    set_keymap({osm_key});
+
+    /* Press and release OSM */
+    EXPECT_NO_REPORT(driver);
+    tap_key(osm_key);
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold OSM */
+    EXPECT_REPORT(driver, (osm_key.report_code)).Times(1);
+    osm_key.press();
+    run_one_scan_loop();
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release OSM */
+    EXPECT_EMPTY_REPORT(driver);
+    osm_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(OneShot, OSMHoldReleaseTwoOSMs) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osm_key1 = KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT};
+    KeymapKey  osm_key2 = KeymapKey{0, 0, 1, OSM(MOD_LCTL), KC_LCTL};
+
+    set_keymap({osm_key1, osm_key2});
+
+    /* Press and release OSM1 */
+    EXPECT_NO_REPORT(driver);
+    tap_key(osm_key1);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and release OSM2 */
+    EXPECT_NO_REPORT(driver);
+    tap_key(osm_key2);
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press and hold OSM1 */
+    EXPECT_REPORT(driver, (osm_key1.report_code, osm_key2.report_code)).Times(1);
+    osm_key1.press();
+    run_one_scan_loop();
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release OSM1 */
+    EXPECT_EMPTY_REPORT(driver);
+    osm_key1.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(OneShot, OSMNonOSMMod) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osm_key     = KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT};
+    KeymapKey  regular_mod = KeymapKey{0, 1, 0, KC_LCTL};
+
+    set_keymap({osm_key, regular_mod});
+
+    /* Press and release OSM */
+    EXPECT_NO_REPORT(driver);
+    tap_key(osm_key);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press regular mod */
+    EXPECT_REPORT(driver, (osm_key.report_code, regular_mod.report_code)).Times(1);
+    regular_mod.press();
+    run_one_scan_loop();
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular mod */
+    EXPECT_EMPTY_REPORT(driver);
+    regular_mod.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(OneShot, OSMLockRelease) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osm_key = KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT};
+
+    set_keymap({osm_key});
+
+    EXPECT_NO_REPORT(driver);
+    for (int i = 1; i < ONESHOT_TAP_TOGGLE; i++) {
+        /* Press and release OSM */
+        tap_key(osm_key);
+    }
+    VERIFY_AND_CLEAR(driver);
+
+    /* Lock OSM */
+    EXPECT_REPORT(driver, (osm_key.report_code)).Times(1);
+    tap_key(osm_key);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Unlock OSM */
+    EXPECT_NO_REPORT(driver);
+    tap_key(osm_key);
     VERIFY_AND_CLEAR(driver);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
While testing out One Shot Mods for my keymap, I ran into several cases where the modifiers are sent to the OS but keyup is not sent, leaving them stuck in a pressed state until another key is pressed.  The stuck keys do not affect the next keypress but they do make it annoying to click with the mouse 

### Cases where OSMs get stuck:

#### One OSM key

1. Tap an OSM key
2. Long tap the same OSM key
3. The OSM registers a keydown but no keyup

#### Two OSM keys

1. Tap two OSM keys
2. Long tap one of the OSM keys
3. Both keys register a keydown but no keyup

#### Non OSM modifier

1. Tap an OSM key
2. Tap a non-OSM modifier key
3. The OSM registers a keydown but no keyup

#### Unlocking OSM

1. Tap an OSM key `ONESHOT_TAP_TOGGLE` times to lock it
2. The locked OSM registers a keydown
3. Tap the key one more time to unlock it
4. The OSM is unlocked but no keyup is sent


These changes create a `oneshot_mods_fired` state that activates when you activate at least one OSM and then press any normal key to send a key report.  This state lasts until all non-OSM keys are released, resetting all OSMs.  


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes https://github.com/qmk/qmk_firmware/issues/25106

Two other PRs partially fix this bug but they don't fix all the cases I found:
* https://github.com/qmk/qmk_firmware/pull/24925
* https://github.com/qmk/qmk_firmware/pull/25107

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
