### PR TITLE
Clean up mod & mod-tap shortcuts

### DIFF
--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -8,19 +8,28 @@ These allow you to combine a modifier with a keycode. When pressed, the keydown 
 |`LSFT(kc)`|`S(kc)`                           |Hold Left Shift and press `kc`                                                 |
 |`LALT(kc)`|`A(kc)`, `LOPT(kc)`               |Hold Left Alt and press `kc`                                                   |
 |`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`   |Hold Left GUI and press `kc`                                                   |
+|`LCS(kc)` |                                  |Hold Left Control and Left Shift and press `kc`                                |
 |`LCA(kc)` |                                  |Hold Left Control and Left Alt and press `kc`                                  |
+|`LCG(kc)` |                                  |Hold Left Control and Left GUI and press `kc`                                  |
 |`LSA(kc)` |                                  |Hold Left Shift and Left Alt and press `kc`                                    |
 |`LSG(kc)` |`SGUI(kc)`, `SCMD(kc)`, `SWIN(kc)`|Hold Left Shift and Left GUI and press `kc`                                    |
 |`LAG(kc)` |                                  |Hold Left Alt and Left GUI and press `kc`                                      |
+|`LCSG(kc)`|                                  |Hold Left Control, Left Shift and Left GUI and press `kc`                      |
 |`LCAG(kc)`|                                  |Hold Left Control, Left Alt and Left GUI and press `kc`                        |
