### PR TITLE
[docs] Change GUI key references to "Meta" -> "Super"

### DIFF
--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -176,11 +176,11 @@ See also: [Basic Keycodes](keycodes_basic)
 |`KC_LEFT_CTRL`          |`KC_LCTL`                      |Left Control                           |✔            |✔            |✔                |
 |`KC_LEFT_SHIFT`         |`KC_LSFT`                      |Left Shift                             |✔            |✔            |✔                |
 |`KC_LEFT_ALT`           |`KC_LALT`, `KC_LOPT`           |Left Alt (Option)                      |✔            |✔            |✔                |
-|`KC_LEFT_GUI`           |`KC_LGUI`, `KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key)    |✔            |✔            |✔                |
+|`KC_LEFT_GUI`           |`KC_LGUI`, `KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Super key)   |✔            |✔            |✔                |
 |`KC_RIGHT_CTRL`         |`KC_RCTL`                      |Right Control                          |✔            |✔            |✔                |
 |`KC_RIGHT_SHIFT`        |`KC_RSFT`                      |Right Shift                            |✔            |✔            |✔                |
 |`KC_RIGHT_ALT`          |`KC_RALT`, `KC_ROPT`, `KC_ALGR`|Right Alt (Option/AltGr)               |✔            |✔            |✔                |
-|`KC_RIGHT_GUI`          |`KC_RGUI`, `KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)   |✔            |✔            |✔                |
+|`KC_RIGHT_GUI`          |`KC_RGUI`, `KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Super key)  |✔            |✔            |✔                |
 |`KC_SYSTEM_POWER`       |`KC_PWR`                       |System Power Down                      |✔            |✔<sup>3</sup>|✔                |
 |`KC_SYSTEM_SLEEP`       |`KC_SLEP`                      |System Sleep                           |✔            |✔<sup>3</sup>|✔                |
 |`KC_SYSTEM_WAKE`        |`KC_WAKE`                      |System Wake                            |             |✔<sup>3</sup>|✔                |

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -108,16 +108,16 @@ The basic set of keycodes are based on the [HID Keyboard/Keypad Usage Page (0x07
 
 ## Modifiers
 
-|Key             |Aliases                        |Description                         |
-|----------------|-------------------------------|------------------------------------|
-|`KC_LEFT_CTRL`  |`KC_LCTL`                      |Left Control                        |
-|`KC_LEFT_SHIFT` |`KC_LSFT`                      |Left Shift                          |
-|`KC_LEFT_ALT`   |`KC_LALT`, `KC_LOPT`           |Left Alt (Option)                   |
-|`KC_LEFT_GUI`   |`KC_LGUI`, `KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Meta key) |
-|`KC_RIGHT_CTRL` |`KC_RCTL`                      |Right Control                       |
-|`KC_RIGHT_SHIFT`|`KC_RSFT`                      |Right Shift                         |
-|`KC_RIGHT_ALT`  |`KC_RALT`, `KC_ROPT`, `KC_ALGR`|Right Alt (Option/AltGr)            |
-|`KC_RIGHT_GUI`  |`KC_RGUI`, `KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Meta key)|
+|Key             |Aliases                        |Description                          |
+|----------------|-------------------------------|-------------------------------------|
+|`KC_LEFT_CTRL`  |`KC_LCTL`                      |Left Control                         |
+|`KC_LEFT_SHIFT` |`KC_LSFT`                      |Left Shift                           |
+|`KC_LEFT_ALT`   |`KC_LALT`, `KC_LOPT`           |Left Alt (Option)                    |
+|`KC_LEFT_GUI`   |`KC_LGUI`, `KC_LCMD`, `KC_LWIN`|Left GUI (Windows/Command/Super key) |
+|`KC_RIGHT_CTRL` |`KC_RCTL`                      |Right Control                        |
+|`KC_RIGHT_SHIFT`|`KC_RSFT`                      |Right Shift                          |
+|`KC_RIGHT_ALT`  |`KC_RALT`, `KC_ROPT`, `KC_ALGR`|Right Alt (Option/AltGr)             |
+|`KC_RIGHT_GUI`  |`KC_RGUI`, `KC_RCMD`, `KC_RWIN`|Right GUI (Windows/Command/Super key)|
 
 ## International
 

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -9,11 +9,11 @@ The modifiers (`mod`) argument to the `MT()` macro are prefixed with `MOD_`, not
 |`MOD_LCTL`|Left Control                            |
 |`MOD_LSFT`|Left Shift                              |
 |`MOD_LALT`|Left Alt                                |
-|`MOD_LGUI`|Left GUI (Windows/Command/Meta key)     |
+|`MOD_LGUI`|Left GUI (Windows/Command/Super key)    |
 |`MOD_RCTL`|Right Control                           |
 |`MOD_RSFT`|Right Shift                             |
 |`MOD_RALT`|Right Alt (AltGr)                       |
-|`MOD_RGUI`|Right GUI (Windows/Command/Meta key)    |
+|`MOD_RGUI`|Right GUI (Windows/Command/Super key)   |
 |`MOD_HYPR`|Hyper (Left Control, Shift, Alt and GUI)|
 |`MOD_MEH` |Meh (Left Control, Shift, and Alt)      |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

A small terminology tweak based on a quick Google, it seems like Super is the more common name for the GUI key in Linux land (although it may possibly depend on your DE?).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
