### PR TITLE
Only userspace should be searched for keyboard aliases when locating keymaps

### DIFF
--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -343,24 +343,21 @@ def locate_keymap(keyboard, keymap, force_layout=None):
     # Check the keyboard folder first, last match wins
     keymap_path = ''
 
-    search_dirs = [QMK_FIRMWARE]
-    keyboard_dirs = [keyboard_folder(keyboard)]
+    search_conf = {QMK_FIRMWARE: [keyboard_folder(keyboard)]}
     if HAS_QMK_USERSPACE:
         # When we've got userspace, check there _last_ as we want them to override anything in the main repo.
-        search_dirs.append(QMK_USERSPACE)
         # We also want to search for any aliases as QMK's folder structure may have changed, with an alias, but the user
         # hasn't updated their keymap location yet.
-        keyboard_dirs.extend(keyboard_aliases(keyboard))
-        keyboard_dirs = list(set(keyboard_dirs))
+        search_conf[QMK_USERSPACE] = list(set([keyboard_folder(keyboard), *keyboard_aliases(keyboard)]))
 
-    for search_dir in search_dirs:
+    for search_dir, keyboard_dirs in search_conf.items():
         for keyboard_dir in keyboard_dirs:
             checked_dirs = ''
-            for dir in keyboard_dir.split('/'):
+            for folder_name in keyboard_dir.split('/'):
                 if checked_dirs:
-                    checked_dirs = '/'.join((checked_dirs, dir))
+                    checked_dirs = '/'.join((checked_dirs, folder_name))
                 else:
-                    checked_dirs = dir
+                    checked_dirs = folder_name
 
                 keymap_dir = Path(search_dir) / Path('keyboards') / checked_dirs / 'keymaps'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently resolving keymap location incorrectly falls back to looking for aliases in qmk_firmware, when userspace is configured.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