+|`LSAG(kc)`|                                  |Hold Left Shift, Left Alt and Left GUI and press `kc`                          |
 |`RCTL(kc)`|                                  |Hold Right Control and press `kc`                                              |
 |`RSFT(kc)`|                                  |Hold Right Shift and press `kc`                                                |
 |`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt and press `kc`                                                  |
 |`RGUI(kc)`|`RCMD(kc)`, `RWIN(kc)`            |Hold Right GUI and press `kc`                                                  |
+|`RCA(kc)` |                                  |Hold Right Control and Right Alt and press `kc`                                |
 |`RCS(kc)` |                                  |Hold Right Control and Right Shift and press `kc`                              |
-|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt (AltGr) and press `kc`                          |
+|`RCG(kc)` |                                  |Hold Right Control and Right GUI and press `kc`                                |
+|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt and press `kc`                                  |
 |`RSG(kc)` |                                  |Hold Right Shift and Right GUI and press `kc`                                  |
 |`RAG(kc)` |                                  |Hold Right Alt and Right GUI and press `kc`                                    |
+|`RCSG(kc)`|                                  |Hold Right Control, Right Shift and Right GUI and press `kc`                   |
+|`RCAG(kc)`|                                  |Hold Right Control, Right Alt and Right GUI and press `kc`                     |
+|`RSAG(kc)`|                                  |Hold Right Shift, Right Alt and Right GUI and press `kc`                       |
 |`MEH(kc)` |                                  |Hold Left Control, Left Shift and Left Alt and press `kc`                      |
 |`HYPR(kc)`|                                  |Hold Left Control, Left Shift, Left Alt and Left GUI and press `kc`<sup>1</sup>|
 

--- a/docs/feature_advanced_keycodes.md
+++ b/docs/feature_advanced_keycodes.md
@@ -2,29 +2,31 @@
 
 These allow you to combine a modifier with a keycode. When pressed, the keydown event for the modifier, then `kc` will be sent. On release, the keyup event for `kc`, then the modifier will be sent.
 
-|Key       |Aliases                           |Description                                           |
-|----------|----------------------------------|------------------------------------------------------|
-|`LCTL(kc)`|`C(kc)`                           |Hold Left Control and press `kc`                      |
-|`LSFT(kc)`|`S(kc)`                           |Hold Left Shift and press `kc`                        |
-|`LALT(kc)`|`A(kc)`, `LOPT(kc)`               |Hold Left Alt and press `kc`                          |
-|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`   |Hold Left GUI and press `kc`                          |
-|`RCTL(kc)`|                                  |Hold Right Control and press `kc`                     |
-|`RSFT(kc)`|                                  |Hold Right Shift and press `kc`                       |
-|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt and press `kc`                         |
-|`RGUI(kc)`|`RCMD(kc)`, `RWIN(kc)`            |Hold Right GUI and press `kc`                         |
-|`LSG(kc)` |`SGUI(kc)`, `SCMD(kc)`, `SWIN(kc)`|Hold Left Shift and GUI and press `kc`                |
-|`LAG(kc)` |                                  |Hold Left Alt and Left GUI and press `kc`             |
-|`RSG(kc)` |                                  |Hold Right Shift and Right GUI and press `kc`         |
-|`RAG(kc)` |                                  |Hold Right Alt and Right GUI and press `kc`           |
-|`LCA(kc)` |                                  |Hold Left Control and Alt and press `kc`              |
-|`LSA(kc)` |                                  |Hold Left Shift and Left Alt and press `kc`           |
-|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt (AltGr) and press `kc` |
-|`RCS(kc)` |                                  |Hold Right Control and Right Shift and press `kc`     |
-|`LCAG(kc)`|                                  |Hold Left Control, Alt and GUI and press `kc`         |
-|`MEH(kc)` |                                  |Hold Left Control, Shift and Alt and press `kc`       |
-|`HYPR(kc)`|                                  |Hold Left Control, Shift, Alt and GUI and press `kc`  |
+|Key       |Aliases                           |Description                                                                    |
+|----------|----------------------------------|-------------------------------------------------------------------------------|
+|`LCTL(kc)`|`C(kc)`                           |Hold Left Control and press `kc`                                               |
+|`LSFT(kc)`|`S(kc)`                           |Hold Left Shift and press `kc`                                                 |
+|`LALT(kc)`|`A(kc)`, `LOPT(kc)`               |Hold Left Alt and press `kc`                                                   |
+|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`   |Hold Left GUI and press `kc`                                                   |
+|`LCA(kc)` |                                  |Hold Left Control and Left Alt and press `kc`                                  |
+|`LSA(kc)` |                                  |Hold Left Shift and Left Alt and press `kc`                                    |
+|`LSG(kc)` |`SGUI(kc)`, `SCMD(kc)`, `SWIN(kc)`|Hold Left Shift and Left GUI and press `kc`                                    |
+|`LAG(kc)` |                                  |Hold Left Alt and Left GUI and press `kc`                                      |
+|`LCAG(kc)`|                                  |Hold Left Control, Left Alt and Left GUI and press `kc`                        |
+|`RCTL(kc)`|                                  |Hold Right Control and press `kc`                                              |
+|`RSFT(kc)`|                                  |Hold Right Shift and press `kc`                                                |
+|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt and press `kc`                                                  |
+|`RGUI(kc)`|`RCMD(kc)`, `RWIN(kc)`            |Hold Right GUI and press `kc`                                                  |
+|`RCS(kc)` |                                  |Hold Right Control and Right Shift and press `kc`                              |
+|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt (AltGr) and press `kc`                          |
+|`RSG(kc)` |                                  |Hold Right Shift and Right GUI and press `kc`                                  |
+|`RAG(kc)` |                                  |Hold Right Alt and Right GUI and press `kc`                                    |
+|`MEH(kc)` |                                  |Hold Left Control, Left Shift and Left Alt and press `kc`                      |
+|`HYPR(kc)`|                                  |Hold Left Control, Left Shift, Left Alt and Left GUI and press `kc`<sup>1</sup>|
 
-You can also chain them, for example `LCTL(LALT(KC_DEL))` or `C(A(KC_DEL))` makes a key that sends Control+Alt+Delete with a single keypress.
+<sup>1. More information on the Hyper key can be found on [this blog post by Brett Terpstra](https://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/).</sup>
+
+You can also chain them, for example `LCTL(LALT(KC_DEL))`, `C(A(KC_DEL))`, or `LCA(KC_DEL)` all make a key that sends Control+Alt+Delete with a single keypress.
 
 # Checking Modifier State {#checking-modifier-state}
 

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -658,58 +658,58 @@ See also: [Mouse Keys](features/mouse_keys)
 
 See also: [Modifier Keys](feature_advanced_keycodes#modifier-keys)
 
-|Key       |Aliases                           |Description                                           |
-|----------|----------------------------------|------------------------------------------------------|
-|`LCTL(kc)`|`C(kc)`                           |Hold Left Control and press `kc`                      |
-|`LSFT(kc)`|`S(kc)`                           |Hold Left Shift and press `kc`                        |
-|`LALT(kc)`|`A(kc)`, `LOPT(kc)`               |Hold Left Alt and press `kc`                          |
-|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`   |Hold Left GUI and press `kc`                          |
-|`RCTL(kc)`|                                  |Hold Right Control and press `kc`                     |
-|`RSFT(kc)`|                                  |Hold Right Shift and press `kc`                       |
-|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt (AltGr) and press `kc`                 |
-|`RGUI(kc)`|`RCMD(kc)`, `RWIN(kc)`            |Hold Right GUI and press `kc`                         |
-|`LSG(kc)` |`SGUI(kc)`, `SCMD(kc)`, `SWIN(kc)`|Hold Left Shift and Left GUI and press `kc`           |
-|`LAG(kc)` |                                  |Hold Left Alt and Left GUI and press `kc`             |
-|`RSG(kc)` |                                  |Hold Right Shift and Right GUI and press `kc`         |
-|`RAG(kc)` |                                  |Hold Right Alt and Right GUI and press `kc`           |
-|`LCA(kc)` |                                  |Hold Left Control and Alt and press `kc`              |
-|`LSA(kc)` |                                  |Hold Left Shift and Left Alt and press `kc`           |
-|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt (AltGr) and press `kc` |
-|`RCS(kc)` |                                  |Hold Right Control and Right Shift and press `kc`     |
-|`LCAG(kc)`|                                  |Hold Left Control, Alt and GUI and press `kc`         |
-|`MEH(kc)` |                                  |Hold Left Control, Shift and Alt and press `kc`       |
-|`HYPR(kc)`|                                  |Hold Left Control, Shift, Alt and GUI and press `kc`  |
-|`KC_MEH`  |                                  |Left Control, Shift and Alt                           |
-|`KC_HYPR` |                                  |Left Control, Shift, Alt and GUI                      |
+|Key       |Aliases                           |Description                                                        |
+|----------|----------------------------------|-------------------------------------------------------------------|
+|`LCTL(kc)`|`C(kc)`                           |Hold Left Control and press `kc`                                   |
+|`LSFT(kc)`|`S(kc)`                           |Hold Left Shift and press `kc`                                     |
+|`LALT(kc)`|`A(kc)`, `LOPT(kc)`               |Hold Left Alt and press `kc`                                       |
+|`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`   |Hold Left GUI and press `kc`                                       |
+|`LCA(kc)` |                                  |Hold Left Control and Left Alt and press `kc`                      |
+|`LSA(kc)` |                                  |Hold Left Shift and Left Alt and press `kc`                        |
+|`LSG(kc)` |`SGUI(kc)`, `SCMD(kc)`, `SWIN(kc)`|Hold Left Shift and Left GUI and press `kc`                        |
+|`LAG(kc)` |                                  |Hold Left Alt and Left GUI and press `kc`                          |
+|`LCAG(kc)`|                                  |Hold Left Control, Left Alt and Left GUI and press `kc`            |
+|`RCTL(kc)`|                                  |Hold Right Control and press `kc`                                  |
+|`RSFT(kc)`|                                  |Hold Right Shift and press `kc`                                    |
+|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt (AltGr) and press `kc`                              |
+|`RGUI(kc)`|`RCMD(kc)`, `RWIN(kc)`            |Hold Right GUI and press `kc`                                      |
+|`RCS(kc)` |                                  |Hold Right Control and Right Shift and press `kc`                  |
+|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt (AltGr) and press `kc`              |
+|`RSG(kc)` |                                  |Hold Right Shift and Right GUI and press `kc`                      |
+|`RAG(kc)` |                                  |Hold Right Alt and Right GUI and press `kc`                        |
+|`MEH(kc)` |                                  |Hold Left Control, Left Shift and Left Alt and press `kc`          |
+|`HYPR(kc)`|                                  |Hold Left Control, Left Shift, Left Alt and Left GUI and press `kc`|
+|`KC_MEH`  |                                  |Left Control, Left Shift and Left Alt                              |
+|`KC_HYPR` |                                  |Left Control, Left Shift, Left Alt and Left GUI                    |
 
 ## Mod-Tap Keys {#mod-tap-keys}
 
 See also: [Mod-Tap](mod_tap)
 
