### PR TITLE
Guard remapping logic with MAGIC_ENABLE

### DIFF
--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -24,6 +24,7 @@ keymap_config_t keymap_config;
  * and will return the corrected keycode, when appropriate.
  */
 __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
+#ifdef MAGIC_ENABLE
     switch (keycode) {
         case KC_CAPS_LOCK:
         case KC_LOCKING_CAPS_LOCK:
@@ -115,6 +116,9 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
         default:
             return keycode;
     }
+#else
+    return keycode;
+#endif // MAGIC_ENABLE
 }
 
 /** \brief mod_config
@@ -124,6 +128,7 @@ __attribute__((weak)) uint16_t keycode_config(uint16_t keycode) {
  */
 
 __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
+#ifdef MAGIC_ENABLE
     /**
      * Note: This function is for the 5-bit packed mods, NOT the full 8-bit mods.
      * More info about the mods can be seen in modifiers.h.
@@ -161,5 +166,6 @@ __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
         mod &= ~MOD_RGUI;
     }
 
+#endif // MAGIC_ENABLE
     return mod;
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* Only perform key and mod remapping in keycode_config() and mod_config() when MAGIC_ENABLE is defined.
* If not set, these functions now return the original keycode or modifier unchanged.
* Reduces firmware size, and unnecessary code when MAGIC_ENABLE is not enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
