### PR TITLE
[Bugfix] WS2812 indexing in split boards

### DIFF
--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -147,14 +147,31 @@ void rgb_matrix_update_pwm_buffers(void) {
 
 __attribute__((weak)) int rgb_matrix_led_index(int index) {
 #if defined(RGB_MATRIX_SPLIT)
-    if (!is_keyboard_left() && index >= k_rgb_matrix_split[0]) {
-        return index - k_rgb_matrix_split[0];
+    const bool index_in_left_side = index < k_rgb_matrix_split[0];
+
+    if (is_keyboard_left()) {
+        if (index_in_left_side) {
+            return index;
+        }
+
+        return -1;
     }
+
+    if (index_in_left_side) {
+        return -1;
+    }
+
+    return index - k_rgb_matrix_split[0];
 #endif
     return index;
 }
 
 void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue) {
+    const int led_index = rgb_matrix_led_index(index);
+    if (led_index < 0) {
+        return;
+    }
+
     rgb_matrix_driver.set_color(rgb_matrix_led_index(index), red, green, blue);
 }
 

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -151,6 +151,14 @@ void eeconfig_force_flush_rgb_matrix(void);
 uint8_t rgb_matrix_map_row_column_to_led_kb(uint8_t row, uint8_t column, uint8_t *led_i);
 uint8_t rgb_matrix_map_row_column_to_led(uint8_t row, uint8_t column, uint8_t *led_i);
 
+/**
+ * @brief Convert an index to the addressing used by underlying driver
+ *
+ * @param index  Logical index of the LED we want to work on
+ *
+ * @return       Resolved index to be used on the driver
+ * @retval < 0   Error (eg: trying to address a LED on the other half of a split board)
+ */
 int rgb_matrix_led_index(int index);
 
 void rgb_matrix_set_color(int index, uint8_t red, uint8_t green, uint8_t blue);


### PR DESCRIPTION
## Description

See related issue

## Types of Changes
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR
* #25406

## Checklist
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
