### PR TITLE
Enable correct SPI peripheral `dilemma/3x5_2/assembled`

### DIFF
--- a/keyboards/bastardkb/dilemma/3x5_2/assembled/mcuconf.h
+++ b/keyboards/bastardkb/dilemma/3x5_2/assembled/mcuconf.h
@@ -19,5 +19,5 @@
 
 #include_next <mcuconf.h>
 
-#undef RP_SPI_USE_SPI1
-#define RP_SPI_USE_SPI1 TRUE
+#undef RP_SPI_USE_SPI0
+#define RP_SPI_USE_SPI0 TRUE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Per this keyboard's SPI pins:
https://github.com/qmk/qmk_firmware/blob/c3773d9c350cef5c4323c209f85ffd076177f8f1/keyboards/bastardkb/dilemma/3x5_2/assembled/config.h#L29-L31

SPI1 is not the correct peripheral to be enabled:

<img width="883" height="449" alt="image" src="https://github.com/user-attachments/assets/4746d5fb-1dc3-4a3f-9da6-59cb03bd9534" />

This functioned correctly nonetheless because SPI0 is enabled by `GENERIC_PROMICRO_RP2040`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix
- [x] Keyboard (addition or update)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
