### PR TITLE
Generate `CUSTOM_MATRIX = lite` without `matrix_pins.custom`

### DIFF
--- a/lib/python/qmk/cli/generate/rules_mk.py
+++ b/lib/python/qmk/cli/generate/rules_mk.py
@@ -96,11 +96,10 @@ def generate_rules_mk(cli):
         rules_mk_lines.append(generate_rule('SPLIT_TRANSPORT', 'custom'))
 
     # Set CUSTOM_MATRIX, if needed
-    if kb_info_json.get('matrix_pins', {}).get('custom'):
-        if kb_info_json.get('matrix_pins', {}).get('custom_lite'):
-            rules_mk_lines.append(generate_rule('CUSTOM_MATRIX', 'lite'))
-        else:
-            rules_mk_lines.append(generate_rule('CUSTOM_MATRIX', 'yes'))
+    if kb_info_json.get('matrix_pins', {}).get('custom_lite'):
+        rules_mk_lines.append(generate_rule('CUSTOM_MATRIX', 'lite'))
+    elif kb_info_json.get('matrix_pins', {}).get('custom'):
+        rules_mk_lines.append(generate_rule('CUSTOM_MATRIX', 'yes'))
 
     if converter:
         rules_mk_lines.append(generate_rule('CONVERT_TO', converter))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Avoids
```json
"matrix_pins": {
  "custom": true,
  "custom_lite": true,
```

Where it can now just be
```json
"matrix_pins": {
  "custom_lite": true,
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
