### PR TITLE
Configure SPI for `QMK_PM2040` board

### DIFF
--- a/platforms/chibios/boards/QMK_PM2040/configs/config.h
+++ b/platforms/chibios/boards/QMK_PM2040/configs/config.h
@@ -18,6 +18,22 @@
 #endif
 
 /**======================
+ **    SPI Driver
+ *========================**/
+#ifndef SPI_DRIVER
+#    define SPI_DRIVER SPID0
+#endif
+#ifndef SPI_SCK_PIN
+#    define SPI_SCK_PIN B1
+#endif
+#ifndef SPI_MISO_PIN
+#    define SPI_MISO_PIN B3
+#endif
+#ifndef SPI_MOSI_PIN
+#    define SPI_MOSI_PIN B2
+#endif
+
+/**======================
  **      UART Driver
  *========================**/
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Configures the appropriate driver and pins for SPI in the `QMK_PM2040` `BOARD`. The necessary peripheral `RP_SPI_USE_SPI0` is already enabled in the board's `mcuconf.h`.

Backwards compatibility should be no issue, as these values did not exist previously, and can still be overridden at the keyboard level.

This will allow for converters that use the `QMK_PM2040` board to have SPI automagically configured.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
