### PR TITLE
Fix inverted encoder on Inland KB83

### DIFF
--- a/keyboards/inland/kb83/keyboard.json
+++ b/keyboards/inland/kb83/keyboard.json
@@ -60,7 +60,7 @@
     },
     "encoder": {
         "rotary": [
-            {"pin_a": "B14", "pin_b": "B13", "resolution": 4}
+            {"pin_a": "B13", "pin_b": "B14", "resolution": 4}
         ]
     },
     "qmk": {

--- a/keyboards/inland/kb83/keymaps/default/keymap.c
+++ b/keyboards/inland/kb83/keymaps/default/keymap.c
@@ -64,10 +64,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 #if defined(ENCODER_MAP_ENABLE)
 const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
-    [WIN_B] = { ENCODER_CCW_CW(KC_VOLU, KC_VOLD) },
-    [WIN_FN] = { ENCODER_CCW_CW(RM_SATU, RM_SATD) },
-    [MAC_B] = { ENCODER_CCW_CW(KC_VOLU, KC_VOLD) },
-    [MAC_FN] = { ENCODER_CCW_CW(RM_SATU, RM_SATD) },
+    [WIN_B] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU) },
+    [WIN_FN] = { ENCODER_CCW_CW(RM_SATD, RM_SATU) },
+    [MAC_B] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU) },
+    [MAC_FN] = { ENCODER_CCW_CW(RM_SATD, RM_SATU) },
 };
 #endif
 

--- a/keyboards/inland/kb83/keymaps/default/rules.mk
+++ b/keyboards/inland/kb83/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+ENCODER_MAP_ENABLE = yes


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Inland KB83 had GPIOs backwards for encoder CCW and CW. Also enabled the encoder for default and fixed directions for the encoder keys. This keyboard ships with VIA and the same double-inversion encoder swap is done in the VIA user keymaps too, so a keymap fix will be needed in the-via/qmk_userspace_via as well.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
