### PR TITLE
[Keyboard] add optional rgb matrix lighting support to winry25tc

### DIFF
--- a/keyboards/winry/winry25tc/keyboard.json
+++ b/keyboards/winry/winry25tc/keyboard.json
@@ -1,24 +1,9 @@
 {
-    "keyboard_name": "Winry 25tc",
     "manufacturer": "SpiderIsland",
+    "keyboard_name": "Winry 25tc",
     "maintainer": "qmk",
-    "usb": {
-        "vid": "0xF1F1",
-        "pid": "0x0025",
-        "device_version": "0.0.1"
-    },
-    "ws2812": {
-        "pin": "D5"
-    },
-    "rgblight": {
-        "saturation_steps": 8,
-        "brightness_steps": 8,
-        "led_count": 40,
-        "max_brightness": 150,
-        "animations": {
-            "rainbow_swirl": true
-        }
-    },
+    "bootloader": "atmel-dfu",
+    "diode_direction": "COL2ROW",
     "features": {
         "bootmagic": true,
         "extrakey": true,
@@ -31,9 +16,105 @@
         "cols": ["F5", "C7", "B7", "B2", "B4"],
         "rows": ["E6", "F0", "D6", "D2", "B6"]
     },
-    "diode_direction": "COL2ROW",
     "processor": "atmega32u4",
-    "bootloader": "atmel-dfu",
+    "rgb_matrix": {
+        "animations": {
+            "alphas_mods": true,
+            "band_pinwheel_sat": true,
+            "band_pinwheel_val": true,
+            "band_sat": true,
+            "band_spiral_sat": true,
+            "band_spiral_val": true,
+            "band_val": true,
+            "breathing": true,
+            "cycle_all": true,
+            "cycle_left_right": true,
+            "cycle_out_in": true,
+            "cycle_out_in_dual": true,
+            "cycle_pinwheel": true,
+            "cycle_spiral": true,
+            "cycle_up_down": true,
+            "dual_beacon": true,
+            "gradient_left_right": true,
+            "gradient_up_down": true,
+            "hue_breathing": true,
+            "hue_pendulum": true,
+            "hue_wave": true,
+            "jellybean_raindrops": true,
+            "multisplash": true,
+            "pixel_rain": true,
+            "rainbow_beacon": true,
+            "rainbow_moving_chevron": true,
+            "rainbow_pinwheels": true,
+            "raindrops": true,
+            "solid_multisplash": true,
+            "solid_reactive": true,
+            "solid_reactive_cross": true,
+            "solid_reactive_multicross": true,
+            "solid_reactive_multinexus": true,
+            "solid_reactive_multiwide": true,
+            "solid_reactive_nexus": true,
+            "solid_reactive_simple": true,
+            "solid_reactive_wide": true,
+            "solid_splash": true,
+            "splash": true
+        },
+        "driver": "ws2812",
+        "layout": [
+            {"matrix": [2, 2], "x": 112, "y": 32, "flags": 4},
+            {"matrix": [2, 3], "x": 168, "y": 32, "flags": 4},
+            {"matrix": [3, 3], "x": 168, "y": 48, "flags": 4},
+            {"matrix": [3, 2], "x": 112, "y": 48, "flags": 4},
+            {"matrix": [3, 1], "x": 56, "y": 48, "flags": 4},
+            {"matrix": [2, 1], "x": 56, "y": 32, "flags": 4},
+            {"matrix": [1, 1], "x": 56, "y": 16, "flags": 4},
+            {"matrix": [1, 2], "x": 112, "y": 16, "flags": 4},
+            {"matrix": [1, 3], "x": 168, "y": 16, "flags": 4},
+            {"matrix": [1, 4], "x": 224, "y": 16, "flags": 4},
+            {"matrix": [2, 4], "x": 224, "y": 32, "flags": 4},
+            {"matrix": [3, 4], "x": 224, "y": 48, "flags": 4},
+            {"matrix": [4, 4], "x": 224, "y": 64, "flags": 4},
+            {"matrix": [4, 3], "x": 168, "y": 64, "flags": 4},
+            {"matrix": [4, 2], "x": 112, "y": 64, "flags": 4},
+            {"matrix": [4, 1], "x": 56, "y": 64, "flags": 4},
+            {"matrix": [4, 0], "x": 0, "y": 64, "flags": 4},
+            {"matrix": [3, 0], "x": 0, "y": 48, "flags": 4},
+            {"matrix": [2, 0], "x": 0, "y": 32, "flags": 4},
+            {"matrix": [1, 0], "x": 0, "y": 16, "flags": 4},
+            {"matrix": [0, 0], "x": 0, "y": 0, "flags": 4},
+            {"matrix": [0, 1], "x": 56, "y": 0, "flags": 4},
+            {"matrix": [0, 2], "x": 112, "y": 0, "flags": 4},
+            {"matrix": [0, 3], "x": 168, "y": 0, "flags": 4},
+            {"matrix": [0, 4], "x": 224, "y": 0, "flags": 4},
+            {"x": 197, "y": 9, "flags": 2},
+            {"x": 206, "y": 29, "flags": 2},
+            {"x": 206, "y": 61, "flags": 2},
+            {"x": 141, "y": 65, "flags": 2},
+            {"x": 85, "y": 65, "flags": 2},
+            {"x": 21, "y": 61, "flags": 2},
+            {"x": 21, "y": 29, "flags": 2},
+            {"x": 29, "y": 9, "flags": 2}
+        ],
+        "max_brightness": 150,
+        "sleep": true
+    },
+    "rgblight": {
+        "animations": {
+            "rainbow_swirl": true
+        },
+        "brightness_steps": 8,
+        "led_count": 40,
+        "max_brightness": 150,
+        "saturation_steps": 8
+    },
+    "usb": {
+        "device_version": "0.0.1",
+        "pid": "0x0025",
+        "vid": "0xF1F1"
+    },
+    "ws2812": {
+        "pin": "D5"
+    },
     "layouts": {
         "LAYOUT": {
             "layout": [
@@ -42,25 +123,21 @@
                 {"matrix": [0, 2], "x": 2, "y": 0},
                 {"matrix": [0, 3], "x": 3, "y": 0},
                 {"matrix": [0, 4], "x": 4, "y": 0},
-
                 {"matrix": [1, 0], "x": 0, "y": 1},
                 {"matrix": [1, 1], "x": 1, "y": 1},
                 {"matrix": [1, 2], "x": 2, "y": 1},
                 {"matrix": [1, 3], "x": 3, "y": 1},
                 {"matrix": [1, 4], "x": 4, "y": 1},
-
                 {"matrix": [2, 0], "x": 0, "y": 2},
                 {"matrix": [2, 1], "x": 1, "y": 2},
                 {"matrix": [2, 2], "x": 2, "y": 2},
                 {"matrix": [2, 3], "x": 3, "y": 2},
                 {"matrix": [2, 4], "x": 4, "y": 2},
-
                 {"matrix": [3, 0], "x": 0, "y": 3},
                 {"matrix": [3, 1], "x": 1, "y": 3},
                 {"matrix": [3, 2], "x": 2, "y": 3},
                 {"matrix": [3, 3], "x": 3, "y": 3},
                 {"matrix": [3, 4], "x": 4, "y": 3},
-
                 {"matrix": [4, 0], "x": 0, "y": 4},
                 {"matrix": [4, 1], "x": 1, "y": 4},
                 {"matrix": [4, 2], "x": 2, "y": 4},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This change adds support for RGB matrix lighting to the winry25tc.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