-|Key          |Aliases                                                          |Description                                                   |
-|-------------|-----------------------------------------------------------------|--------------------------------------------------------------|
-|`MT(mod, kc)`|                                                                 |`mod` when held, `kc` when tapped                             |
-|`LCTL_T(kc)` |`CTL_T(kc)`                                                      |Left Control when held, `kc` when tapped                      |
-|`LSFT_T(kc)` |`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                        |
-|`LALT_T(kc)` |`LOPT_T(kc)`, `ALT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                          |
-|`LGUI_T(kc)` |`LCMD_T(kc)`, `LWIN_T(kc)`, `GUI_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                          |
-|`RCTL_T(kc)` |                                                                 |Right Control when held, `kc` when tapped                     |
-|`RSFT_T(kc)` |                                                                 |Right Shift when held, `kc` when tapped                       |
-|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (AltGr) when held, `kc` when tapped                 |
-|`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
-|`LSG_T(kc)`  |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and GUI when held, `kc` when tapped                |
-|`LAG_T(kc)`  |                                                                 |Left Alt and GUI when held, `kc` when tapped                  |
-|`RSG_T(kc)`  |                                                                 |Right Shift and GUI when held, `kc` when tapped               |
-|`RAG_T(kc)`  |                                                                 |Right Alt and GUI when held, `kc` when tapped                 |
-|`LCA_T(kc)`  |                                                                 |Left Control and Alt when held, `kc` when tapped              |
-|`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped           |
-|`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |
-|`RCS_T(kc)`  |                                                                 |Right Control and Right Shift when held, `kc` when tapped     |
-|`LCAG_T(kc)` |                                                                 |Left Control, Alt and GUI when held, `kc` when tapped         |
-|`RCAG_T(kc)` |                                                                 |Right Control, Alt and GUI when held, `kc` when tapped        |
-|`C_S_T(kc)`  |                                                                 |Left Control and Shift when held, `kc` when tapped            |
-|`MEH_T(kc)`  |                                                                 |Left Control, Shift and Alt when held, `kc` when tapped       |
-|`HYPR_T(kc)` |`ALL_T(kc)`                                                      |Left Control, Shift, Alt and GUI when held, `kc` when tapped - more info [here](https://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/)|
+|Key          |Aliases                                                          |Description                                                                |
+|-------------|-----------------------------------------------------------------|---------------------------------------------------------------------------|
+|`MT(mod, kc)`|                                                                 |`mod` when held, `kc` when tapped                                          |
+|`LCTL_T(kc)` |`CTL_T(kc)`                                                      |Left Control when held, `kc` when tapped                                   |
+|`LSFT_T(kc)` |`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                                     |
+|`LALT_T(kc)` |`ALT_T(kc)`, `LOPT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                                       |
+|`LGUI_T(kc)` |`GUI_T(kc)`, `LCMD_T(kc)`, `LWIN_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                                       |
+|`C_S_T(kc)`  |                                                                 |Left Control and Left Shift when held, `kc` when tapped                    |
+|`LCA_T(kc)`  |                                                                 |Left Control and Left Alt when held, `kc` when tapped                      |
+|`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped                        |
+|`LSG_T(kc)`  |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and Left GUI when held, `kc` when tapped                        |
+|`LAG_T(kc)`  |                                                                 |Left Alt and Left GUI when held, `kc` when tapped                          |
+|`LCAG_T(kc)` |                                                                 |Left Control, Left Alt and Left GUI when held, `kc` when tapped            |
+|`RCTL_T(kc)` |                                                                 |Right Control when held, `kc` when tapped                                  |
+|`RSFT_T(kc)` |                                                                 |Right Shift when held, `kc` when tapped                                    |
+|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (AltGr) when held, `kc` when tapped                              |
+|`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                                      |
+|`RCS_T(kc)`  |                                                                 |Right Control and Right Shift when held, `kc` when tapped                  |
+|`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped              |
+|`RSG_T(kc)`  |                                                                 |Right Shift and Right GUI when held, `kc` when tapped                      |
+|`RAG_T(kc)`  |                                                                 |Right Alt and Right GUI when held, `kc` when tapped                        |
+|`RCAG_T(kc)` |                                                                 |Right Control, Right Alt and Right GUI when held, `kc` when tapped         |
+|`MEH_T(kc)`  |                                                                 |Left Control, Left Shift and Left Alt when held, `kc` when tapped          |
+|`HYPR_T(kc)` |`ALL_T(kc)`                                                      |Left Control, Left Shift, Left Alt and Left GUI when held, `kc` when tapped|
 
 ## Tapping Term Keys {#tapping-term-keys}
 

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -664,19 +664,28 @@ See also: [Modifier Keys](feature_advanced_keycodes#modifier-keys)
 |`LSFT(kc)`|`S(kc)`                           |Hold Left Shift and press `kc`                                     |
 |`LALT(kc)`|`A(kc)`, `LOPT(kc)`               |Hold Left Alt and press `kc`                                       |
 |`LGUI(kc)`|`G(kc)`, `LCMD(kc)`, `LWIN(kc)`   |Hold Left GUI and press `kc`                                       |
+|`LCS(kc)` |                                  |Hold Left Control and Left Shift and press `kc`                    |
 |`LCA(kc)` |                                  |Hold Left Control and Left Alt and press `kc`                      |
+|`LCG(kc)` |                                  |Hold Left Control and Left GUI and press `kc`                      |
 |`LSA(kc)` |                                  |Hold Left Shift and Left Alt and press `kc`                        |
 |`LSG(kc)` |`SGUI(kc)`, `SCMD(kc)`, `SWIN(kc)`|Hold Left Shift and Left GUI and press `kc`                        |
 |`LAG(kc)` |                                  |Hold Left Alt and Left GUI and press `kc`                          |
+|`LCSG(kc)`|                                  |Hold Left Control, Left Shift and Left GUI and press `kc`          |
 |`LCAG(kc)`|                                  |Hold Left Control, Left Alt and Left GUI and press `kc`            |
+|`LSAG(kc)`|                                  |Hold Left Shift, Left Alt and Left GUI and press `kc`              |
 |`RCTL(kc)`|                                  |Hold Right Control and press `kc`                                  |
 |`RSFT(kc)`|                                  |Hold Right Shift and press `kc`                                    |
-|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt (AltGr) and press `kc`                              |
+|`RALT(kc)`|`ROPT(kc)`, `ALGR(kc)`            |Hold Right Alt and press `kc`                                      |
 |`RGUI(kc)`|`RCMD(kc)`, `RWIN(kc)`            |Hold Right GUI and press `kc`                                      |
 |`RCS(kc)` |                                  |Hold Right Control and Right Shift and press `kc`                  |
-|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt (AltGr) and press `kc`              |
+|`RCA(kc)` |                                  |Hold Right Control and Right Alt and press `kc`                    |
+|`RCG(kc)` |                                  |Hold Right Control and Right GUI and press `kc`                    |
+|`RSA(kc)` |`SAGR(kc)`                        |Hold Right Shift and Right Alt and press `kc`                      |
 |`RSG(kc)` |                                  |Hold Right Shift and Right GUI and press `kc`                      |
 |`RAG(kc)` |                                  |Hold Right Alt and Right GUI and press `kc`                        |
+|`RCSG(kc)`|                                  |Hold Right Control, Right Shift and Right GUI and press `kc`       |
+|`RCAG(kc)`|                                  |Hold Right Control, Right Alt and Right GUI and press `kc`         |
+|`RSAG(kc)`|                                  |Hold Right Shift, Right Alt and Right GUI and press `kc`           |
 |`MEH(kc)` |                                  |Hold Left Control, Left Shift and Left Alt and press `kc`          |
 |`HYPR(kc)`|                                  |Hold Left Control, Left Shift, Left Alt and Left GUI and press `kc`|
 |`KC_MEH`  |                                  |Left Control, Left Shift and Left Alt                              |
@@ -693,21 +702,28 @@ See also: [Mod-Tap](mod_tap)
 |`LSFT_T(kc)` |`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                                     |
 |`LALT_T(kc)` |`ALT_T(kc)`, `LOPT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                                       |
 |`LGUI_T(kc)` |`GUI_T(kc)`, `LCMD_T(kc)`, `LWIN_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                                       |
-|`C_S_T(kc)`  |                                                                 |Left Control and Left Shift when held, `kc` when tapped                    |
+|`LCS_T(kc)`  |                                                                 |Left Control and Left Shift when held, `kc` when tapped                    |
 |`LCA_T(kc)`  |                                                                 |Left Control and Left Alt when held, `kc` when tapped                      |
+|`LCG_T(kc)`  |                                                                 |Left Control and Left GUI when held, `kc` when tapped                      |
 |`LSA_T(kc)`  |                                                                 |Left Shift and Left Alt when held, `kc` when tapped                        |
 |`LSG_T(kc)`  |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and Left GUI when held, `kc` when tapped                        |
 |`LAG_T(kc)`  |                                                                 |Left Alt and Left GUI when held, `kc` when tapped                          |
+|`LCSG_T(kc)` |                                                                 |Left Control, Left Shift and Left GUI when held, `kc` when tapped          |
 |`LCAG_T(kc)` |                                                                 |Left Control, Left Alt and Left GUI when held, `kc` when tapped            |
+|`LSAG_T(kc)` |                                                                 |Left Shift, Left Alt and Left GUI when held, `kc` when tapped              |
 |`RCTL_T(kc)` |                                                                 |Right Control when held, `kc` when tapped                                  |
 |`RSFT_T(kc)` |                                                                 |Right Shift when held, `kc` when tapped                                    |
-|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt (AltGr) when held, `kc` when tapped                              |
+|`RALT_T(kc)` |`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt when held, `kc` when tapped                                      |
 |`RGUI_T(kc)` |`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                                      |
 |`RCS_T(kc)`  |                                                                 |Right Control and Right Shift when held, `kc` when tapped                  |
-|`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped              |
+|`RCA_T(kc)`  |                                                                 |Right Control and Right Alt when held, `kc` when tapped                    |
+|`RCG_T(kc)`  |                                                                 |Right Control and Right GUI when held, `kc` when tapped                    |
+|`RSA_T(kc)`  |`SAGR_T(kc)`                                                     |Right Shift and Right Alt when held, `kc` when tapped                      |
 |`RSG_T(kc)`  |                                                                 |Right Shift and Right GUI when held, `kc` when tapped                      |
 |`RAG_T(kc)`  |                                                                 |Right Alt and Right GUI when held, `kc` when tapped                        |
+|`RCSG_T(kc)` |                                                                 |Right Control, Right Shift and Right GUI when held, `kc` when tapped       |
 |`RCAG_T(kc)` |                                                                 |Right Control, Right Alt and Right GUI when held, `kc` when tapped         |
+|`RSAG_T(kc)` |                                                                 |Right Shift, Right Alt and Right GUI when held, `kc` when tapped           |
 |`MEH_T(kc)`  |                                                                 |Left Control, Left Shift and Left Alt when held, `kc` when tapped          |
 |`HYPR_T(kc)` |`ALL_T(kc)`                                                      |Left Control, Left Shift, Left Alt and Left GUI when held, `kc` when tapped|
 

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -33,21 +33,28 @@ For convenience, QMK includes some Mod-Tap shortcuts to make common combinations
 |`LSFT_T(kc)`|`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                                                 |
 |`LALT_T(kc)`|`ALT_T(kc)`, `LOPT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                                                   |
 |`LGUI_T(kc)`|`GUI_T(kc)`, `LCMD_T(kc)`, `LWIN_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                                                   |
-|`C_S_T(kc)` |                                                                 |Left Control and Left Shift when held, `kc` when tapped                                |
+|`LCS_T(kc)` |                                                                 |Left Control and Left Shift when held, `kc` when tapped                                |
 |`LCA_T(kc)` |                                                                 |Left Control and Left Alt when held, `kc` when tapped                                  |
+|`LCG_T(kc)` |                                                                 |Left Control and Left GUI when held, `kc` when tapped                                  |
 |`LSA_T(kc)` |                                                                 |Left Shift and Left Alt when held, `kc` when tapped                                    |
 |`LSG_T(kc)` |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and Left GUI when held, `kc` when tapped                                    |
 |`LAG_T(kc)` |                                                                 |Left Alt and Left GUI when held, `kc` when tapped                                      |
+|`LCSG_T(kc)`|                                                                 |Left Control, Left Shift and Left GUI when held, `kc` when tapped                      |
 |`LCAG_T(kc)`|                                                                 |Left Control, Left Alt and Left GUI when held, `kc` when tapped                        |
+|`LSAG_T(kc)`|                                                                 |Left Shift, Left Alt and Left GUI when held, `kc` when tapped                          |
 |`RCTL_T(kc)`|                                                                 |Right Control when held, `kc` when tapped                                              |
 |`RSFT_T(kc)`|                                                                 |Right Shift when held, `kc` when tapped                                                |
 |`RALT_T(kc)`|`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt when held, `kc` when tapped                                                  |
 |`RGUI_T(kc)`|`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                                                  |
 |`RCS_T(kc)` |                                                                 |Right Control and Right Shift when held, `kc` when tapped                              |
-|`RSA_T(kc)` |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped                          |
+|`RCA_T(kc)` |                                                                 |Right Control and Right Alt when held, `kc` when tapped                                |
+|`RCG_T(kc)` |                                                                 |Right Control and Right GUI when held, `kc` when tapped                                |
+|`RSA_T(kc)` |`SAGR_T(kc)`                                                     |Right Shift and Right Alt when held, `kc` when tapped                                  |
 |`RSG_T(kc)` |                                                                 |Right Shift and Right GUI when held, `kc` when tapped                                  |
 |`RAG_T(kc)` |                                                                 |Right Alt and Right GUI when held, `kc` when tapped                                    |
+|`RCSG_T(kc)`|                                                                 |Right Control, Right Shift and Right GUI when held, `kc` when tapped                   |
 |`RCAG_T(kc)`|                                                                 |Right Control, Right Alt and Right GUI when held, `kc` when tapped                     |
+|`RSAG_T(kc)`|                                                                 |Right Shift, Right Alt and Right GUI when held, `kc` when tapped                       |
 |`MEH_T(kc)` |                                                                 |Left Control, Left Shift and Left Alt when held, `kc` when tapped                      |
 |`HYPR_T(kc)`|`ALL_T(kc)`                                                      |Left Control, Left Shift, Left Alt and Left GUI when held, `kc` when tapped<sup>1</sup>|
 

--- a/docs/mod_tap.md
+++ b/docs/mod_tap.md
@@ -27,29 +27,31 @@ This key would activate Left Control and Left Shift when held, and send Escape w
 
 For convenience, QMK includes some Mod-Tap shortcuts to make common combinations more compact in your keymap:
 
-|Key         |Aliases                                                          |Description                                                   |
-|------------|-----------------------------------------------------------------|--------------------------------------------------------------|
-|`LCTL_T(kc)`|`CTL_T(kc)`                                                      |Left Control when held, `kc` when tapped                      |
-|`LSFT_T(kc)`|`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                        |
-|`LALT_T(kc)`|`LOPT_T(kc)`, `ALT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                          |
-|`LGUI_T(kc)`|`LCMD_T(kc)`, `LWIN_T(kc)`, `GUI_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                          |
-|`RCTL_T(kc)`|                                                                 |Right Control when held, `kc` when tapped                     |
-|`RSFT_T(kc)`|                                                                 |Right Shift when held, `kc` when tapped                       |
-|`RALT_T(kc)`|`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt when held, `kc` when tapped                         |
-|`RGUI_T(kc)`|`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                         |
-|`LSG_T(kc)` |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and GUI when held, `kc` when tapped                |
-|`LAG_T(kc)` |                                                                 |Left Alt and GUI when held, `kc` when tapped                  |
-|`RSG_T(kc)` |                                                                 |Right Shift and GUI when held, `kc` when tapped               |
-|`RAG_T(kc)` |                                                                 |Right Alt and GUI when held, `kc` when tapped                 |
-|`LCA_T(kc)` |                                                                 |Left Control and Alt when held, `kc` when tapped              |
-|`LSA_T(kc)` |                                                                 |Left Shift and Alt when held, `kc` when tapped                |
-|`RSA_T(kc)` |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped |
-|`RCS_T(kc)` |                                                                 |Right Control and Right Shift when held, `kc` when tapped     |
-|`LCAG_T(kc)`|                                                                 |Left Control, Alt and GUI when held, `kc` when tapped         |
-|`RCAG_T(kc)`|                                                                 |Right Control, Alt and GUI when held, `kc` when tapped        |
-|`C_S_T(kc)` |                                                                 |Left Control and Shift when held, `kc` when tapped            |
-|`MEH_T(kc)` |                                                                 |Left Control, Shift and Alt when held, `kc` when tapped       |
-|`HYPR_T(kc)`|`ALL_T(kc)`                                                      |Left Control, Shift, Alt and GUI when held, `kc` when tapped - more info [here](https://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/)|
+|Key         |Aliases                                                          |Description                                                                            |
+|------------|-----------------------------------------------------------------|---------------------------------------------------------------------------------------|
+|`LCTL_T(kc)`|`CTL_T(kc)`                                                      |Left Control when held, `kc` when tapped                                               |
+|`LSFT_T(kc)`|`SFT_T(kc)`                                                      |Left Shift when held, `kc` when tapped                                                 |
+|`LALT_T(kc)`|`ALT_T(kc)`, `LOPT_T(kc)`, `OPT_T(kc)`                           |Left Alt when held, `kc` when tapped                                                   |
+|`LGUI_T(kc)`|`GUI_T(kc)`, `LCMD_T(kc)`, `LWIN_T(kc)`, `CMD_T(kc)`, `WIN_T(kc)`|Left GUI when held, `kc` when tapped                                                   |
+|`C_S_T(kc)` |                                                                 |Left Control and Left Shift when held, `kc` when tapped                                |
+|`LCA_T(kc)` |                                                                 |Left Control and Left Alt when held, `kc` when tapped                                  |
+|`LSA_T(kc)` |                                                                 |Left Shift and Left Alt when held, `kc` when tapped                                    |
+|`LSG_T(kc)` |`SGUI_T(kc)`, `SCMD_T(kc)`, `SWIN_T(kc)`                         |Left Shift and Left GUI when held, `kc` when tapped                                    |
+|`LAG_T(kc)` |                                                                 |Left Alt and Left GUI when held, `kc` when tapped                                      |
+|`LCAG_T(kc)`|                                                                 |Left Control, Left Alt and Left GUI when held, `kc` when tapped                        |
+|`RCTL_T(kc)`|                                                                 |Right Control when held, `kc` when tapped                                              |
+|`RSFT_T(kc)`|                                                                 |Right Shift when held, `kc` when tapped                                                |
+|`RALT_T(kc)`|`ROPT_T(kc)`, `ALGR_T(kc)`                                       |Right Alt when held, `kc` when tapped                                                  |
+|`RGUI_T(kc)`|`RCMD_T(kc)`, `RWIN_T(kc)`                                       |Right GUI when held, `kc` when tapped                                                  |
+|`RCS_T(kc)` |                                                                 |Right Control and Right Shift when held, `kc` when tapped                              |
+|`RSA_T(kc)` |`SAGR_T(kc)`                                                     |Right Shift and Right Alt (AltGr) when held, `kc` when tapped                          |
+|`RSG_T(kc)` |                                                                 |Right Shift and Right GUI when held, `kc` when tapped                                  |
+|`RAG_T(kc)` |                                                                 |Right Alt and Right GUI when held, `kc` when tapped                                    |
+|`RCAG_T(kc)`|                                                                 |Right Control, Right Alt and Right GUI when held, `kc` when tapped                     |
+|`MEH_T(kc)` |                                                                 |Left Control, Left Shift and Left Alt when held, `kc` when tapped                      |
+|`HYPR_T(kc)`|`ALL_T(kc)`                                                      |Left Control, Left Shift, Left Alt and Left GUI when held, `kc` when tapped<sup>1</sup>|
+
+<sup>1. More information on the Hyper key can be found on [this blog post by Brett Terpstra](https://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/).</sup>
 
 ## Caveats
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -41,44 +41,50 @@
 #define QK_MODS_GET_MODS(kc) (((kc) >> 8) & 0x1F)
 #define QK_MODS_GET_BASIC_KEYCODE(kc) ((kc)&0xFF)
 
-// Keycode modifiers & aliases
+// Modified keycodes
 #define LCTL(kc) (QK_LCTL | (kc))
 #define LSFT(kc) (QK_LSFT | (kc))
 #define LALT(kc) (QK_LALT | (kc))
 #define LGUI(kc) (QK_LGUI | (kc))
+
 #define LOPT(kc) LALT(kc)
 #define LCMD(kc) LGUI(kc)
 #define LWIN(kc) LGUI(kc)
+
+#define C(kc) LCTL(kc)
+#define S(kc) LSFT(kc)
+#define A(kc) LALT(kc)
+#define G(kc) LGUI(kc)
+
+#define LCA(kc) (QK_LCTL | QK_LALT | (kc))
+#define LSA(kc) (QK_LSFT | QK_LALT | (kc))
+#define LSG(kc) (QK_LSFT | QK_LGUI | (kc))
+#define LAG(kc) (QK_LALT | QK_LGUI | (kc))
+#define LCAG(kc) (QK_LCTL | QK_LALT | QK_LGUI | (kc))
+
+#define SGUI(kc) LSG(kc)
+#define SCMD(kc) LSG(kc)
+#define SWIN(kc) LSG(kc)
+
 #define RCTL(kc) (QK_RCTL | (kc))
 #define RSFT(kc) (QK_RSFT | (kc))
 #define RALT(kc) (QK_RALT | (kc))
 #define RGUI(kc) (QK_RGUI | (kc))
+
 #define ALGR(kc) RALT(kc)
 #define ROPT(kc) RALT(kc)
 #define RCMD(kc) RGUI(kc)
 #define RWIN(kc) RGUI(kc)
 
-#define HYPR(kc) (QK_LCTL | QK_LSFT | QK_LALT | QK_LGUI | (kc))
-#define MEH(kc) (QK_LCTL | QK_LSFT | QK_LALT | (kc))
-#define LCAG(kc) (QK_LCTL | QK_LALT | QK_LGUI | (kc))
-#define LSG(kc) (QK_LSFT | QK_LGUI | (kc))
-#define SGUI(kc) LSG(kc)
-#define SCMD(kc) LSG(kc)
-#define SWIN(kc) LSG(kc)
-#define LAG(kc) (QK_LALT | QK_LGUI | (kc))
+#define RCS(kc) (QK_RCTL | QK_RSFT | (kc))
+#define RSA(kc) (QK_RSFT | QK_RALT | (kc))
 #define RSG(kc) (QK_RSFT | QK_RGUI | (kc))
 #define RAG(kc) (QK_RALT | QK_RGUI | (kc))
-#define LCA(kc) (QK_LCTL | QK_LALT | (kc))
-#define LSA(kc) (QK_LSFT | QK_LALT | (kc))
-#define RSA(kc) (QK_RSFT | QK_RALT | (kc))
-#define RCS(kc) (QK_RCTL | QK_RSFT | (kc))
+
 #define SAGR(kc) RSA(kc)
 
-// Modified keycode aliases
-#define C(kc) LCTL(kc)
-#define S(kc) LSFT(kc)
-#define A(kc) LALT(kc)
-#define G(kc) LGUI(kc)
+#define HYPR(kc) (QK_LCTL | QK_LSFT | QK_LALT | QK_LGUI | (kc))
+#define MEH(kc) (QK_LCTL | QK_LSFT | QK_LALT | (kc))
 
 // GOTO layer - 32 layer max
 #define TO(layer) (QK_TO | ((layer)&0x1F))
@@ -127,50 +133,56 @@
 #define QK_MOD_TAP_GET_MODS(kc) (((kc) >> 8) & 0x1F)
 #define QK_MOD_TAP_GET_TAP_KEYCODE(kc) ((kc)&0xFF)
 
+// Mod-Tap shortcuts
 #define LCTL_T(kc) MT(MOD_LCTL, kc)
-#define RCTL_T(kc) MT(MOD_RCTL, kc)
-#define CTL_T(kc) LCTL_T(kc)
-
 #define LSFT_T(kc) MT(MOD_LSFT, kc)
-#define RSFT_T(kc) MT(MOD_RSFT, kc)
-#define SFT_T(kc) LSFT_T(kc)
-
 #define LALT_T(kc) MT(MOD_LALT, kc)
-#define RALT_T(kc) MT(MOD_RALT, kc)
-#define LOPT_T(kc) LALT_T(kc)
-#define ROPT_T(kc) RALT_T(kc)
-#define ALGR_T(kc) RALT_T(kc)
-#define ALT_T(kc) LALT_T(kc)
-#define OPT_T(kc) LOPT_T(kc)
-
 #define LGUI_T(kc) MT(MOD_LGUI, kc)
-#define RGUI_T(kc) MT(MOD_RGUI, kc)
+
+#define CTL_T(kc) LCTL_T(kc)
+#define SFT_T(kc) LSFT_T(kc)
+#define ALT_T(kc) LALT_T(kc)
+#define GUI_T(kc) LGUI_T(kc)
+
+#define LOPT_T(kc) LALT_T(kc)
 #define LCMD_T(kc) LGUI_T(kc)
 #define LWIN_T(kc) LGUI_T(kc)
-#define RCMD_T(kc) RGUI_T(kc)
-#define RWIN_T(kc) RGUI_T(kc)
-#define GUI_T(kc) LGUI_T(kc)
+
+#define OPT_T(kc) LOPT_T(kc)
 #define CMD_T(kc) LCMD_T(kc)
 #define WIN_T(kc) LWIN_T(kc)
 
-#define C_S_T(kc) MT(MOD_LCTL | MOD_LSFT, kc)                        // Left Control + Shift e.g. for gnome-terminal
-#define MEH_T(kc) MT(MOD_LCTL | MOD_LSFT | MOD_LALT, kc)             // Meh is a less hyper version of the Hyper key -- doesn't include GUI, so just Left Control + Shift + Alt
-#define LCAG_T(kc) MT(MOD_LCTL | MOD_LALT | MOD_LGUI, kc)            // Left Control + Alt + GUI
-#define RCAG_T(kc) MT(MOD_RCTL | MOD_RALT | MOD_RGUI, kc)            // Right Control + Alt + GUI
-#define HYPR_T(kc) MT(MOD_LCTL | MOD_LSFT | MOD_LALT | MOD_LGUI, kc) // see http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/
-#define LSG_T(kc) MT(MOD_LSFT | MOD_LGUI, kc)                        // Left Shift + GUI
+#define C_S_T(kc) MT(MOD_LCTL | MOD_LSFT, kc)
+#define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc)
+#define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)
+#define LSG_T(kc) MT(MOD_LSFT | MOD_LGUI, kc)
+#define LAG_T(kc) MT(MOD_LALT | MOD_LGUI, kc)
+#define LCAG_T(kc) MT(MOD_LCTL | MOD_LALT | MOD_LGUI, kc)
+
 #define SGUI_T(kc) LSG_T(kc)
 #define SCMD_T(kc) LSG_T(kc)
 #define SWIN_T(kc) LSG_T(kc)
-#define LAG_T(kc) MT(MOD_LALT | MOD_LGUI, kc) // Left Alt + GUI
-#define RSG_T(kc) MT(MOD_RSFT | MOD_RGUI, kc) // Right Shift + GUI
-#define RAG_T(kc) MT(MOD_RALT | MOD_RGUI, kc) // Right Alt + GUI
-#define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc) // Left Control + Alt
-#define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc) // Left Shift + Alt
-#define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc) // Right Shift + Alt
-#define RCS_T(kc) MT(MOD_RCTL | MOD_RSFT, kc) // Right Control + Shift
+
+#define RCTL_T(kc) MT(MOD_RCTL, kc)
+#define RSFT_T(kc) MT(MOD_RSFT, kc)
+#define RALT_T(kc) MT(MOD_RALT, kc)
+#define RGUI_T(kc) MT(MOD_RGUI, kc)
+
+#define ROPT_T(kc) RALT_T(kc)
+#define ALGR_T(kc) RALT_T(kc)
+#define RCMD_T(kc) RGUI_T(kc)
+#define RWIN_T(kc) RGUI_T(kc)
+
+#define RCS_T(kc) MT(MOD_RCTL | MOD_RSFT, kc)
+#define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)
+#define RSG_T(kc) MT(MOD_RSFT | MOD_RGUI, kc)
+#define RAG_T(kc) MT(MOD_RALT | MOD_RGUI, kc)
+#define RCAG_T(kc) MT(MOD_RCTL | MOD_RALT | MOD_RGUI, kc)
+
 #define SAGR_T(kc) RSA_T(kc)
 
+#define MEH_T(kc) MT(MOD_LCTL | MOD_LSFT | MOD_LALT, kc)
+#define HYPR_T(kc) MT(MOD_LCTL | MOD_LSFT | MOD_LALT | MOD_LGUI, kc)
 #define ALL_T(kc) HYPR_T(kc)
 
 // Dedicated keycode versions for Hyper and Meh, if you want to use them as standalone keys rather than mod-tap

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -56,11 +56,15 @@
 #define A(kc) LALT(kc)
 #define G(kc) LGUI(kc)
 
+#define LCS(kc) (QK_LCTL | QK_LSFT | (kc))
 #define LCA(kc) (QK_LCTL | QK_LALT | (kc))
+#define LCG(kc) (QK_LCTL | QK_LGUI | (kc))
 #define LSA(kc) (QK_LSFT | QK_LALT | (kc))
 #define LSG(kc) (QK_LSFT | QK_LGUI | (kc))
 #define LAG(kc) (QK_LALT | QK_LGUI | (kc))
+#define LCSG(kc) (QK_LCTL | QK_LSFT | QK_LGUI | (kc))
 #define LCAG(kc) (QK_LCTL | QK_LALT | QK_LGUI | (kc))
+#define LSAG(kc) (QK_LSFT | QK_LALT | QK_LGUI | (kc))
 
 #define SGUI(kc) LSG(kc)
 #define SCMD(kc) LSG(kc)
@@ -76,10 +80,15 @@
 #define RCMD(kc) RGUI(kc)
 #define RWIN(kc) RGUI(kc)
 
+#define RCA(kc) (QK_RCTL | QK_RALT | (kc))
 #define RCS(kc) (QK_RCTL | QK_RSFT | (kc))
+#define RCG(kc) (QK_RCTL | QK_RGUI | (kc))
 #define RSA(kc) (QK_RSFT | QK_RALT | (kc))
 #define RSG(kc) (QK_RSFT | QK_RGUI | (kc))
 #define RAG(kc) (QK_RALT | QK_RGUI | (kc))
+#define RCSG(kc) (QK_RCTL | QK_RSFT | QK_RGUI | (kc))
+#define RCAG(kc) (QK_RCTL | QK_RALT | QK_RGUI | (kc))
+#define RSAG(kc) (QK_RSFT | QK_RALT | QK_RGUI | (kc))
 
 #define SAGR(kc) RSA(kc)
 
@@ -152,12 +161,15 @@
 #define CMD_T(kc) LCMD_T(kc)
 #define WIN_T(kc) LWIN_T(kc)
 
-#define C_S_T(kc) MT(MOD_LCTL | MOD_LSFT, kc)
+#define LCS_T(kc) MT(MOD_LCTL | MOD_LSFT, kc)
 #define LCA_T(kc) MT(MOD_LCTL | MOD_LALT, kc)
+#define LCG_T(kc) MT(MOD_LCTL | MOD_LGUI, kc)
 #define LSA_T(kc) MT(MOD_LSFT | MOD_LALT, kc)
 #define LSG_T(kc) MT(MOD_LSFT | MOD_LGUI, kc)
 #define LAG_T(kc) MT(MOD_LALT | MOD_LGUI, kc)
+#define LCSG_T(kc) MT(MOD_LCTL | MOD_LSFT | MOD_LGUI, kc)
 #define LCAG_T(kc) MT(MOD_LCTL | MOD_LALT | MOD_LGUI, kc)
+#define LSAG_T(kc) MT(MOD_LSFT | MOD_LALT | MOD_LGUI, kc)
 
 #define SGUI_T(kc) LSG_T(kc)
 #define SCMD_T(kc) LSG_T(kc)
@@ -174,10 +186,14 @@
 #define RWIN_T(kc) RGUI_T(kc)
 
 #define RCS_T(kc) MT(MOD_RCTL | MOD_RSFT, kc)
+#define RCA_T(kc) MT(MOD_RCTL | MOD_RALT, kc)
+#define RCG_T(kc) MT(MOD_RCTL | MOD_RGUI, kc)
 #define RSA_T(kc) MT(MOD_RSFT | MOD_RALT, kc)
 #define RSG_T(kc) MT(MOD_RSFT | MOD_RGUI, kc)
 #define RAG_T(kc) MT(MOD_RALT | MOD_RGUI, kc)
+#define RCSG_T(kc) MT(MOD_RCTL | MOD_RSFT | MOD_RGUI, kc)
 #define RCAG_T(kc) MT(MOD_RCTL | MOD_RALT | MOD_RGUI, kc)
+#define RSAG_T(kc) MT(MOD_RSFT | MOD_RALT | MOD_RGUI, kc)
 
 #define SAGR_T(kc) RSA_T(kc)
 

--- a/quantum/quantum_keycodes_legacy.h
+++ b/quantum/quantum_keycodes_legacy.h
@@ -57,3 +57,5 @@
 #define KC_ACL2 QK_MOUSE_ACCELERATION_2
 
 #define QK_OUTPUT_AUTO OU_AUTO
+
+#define C_S_T(kc) LCS_T(kc)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

 - Reorganised mod & mod-tap sections in quantum_keycodes
 - Added missing combinations eg. `LCG()`, `RCA()` etc.
 - Deprecated `C_S_T()` in favour of `LCS_T()`
 - Hyper key blog post link kept but moved out of the keycode reference page, as a footnote to the keycode tables
 - Adjusted keycode descriptions to always specify left/right for each modifier

Meh and Hyper could potentially become aliases of their "standard" representations, ie. `LCSA/_T()` and `LCSAG/_T()` (and have right-hand versions of each), but I'll leave those for now.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
