### PR TITLE
Replace debounce malloc+loop with calloc

### DIFF
--- a/quantum/debounce/asym_eager_defer_pk.c
+++ b/quantum/debounce/asym_eager_defer_pk.c
@@ -64,13 +64,7 @@ static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], ui
 
 // we use num_rows rather than MATRIX_ROWS to support split keyboards
 void debounce_init(uint8_t num_rows) {
-    debounce_counters = malloc(num_rows * MATRIX_COLS * sizeof(debounce_counter_t));
-    int i             = 0;
-    for (uint8_t r = 0; r < num_rows; r++) {
-        for (uint8_t c = 0; c < MATRIX_COLS; c++) {
-            debounce_counters[i++].time = DEBOUNCE_ELAPSED;
-        }
-    }
+    debounce_counters = calloc(num_rows * MATRIX_COLS, sizeof(debounce_counter_t));
 }
 
 void debounce_free(void) {

--- a/quantum/debounce/sym_defer_pk.c
+++ b/quantum/debounce/sym_defer_pk.c
@@ -56,13 +56,7 @@ static void start_debounce_counters(matrix_row_t raw[], matrix_row_t cooked[], u
 
 // we use num_rows rather than MATRIX_ROWS to support split keyboards
 void debounce_init(uint8_t num_rows) {
-    debounce_counters = (debounce_counter_t *)malloc(num_rows * MATRIX_COLS * sizeof(debounce_counter_t));
-    int i             = 0;
-    for (uint8_t r = 0; r < num_rows; r++) {
-        for (uint8_t c = 0; c < MATRIX_COLS; c++) {
-            debounce_counters[i++] = DEBOUNCE_ELAPSED;
-        }
-    }
+    debounce_counters = calloc(num_rows * MATRIX_COLS, sizeof(debounce_counter_t));
 }
 
 void debounce_free(void) {

--- a/quantum/debounce/sym_defer_pr.c
+++ b/quantum/debounce/sym_defer_pr.c
@@ -34,8 +34,7 @@ static matrix_row_t* last_raw;
 void debounce_init(uint8_t num_rows) {
     countdowns = (uint8_t*)calloc(num_rows, sizeof(uint8_t));
     last_raw   = (matrix_row_t*)calloc(num_rows, sizeof(matrix_row_t));
-
-    last_time = timer_read();
+    last_time  = timer_read();
 }
 
 void debounce_free(void) {

--- a/quantum/debounce/sym_eager_pk.c
+++ b/quantum/debounce/sym_eager_pk.c
@@ -57,13 +57,7 @@ static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], ui
 
 // we use num_rows rather than MATRIX_ROWS to support split keyboards
 void debounce_init(uint8_t num_rows) {
-    debounce_counters = (debounce_counter_t *)malloc(num_rows * MATRIX_COLS * sizeof(debounce_counter_t));
-    int i             = 0;
-    for (uint8_t r = 0; r < num_rows; r++) {
-        for (uint8_t c = 0; c < MATRIX_COLS; c++) {
-            debounce_counters[i++] = DEBOUNCE_ELAPSED;
-        }
-    }
+    debounce_counters = calloc(num_rows * MATRIX_COLS, sizeof(debounce_counter_t));
 }
 
 void debounce_free(void) {

--- a/quantum/debounce/sym_eager_pr.c
+++ b/quantum/debounce/sym_eager_pr.c
@@ -56,10 +56,7 @@ static void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], ui
 
 // we use num_rows rather than MATRIX_ROWS to support split keyboards
 void debounce_init(uint8_t num_rows) {
-    debounce_counters = (debounce_counter_t *)malloc(num_rows * sizeof(debounce_counter_t));
-    for (uint8_t r = 0; r < num_rows; r++) {
-        debounce_counters[r] = DEBOUNCE_ELAPSED;
-    }
+    debounce_counters = calloc(num_rows, sizeof(debounce_counter_t));
 }
 
 void debounce_free(void) {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Replace malloc() with calloc() to eliminate zero-initialisation loops
* Minor code spacing edit

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
