### PR TITLE
Configure SPI for `STEMCELL` board

### DIFF
--- a/platforms/chibios/boards/STEMCELL/configs/config.h
+++ b/platforms/chibios/boards/STEMCELL/configs/config.h
@@ -27,3 +27,18 @@
 #    define SERIAL_USART_DRIVER SD2
 #endif
 
+/**======================
+ **    SPI Driver
+ *========================**/
+#ifndef SPI_DRIVER
+#    define SPI_DRIVER SPID1
+#endif
+#ifndef SPI_SCK_PIN
+#    define SPI_SCK_PIN B1
+#endif
+#ifndef SPI_MISO_PIN
+#    define SPI_MISO_PIN B3
+#endif
+#ifndef SPI_MOSI_PIN
+#    define SPI_MOSI_PIN B2
+#endif

--- a/platforms/chibios/boards/STEMCELL/configs/mcuconf.h
+++ b/platforms/chibios/boards/STEMCELL/configs/mcuconf.h
@@ -196,7 +196,7 @@
 /*
  * SPI driver system settings.
  */
-#define STM32_SPI_USE_SPI1                  FALSE
+#define STM32_SPI_USE_SPI1                  TRUE
 #define STM32_SPI_USE_SPI2                  FALSE
 #define STM32_SPI_USE_SPI3                  FALSE
 #define STM32_SPI_SPI1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Configures the appropriate driver, pins for SPI in the `STEMCELL` `BOARD`, and enables `STM32_SPI_USE_SPI1` peripheral, per STM32F4x1 datasheet:

<img width="802" height="366" alt="20250712_17h03m23s_grim" src="https://github.com/user-attachments/assets/4ae0b480-301d-442e-91a5-9935790d37c3" />

and the pins configured line up appropriately with Stemcell's pin mappings:
https://github.com/qmk/qmk_firmware/blob/c7a24a441f6b3e25b726089c3305ef2d92b46fd4/platforms/chibios/converters/promicro_to_stemcell/_pin_defs.h#L44-L46

Backwards compatibility should be no issue, as these values did not exist previously, and can still be overridden at the keyboard level.

This will allow for converters that use the `STEMCELL` board to have SPI automagically configured.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
