### PR TITLE
[Docs] Fix typo in Chordal Hold example JSON, comma to colon.

### DIFF
--- a/docs/tap_hold.md
+++ b/docs/tap_hold.md
@@ -519,7 +519,7 @@ either `"L"`, `"R"`, or `"*"`. Note that if `"layouts"` contains multiple
 layouts, only the first one is read. For example:
 
 ```json
-{"matrix": [5, 6], "x": 0, "y": 5.5, "w": 1.25, "hand", "*"},
+{"matrix": [5, 6], "x": 0, "y": 5.5, "w": 1.25, "hand": "*"},
 ```
 
 Alternatively, handedness may be defined functionally with


### PR DESCRIPTION
Single-char typo fix in the JSON example in the Chordal Hold documentation.

## Description

The Chordal Hold documentation has an example JSON, but incorrectly, there is a comma instead of a colon after `"hand"`:

```json
{"matrix": [5, 6], "x": 0, "y": 5.5, "w": 1.25, "hand", "*"},
```

That is, it should be:

```json
{"matrix": [5, 6], "x": 0, "y": 5.5, "w": 1.25, "hand": "*"},
```

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
