### PR TITLE
Allow keymap.json to disable config flags

### DIFF
--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -14,6 +14,14 @@ from qmk.path import normpath, FileType
 from qmk.constants import GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE
 
 
+def generate_flag(define, value=None):
+    # TODO: Change behavior to always use is_keymap logic for keyboard level config
+    is_keymap = cli.args.filename
+    if is_keymap:
+        return f'\n#define {define}' if value else f'\n#undef {define}'
+    return f'\n#define {define}' if value else ''
+
+
 def generate_define(define, value=None):
     is_keymap = cli.args.filename
     value = f' {value}' if value is not None else ''
@@ -97,8 +105,7 @@ def generate_config_items(kb_info_json, config_h_lines):
         elif key_type == 'bool':
             config_h_lines.append(generate_define(config_key, 'true' if config_value else 'false'))
         elif key_type == 'flag':
-            if config_value:
-                config_h_lines.append(generate_define(config_key))
+            config_h_lines.append(generate_flag(config_key, config_value))
         elif key_type == 'mapping':
             for key, value in config_value.items():
                 config_h_lines.append(generate_define(key, value))
@@ -159,8 +166,7 @@ def generate_led_animations_config(feature, led_feature_json, config_h_lines, en
         config_h_lines.append(generate_define(f'{feature.upper()}_DEFAULT_MODE', f'{animation_prefix}{led_feature_json["default"]["animation"].upper()}'))
 
     for animation in led_feature_json.get('animations', {}):
-        if led_feature_json['animations'][animation]:
-            config_h_lines.append(generate_define(f'{enable_prefix}{animation.upper()}'))
+        config_h_lines.append(generate_flag(f'{enable_prefix}{animation.upper()}', led_feature_json['animations'][animation]))
 
 
 @cli.argument('filename', nargs='?', arg_only=True, type=FileType('r'), completer=FilesCompleter('.json'), help='A configurator export JSON to be compiled and flashed or a pre-compiled binary firmware file (bin/hex) to be flashed.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the following `keymap.json` chunk does not function as expected,
```json
{
    "config": {
        "rgblight": {
            "animations": {
                "breathing": false
            }
        }
    }
}
```

Existing keyboard level behaviour has been maintained for now.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
