### PR TITLE
Add missing labels to DD keycode definitions

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.1_audio.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_audio.hjson
@@ -3,6 +3,7 @@
         "0x7480": {
             "group": "audio",
             "key": "QK_AUDIO_ON",
+            "label": "Audio On",
             "aliases": [
                 "AU_ON"
             ]
@@ -10,6 +11,7 @@
         "0x7481": {
             "group": "audio",
             "key": "QK_AUDIO_OFF",
+            "label": "Audio Off",
             "aliases": [
                 "AU_OFF"
             ]
@@ -17,6 +19,7 @@
         "0x7482": {
             "group": "audio",
             "key": "QK_AUDIO_TOGGLE",
+            "label": "Toggle Audio",
             "aliases": [
                 "AU_TOGG"
             ]
@@ -25,6 +28,7 @@
         "0x748A": {
             "group": "audio",
             "key": "QK_AUDIO_CLICKY_TOGGLE",
+            "label": "Toggle Audio Clicky",
             "aliases": [
                 "CK_TOGG"
             ]
@@ -32,6 +36,7 @@
         "0x748B": {
             "group": "audio",
             "key": "QK_AUDIO_CLICKY_ON",
+            "label": "Audio Clicky On",
             "aliases": [
                 "CK_ON"
             ]
@@ -39,6 +44,7 @@
         "0x748C": {
             "group": "audio",
             "key": "QK_AUDIO_CLICKY_OFF",
+            "label": "Audio Clicky Off",
             "aliases": [
                 "CK_OFF"
             ]
@@ -46,6 +52,7 @@
         "0x748D": {
             "group": "audio",
             "key": "QK_AUDIO_CLICKY_UP",
+            "label": "Audio Clicky Up",
             "aliases": [
                 "CK_UP"
             ]
@@ -53,6 +60,7 @@
         "0x748E": {
             "group": "audio",
             "key": "QK_AUDIO_CLICKY_DOWN",
+            "label": "Audio Clicky Down",
             "aliases": [
                 "CK_DOWN"
             ]
@@ -60,6 +68,7 @@
         "0x748F": {
             "group": "audio",
             "key": "QK_AUDIO_CLICKY_RESET",
+            "label": "Audio Clicky Reset",
             "aliases": [
                 "CK_RST"
             ]
@@ -68,6 +77,7 @@
         "0x7490": {
             "group": "audio",
             "key": "QK_MUSIC_ON",
+            "label": "Music On",
             "aliases": [
                 "MU_ON"
             ]
@@ -75,6 +85,7 @@
         "0x7491": {
             "group": "audio",
             "key": "QK_MUSIC_OFF",
+            "label": "Music Off",
             "aliases": [
                 "MU_OFF"
             ]
@@ -82,6 +93,7 @@
         "0x7492": {
             "group": "audio",
             "key": "QK_MUSIC_TOGGLE",
+            "label": "Toggle Music",
             "aliases": [
                 "MU_TOGG"
             ]
@@ -89,6 +101,7 @@
         "0x7493": {
             "group": "audio",
             "key": "QK_MUSIC_MODE_NEXT",
+            "label": "Music Next",
             "aliases": [
                 "MU_NEXT"
             ]
@@ -97,6 +110,7 @@
         "0x7494": {
             "group": "audio",
             "key": "QK_AUDIO_VOICE_NEXT",
+            "label": "Audio Voice Next",
             "aliases": [
                 "AU_NEXT"
             ]
@@ -104,6 +118,7 @@
         "0x7495": {
             "group": "audio",
             "key": "QK_AUDIO_VOICE_PREVIOUS",
+            "label": "Audio Voice Previous",
             "aliases": [
                 "AU_PREV"
             ]

--- a/data/constants/keycodes/keycodes_0.0.1_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_basic.hjson
@@ -3,7 +3,7 @@
         "0x0000": {
             "group": "internal",
             "key": "KC_NO",
-            "label": "",
+            "label": "N/A",
             "aliases": [
                 "XXXXXXX"
             ]
@@ -11,7 +11,7 @@
         "0x0001": {
             "group": "internal",
             "key": "KC_TRANSPARENT",
-            "label": "",
+            "label": "Transparent",
             "aliases": [
                 "_______",
                 "KC_TRNS"
@@ -634,7 +634,7 @@
         "0x0065": {
             "group": "basic",
             "key": "KC_APPLICATION",
-            "label": "Application",
+            "label": "App",
             "aliases": [
                 "KC_APP"
             ]
@@ -642,7 +642,7 @@
         "0x0066": {
             "group": "basic",
             "key": "KC_KB_POWER",
-            "label": "Application"
+            "label": "Power"
         },
         "0x0067": {
             "group": "basic",
@@ -1068,7 +1068,7 @@
         "0x00A5": {
             "group": "system",
             "key": "KC_SYSTEM_POWER",
-            "label": "System Power Down",
+            "label": "Power",
             "aliases": [
                 "KC_PWR"
             ]
@@ -1076,7 +1076,7 @@
         "0x00A6": {
             "group": "system",
             "key": "KC_SYSTEM_SLEEP",
-            "label": "System Sleep",
+            "label": "Sleep",
             "aliases": [
                 "KC_SLEP"
             ]
@@ -1084,7 +1084,7 @@
         "0x00A7": {
             "group": "system",
             "key": "KC_SYSTEM_WAKE",
-            "label": "System Wake",
+            "label": "Wake",
             "aliases": [
                 "KC_WAKE"
             ]
@@ -1140,7 +1140,7 @@
         "0x00AE": {
             "group": "media",
             "key": "KC_MEDIA_PLAY_PAUSE",
-            "label": "Play/Pause Track",
+            "label": "Play/Pause",
             "aliases": [
                 "KC_MPLY"
             ]
@@ -1148,7 +1148,7 @@
         "0x00AF": {
             "group": "media",
             "key": "KC_MEDIA_SELECT",
-            "label": "Launch Player",
+            "label": "Media",
             "aliases": [
                 "KC_MSEL"
             ]
@@ -1164,12 +1164,12 @@
         "0x00B1": {
             "group": "media",
             "key": "KC_MAIL",
-            "label": "Launch Mail"
+            "label": "Mail",
         },
         "0x00B2": {
             "group": "media",
             "key": "KC_CALCULATOR",
-            "label": "Launch Calculator",
+            "label": "Calculator",
             "aliases": [
                 "KC_CALC"
             ]
@@ -1177,7 +1177,7 @@
         "0x00B3": {
             "group": "media",
             "key": "KC_MY_COMPUTER",
-            "label": "Launch My Computer",
+            "label": "My Computer",
             "aliases": [
                 "KC_MYCM"
             ]
@@ -1185,7 +1185,7 @@
         "0x00B4": {
             "group": "media",
             "key": "KC_WWW_SEARCH",
-            "label": "Browser Search",
+            "label": "Search",
             "aliases": [
                 "KC_WSCH"
             ]
@@ -1193,7 +1193,7 @@
         "0x00B5": {
             "group": "media",
             "key": "KC_WWW_HOME",
-            "label": "Browser Home",
+            "label": "Home",
             "aliases": [
                 "KC_WHOM"
             ]
@@ -1201,7 +1201,7 @@
         "0x00B6": {
             "group": "media",
             "key": "KC_WWW_BACK",
-            "label": "Browser Back",
+            "label": "Back",
             "aliases": [
                 "KC_WBAK"
             ]
@@ -1209,7 +1209,7 @@
         "0x00B7": {
             "group": "media",
             "key": "KC_WWW_FORWARD",
-            "label": "Browser Forward",
+            "label": "Forward",
             "aliases": [
                 "KC_WFWD"
             ]
@@ -1217,7 +1217,7 @@
         "0x00B8": {
             "group": "media",
             "key": "KC_WWW_STOP",
-            "label": "Browser Stop",
+            "label": "Stop",
             "aliases": [
                 "KC_WSTP"
             ]
@@ -1225,7 +1225,7 @@
         "0x00B9": {
             "group": "media",
             "key": "KC_WWW_REFRESH",
-            "label": "Browser Refresh",
+            "label": "Refresh",
             "aliases": [
                 "KC_WREF"
             ]
@@ -1233,7 +1233,7 @@
         "0x00BA": {
             "group": "media",
             "key": "KC_WWW_FAVORITES",
-            "label": "Browser Favorites",
+            "label": "Favorites",
             "aliases": [
                 "KC_WFAV"
             ]
@@ -1241,7 +1241,7 @@
         "0x00BB": {
             "group": "media",
             "key": "KC_MEDIA_FAST_FORWARD",
-            "label": "Next Track",
+            "label": "Fast Forward",
             "aliases": [
                 "KC_MFFD"
             ]
@@ -1249,7 +1249,7 @@
         "0x00BC": {
             "group": "media",
             "key": "KC_MEDIA_REWIND",
-            "label": "Previous Track",
+            "label": "Rewind",
             "aliases": [
                 "KC_MRWD"
             ]
@@ -1273,7 +1273,7 @@
         "0x00BF": {
             "group": "media",
             "key": "KC_CONTROL_PANEL",
-            "label": "Open Control Panel",
+            "label": "Control Panel",
             "aliases": [
                 "KC_CPNL"
             ]
@@ -1281,7 +1281,7 @@
         "0x00C0": {
             "group": "media",
             "key": "KC_ASSISTANT",
-            "label": "Launch Assistant",
+            "label": "Assistant",
             "aliases": [
                 "KC_ASST"
             ]

--- a/data/constants/keycodes/keycodes_0.0.1_joystick.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_joystick.hjson
@@ -3,6 +3,7 @@
         "0x7400": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_0",
+            "label": "Button 0",
             "aliases": [
                 "JS_0"
             ]
@@ -10,6 +11,7 @@
         "0x7401": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_1",
+            "label": "Button 1",
             "aliases": [
                 "JS_1"
             ]
@@ -17,6 +19,7 @@
         "0x7402": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_2",
+            "label": "Button 2",
             "aliases": [
                 "JS_2"
             ]
@@ -24,6 +27,7 @@
         "0x7403": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_3",
+            "label": "Button 3",
             "aliases": [
                 "JS_3"
             ]
@@ -31,6 +35,7 @@
         "0x7404": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_4",
+            "label": "Button 4",
             "aliases": [
                 "JS_4"
             ]
@@ -38,6 +43,7 @@
         "0x7405": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_5",
+            "label": "Button 5",
             "aliases": [
                 "JS_5"
             ]
@@ -45,6 +51,7 @@
         "0x7406": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_6",
+            "label": "Button 6",
             "aliases": [
                 "JS_6"
             ]
@@ -52,6 +59,7 @@
         "0x7407": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_7",
+            "label": "Button 7",
             "aliases": [
                 "JS_7"
             ]
@@ -59,6 +67,7 @@
         "0x7408": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_8",
+            "label": "Button 8",
             "aliases": [
                 "JS_8"
             ]
@@ -66,6 +75,7 @@
         "0x7409": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_9",
+            "label": "Button 9",
             "aliases": [
                 "JS_9"
             ]
@@ -73,6 +83,7 @@
         "0x740A": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_10",
+            "label": "Button 10",
             "aliases": [
                 "JS_10"
             ]
@@ -80,6 +91,7 @@
         "0x740B": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_11",
+            "label": "Button 11",
             "aliases": [
                 "JS_11"
             ]
@@ -87,6 +99,7 @@
         "0x740C": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_12",
+            "label": "Button 12",
             "aliases": [
                 "JS_12"
             ]
@@ -94,6 +107,7 @@
         "0x740D": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_13",
+            "label": "Button 13",
             "aliases": [
                 "JS_13"
             ]
@@ -101,6 +115,7 @@
         "0x740E": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_14",
+            "label": "Button 14",
             "aliases": [
                 "JS_14"
             ]
@@ -108,6 +123,7 @@
         "0x740F": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_15",
+            "label": "Button 15",
             "aliases": [
                 "JS_15"
             ]
@@ -115,6 +131,7 @@
         "0x7410": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_16",
+            "label": "Button 16",
             "aliases": [
                 "JS_16"
             ]
@@ -122,6 +139,7 @@
         "0x7411": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_17",
+            "label": "Button 17",
             "aliases": [
                 "JS_17"
             ]
@@ -129,6 +147,7 @@
         "0x7412": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_18",
+            "label": "Button 18",
             "aliases": [
                 "JS_18"
             ]
@@ -136,6 +155,7 @@
         "0x7413": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_19",
+            "label": "Button 19",
             "aliases": [
                 "JS_19"
             ]
@@ -143,6 +163,7 @@
         "0x7414": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_20",
+            "label": "Button 20",
             "aliases": [
                 "JS_20"
             ]
@@ -150,6 +171,7 @@
         "0x7415": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_21",
+            "label": "Button 21",
             "aliases": [
                 "JS_21"
             ]
@@ -157,6 +179,7 @@
         "0x7416": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_22",
+            "label": "Button 22",
             "aliases": [
                 "JS_22"
             ]
@@ -164,6 +187,7 @@
         "0x7417": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_23",
+            "label": "Button 23",
             "aliases": [
                 "JS_23"
             ]
@@ -171,6 +195,7 @@
         "0x7418": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_24",
+            "label": "Button 24",
             "aliases": [
                 "JS_24"
             ]
@@ -178,6 +203,7 @@
         "0x7419": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_25",
+            "label": "Button 25",
             "aliases": [
                 "JS_25"
             ]
@@ -185,6 +211,7 @@
         "0x741A": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_26",
+            "label": "Button 26",
             "aliases": [
                 "JS_26"
             ]
@@ -192,6 +219,7 @@
         "0x741B": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_27",
+            "label": "Button 27",
             "aliases": [
                 "JS_27"
             ]
@@ -199,6 +227,7 @@
         "0x741C": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_28",
+            "label": "Button 28",
             "aliases": [
                 "JS_28"
             ]
@@ -206,6 +235,7 @@
         "0x741D": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_29",
+            "label": "Button 29",
             "aliases": [
                 "JS_29"
             ]
@@ -213,6 +243,7 @@
         "0x741E": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_30",
+            "label": "Button 30",
             "aliases": [
                 "JS_30"
             ]
@@ -220,6 +251,7 @@
         "0x741F": {
             "group": "joystick",
             "key": "QK_JOYSTICK_BUTTON_31",
+            "label": "Button 31",
             "aliases": [
                 "JS_31"
             ]

--- a/data/constants/keycodes/keycodes_0.0.1_lighting.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_lighting.hjson
@@ -3,6 +3,7 @@
         "0x7800": {
             "group": "backlight",
             "key": "QK_BACKLIGHT_ON",
+            "label": "Backlight On",
             "aliases": [
                 "BL_ON"
             ]
@@ -10,6 +11,7 @@
         "0x7801": {
             "group": "backlight",
             "key": "QK_BACKLIGHT_OFF",
+            "label": "Backlight Off",
             "aliases": [
                 "BL_OFF"
             ]
@@ -17,6 +19,7 @@
         "0x7802": {
             "group": "backlight",
             "key": "QK_BACKLIGHT_TOGGLE",
+            "label": "Toggle Backlight",
             "aliases": [
                 "BL_TOGG"
             ]
@@ -24,6 +27,7 @@
         "0x7803": {
             "group": "backlight",
             "key": "QK_BACKLIGHT_DOWN",
+            "label": "Backlight Down",
             "aliases": [
                 "BL_DOWN"
             ]
@@ -31,6 +35,7 @@
         "0x7804": {
             "group": "backlight",
             "key": "QK_BACKLIGHT_UP",
+            "label": "Backlight Up",
             "aliases": [
                 "BL_UP"
             ]
@@ -38,6 +43,7 @@
         "0x7805": {
             "group": "backlight",
             "key": "QK_BACKLIGHT_STEP",
+            "label": "Backlight Step",
             "aliases": [
                 "BL_STEP"
             ]
@@ -45,6 +51,7 @@
         "0x7806": {
             "group": "backlight",
             "key": "QK_BACKLIGHT_TOGGLE_BREATHING",
+            "label": "Toggle Breathing",
             "aliases": [
                 "BL_BRTG"
             ]

--- a/data/constants/keycodes/keycodes_0.0.1_macro.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_macro.hjson
@@ -1,9 +1,9 @@
 {
     "keycodes": {
-
         "0x7700": {
             "group": "macro",
             "key": "QK_MACRO_0",
+            "label": "Macro 0",
             "aliases": [
                 "MC_0"
             ]
@@ -11,6 +11,7 @@
         "0x7701": {
             "group": "macro",
             "key": "QK_MACRO_1",
+            "label": "Macro 1",
             "aliases": [
                 "MC_1"
             ]
@@ -18,6 +19,7 @@
         "0x7702": {
             "group": "macro",
             "key": "QK_MACRO_2",
+            "label": "Macro 2",
             "aliases": [
                 "MC_2"
             ]
@@ -25,6 +27,7 @@
         "0x7703": {
             "group": "macro",
             "key": "QK_MACRO_3",
+            "label": "Macro 3",
             "aliases": [
                 "MC_3"
             ]
@@ -32,6 +35,7 @@
         "0x7704": {
             "group": "macro",
             "key": "QK_MACRO_4",
+            "label": "Macro 4",
             "aliases": [
                 "MC_4"
             ]
@@ -39,6 +43,7 @@
         "0x7705": {
             "group": "macro",
             "key": "QK_MACRO_5",
+            "label": "Macro 5",
             "aliases": [
                 "MC_5"
             ]
@@ -46,6 +51,7 @@
         "0x7706": {
             "group": "macro",
             "key": "QK_MACRO_6",
+            "label": "Macro 6",
             "aliases": [
                 "MC_6"
             ]
@@ -53,6 +59,7 @@
         "0x7707": {
             "group": "macro",
             "key": "QK_MACRO_7",
+            "label": "Macro 7",
             "aliases": [
                 "MC_7"
             ]
@@ -60,6 +67,7 @@
         "0x7708": {
             "group": "macro",
             "key": "QK_MACRO_8",
+            "label": "Macro 8",
             "aliases": [
                 "MC_8"
             ]
@@ -67,6 +75,7 @@
         "0x7709": {
             "group": "macro",
             "key": "QK_MACRO_9",
+            "label": "Macro 9",
             "aliases": [
                 "MC_9"
             ]
@@ -74,6 +83,7 @@
         "0x770A": {
             "group": "macro",
             "key": "QK_MACRO_10",
+            "label": "Macro 10",
             "aliases": [
                 "MC_10"
             ]
@@ -81,6 +91,7 @@
         "0x770B": {
             "group": "macro",
             "key": "QK_MACRO_11",
+            "label": "Macro 11",
             "aliases": [
                 "MC_11"
             ]
@@ -88,6 +99,7 @@
         "0x770C": {
             "group": "macro",
             "key": "QK_MACRO_12",
+            "label": "Macro 12",
             "aliases": [
                 "MC_12"
             ]
@@ -95,6 +107,7 @@
         "0x770D": {
             "group": "macro",
             "key": "QK_MACRO_13",
+            "label": "Macro 13",
             "aliases": [
                 "MC_13"
             ]
@@ -102,6 +115,7 @@
         "0x770E": {
             "group": "macro",
             "key": "QK_MACRO_14",
+            "label": "Macro 14",
             "aliases": [
                 "MC_14"
             ]
@@ -109,6 +123,7 @@
         "0x770F": {
             "group": "macro",
             "key": "QK_MACRO_15",
+            "label": "Macro 15",
             "aliases": [
                 "MC_15"
             ]
@@ -116,6 +131,7 @@
         "0x7710": {
             "group": "macro",
             "key": "QK_MACRO_16",
+            "label": "Macro 16",
             "aliases": [
                 "MC_16"
             ]
@@ -123,6 +139,7 @@
         "0x7711": {
             "group": "macro",
             "key": "QK_MACRO_17",
+            "label": "Macro 17",
             "aliases": [
                 "MC_17"
             ]
@@ -130,6 +147,7 @@
         "0x7712": {
             "group": "macro",
             "key": "QK_MACRO_18",
+            "label": "Macro 18",
             "aliases": [
                 "MC_18"
             ]
@@ -137,6 +155,7 @@
         "0x7713": {
             "group": "macro",
             "key": "QK_MACRO_19",
+            "label": "Macro 19",
             "aliases": [
                 "MC_19"
             ]
@@ -144,6 +163,7 @@
         "0x7714": {
             "group": "macro",
             "key": "QK_MACRO_20",
+            "label": "Macro 20",
             "aliases": [
                 "MC_20"
             ]
@@ -151,6 +171,7 @@
         "0x7715": {
             "group": "macro",
             "key": "QK_MACRO_21",
+            "label": "Macro 21",
             "aliases": [
                 "MC_21"
             ]
@@ -158,6 +179,7 @@
         "0x7716": {
             "group": "macro",
             "key": "QK_MACRO_22",
+            "label": "Macro 22",
             "aliases": [
                 "MC_22"
             ]
@@ -165,6 +187,7 @@
         "0x7717": {
             "group": "macro",
             "key": "QK_MACRO_23",
+            "label": "Macro 23",
             "aliases": [
                 "MC_23"
             ]
@@ -172,6 +195,7 @@
         "0x7718": {
             "group": "macro",
             "key": "QK_MACRO_24",
+            "label": "Macro 24",
             "aliases": [
                 "MC_24"
             ]
@@ -179,6 +203,7 @@
         "0x7719": {
             "group": "macro",
             "key": "QK_MACRO_25",
+            "label": "Macro 25",
             "aliases": [
                 "MC_25"
             ]
@@ -186,6 +211,7 @@
         "0x771A": {
             "group": "macro",
             "key": "QK_MACRO_26",
+            "label": "Macro 26",
             "aliases": [
                 "MC_26"
             ]
@@ -193,6 +219,7 @@
         "0x771B": {
             "group": "macro",
             "key": "QK_MACRO_27",
+            "label": "Macro 27",
             "aliases": [
                 "MC_27"
             ]
@@ -200,6 +227,7 @@
         "0x771C": {
             "group": "macro",
             "key": "QK_MACRO_28",
+            "label": "Macro 28",
             "aliases": [
                 "MC_28"
             ]
@@ -207,6 +235,7 @@
         "0x771D": {
             "group": "macro",
             "key": "QK_MACRO_29",
+            "label": "Macro 29",
             "aliases": [
                 "MC_29"
             ]
@@ -214,6 +243,7 @@
         "0x771E": {
             "group": "macro",
             "key": "QK_MACRO_30",
+            "label": "Macro 30",
             "aliases": [
                 "MC_30"
             ]
@@ -221,6 +251,7 @@
         "0x771F": {
             "group": "macro",
             "key": "QK_MACRO_31",
+            "label": "Macro 31",
             "aliases": [
                 "MC_31"
             ]

--- a/data/constants/keycodes/keycodes_0.0.1_programmable_button.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_programmable_button.hjson
@@ -3,6 +3,7 @@
         "0x7440": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_1",
+            "label": "Button 1",
             "aliases": [
                 "PB_1"
             ]
@@ -10,6 +11,7 @@
         "0x7441": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_2",
+            "label": "Button 2",
             "aliases": [
                 "PB_2"
             ]
@@ -17,6 +19,7 @@
         "0x7442": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_3",
+            "label": "Button 3",
             "aliases": [
                 "PB_3"
             ]
@@ -24,6 +27,7 @@
         "0x7443": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_4",
+            "label": "Button 4",
             "aliases": [
                 "PB_4"
             ]
@@ -31,6 +35,7 @@
         "0x7444": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_5",
+            "label": "Button 5",
             "aliases": [
                 "PB_5"
             ]
@@ -38,6 +43,7 @@
         "0x7445": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_6",
+            "label": "Button 6",
             "aliases": [
                 "PB_6"
             ]
@@ -45,6 +51,7 @@
         "0x7446": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_7",
+            "label": "Button 7",
             "aliases": [
                 "PB_7"
             ]
@@ -52,6 +59,7 @@
         "0x7447": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_8",
+            "label": "Button 8",
             "aliases": [
                 "PB_8"
             ]
@@ -59,6 +67,7 @@
         "0x7448": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_9",
+            "label": "Button 9",
             "aliases": [
                 "PB_9"
             ]
@@ -66,6 +75,7 @@
         "0x7449": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_10",
+            "label": "Button 10",
             "aliases": [
                 "PB_10"
             ]
@@ -73,6 +83,7 @@
         "0x744A": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_11",
+            "label": "Button 11",
             "aliases": [
                 "PB_11"
             ]
@@ -80,6 +91,7 @@
         "0x744B": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_12",
+            "label": "Button 12",
             "aliases": [
                 "PB_12"
             ]
@@ -87,6 +99,7 @@
         "0x744C": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_13",
+            "label": "Button 13",
             "aliases": [
                 "PB_13"
             ]
@@ -94,6 +107,7 @@
         "0x744D": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_14",
+            "label": "Button 14",
             "aliases": [
                 "PB_14"
             ]
@@ -101,6 +115,7 @@
         "0x744E": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_15",
+            "label": "Button 15",
             "aliases": [
                 "PB_15"
             ]
@@ -108,6 +123,7 @@
         "0x744F": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_16",
+            "label": "Button 16",
             "aliases": [
                 "PB_16"
             ]
@@ -115,6 +131,7 @@
         "0x7450": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_17",
+            "label": "Button 17",
             "aliases": [
                 "PB_17"
             ]
@@ -122,6 +139,7 @@
         "0x7451": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_18",
+            "label": "Button 18",
             "aliases": [
                 "PB_18"
             ]
@@ -129,6 +147,7 @@
         "0x7452": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_19",
+            "label": "Button 19",
             "aliases": [
                 "PB_19"
             ]
@@ -136,6 +155,7 @@
         "0x7453": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_20",
+            "label": "Button 20",
             "aliases": [
                 "PB_20"
             ]
@@ -143,6 +163,7 @@
         "0x7454": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_21",
+            "label": "Button 21",
             "aliases": [
                 "PB_21"
             ]
@@ -150,6 +171,7 @@
         "0x7455": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_22",
+            "label": "Button 22",
             "aliases": [
                 "PB_22"
             ]
@@ -157,6 +179,7 @@
         "0x7456": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_23",
+            "label": "Button 23",
             "aliases": [
                 "PB_23"
             ]
@@ -164,6 +187,7 @@
         "0x7457": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_24",
+            "label": "Button 24",
             "aliases": [
                 "PB_24"
             ]
@@ -171,6 +195,7 @@
         "0x7458": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_25",
+            "label": "Button 25",
             "aliases": [
                 "PB_25"
             ]
@@ -178,6 +203,7 @@
         "0x7459": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_26",
+            "label": "Button 26",
             "aliases": [
                 "PB_26"
             ]
@@ -185,6 +211,7 @@
         "0x745A": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_27",
+            "label": "Button 27",
             "aliases": [
                 "PB_27"
             ]
@@ -192,6 +219,7 @@
         "0x745B": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_28",
+            "label": "Button 28",
             "aliases": [
                 "PB_28"
             ]
@@ -199,6 +227,7 @@
         "0x745C": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_29",
+            "label": "Button 29",
             "aliases": [
                 "PB_29"
             ]
@@ -206,6 +235,7 @@
         "0x745D": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_30",
+            "label": "Button 30",
             "aliases": [
                 "PB_30"
             ]
@@ -213,6 +243,7 @@
         "0x745E": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_31",
+            "label": "Button 31",
             "aliases": [
                 "PB_31"
             ]
@@ -220,6 +251,7 @@
         "0x745F": {
             "group": "programmable_button",
             "key": "QK_PROGRAMMABLE_BUTTON_32",
+            "label": "Button 32",
             "aliases": [
                 "PB_32"
             ]

--- a/data/constants/keycodes/keycodes_0.0.1_quantum.hjson
+++ b/data/constants/keycodes/keycodes_0.0.1_quantum.hjson
@@ -3,6 +3,7 @@
         "0x7C00": {
             "group": "quantum",
             "key": "QK_BOOTLOADER",
+            "label": "Bootloader",
             "aliases": [
                 "QK_BOOT"
             ]
@@ -10,6 +11,7 @@
         "0x7C01": {
             "group": "quantum",
             "key": "QK_REBOOT",
+            "label": "Reboot",
             "aliases": [
                 "QK_RBT"
             ]
@@ -17,6 +19,7 @@
         "0x7C02": {
             "group": "quantum",
             "key": "QK_DEBUG_TOGGLE",
+            "label": "Toggle Debug",
             "aliases": [
                 "DB_TOGG"
             ]
@@ -24,18 +27,21 @@
         "0x7C03": {
             "group": "quantum",
             "key": "QK_CLEAR_EEPROM",
+            "label": "Clear EEPROM",
             "aliases": [
                 "EE_CLR"
             ]
         },
         "0x7C04": {
             "group": "quantum",
-            "key": "QK_MAKE"
+            "key": "QK_MAKE",
+            "label": "Make"
         },
 
         "0x7C10": {
             "group": "quantum",
             "key": "QK_AUTO_SHIFT_DOWN",
+            "label": "Auto Shift Down",
             "aliases": [
                 "AS_DOWN"
             ]
@@ -43,6 +49,7 @@
         "0x7C11": {
             "group": "quantum",
             "key": "QK_AUTO_SHIFT_UP",
+            "label": "Auto Shift Up",
             "aliases": [
                 "AS_UP"
             ]
@@ -50,6 +57,7 @@
         "0x7C12": {
             "group": "quantum",
             "key": "QK_AUTO_SHIFT_REPORT",
+            "label": "Auto Shift Report",
             "aliases": [
                 "AS_RPT"
             ]
@@ -57,6 +65,7 @@
         "0x7C13": {
             "group": "quantum",
             "key": "QK_AUTO_SHIFT_ON",
+            "label": "Auto Shift On",
             "aliases": [
                 "AS_ON"
             ]
@@ -64,6 +73,7 @@
         "0x7C14": {
             "group": "quantum",
             "key": "QK_AUTO_SHIFT_OFF",
+            "label": "Auto Shift Off",
             "aliases": [
                 "AS_OFF"
             ]
@@ -71,6 +81,7 @@
         "0x7C15": {
             "group": "quantum",
             "key": "QK_AUTO_SHIFT_TOGGLE",
+            "label": "Toggle Auto Shift",
             "aliases": [
                 "AS_TOGG"
             ]
@@ -79,6 +90,7 @@
         "0x7C16": {
             "group": "quantum",
             "key": "QK_GRAVE_ESCAPE",
+            "label": "Grave Esc",
             "aliases": [
                 "QK_GESC"
             ]
@@ -95,6 +107,7 @@
         "0x7C18": {
             "group": "quantum",
             "key": "QK_SPACE_CADET_LEFT_CTRL_PARENTHESIS_OPEN",
+            "label": "LCtl/(",
             "aliases": [
                 "SC_LCPO"
             ]
@@ -102,6 +115,7 @@
         "0x7C19": {
             "group": "quantum",
             "key": "QK_SPACE_CADET_RIGHT_CTRL_PARENTHESIS_CLOSE",
+            "label": "RCtl/)",
             "aliases": [
                 "SC_RCPC"
             ]
@@ -109,6 +123,7 @@
         "0x7C1A": {
             "group": "quantum",
             "key": "QK_SPACE_CADET_LEFT_SHIFT_PARENTHESIS_OPEN",
+            "label": "LSft/)",
             "aliases": [
                 "SC_LSPO"
             ]
@@ -116,6 +131,7 @@
         "0x7C1B": {
             "group": "quantum",
             "key": "QK_SPACE_CADET_RIGHT_SHIFT_PARENTHESIS_CLOSE",
+            "label": "RSft/)",
             "aliases": [
                 "SC_RSPC"
             ]
@@ -123,6 +139,7 @@
         "0x7C1C": {
             "group": "quantum",
             "key": "QK_SPACE_CADET_LEFT_ALT_PARENTHESIS_OPEN",
+            "label": "LAlt/(",
             "aliases": [
                 "SC_LAPO"
             ]
@@ -130,6 +147,7 @@
         "0x7C1D": {
             "group": "quantum",
             "key": "QK_SPACE_CADET_RIGHT_ALT_PARENTHESIS_CLOSE",
+            "label": "RAlt/)",
             "aliases": [
                 "SC_RAPC"
             ]
@@ -137,6 +155,7 @@
         "0x7C1E": {
             "group": "quantum",
             "key": "QK_SPACE_CADET_RIGHT_SHIFT_ENTER",
+            "label": "RSft/Ent",
             "aliases": [
                 "SC_SENT"
             ]
@@ -167,6 +186,7 @@
         "0x7C30": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_NEXT",
+            "label": "Unicode Mode Next",
             "aliases": [
                 "UC_NEXT"
             ]
@@ -174,6 +194,7 @@
         "0x7C31": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_PREVIOUS",
+            "label": "Unicode Mode Previous",
             "aliases": [
                 "UC_PREV"
             ]
@@ -181,6 +202,7 @@
         "0x7C32": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_MACOS",
+            "label": "Unicode Mode macOS",
             "aliases": [
                 "UC_MAC"
             ]
@@ -188,6 +210,7 @@
         "0x7C33": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_LINUX",
+            "label": "Unicode Mode Linux",
             "aliases": [
                 "UC_LINX"
             ]
@@ -195,6 +218,7 @@
         "0x7C34": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_WINDOWS",
+            "label": "Unicode Mode Windows",
             "aliases": [
                 "UC_WIN"
             ]
@@ -202,6 +226,7 @@
         "0x7C35": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_BSD",
+            "label": "Unicode Mode BSD",
             "aliases": [
                 "UC_BSD"
             ]
@@ -209,6 +234,7 @@
         "0x7C36": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_WINCOMPOSE",
+            "label": "Unicode Mode WinCompose",
             "aliases": [
                 "UC_WINC"
             ]
@@ -216,6 +242,7 @@
         "0x7C37": {
             "group": "quantum",
             "key": "QK_UNICODE_MODE_EMACS",
+            "label": "Unicode Mode emacs",
             "aliases": [
                 "UC_EMAC"
             ]
@@ -224,6 +251,7 @@
         "0x7C40": {
             "group": "quantum",
             "key": "QK_HAPTIC_ON",
+            "label": "Haptic On",
             "aliases": [
                 "HF_ON"
             ]
@@ -231,6 +259,7 @@
         "0x7C41": {
             "group": "quantum",
             "key": "QK_HAPTIC_OFF",
+            "label": "Haptic Off",
             "aliases": [
                 "HF_OFF"
             ]
@@ -238,6 +267,7 @@
         "0x7C42": {
             "group": "quantum",
             "key": "QK_HAPTIC_TOGGLE",
+            "label": "Toggle Haptic",
             "aliases": [
                 "HF_TOGG"
             ]
@@ -245,6 +275,7 @@
         "0x7C43": {
             "group": "quantum",
             "key": "QK_HAPTIC_RESET",
+            "label": "Haptic Reset",
             "aliases": [
                 "HF_RST"
             ]
@@ -252,6 +283,7 @@
         "0x7C44": {
             "group": "quantum",
             "key": "QK_HAPTIC_FEEDBACK_TOGGLE",
+            "label": "Toggle Haptic Feedback",
             "aliases": [
                 "HF_FDBK"
             ]
@@ -259,6 +291,7 @@
         "0x7C45": {
             "group": "quantum",
             "key": "QK_HAPTIC_BUZZ_TOGGLE",
+            "label": "Toggle Haptic Buzz",
             "aliases": [
                 "HF_BUZZ"
             ]
@@ -266,6 +299,7 @@
         "0x7C46": {
             "group": "quantum",
             "key": "QK_HAPTIC_MODE_NEXT",
+            "label": "Haptic Mode Next",
             "aliases": [
                 "HF_NEXT"
             ]
@@ -273,6 +307,7 @@
         "0x7C47": {
             "group": "quantum",
             "key": "QK_HAPTIC_MODE_PREVIOUS",
+            "label": "Haptic Mode Previous",
             "aliases": [
                 "HF_PREV"
             ]
@@ -280,6 +315,7 @@
         "0x7C48": {
             "group": "quantum",
             "key": "QK_HAPTIC_CONTINUOUS_TOGGLE",
+            "label": "Toggle Haptic Continuous",
             "aliases": [
                 "HF_CONT"
             ]
@@ -287,6 +323,7 @@
         "0x7C49": {
             "group": "quantum",
             "key": "QK_HAPTIC_CONTINUOUS_UP",
+            "label": "Haptic Continuous Up",
             "aliases": [
                 "HF_CONU"
             ]
@@ -294,6 +331,7 @@
         "0x7C4A": {
             "group": "quantum",
             "key": "QK_HAPTIC_CONTINUOUS_DOWN",
+            "label": "Haptic Continuous Down",
             "aliases": [
                 "HF_COND"
             ]
@@ -301,6 +339,7 @@
         "0x7C4B": {
             "group": "quantum",
             "key": "QK_HAPTIC_DWELL_UP",
+            "label": "Haptic Dwell Up",
             "aliases": [
                 "HF_DWLU"
             ]
@@ -308,6 +347,7 @@
         "0x7C4C": {
             "group": "quantum",
             "key": "QK_HAPTIC_DWELL_DOWN",
+            "label": "Haptic Dwell Down",
             "aliases": [
                 "HF_DWLD"
             ]
@@ -316,6 +356,7 @@
         "0x7C50": {
             "group": "quantum",
             "key": "QK_COMBO_ON",
+            "label": "Combo On",
             "aliases": [
                 "CM_ON"
             ]
@@ -323,6 +364,7 @@
         "0x7C51": {
             "group": "quantum",
             "key": "QK_COMBO_OFF",
+            "label": "Combo Off",
             "aliases": [
                 "CM_OFF"
             ]
@@ -330,6 +372,7 @@
         "0x7C52": {
             "group": "quantum",
             "key": "QK_COMBO_TOGGLE",
+            "label": "Toggle Combo",
             "aliases": [
                 "CM_TOGG"
             ]
@@ -338,6 +381,7 @@
         "0x7C53": {
             "group": "quantum",
             "key": "QK_DYNAMIC_MACRO_RECORD_START_1",
+            "label": "Dynamic Macro Record 1",
             "aliases": [
                 "DM_REC1"
             ]
@@ -345,6 +389,7 @@
         "0x7C54": {
             "group": "quantum",
             "key": "QK_DYNAMIC_MACRO_RECORD_START_2",
+            "label": "Dynamic Macro Record 2",
             "aliases": [
                 "DM_REC2"
             ]
@@ -352,6 +397,7 @@
         "0x7C55": {
             "group": "quantum",
             "key": "QK_DYNAMIC_MACRO_RECORD_STOP",
+            "label": "Dynamic Macro Stop Recording",
             "aliases": [
                 "DM_RSTP"
             ]
@@ -359,6 +405,7 @@
         "0x7C56": {
             "group": "quantum",
             "key": "QK_DYNAMIC_MACRO_PLAY_1",
+            "label": "Dynamic Macro Play 1",
             "aliases": [
                 "DM_PLY1"
             ]
@@ -366,6 +413,7 @@
         "0x7C57": {
             "group": "quantum",
             "key": "QK_DYNAMIC_MACRO_PLAY_2",
+            "label": "Dynamic Macro Play 2",
             "aliases": [
                 "DM_PLY2"
             ]
@@ -374,6 +422,7 @@
         "0x7C58": {
             "group": "quantum",
             "key": "QK_LEADER",
+            "label": "Leader",
             "aliases": [
                 "QK_LEAD"
             ]
@@ -381,12 +430,14 @@
 
         "0x7C59": {
             "group": "quantum",
-            "key": "QK_LOCK"
+            "key": "QK_LOCK",
+            "label": "Lock"
         },
 
         "0x7C5A": {
             "group": "quantum",
             "key": "QK_ONE_SHOT_ON",
+            "label": "One Shot On",
             "aliases": [
                 "OS_ON"
             ]
@@ -394,6 +445,7 @@
         "0x7C5B": {
             "group": "quantum",
             "key": "QK_ONE_SHOT_OFF",
+            "label": "One Shot Off",
             "aliases": [
                 "OS_OFF"
             ]
@@ -401,6 +453,7 @@
         "0x7C5C": {
             "group": "quantum",
             "key": "QK_ONE_SHOT_TOGGLE",
+            "label": "Toggle One Shot",
             "aliases": [
                 "OS_TOGG"
             ]
@@ -409,6 +462,7 @@
         "0x7C5D": {
             "group": "quantum",
             "key": "QK_KEY_OVERRIDE_TOGGLE",
+            "label": "Toggle Key Overrides",
             "aliases": [
                 "KO_TOGG"
             ]
@@ -416,6 +470,7 @@
         "0x7C5E": {
             "group": "quantum",
             "key": "QK_KEY_OVERRIDE_ON",
+            "label": "Key Overrides On",
             "aliases": [
                 "KO_ON"
             ]
@@ -423,6 +478,7 @@
         "0x7C5F": {
             "group": "quantum",
             "key": "QK_KEY_OVERRIDE_OFF",
+            "label": "Key Overrides Off",
             "aliases": [
                 "KO_OFF"
             ]
@@ -431,6 +487,7 @@
         "0x7C60": {
             "group": "quantum",
             "key": "QK_SECURE_LOCK",
+            "label": "Lock",
             "aliases": [
                 "SE_LOCK"
             ]
@@ -438,6 +495,7 @@
         "0x7C61": {
             "group": "quantum",
             "key": "QK_SECURE_UNLOCK",
+            "label": "Unlock",
             "aliases": [
                 "SE_UNLK"
             ]
@@ -445,6 +503,7 @@
         "0x7C62": {
             "group": "quantum",
             "key": "QK_SECURE_TOGGLE",
+            "label": "Toggle Lock",
             "aliases": [
                 "SE_TOGG"
             ]
@@ -452,6 +511,7 @@
         "0x7C63": {
             "group": "quantum",
             "key": "QK_SECURE_REQUEST",
+            "label": "Request Unlock",
             "aliases": [
                 "SE_REQ"
             ]
@@ -460,6 +520,7 @@
         "0x7C70": {
             "group": "quantum",
             "key": "QK_DYNAMIC_TAPPING_TERM_PRINT",
+            "label": "Print Dynamic Tapping Term",
             "aliases": [
                 "DT_PRNT"
             ]
@@ -467,6 +528,7 @@
         "0x7C71": {
             "group": "quantum",
             "key": "QK_DYNAMIC_TAPPING_TERM_UP",
+            "label": "Dynamic Tapping Term Up",
             "aliases": [
                 "DT_UP"
             ]
@@ -474,6 +536,7 @@
         "0x7C72": {
             "group": "quantum",
             "key": "QK_DYNAMIC_TAPPING_TERM_DOWN",
+            "label": "Dynamic Tapping Term Down",
             "aliases": [
                 "DT_DOWN"
             ]
@@ -482,6 +545,7 @@
         "0x7C73": {
             "group": "quantum",
             "key": "QK_CAPS_WORD_TOGGLE",
+            "label": "Toggle Caps Word",
             "aliases": [
                 "CW_TOGG"
             ]
@@ -490,6 +554,7 @@
         "0x7C74": {
             "group": "quantum",
             "key": "QK_AUTOCORRECT_ON",
+            "label": "Autocorrect On",
             "aliases": [
                 "AC_ON"
             ]
@@ -497,6 +562,7 @@
         "0x7C75": {
             "group": "quantum",
             "key": "QK_AUTOCORRECT_OFF",
+            "label": "Autocorrect Off",
             "aliases": [
                 "AC_OFF"
             ]
@@ -504,6 +570,7 @@
         "0x7C76": {
             "group": "quantum",
             "key": "QK_AUTOCORRECT_TOGGLE",
+            "label": "Toggle Autocorrect",
             "aliases": [
                 "AC_TOGG"
             ]

--- a/data/constants/keycodes/keycodes_0.0.2_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_basic.hjson
@@ -3,7 +3,7 @@
         "0x00C1": {
             "group": "media",
             "key": "KC_MISSION_CONTROL",
-            "label": "Open Mission Control",
+            "label": "Mission Control",
             "aliases": [
                 "KC_MCTL"
             ]
@@ -11,7 +11,7 @@
         "0x00C2": {
             "group": "media",
             "key": "KC_LAUNCHPAD",
-            "label": "Open Launchpad",
+            "label": "Launchpad",
             "aliases": [
                 "KC_LPAD"
             ]

--- a/data/constants/keycodes/keycodes_0.0.2_kb.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_kb.hjson
@@ -2,131 +2,163 @@
     "keycodes": {
         "0x7E00": {
             "group": "kb",
-            "key": "QK_KB_0"
+            "key": "QK_KB_0",
+            "label": "Keyboard 0"
         },
         "0x7E01": {
             "group": "kb",
-            "key": "QK_KB_1"
+            "key": "QK_KB_1",
+            "label": "Keyboard 1"
         },
         "0x7E02": {
             "group": "kb",
-            "key": "QK_KB_2"
+            "key": "QK_KB_2",
+            "label": "Keyboard 2"
         },
         "0x7E03": {
             "group": "kb",
-            "key": "QK_KB_3"
+            "key": "QK_KB_3",
+            "label": "Keyboard 3"
         },
         "0x7E04": {
             "group": "kb",
-            "key": "QK_KB_4"
+            "key": "QK_KB_4",
+            "label": "Keyboard 4"
         },
         "0x7E05": {
             "group": "kb",
-            "key": "QK_KB_5"
+            "key": "QK_KB_5",
+            "label": "Keyboard 5"
         },
         "0x7E06": {
             "group": "kb",
-            "key": "QK_KB_6"
+            "key": "QK_KB_6",
+            "label": "Keyboard 6"
         },
         "0x7E07": {
             "group": "kb",
-            "key": "QK_KB_7"
+            "key": "QK_KB_7",
+            "label": "Keyboard 7"
         },
         "0x7E08": {
             "group": "kb",
-            "key": "QK_KB_8"
+            "key": "QK_KB_8",
+            "label": "Keyboard 8"
         },
         "0x7E09": {
             "group": "kb",
-            "key": "QK_KB_9"
+            "key": "QK_KB_9",
+            "label": "Keyboard 9"
         },
         "0x7E0A": {
             "group": "kb",
-            "key": "QK_KB_10"
+            "key": "QK_KB_10",
+            "label": "Keyboard 10"
         },
         "0x7E0B": {
             "group": "kb",
-            "key": "QK_KB_11"
+            "key": "QK_KB_11",
+            "label": "Keyboard 11"
         },
         "0x7E0C": {
             "group": "kb",
-            "key": "QK_KB_12"
+            "key": "QK_KB_12",
+            "label": "Keyboard 12"
         },
         "0x7E0D": {
             "group": "kb",
-            "key": "QK_KB_13"
+            "key": "QK_KB_13",
+            "label": "Keyboard 13"
         },
         "0x7E0E": {
             "group": "kb",
-            "key": "QK_KB_14"
+            "key": "QK_KB_14",
+            "label": "Keyboard 14"
         },
         "0x7E0F": {
             "group": "kb",
-            "key": "QK_KB_15"
+            "key": "QK_KB_15",
+            "label": "Keyboard 15"
         },
         "0x7E10": {
             "group": "kb",
-            "key": "QK_KB_16"
+            "key": "QK_KB_16",
+            "label": "Keyboard 16"
         },
         "0x7E11": {
             "group": "kb",
-            "key": "QK_KB_17"
+            "key": "QK_KB_17",
+            "label": "Keyboard 17"
         },
          "0x7E12": {
             "group": "kb",
-            "key": "QK_KB_18"
+            "key": "QK_KB_18",
+            "label": "Keyboard 18"
         },
         "0x7E13": {
             "group": "kb",
-            "key": "QK_KB_19"
+            "key": "QK_KB_19",
+            "label": "Keyboard 19"
         },
         "0x7E14": {
             "group": "kb",
-            "key": "QK_KB_20"
+            "key": "QK_KB_20",
+            "label": "Keyboard 20"
         },
         "0x7E15": {
             "group": "kb",
-            "key": "QK_KB_21"
+            "key": "QK_KB_21",
+            "label": "Keyboard 21"
         },
         "0x7E16": {
             "group": "kb",
-            "key": "QK_KB_22"
+            "key": "QK_KB_22",
+            "label": "Keyboard 22"
         },
         "0x7E17": {
             "group": "kb",
-            "key": "QK_KB_23"
+            "key": "QK_KB_23",
+            "label": "Keyboard 23"
         },
         "0x7E18": {
             "group": "kb",
-            "key": "QK_KB_24"
+            "key": "QK_KB_24",
+            "label": "Keyboard 24"
         },
         "0x7E19": {
             "group": "kb",
-            "key": "QK_KB_25"
+            "key": "QK_KB_25",
+            "label": "Keyboard 25"
         },
         "0x7E1A": {
             "group": "kb",
-            "key": "QK_KB_26"
+            "key": "QK_KB_26",
+            "label": "Keyboard 26"
         },
         "0x7E1B": {
             "group": "kb",
-            "key": "QK_KB_27"
+            "key": "QK_KB_27",
+            "label": "Keyboard 27"
         },
         "0x7E1C": {
             "group": "kb",
-            "key": "QK_KB_28"
+            "key": "QK_KB_28",
+            "label": "Keyboard 28"
         },
         "0x7E1D": {
             "group": "kb",
-            "key": "QK_KB_29"
+            "key": "QK_KB_29",
+            "label": "Keyboard 29"
         },
         "0x7E1E": {
             "group": "kb",
-            "key": "QK_KB_30"
+            "key": "QK_KB_30",
+            "label": "Keyboard 30"
         },
         "0x7E1F": {
             "group": "kb",
-            "key": "QK_KB_31"
+            "key": "QK_KB_31",
+            "label": "Keyboard 31"
         }
     }
 }

--- a/data/constants/keycodes/keycodes_0.0.2_magic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_magic.hjson
@@ -5,6 +5,7 @@
         "0x7000": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_CONTROL_CAPS_LOCK",
+            "label": "Swap LCtl⇄Caps",
             "aliases": [
                 "CL_SWAP"
             ]
@@ -12,6 +13,7 @@
         "0x7001": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_CONTROL_CAPS_LOCK",
+            "label": "Unswap LCtl⇄Caps",
             "aliases": [
                 "CL_NORM"
             ]
@@ -19,6 +21,7 @@
         "0x7002": {
             "group": "magic",
             "key": "QK_MAGIC_TOGGLE_CONTROL_CAPS_LOCK",
+            "label": "Toggle LCtl⇄Caps",
             "aliases": [
                 "CL_TOGG"
             ]
@@ -26,6 +29,7 @@
         "0x7003": {
             "group": "magic",
             "key": "QK_MAGIC_CAPS_LOCK_AS_CONTROL_OFF",
+            "label": "Caps≠LCtl",
             "aliases": [
                 "CL_CAPS"
             ]
@@ -33,6 +37,7 @@
         "0x7004": {
             "group": "magic",
             "key": "QK_MAGIC_CAPS_LOCK_AS_CONTROL_ON",
+            "label": "Caps=LCtl",
             "aliases": [
                 "CL_CTRL"
             ]
@@ -40,6 +45,7 @@
         "0x7005": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_LALT_LGUI",
+            "label": "Swap LAlt⇄LGUI",
             "aliases": [
                 "AG_LSWP"
             ]
@@ -47,6 +53,7 @@
         "0x7006": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_LALT_LGUI",
+            "label": "Unswap LAlt⇄LGUI",
             "aliases": [
                 "AG_LNRM"
             ]
@@ -54,6 +61,7 @@
         "0x7007": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_RALT_RGUI",
+            "label": "Swap RAlt⇄RGUI",
             "aliases": [
                 "AG_RSWP"
             ]
@@ -61,6 +69,7 @@
         "0x7008": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_RALT_RGUI",
+            "label": "Unswap RAlt⇄RGUI",
             "aliases": [
                 "AG_RNRM"
             ]
@@ -68,6 +77,7 @@
         "0x7009": {
             "group": "magic",
             "key": "QK_MAGIC_GUI_ON",
+            "label": "GUI On",
             "aliases": [
                 "GU_ON"
             ]
@@ -75,6 +85,7 @@
         "0x700A": {
             "group": "magic",
             "key": "QK_MAGIC_GUI_OFF",
+            "label": "GUI Off",
             "aliases": [
                 "GU_OFF"
             ]
@@ -82,6 +93,7 @@
         "0x700B": {
             "group": "magic",
             "key": "QK_MAGIC_TOGGLE_GUI",
+            "label": "Toggle GUI",
             "aliases": [
                 "GU_TOGG"
             ]
@@ -89,6 +101,7 @@
         "0x700C": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_GRAVE_ESC",
+            "label": "Swap `⇄Esc",
             "aliases": [
                 "GE_SWAP"
             ]
@@ -96,6 +109,7 @@
         "0x700D": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_GRAVE_ESC",
+            "label": "Unswap `⇄Esc",
             "aliases": [
                 "GE_NORM"
             ]
@@ -103,6 +117,7 @@
         "0x700E": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_BACKSLASH_BACKSPACE",
+            "label": "Swap \\⇄Bspc",
             "aliases": [
                 "BS_SWAP"
             ]
@@ -110,6 +125,7 @@
         "0x700F": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_BACKSLASH_BACKSPACE",
+            "label": "Unswap \\⇄Bspc",
             "aliases": [
                 "BS_NORM"
             ]
@@ -117,6 +133,7 @@
         "0x7010": {
             "group": "magic",
             "key": "QK_MAGIC_TOGGLE_BACKSLASH_BACKSPACE",
+            "label": "Toggle \\⇄Bspc",
             "aliases": [
                 "BS_TOGG"
             ]
@@ -124,6 +141,7 @@
         "0x7011": {
             "group": "magic",
             "key": "QK_MAGIC_NKRO_ON",
+            "label": "NKRO On",
             "aliases": [
                 "NK_ON"
             ]
@@ -131,6 +149,7 @@
         "0x7012": {
             "group": "magic",
             "key": "QK_MAGIC_NKRO_OFF",
+            "label": "NKRO Off",
             "aliases": [
                 "NK_OFF"
             ]
@@ -138,6 +157,7 @@
         "0x7013": {
             "group": "magic",
             "key": "QK_MAGIC_TOGGLE_NKRO",
+            "label": "Toggle NKRO",
             "aliases": [
                 "NK_TOGG"
             ]
@@ -145,6 +165,7 @@
         "0x7014": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_ALT_GUI",
+            "label": "Swap Alt⇄GUI",
             "aliases": [
                 "AG_SWAP"
             ]
@@ -152,6 +173,7 @@
         "0x7015": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_ALT_GUI",
+            "label": "Unswap Alt⇄GUI",
             "aliases": [
                 "AG_NORM"
             ]
@@ -159,6 +181,7 @@
         "0x7016": {
             "group": "magic",
             "key": "QK_MAGIC_TOGGLE_ALT_GUI",
+            "label": "Toggle Alt⇄GUI",
             "aliases": [
                 "AG_TOGG"
             ]
@@ -166,6 +189,7 @@
         "0x7017": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_LCTL_LGUI",
+            "label": "Swap LCtl⇄LGUI",
             "aliases": [
                 "CG_LSWP"
             ]
@@ -173,6 +197,7 @@
         "0x7018": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_LCTL_LGUI",
+            "label": "Unswap LCtl⇄LGUI",
             "aliases": [
                 "CG_LNRM"
             ]
@@ -180,6 +205,7 @@
         "0x7019": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_RCTL_RGUI",
+            "label": "Swap RCtl⇄RGUI",
             "aliases": [
                 "CG_RSWP"
             ]
@@ -187,6 +213,7 @@
         "0x701A": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_RCTL_RGUI",
+            "label": "Unswap RCtl⇄RGUI",
             "aliases": [
                 "CG_RNRM"
             ]
@@ -194,6 +221,7 @@
         "0x701B": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_CTL_GUI",
+            "label": "Swap Ctl⇄GUI",
             "aliases": [
                 "CG_SWAP"
             ]
@@ -201,6 +229,7 @@
         "0x701C": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_CTL_GUI",
+            "label": "Unswap Ctl⇄GUI",
             "aliases": [
                 "CG_NORM"
             ]
@@ -208,6 +237,7 @@
         "0x701D": {
             "group": "magic",
             "key": "QK_MAGIC_TOGGLE_CTL_GUI",
+            "label": "Toggle Ctl⇄GUI",
             "aliases": [
                 "CG_TOGG"
             ]
@@ -215,6 +245,7 @@
         "0x701E": {
             "group": "magic",
             "key": "QK_MAGIC_EE_HANDS_LEFT",
+            "label": "EE Hands Left",
             "aliases": [
                 "EH_LEFT"
             ]
@@ -222,6 +253,7 @@
         "0x701F": {
             "group": "magic",
             "key": "QK_MAGIC_EE_HANDS_RIGHT",
+            "label": "EE Hands Right",
             "aliases": [
                 "EH_RGHT"
             ]
@@ -229,6 +261,7 @@
         "0x7020": {
             "group": "magic",
             "key": "QK_MAGIC_SWAP_ESCAPE_CAPS_LOCK",
+            "label": "Swap Esc⇄Caps",
             "aliases": [
                 "EC_SWAP"
             ]
@@ -236,6 +269,7 @@
         "0x7021": {
             "group": "magic",
             "key": "QK_MAGIC_UNSWAP_ESCAPE_CAPS_LOCK",
+            "label": "Unswap Esc⇄Caps",
             "aliases": [
                 "EC_NORM"
             ]
@@ -243,6 +277,7 @@
         "0x7022": {
             "group": "magic",
             "key": "QK_MAGIC_TOGGLE_ESCAPE_CAPS_LOCK",
+            "label": "Toggle Esc⇄Caps",
             "aliases": [
                 "EC_TOGG"
             ]

--- a/data/constants/keycodes/keycodes_0.0.2_midi.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_midi.hjson
@@ -5,6 +5,7 @@
         "0x7100": {
             "group": "midi",
             "key": "QK_MIDI_ON",
+            "label": "MIDI On",
             "aliases": [
                 "MI_ON"
             ]
@@ -12,6 +13,7 @@
         "0x7101": {
             "group": "midi",
             "key": "QK_MIDI_OFF",
+            "label": "MIDI Off",
             "aliases": [
                 "MI_OFF"
             ]
@@ -19,6 +21,7 @@
         "0x7102": {
             "group": "midi",
             "key": "QK_MIDI_TOGGLE",
+            "label": "Toggle MIDI",
             "aliases": [
                 "MI_TOGG"
             ]
@@ -26,6 +29,7 @@
         "0x7103": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_0",
+            "label": "C0",
             "aliases": [
                 "MI_C"
             ]
@@ -33,6 +37,7 @@
         "0x7104": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_SHARP_0",
+            "label": "C♯0",
             "aliases": [
                 "MI_Cs",
                 "MI_Db"
@@ -41,6 +46,7 @@
         "0x7105": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_0",
+            "label": "D0",
             "aliases": [
                 "MI_D"
             ]
@@ -48,6 +54,7 @@
         "0x7106": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_SHARP_0",
+            "label": "D♯0",
             "aliases": [
                 "MI_Ds",
                 "MI_Eb"
@@ -56,6 +63,7 @@
         "0x7107": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_E_0",
+            "label": "E0",
             "aliases": [
                 "MI_E"
             ]
@@ -63,6 +71,7 @@
         "0x7108": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_0",
+            "label": "F0",
             "aliases": [
                 "MI_F"
             ]
@@ -70,6 +79,7 @@
         "0x7109": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_SHARP_0",
+            "label": "F♯0",
             "aliases": [
                 "MI_Fs",
                 "MI_Gb"
@@ -78,6 +88,7 @@
         "0x710A": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_0",
+            "label": "G0",
             "aliases": [
                 "MI_G"
             ]
@@ -85,6 +96,7 @@
         "0x710B": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_SHARP_0",
+            "label": "G♯0",
             "aliases": [
                 "MI_Gs",
                 "MI_Ab"
@@ -93,6 +105,7 @@
         "0x710C": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_0",
+            "label": "A0",
             "aliases": [
                 "MI_A"
             ]
@@ -100,6 +113,7 @@
         "0x710D": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_SHARP_0",
+            "label": "A♯0",
             "aliases": [
                 "MI_As",
                 "MI_Bb"
@@ -108,6 +122,7 @@
         "0x710E": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_B_0",
+            "label": "B0",
             "aliases": [
                 "MI_B"
             ]
@@ -115,6 +130,7 @@
         "0x710F": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_1",
+            "label": "C1",
             "aliases": [
                 "MI_C1"
             ]
@@ -122,6 +138,7 @@
         "0x7110": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_SHARP_1",
+            "label": "C♯1",
             "aliases": [
                 "MI_Cs1",
                 "MI_Db1"
@@ -130,6 +147,7 @@
         "0x7111": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_1",
+            "label": "D1",
             "aliases": [
                 "MI_D1"
             ]
@@ -137,6 +155,7 @@
         "0x7112": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_SHARP_1",
+            "label": "D♯1",
             "aliases": [
                 "MI_Ds1",
                 "MI_Eb1"
@@ -145,6 +164,7 @@
         "0x7113": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_E_1",
+            "label": "E1",
             "aliases": [
                 "MI_E1"
             ]
@@ -152,6 +172,7 @@
         "0x7114": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_1",
+            "label": "F1",
             "aliases": [
                 "MI_F1"
             ]
@@ -159,6 +180,7 @@
         "0x7115": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_SHARP_1",
+            "label": "F♯1",
             "aliases": [
                 "MI_Fs1",
                 "MI_Gb1"
@@ -167,6 +189,7 @@
         "0x7116": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_1",
+            "label": "G1",
             "aliases": [
                 "MI_G1"
             ]
@@ -174,6 +197,7 @@
         "0x7117": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_SHARP_1",
+            "label": "G♯1",
             "aliases": [
                 "MI_Gs1",
                 "MI_Ab1"
@@ -182,6 +206,7 @@
         "0x7118": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_1",
+            "label": "A1",
             "aliases": [
                 "MI_A1"
             ]
@@ -189,6 +214,7 @@
         "0x7119": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_SHARP_1",
+            "label": "A♯1",
             "aliases": [
                 "MI_As1",
                 "MI_Bb1"
@@ -197,6 +223,7 @@
         "0x711A": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_B_1",
+            "label": "B1",
             "aliases": [
                 "MI_B1"
             ]
@@ -204,6 +231,7 @@
         "0x711B": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_2",
+            "label": "C2",
             "aliases": [
                 "MI_C2"
             ]
@@ -211,6 +239,7 @@
         "0x711C": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_SHARP_2",
+            "label": "C♯2",
             "aliases": [
                 "MI_Cs2",
                 "MI_Db2"
@@ -219,6 +248,7 @@
         "0x711D": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_2",
+            "label": "D2",
             "aliases": [
                 "MI_D2"
             ]
@@ -226,6 +256,7 @@
         "0x711E": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_SHARP_2",
+            "label": "D♯2",
             "aliases": [
                 "MI_Ds2",
                 "MI_Eb2"
@@ -234,6 +265,7 @@
         "0x711F": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_E_2",
+            "label": "E2",
             "aliases": [
                 "MI_E2"
             ]
@@ -241,6 +273,7 @@
         "0x7120": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_2",
+            "label": "F2",
             "aliases": [
                 "MI_F2"
             ]
@@ -248,6 +281,7 @@
         "0x7121": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_SHARP_2",
+            "label": "F♯2",
             "aliases": [
                 "MI_Fs2",
                 "MI_Gb2"
@@ -256,6 +290,7 @@
         "0x7122": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_2",
+            "label": "G2",
             "aliases": [
                 "MI_G2"
             ]
@@ -263,6 +298,7 @@
         "0x7123": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_SHARP_2",
+            "label": "G♯2",
             "aliases": [
                 "MI_Gs2",
                 "MI_Ab2"
@@ -271,6 +307,7 @@
         "0x7124": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_2",
+            "label": "A2",
             "aliases": [
                 "MI_A2"
             ]
@@ -278,6 +315,7 @@
         "0x7125": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_SHARP_2",
+            "label": "A♯2",
             "aliases": [
                 "MI_As2",
                 "MI_Bb2"
@@ -286,6 +324,7 @@
         "0x7126": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_B_2",
+            "label": "B2",
             "aliases": [
                 "MI_B2"
             ]
@@ -293,6 +332,7 @@
         "0x7127": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_3",
+            "label": "C3",
             "aliases": [
                 "MI_C3"
             ]
@@ -300,6 +340,7 @@
         "0x7128": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_SHARP_3",
+            "label": "C♯3",
             "aliases": [
                 "MI_Cs3",
                 "MI_Db3"
@@ -308,6 +349,7 @@
         "0x7129": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_3",
+            "label": "D3",
             "aliases": [
                 "MI_D3"
             ]
@@ -315,6 +357,7 @@
         "0x712A": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_SHARP_3",
+            "label": "D♯3",
             "aliases": [
                 "MI_Ds3",
                 "MI_Eb3"
@@ -323,6 +366,7 @@
         "0x712B": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_E_3",
+            "label": "E3",
             "aliases": [
                 "MI_E3"
             ]
@@ -330,6 +374,7 @@
         "0x712C": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_3",
+            "label": "F3",
             "aliases": [
                 "MI_F3"
             ]
@@ -337,6 +382,7 @@
         "0x712D": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_SHARP_3",
+            "label": "F♯3",
             "aliases": [
                 "MI_Fs3",
                 "MI_Gb3"
@@ -345,6 +391,7 @@
         "0x712E": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_3",
+            "label": "G3",
             "aliases": [
                 "MI_G3"
             ]
@@ -352,6 +399,7 @@
         "0x712F": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_SHARP_3",
+            "label": "G♯3",
             "aliases": [
                 "MI_Gs3",
                 "MI_Ab3"
@@ -360,6 +408,7 @@
         "0x7130": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_3",
+            "label": "A3",
             "aliases": [
                 "MI_A3"
             ]
@@ -367,6 +416,7 @@
         "0x7131": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_SHARP_3",
+            "label": "A♯3",
             "aliases": [
                 "MI_As3",
                 "MI_Bb3"
@@ -375,6 +425,7 @@
         "0x7132": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_B_3",
+            "label": "B3",
             "aliases": [
                 "MI_B3"
             ]
@@ -382,6 +433,7 @@
         "0x7133": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_4",
+            "label": "C4",
             "aliases": [
                 "MI_C4"
             ]
@@ -389,6 +441,7 @@
         "0x7134": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_SHARP_4",
+            "label": "C♯4",
             "aliases": [
                 "MI_Cs4",
                 "MI_Db4"
@@ -397,6 +450,7 @@
         "0x7135": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_4",
+            "label": "D4",
             "aliases": [
                 "MI_D4"
             ]
@@ -404,6 +458,7 @@
         "0x7136": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_SHARP_4",
+            "label": "D♯4",
             "aliases": [
                 "MI_Ds4",
                 "MI_Eb4"
@@ -412,6 +467,7 @@
         "0x7137": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_E_4",
+            "label": "E4",
             "aliases": [
                 "MI_E4"
             ]
@@ -419,6 +475,7 @@
         "0x7138": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_4",
+            "label": "F4",
             "aliases": [
                 "MI_F4"
             ]
@@ -426,6 +483,7 @@
         "0x7139": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_SHARP_4",
+            "label": "F♯4",
             "aliases": [
                 "MI_Fs4",
                 "MI_Gb4"
@@ -434,6 +492,7 @@
         "0x713A": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_4",
+            "label": "G4",
             "aliases": [
                 "MI_G4"
             ]
@@ -441,6 +500,7 @@
         "0x713B": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_SHARP_4",
+            "label": "G♯4",
             "aliases": [
                 "MI_Gs4",
                 "MI_Ab4"
@@ -449,6 +509,7 @@
         "0x713C": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_4",
+            "label": "A4",
             "aliases": [
                 "MI_A4"
             ]
@@ -456,6 +517,7 @@
         "0x713D": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_SHARP_4",
+            "label": "A♯4",
             "aliases": [
                 "MI_As4",
                 "MI_Bb4"
@@ -464,6 +526,7 @@
         "0x713E": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_B_4",
+            "label": "B4",
             "aliases": [
                 "MI_B4"
             ]
@@ -471,6 +534,7 @@
         "0x713F": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_5",
+            "label": "C5",
             "aliases": [
                 "MI_C5"
             ]
@@ -478,6 +542,7 @@
         "0x7140": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_C_SHARP_5",
+            "label": "C♯5",
             "aliases": [
                 "MI_Cs5",
                 "MI_Db5"
@@ -486,6 +551,7 @@
         "0x7141": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_5",
+            "label": "D5",
             "aliases": [
                 "MI_D5"
             ]
@@ -493,6 +559,7 @@
         "0x7142": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_D_SHARP_5",
+            "label": "D♯5",
             "aliases": [
                 "MI_Ds5",
                 "MI_Eb5"
@@ -501,6 +568,7 @@
         "0x7143": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_E_5",
+            "label": "E5",
             "aliases": [
                 "MI_E5"
             ]
@@ -508,6 +576,7 @@
         "0x7144": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_5",
+            "label": "F5",
             "aliases": [
                 "MI_F5"
             ]
@@ -515,6 +584,7 @@
         "0x7145": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_F_SHARP_5",
+            "label": "F♯5",
             "aliases": [
                 "MI_Fs5",
                 "MI_Gb5"
@@ -523,6 +593,7 @@
         "0x7146": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_5",
+            "label": "G5",
             "aliases": [
                 "MI_G5"
             ]
@@ -530,6 +601,7 @@
         "0x7147": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_G_SHARP_5",
+            "label": "G♯5",
             "aliases": [
                 "MI_Gs5",
                 "MI_Ab5"
@@ -538,6 +610,7 @@
         "0x7148": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_5",
+            "label": "A5",
             "aliases": [
                 "MI_A5"
             ]
@@ -545,6 +618,7 @@
         "0x7149": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_A_SHARP_5",
+            "label": "A♯5",
             "aliases": [
                 "MI_As5",
                 "MI_Bb5"
@@ -553,6 +627,7 @@
         "0x714A": {
             "group": "midi",
             "key": "QK_MIDI_NOTE_B_5",
+            "label": "B5",
             "aliases": [
                 "MI_B5"
             ]
@@ -560,6 +635,7 @@
         "0x714B": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_N2",
+            "label": "Octave -2",
             "aliases": [
                 "MI_OCN2"
             ]
@@ -567,6 +643,7 @@
         "0x714C": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_N1",
+            "label": "Octave -1",
             "aliases": [
                 "MI_OCN1"
             ]
@@ -574,6 +651,7 @@
         "0x714D": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_0",
+            "label": "Octave 0",
             "aliases": [
                 "MI_OC0"
             ]
@@ -581,6 +659,7 @@
         "0x714E": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_1",
+            "label": "Octave 1",
             "aliases": [
                 "MI_OC1"
             ]
@@ -588,6 +667,7 @@
         "0x714F": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_2",
+            "label": "Octave 2",
             "aliases": [
                 "MI_OC2"
             ]
@@ -595,6 +675,7 @@
         "0x7150": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_3",
+            "label": "Octave 3",
             "aliases": [
                 "MI_OC3"
             ]
@@ -602,6 +683,7 @@
         "0x7151": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_4",
+            "label": "Octave 4",
             "aliases": [
                 "MI_OC4"
             ]
@@ -609,6 +691,7 @@
         "0x7152": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_5",
+            "label": "Octave 5",
             "aliases": [
                 "MI_OC5"
             ]
@@ -616,6 +699,7 @@
         "0x7153": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_6",
+            "label": "Octave 6",
             "aliases": [
                 "MI_OC6"
             ]
@@ -623,6 +707,7 @@
         "0x7154": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_7",
+            "label": "Octave 7",
             "aliases": [
                 "MI_OC7"
             ]
@@ -630,6 +715,7 @@
         "0x7155": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_DOWN",
+            "label": "Octave Down",
             "aliases": [
                 "MI_OCTD"
             ]
@@ -637,6 +723,7 @@
         "0x7156": {
             "group": "midi",
             "key": "QK_MIDI_OCTAVE_UP",
+            "label": "Octave Up",
             "aliases": [
                 "MI_OCTU"
             ]
@@ -644,6 +731,7 @@
         "0x7157": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_N6",
+            "label": "Transpose -6",
             "aliases": [
                 "MI_TRN6"
             ]
@@ -651,6 +739,7 @@
         "0x7158": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_N5",
+            "label": "Transpose -5",
             "aliases": [
                 "MI_TRN5"
             ]
@@ -658,6 +747,7 @@
         "0x7159": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_N4",
+            "label": "Transpose -4",
             "aliases": [
                 "MI_TRN4"
             ]
@@ -665,6 +755,7 @@
         "0x715A": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_N3",
+            "label": "Transpose -3",
             "aliases": [
                 "MI_TRN3"
             ]
@@ -672,6 +763,7 @@
         "0x715B": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_N2",
+            "label": "Transpose -2",
             "aliases": [
                 "MI_TRN2"
             ]
@@ -679,6 +771,7 @@
         "0x715C": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_N1",
+            "label": "Transpose -1",
             "aliases": [
                 "MI_TRN1"
             ]
@@ -686,6 +779,7 @@
         "0x715D": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_0",
+            "label": "Transpose 0",
             "aliases": [
                 "MI_TR0"
             ]
@@ -693,6 +787,7 @@
         "0x715E": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_1",
+            "label": "Transpose +1",
             "aliases": [
                 "MI_TR1"
             ]
@@ -700,6 +795,7 @@
         "0x715F": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_2",
+            "label": "Transpose +2",
             "aliases": [
                 "MI_TR2"
             ]
@@ -707,6 +803,7 @@
         "0x7160": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_3",
+            "label": "Transpose +3",
             "aliases": [
                 "MI_TR3"
             ]
@@ -714,6 +811,7 @@
         "0x7161": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_4",
+            "label": "Transpose +4",
             "aliases": [
                 "MI_TR4"
             ]
@@ -721,6 +819,7 @@
         "0x7162": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_5",
+            "label": "Transpose +5",
             "aliases": [
                 "MI_TR5"
             ]
@@ -728,6 +827,7 @@
         "0x7163": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_6",
+            "label": "Transpose +6",
             "aliases": [
                 "MI_TR6"
             ]
@@ -735,6 +835,7 @@
         "0x7164": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_DOWN",
+            "label": "Transpose Down",
             "aliases": [
                 "MI_TRSD"
             ]
@@ -742,6 +843,7 @@
         "0x7165": {
             "group": "midi",
             "key": "QK_MIDI_TRANSPOSE_UP",
+            "label": "Transpose Up",
             "aliases": [
                 "MI_TRSU"
             ]
@@ -749,6 +851,7 @@
         "0x7166": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_0",
+            "label": "Velocity 0",
             "aliases": [
                 "MI_VL0"
             ]
@@ -756,6 +859,7 @@
         "0x7167": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_1",
+            "label": "Velocity 1",
             "aliases": [
                 "MI_VL1"
             ]
@@ -763,6 +867,7 @@
         "0x7168": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_2",
+            "label": "Velocity 2",
             "aliases": [
                 "MI_VL2"
             ]
@@ -770,6 +875,7 @@
         "0x7169": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_3",
+            "label": "Velocity 3",
             "aliases": [
                 "MI_VL3"
             ]
@@ -777,6 +883,7 @@
         "0x716A": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_4",
+            "label": "Velocity 4",
             "aliases": [
                 "MI_VL4"
             ]
@@ -784,6 +891,7 @@
         "0x716B": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_5",
+            "label": "Velocity 5",
             "aliases": [
                 "MI_VL5"
             ]
@@ -791,6 +899,7 @@
         "0x716C": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_6",
+            "label": "Velocity 6",
             "aliases": [
                 "MI_VL6"
             ]
@@ -798,6 +907,7 @@
         "0x716D": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_7",
+            "label": "Velocity 7",
             "aliases": [
                 "MI_VL7"
             ]
@@ -805,6 +915,7 @@
         "0x716E": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_8",
+            "label": "Velocity 8",
             "aliases": [
                 "MI_VL8"
             ]
@@ -812,6 +923,7 @@
         "0x716F": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_9",
+            "label": "Velocity 9",
             "aliases": [
                 "MI_VL9"
             ]
@@ -819,6 +931,7 @@
         "0x7170": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_10",
+            "label": "Velocity 10",
             "aliases": [
                 "MI_VL10"
             ]
@@ -826,6 +939,7 @@
         "0x7171": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_DOWN",
+            "label": "Velocity Down",
             "aliases": [
                 "MI_VELD"
             ]
@@ -833,6 +947,7 @@
         "0x7172": {
             "group": "midi",
             "key": "QK_MIDI_VELOCITY_UP",
+            "label": "Velocity Up",
             "aliases": [
                 "MI_VELU"
             ]
@@ -840,6 +955,7 @@
         "0x7173": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_1",
+            "label": "Channel 1",
             "aliases": [
                 "MI_CH1"
             ]
@@ -847,6 +963,7 @@
         "0x7174": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_2",
+            "label": "Channel 2",
             "aliases": [
                 "MI_CH2"
             ]
@@ -854,6 +971,7 @@
         "0x7175": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_3",
+            "label": "Channel 3",
             "aliases": [
                 "MI_CH3"
             ]
@@ -861,6 +979,7 @@
         "0x7176": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_4",
+            "label": "Channel 4",
             "aliases": [
                 "MI_CH4"
             ]
@@ -868,6 +987,7 @@
         "0x7177": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_5",
+            "label": "Channel 5",
             "aliases": [
                 "MI_CH5"
             ]
@@ -875,6 +995,7 @@
         "0x7178": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_6",
+            "label": "Channel 6",
             "aliases": [
                 "MI_CH6"
             ]
@@ -882,6 +1003,7 @@
         "0x7179": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_7",
+            "label": "Channel 7",
             "aliases": [
                 "MI_CH7"
             ]
@@ -889,6 +1011,7 @@
         "0x717A": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_8",
+            "label": "Channel 8",
             "aliases": [
                 "MI_CH8"
             ]
@@ -896,6 +1019,7 @@
         "0x717B": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_9",
+            "label": "Channel 9",
             "aliases": [
                 "MI_CH9"
             ]
@@ -903,6 +1027,7 @@
         "0x717C": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_10",
+            "label": "Channel 10",
             "aliases": [
                 "MI_CH10"
             ]
@@ -910,6 +1035,7 @@
         "0x717D": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_11",
+            "label": "Channel 11",
             "aliases": [
                 "MI_CH11"
             ]
@@ -917,6 +1043,7 @@
         "0x717E": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_12",
+            "label": "Channel 12",
             "aliases": [
                 "MI_CH12"
             ]
@@ -924,6 +1051,7 @@
         "0x717F": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_13",
+            "label": "Channel 13",
             "aliases": [
                 "MI_CH13"
             ]
@@ -931,6 +1059,7 @@
         "0x7180": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_14",
+            "label": "Channel 14",
             "aliases": [
                 "MI_CH14"
             ]
@@ -938,6 +1067,7 @@
         "0x7181": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_15",
+            "label": "Channel 15",
             "aliases": [
                 "MI_CH15"
             ]
@@ -945,6 +1075,7 @@
         "0x7182": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_16",
+            "label": "Channel 16",
             "aliases": [
                 "MI_CH16"
             ]
@@ -952,6 +1083,7 @@
         "0x7183": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_DOWN",
+            "label": "Channel Down",
             "aliases": [
                 "MI_CHND"
             ]
@@ -959,6 +1091,7 @@
         "0x7184": {
             "group": "midi",
             "key": "QK_MIDI_CHANNEL_UP",
+            "label": "Channel Up",
             "aliases": [
                 "MI_CHNU"
             ]
@@ -966,6 +1099,7 @@
         "0x7185": {
             "group": "midi",
             "key": "QK_MIDI_ALL_NOTES_OFF",
+            "label": "All Notes Off",
             "aliases": [
                 "MI_AOFF"
             ]
@@ -973,6 +1107,7 @@
         "0x7186": {
             "group": "midi",
             "key": "QK_MIDI_SUSTAIN",
+            "label": "Sustain",
             "aliases": [
                 "MI_SUST"
             ]
@@ -980,6 +1115,7 @@
         "0x7187": {
             "group": "midi",
             "key": "QK_MIDI_PORTAMENTO",
+            "label": "Portamento",
             "aliases": [
                 "MI_PORT"
             ]
@@ -987,6 +1123,7 @@
         "0x7188": {
             "group": "midi",
             "key": "QK_MIDI_SOSTENUTO",
+            "label": "Sostenuto",
             "aliases": [
                 "MI_SOST"
             ]
@@ -994,6 +1131,7 @@
         "0x7189": {
             "group": "midi",
             "key": "QK_MIDI_SOFT",
+            "label": "Soft Pedal",
             "aliases": [
                 "MI_SOFT"
             ]
@@ -1001,6 +1139,7 @@
         "0x718A": {
             "group": "midi",
             "key": "QK_MIDI_LEGATO",
+            "label": "Legato",
             "aliases": [
                 "MI_LEG"
             ]
@@ -1008,6 +1147,7 @@
         "0x718B": {
             "group": "midi",
             "key": "QK_MIDI_MODULATION",
+            "label": "Modulation",
             "aliases": [
                 "MI_MOD"
             ]
@@ -1015,6 +1155,7 @@
         "0x718C": {
             "group": "midi",
             "key": "QK_MIDI_MODULATION_SPEED_DOWN",
+            "label": "Modulation Speed Down",
             "aliases": [
                 "MI_MODD"
             ]
@@ -1022,6 +1163,7 @@
         "0x718D": {
             "group": "midi",
             "key": "QK_MIDI_MODULATION_SPEED_UP",
+            "label": "Modulation Speed Up",
             "aliases": [
                 "MI_MODU"
             ]
@@ -1029,6 +1171,7 @@
         "0x718E": {
             "group": "midi",
             "key": "QK_MIDI_PITCH_BEND_DOWN",
+            "label": "Pitch Bend Down",
             "aliases": [
                 "MI_BNDD"
             ]
@@ -1036,6 +1179,7 @@
         "0x718F": {
             "group": "midi",
             "key": "QK_MIDI_PITCH_BEND_UP",
+            "label": "Pitch Bend Up",
             "aliases": [
                 "MI_BNDU"
             ]

--- a/data/constants/keycodes/keycodes_0.0.2_quantum.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_quantum.hjson
@@ -3,6 +3,7 @@
         "0x7C77": {
             "group": "quantum",
             "key": "QK_TRI_LAYER_LOWER",
+            "label": "Lower",
             "aliases": [
                 "TL_LOWR"
             ]
@@ -10,6 +11,7 @@
         "0x7C78": {
             "group": "quantum",
             "key": "QK_TRI_LAYER_UPPER",
+            "label": "Upper",
             "aliases": [
                 "TL_UPPR"
             ]

--- a/data/constants/keycodes/keycodes_0.0.2_sequencer.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_sequencer.hjson
@@ -5,6 +5,7 @@
         "0x7200": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_ON",
+            "label": "Sequencer On",
             "aliases": [
                 "SQ_ON"
             ]
@@ -12,6 +13,7 @@
         "0x7201": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_OFF",
+            "label": "Sequencer Off",
             "aliases": [
                 "SQ_OFF"
             ]
@@ -19,6 +21,7 @@
         "0x7202": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_TOGGLE",
+            "label": "Toggle Sequencer",
             "aliases": [
                 "SQ_TOGG"
             ]
@@ -26,6 +29,7 @@
         "0x7203": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_TEMPO_DOWN",
+            "label": "Tempo Down",
             "aliases": [
                 "SQ_TMPD"
             ]
@@ -33,6 +37,7 @@
         "0x7204": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_TEMPO_UP",
+            "label": "Tempo Up",
             "aliases": [
                 "SQ_TMPU"
             ]
@@ -40,6 +45,7 @@
         "0x7205": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_RESOLUTION_DOWN",
+            "label": "Resolution Down",
             "aliases": [
                 "SQ_RESD"
             ]
@@ -47,6 +53,7 @@
         "0x7206": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_RESOLUTION_UP",
+            "label": "Resolution Up",
             "aliases": [
                 "SQ_RESU"
             ]
@@ -54,6 +61,7 @@
         "0x7207": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_STEPS_ALL",
+            "label": "All Steps",
             "aliases": [
                 "SQ_SALL"
             ]
@@ -61,6 +69,7 @@
         "0x7208": {
             "group": "sequencer",
             "key": "QK_SEQUENCER_STEPS_CLEAR",
+            "label": "Clear Steps",
             "aliases": [
                 "SQ_SCLR"
             ]

--- a/data/constants/keycodes/keycodes_0.0.2_swap_hands.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_swap_hands.hjson
@@ -3,6 +3,7 @@
         "0x56F0": {
             "group": "swap_hands",
             "key": "QK_SWAP_HANDS_TOGGLE",
+            "label": "Toggle Swap Hands",
             "aliases": [
                 "SH_TOGG"
             ]
@@ -10,6 +11,7 @@
         "0x56F1": {
             "group": "swap_hands",
             "key": "QK_SWAP_HANDS_TAP_TOGGLE",
+            "label": "Swap Hands Tap Toggle",
             "aliases": [
                 "SH_TT"
             ]
@@ -17,6 +19,7 @@
         "0x56F2": {
             "group": "swap_hands",
             "key": "QK_SWAP_HANDS_MOMENTARY_ON",
+            "label": "Swap Hands Momentary On",
             "aliases": [
                 "SH_MON"
             ]
@@ -24,6 +27,7 @@
         "0x56F3": {
             "group": "swap_hands",
             "key": "QK_SWAP_HANDS_MOMENTARY_OFF",
+            "label": "Swap Hands Momentary Off",
             "aliases": [
                 "SH_MOFF"
             ]
@@ -31,6 +35,7 @@
         "0x56F4": {
             "group": "swap_hands",
             "key": "QK_SWAP_HANDS_OFF",
+            "label": "Unswap Hands",
             "aliases": [
                 "SH_OFF"
             ]
@@ -38,6 +43,7 @@
         "0x56F5": {
             "group": "swap_hands",
             "key": "QK_SWAP_HANDS_ON",
+            "label": "Swap Hands",
             "aliases": [
                 "SH_ON"
             ]
@@ -45,6 +51,7 @@
         "0x56F6": {
             "group": "swap_hands",
             "key": "QK_SWAP_HANDS_ONE_SHOT",
+            "label": "Swap Hands One Shot",
             "aliases": [
                 "SH_OS"
             ]

--- a/data/constants/keycodes/keycodes_0.0.2_user.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_user.hjson
@@ -2,131 +2,163 @@
     "keycodes": {
         "0x7E40": {
             "group": "user",
-            "key": "QK_USER_0"
+            "key": "QK_USER_0",
+            "label": "User 0"
         },
         "0x7E41": {
             "group": "user",
-            "key": "QK_USER_1"
+            "key": "QK_USER_1",
+            "label": "User 1"
         },
         "0x7E42": {
             "group": "user",
-            "key": "QK_USER_2"
+            "key": "QK_USER_2",
+            "label": "User 2"
         },
         "0x7E43": {
             "group": "user",
-            "key": "QK_USER_3"
+            "key": "QK_USER_3",
+            "label": "User 3"
         },
         "0x7E44": {
             "group": "user",
-            "key": "QK_USER_4"
+            "key": "QK_USER_4",
+            "label": "User 4"
         },
         "0x7E45": {
             "group": "user",
-            "key": "QK_USER_5"
+            "key": "QK_USER_5",
+            "label": "User 5"
         },
         "0x7E46": {
             "group": "user",
-            "key": "QK_USER_6"
+            "key": "QK_USER_6",
+            "label": "User 6"
         },
         "0x7E47": {
             "group": "user",
-            "key": "QK_USER_7"
+            "key": "QK_USER_7",
+            "label": "User 7"
         },
         "0x7E48": {
             "group": "user",
-            "key": "QK_USER_8"
+            "key": "QK_USER_8",
+            "label": "User 8"
         },
         "0x7E49": {
             "group": "user",
-            "key": "QK_USER_9"
+            "key": "QK_USER_9",
+            "label": "User 9"
         },
         "0x7E4A": {
             "group": "user",
-            "key": "QK_USER_10"
+            "key": "QK_USER_10",
+            "label": "User 10"
         },
         "0x7E4B": {
             "group": "user",
-            "key": "QK_USER_11"
+            "key": "QK_USER_11",
+            "label": "User 11"
         },
         "0x7E4C": {
             "group": "user",
-            "key": "QK_USER_12"
+            "key": "QK_USER_12",
+            "label": "User 12"
         },
         "0x7E4D": {
             "group": "user",
-            "key": "QK_USER_13"
+            "key": "QK_USER_13",
+            "label": "User 13"
         },
         "0x7E4E": {
             "group": "user",
-            "key": "QK_USER_14"
+            "key": "QK_USER_14",
+            "label": "User 14"
         },
         "0x7E4F": {
             "group": "user",
-            "key": "QK_USER_15"
+            "key": "QK_USER_15",
+            "label": "User 15"
         },
         "0x7E50": {
             "group": "user",
-            "key": "QK_USER_16"
+            "key": "QK_USER_16",
+            "label": "User 16"
         },
         "0x7E51": {
             "group": "user",
-            "key": "QK_USER_17"
+            "key": "QK_USER_17",
+            "label": "User 17"
         },
          "0x7E52": {
             "group": "user",
-            "key": "QK_USER_18"
+            "key": "QK_USER_18",
+            "label": "User 18"
         },
         "0x7E53": {
             "group": "user",
-            "key": "QK_USER_19"
+            "key": "QK_USER_19",
+            "label": "User 19"
         },
         "0x7E54": {
             "group": "user",
-            "key": "QK_USER_20"
+            "key": "QK_USER_20",
+            "label": "User 20"
         },
         "0x7E55": {
             "group": "user",
-            "key": "QK_USER_21"
+            "key": "QK_USER_21",
+            "label": "User 21"
         },
         "0x7E56": {
             "group": "user",
-            "key": "QK_USER_22"
+            "key": "QK_USER_22",
+            "label": "User 22"
         },
         "0x7E57": {
             "group": "user",
-            "key": "QK_USER_23"
+            "key": "QK_USER_23",
+            "label": "User 23"
         },
         "0x7E58": {
             "group": "user",
-            "key": "QK_USER_24"
+            "key": "QK_USER_24",
+            "label": "User 24"
         },
         "0x7E59": {
             "group": "user",
-            "key": "QK_USER_25"
+            "key": "QK_USER_25",
+            "label": "User 25"
         },
         "0x7E5A": {
             "group": "user",
-            "key": "QK_USER_26"
+            "key": "QK_USER_26",
+            "label": "User 26"
         },
         "0x7E5B": {
             "group": "user",
-            "key": "QK_USER_27"
+            "key": "QK_USER_27",
+            "label": "User 27"
         },
         "0x7E5C": {
             "group": "user",
-            "key": "QK_USER_28"
+            "key": "QK_USER_28",
+            "label": "User 28"
         },
         "0x7E5D": {
             "group": "user",
-            "key": "QK_USER_29"
+            "key": "QK_USER_29",
+            "label": "User 29"
         },
         "0x7E5E": {
             "group": "user",
-            "key": "QK_USER_30"
+            "key": "QK_USER_30",
+            "label": "User 30"
         },
         "0x7E5F": {
             "group": "user",
-            "key": "QK_USER_31"
+            "key": "QK_USER_31",
+            "label": "User 31"
         }
     }
 }

--- a/data/constants/keycodes/keycodes_0.0.3_quantum.hjson
+++ b/data/constants/keycodes/keycodes_0.0.3_quantum.hjson
@@ -3,6 +3,7 @@
        "0x7C79": {
             "group": "quantum",
             "key": "QK_REPEAT_KEY",
+            "label": "Repeat",
             "aliases": [
                 "QK_REP"
             ]
@@ -10,6 +11,7 @@
         "0x7C7A": {
             "group": "quantum",
             "key": "QK_ALT_REPEAT_KEY",
+            "label": "Repeat Alternate",
             "aliases": [
                 "QK_AREP"
             ]

--- a/data/constants/keycodes/keycodes_0.0.4_lighting.hjson
+++ b/data/constants/keycodes/keycodes_0.0.4_lighting.hjson
@@ -3,6 +3,7 @@
         "0x7810": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_ON",
+            "label": "LED Matrix On",
             "aliases": [
                 "LM_ON"
             ]
@@ -10,6 +11,7 @@
         "0x7811": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_OFF",
+            "label": "LED Matrix Off",
             "aliases": [
                 "LM_OFF"
             ]
@@ -17,6 +19,7 @@
         "0x7812": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_TOGGLE",
+            "label": "Toggle LED Matrix",
             "aliases": [
                 "LM_TOGG"
             ]
@@ -24,6 +27,7 @@
         "0x7813": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_MODE_NEXT",
+            "label": "LED Matrix Next",
             "aliases": [
                 "LM_NEXT"
             ]
@@ -31,6 +35,7 @@
         "0x7814": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_MODE_PREVIOUS",
+            "label": "LED Matrix Previous",
             "aliases": [
                 "LM_PREV"
             ]
@@ -38,6 +43,7 @@
         "0x7815": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_BRIGHTNESS_UP",
+            "label": "LED Matrix Brightness Up",
             "aliases": [
                 "LM_BRIU"
             ]
@@ -45,6 +51,7 @@
         "0x7816": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_BRIGHTNESS_DOWN",
+            "label": "LED Matrix Brightness Down",
             "aliases": [
                 "LM_BRID"
             ]
@@ -52,6 +59,7 @@
         "0x7817": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_SPEED_UP",
+            "label": "LED Matrix Speed Up",
             "aliases": [
                 "LM_SPDU"
             ]
@@ -59,6 +67,7 @@
         "0x7818": {
             "group": "led_matrix",
             "key": "QK_LED_MATRIX_SPEED_DOWN",
+            "label": "LED Matrix Speed Down",
             "aliases": [
                 "LM_SPDD"
             ]
@@ -67,6 +76,7 @@
         "0x7820": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_TOGGLE",
+            "label": "Toggle RGB Underglow",
             "aliases": [
                 "UG_TOGG"
             ]
@@ -74,6 +84,7 @@
         "0x7821": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_MODE_NEXT",
+            "label": "RGB Underglow Next",
             "aliases": [
                 "!reset!",
                 "UG_NEXT"
@@ -82,6 +93,7 @@
         "0x7822": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_MODE_PREVIOUS",
+            "label": "RGB Underglow Previous",
             "aliases": [
                 "!reset!",
                 "UG_PREV"
@@ -90,6 +102,7 @@
         "0x7823": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_HUE_UP",
+            "label": "RGB Underglow Hue Up",
             "aliases": [
                 "UG_HUEU"
             ]
@@ -97,6 +110,7 @@
         "0x7824": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_HUE_DOWN",
+            "label": "RGB Underglow Hue Down",
             "aliases": [
                 "UG_HUED"
             ]
@@ -104,6 +118,7 @@
         "0x7825": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_SATURATION_UP",
+            "label": "RGB Underglow Saturation Up",
             "aliases": [
                 "UG_SATU"
             ]
@@ -111,6 +126,7 @@
         "0x7826": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_SATURATION_DOWN",
+            "label": "RGB Underglow Saturation Down",
             "aliases": [
                 "UG_SATD"
             ]
@@ -118,6 +134,7 @@
         "0x7827": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_VALUE_UP",
+            "label": "RGB Underglow Value Up",
             "aliases": [
                 "UG_VALU"
             ]
@@ -125,6 +142,7 @@
         "0x7828": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_VALUE_DOWN",
+            "label": "RGB Underglow Value Down",
             "aliases": [
                 "UG_VALD"
             ]
@@ -132,6 +150,7 @@
         "0x7829": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_SPEED_UP",
+            "label": "RGB Underglow Speed Up",
             "aliases": [
                 "UG_SPDU"
             ]
@@ -139,6 +158,7 @@
         "0x782A": {
             "group": "underglow",
             "key": "QK_UNDERGLOW_SPEED_DOWN",
+            "label": "RGB Underglow Speed Down",
             "aliases": [
                 "UG_SPDD"
             ]
@@ -147,6 +167,7 @@
         "0x7840": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_ON",
+            "label": "RGB Matrix On",
             "aliases": [
                 "RM_ON"
             ]
@@ -154,6 +175,7 @@
         "0x7841": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_OFF",
+            "label": "RGB Matrix Off"
             "aliases": [
                 "RM_OFF"
             ]
@@ -161,6 +183,7 @@
         "0x7842": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_TOGGLE",
+            "label": "Toggle RGB Matrix",
             "aliases": [
                 "RM_TOGG"
             ]
@@ -168,6 +191,7 @@
         "0x7843": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_MODE_NEXT",
+            "label": "RGB Matrix Next",
             "aliases": [
                 "RM_NEXT"
             ]
@@ -175,6 +199,7 @@
         "0x7844": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_MODE_PREVIOUS",
+            "label": "RGB Matrix Previous",
             "aliases": [
                 "RM_PREV"
             ]
@@ -182,6 +207,7 @@
         "0x7845": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_HUE_UP",
+            "label": "RGB Matrix Hue Up",
             "aliases": [
                 "RM_HUEU"
             ]
@@ -189,6 +215,7 @@
         "0x7846": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_HUE_DOWN",
+            "label": "RGB Matrix Hue Down",
             "aliases": [
                 "RM_HUED"
             ]
@@ -196,6 +223,7 @@
         "0x7847": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_SATURATION_UP",
+            "label": "RGB Matrix Saturation Up",
             "aliases": [
                 "RM_SATU"
             ]
@@ -203,6 +231,7 @@
         "0x7848": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_SATURATION_DOWN",
+            "label": "RGB Matrix Saturation Down",
             "aliases": [
                 "RM_SATD"
             ]
@@ -210,6 +239,7 @@
         "0x7849": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_VALUE_UP",
+            "label": "RGB Matrix Value Up",
             "aliases": [
                 "RM_VALU"
             ]
@@ -217,6 +247,7 @@
         "0x784A": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_VALUE_DOWN",
+            "label": "RGB Matrix Value Down",
             "aliases": [
                 "RM_VALD"
             ]
@@ -224,6 +255,7 @@
         "0x784B": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_SPEED_UP",
+            "label": "RGB Matrix Speed Up",
             "aliases": [
                 "RM_SPDU"
             ]
@@ -231,6 +263,7 @@
         "0x784C": {
             "group": "rgb_matrix",
             "key": "QK_RGB_MATRIX_SPEED_DOWN",
+            "label": "RGB Matrix Speed Down",
             "aliases": [
                 "RM_SPDD"
             ]

--- a/data/constants/keycodes/keycodes_0.0.5_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.5_basic.hjson
@@ -3,7 +3,7 @@
         "0x00CD": {
             "group": "mouse",
             "key": "QK_MOUSE_CURSOR_UP",
-            "label": "Mouse cursor up",
+            "label": "Mouse Up",
             "aliases": [
                 "!reset!",
                 "MS_UP"
@@ -12,7 +12,7 @@
         "0x00CE": {
             "group": "mouse",
             "key": "QK_MOUSE_CURSOR_DOWN",
-            "label": "Mouse cursor down",
+            "label": "Mouse Down",
             "aliases": [
                 "!reset!",
                 "MS_DOWN"
@@ -21,7 +21,7 @@
         "0x00CF": {
             "group": "mouse",
             "key": "QK_MOUSE_CURSOR_LEFT",
-            "label": "Mouse cursor left",
+            "label": "Mouse Left",
             "aliases": [
                 "!reset!",
                 "MS_LEFT"
@@ -30,7 +30,7 @@
         "0x00D0": {
             "group": "mouse",
             "key": "QK_MOUSE_CURSOR_RIGHT",
-            "label": "Mouse cursor right",
+            "label": "Mouse Right",
             "aliases": [
                 "!reset!",
                 "MS_RGHT"
@@ -39,7 +39,7 @@
         "0x00D1": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_1",
-            "label": "Mouse button 1",
+            "label": "Mouse Button 1",
             "aliases": [
                 "!reset!",
                 "MS_BTN1"
@@ -48,7 +48,7 @@
         "0x00D2": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_2",
-            "label": "Mouse button 2",
+            "label": "Mouse Button 2",
             "aliases": [
                 "!reset!",
                 "MS_BTN2"
@@ -57,7 +57,7 @@
         "0x00D3": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_3",
-            "label": "Mouse button 3",
+            "label": "Mouse Button 3",
             "aliases": [
                 "!reset!",
                 "MS_BTN3"
@@ -66,7 +66,7 @@
         "0x00D4": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_4",
-            "label": "Mouse button 4",
+            "label": "Mouse Button 4",
             "aliases": [
                 "!reset!",
                 "MS_BTN4"
@@ -75,7 +75,7 @@
         "0x00D5": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_5",
-            "label": "Mouse button 5",
+            "label": "Mouse Button 5",
             "aliases": [
                 "!reset!",
                 "MS_BTN5"
@@ -84,7 +84,7 @@
         "0x00D6": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_6",
-            "label": "Mouse button 6",
+            "label": "Mouse Button 6",
             "aliases": [
                 "!reset!",
                 "MS_BTN6"
@@ -93,7 +93,7 @@
         "0x00D7": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_7",
-            "label": "Mouse button 7",
+            "label": "Mouse Button 7",
             "aliases": [
                 "!reset!",
                 "MS_BTN7"
@@ -102,7 +102,7 @@
         "0x00D8": {
             "group": "mouse",
             "key": "QK_MOUSE_BUTTON_8",
-            "label": "Mouse button 8",
+            "label": "Mouse Button 8",
             "aliases": [
                 "!reset!",
                 "MS_BTN8"
@@ -111,7 +111,7 @@
         "0x00D9": {
             "group": "mouse",
             "key": "QK_MOUSE_WHEEL_UP",
-            "label": "Mouse wheel up",
+            "label": "Mouse Wheel Up",
             "aliases": [
                 "!reset!",
                 "MS_WHLU"
@@ -120,7 +120,7 @@
         "0x00DA": {
             "group": "mouse",
             "key": "QK_MOUSE_WHEEL_DOWN",
-            "label": "Mouse wheel down",
+            "label": "Mouse Wheel Down",
             "aliases": [
                 "!reset!",
                 "MS_WHLD"
@@ -129,7 +129,7 @@
         "0x00DB": {
             "group": "mouse",
             "key": "QK_MOUSE_WHEEL_LEFT",
-            "label": "Mouse wheel left",
+            "label": "Mouse Wheel Left",
             "aliases": [
                 "!reset!",
                 "MS_WHLL"
@@ -138,7 +138,7 @@
         "0x00DC": {
             "group": "mouse",
             "key": "QK_MOUSE_WHEEL_RIGHT",
-            "label": "Mouse wheel right",
+            "label": "Mouse Wheel Right",
             "aliases": [
                 "!reset!",
                 "MS_WHLR"
@@ -147,7 +147,7 @@
         "0x00DD": {
             "group": "mouse",
             "key": "QK_MOUSE_ACCELERATION_0",
-            "label": "Set mouse acceleration to 0",
+            "label": "Acceleration 0",
             "aliases": [
                 "!reset!",
                 "MS_ACL0"
@@ -156,7 +156,7 @@
         "0x00DE": {
             "group": "mouse",
             "key": "QK_MOUSE_ACCELERATION_1",
-            "label": "Set mouse acceleration to 1",
+            "label": "Acceleration 1",
             "aliases": [
                 "!reset!",
                 "MS_ACL1"
@@ -165,7 +165,7 @@
         "0x00DF": {
             "group": "mouse",
             "key": "QK_MOUSE_ACCELERATION_2",
-            "label": "Set mouse acceleration to 2",
+            "label": "Acceleration 2",
             "aliases": [
                 "!reset!",
                 "MS_ACL2"

--- a/data/constants/keycodes/keycodes_0.0.6_connection.hjson
+++ b/data/constants/keycodes/keycodes_0.0.6_connection.hjson
@@ -8,6 +8,7 @@
         "0x7780": {
             "group": "connection",
             "key": "QK_OUTPUT_AUTO",
+            "label": "Output Auto",
             "aliases": [
                 "OU_AUTO"
             ]
@@ -15,6 +16,7 @@
         "0x7781": {
             "group": "connection",
             "key": "QK_OUTPUT_NEXT",
+            "label": "Next Output",
             "aliases": [
                 "OU_NEXT"
             ]
@@ -22,6 +24,7 @@
         "0x7782": {
             "group": "connection",
             "key": "QK_OUTPUT_PREV",
+            "label": "Previous Output",
             "aliases": [
                 "OU_PREV"
             ]
@@ -29,6 +32,7 @@
         "0x7783": {
             "group": "connection",
             "key": "QK_OUTPUT_NONE",
+            "label": "None",
             "aliases": [
                 "OU_NONE"
             ]
@@ -36,6 +40,7 @@
         "0x7784": {
             "group": "connection",
             "key": "QK_OUTPUT_USB",
+            "label": "USB",
             "aliases": [
                 "OU_USB"
             ]
@@ -43,6 +48,7 @@
         "0x7785": {
             "group": "connection",
             "key": "QK_OUTPUT_2P4GHZ",
+            "label": "2.4GHz",
             "aliases": [
                 "OU_2P4G"
             ]
@@ -50,6 +56,7 @@
         "0x7786": {
             "group": "connection",
             "key": "QK_OUTPUT_BLUETOOTH",
+            "label": "Bluetooth",
             "aliases": [
                 "OU_BT"
             ]
@@ -58,6 +65,7 @@
         "0x7790": {
             "group": "connection",
             "key": "QK_BLUETOOTH_PROFILE_NEXT",
+            "label": "Bluetooth Profile Next",
             "aliases": [
                 "BT_NEXT"
             ]
@@ -65,6 +73,7 @@
         "0x7791": {
             "group": "connection",
             "key": "QK_BLUETOOTH_PROFILE_PREV",
+            "label": "Bluetooth Profile Previous",
             "aliases": [
                 "BT_PREV"
             ]
@@ -72,6 +81,7 @@
         "0x7792": {
             "group": "connection",
             "key": "QK_BLUETOOTH_UNPAIR",
+            "label": "Unpair",
             "aliases": [
                 "BT_UNPR"
             ]
@@ -79,6 +89,7 @@
         "0x7793": {
             "group": "connection",
             "key": "QK_BLUETOOTH_PROFILE1",
+            "label": "Bluetooth Profile 1",
             "aliases": [
                 "BT_PRF1"
             ]
@@ -86,6 +97,7 @@
         "0x7794": {
             "group": "connection",
             "key": "QK_BLUETOOTH_PROFILE2",
+            "label": "Bluetooth Profile 2",
             "aliases": [
                 "BT_PRF2"
             ]
@@ -93,6 +105,7 @@
         "0x7795": {
             "group": "connection",
             "key": "QK_BLUETOOTH_PROFILE3",
+            "label": "Bluetooth Profile 3",
             "aliases": [
                 "BT_PRF3"
             ]
@@ -100,6 +113,7 @@
         "0x7796": {
             "group": "connection",
             "key": "QK_BLUETOOTH_PROFILE4",
+            "label": "Bluetooth Profile 4",
             "aliases": [
                 "BT_PRF4"
             ]
@@ -107,6 +121,7 @@
         "0x7797": {
             "group": "connection",
             "key": "QK_BLUETOOTH_PROFILE5",
+            "label": "Bluetooth Profile 5",
             "aliases": [
                 "BT_PRF5"
             ]

--- a/data/constants/keycodes/keycodes_0.0.6_quantum.hjson
+++ b/data/constants/keycodes/keycodes_0.0.6_quantum.hjson
@@ -6,6 +6,7 @@
         "0x7C7B": {
             "group": "quantum",
             "key": "QK_LAYER_LOCK",
+            "label": "Layer Lock",
             "aliases": [
                 "QK_LLCK"
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

With a view to perhaps being able to generate keycode tables for docs at some point in the future. Also motivated by the lack of descriptions in the Configurator keycode picker for alphanumerics due to the way the language aliases are implemented there; these changes don't really help with that but it's just something I noticed along the way.

As far as I can tell the `label` property isn't currently used for anything so it should be fine to change the existing ones. I'm guessing these are roughly meant to be used as legends when rendering keymaps so I tried to keep them short - the idea being to next add a `description` property to the schema, containing what the keycode tables currently have under the Description columns.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
