### PR TITLE
Update rgb x coordinate of rightmost column

### DIFF
--- a/keyboards/boardsource/unicorne/keyboard.json
+++ b/keyboards/boardsource/unicorne/keyboard.json
@@ -118,9 +118,9 @@
             {"matrix": [6, 1], "x": 208, "y": 42, "flags": 4},
             {"matrix": [5, 1], "x": 208, "y": 24, "flags": 4},
             {"matrix": [4, 1], "x": 208, "y": 7, "flags": 4},
-            {"matrix": [4, 0], "x": 0, "y": 7, "flags": 1},
-            {"matrix": [5, 0], "x": 0, "y": 24, "flags": 1},
-            {"matrix": [6, 0], "x": 0, "y": 41, "flags": 1}
+            {"matrix": [4, 0], "x": 223, "y": 7, "flags": 1},
+            {"matrix": [5, 0], "x": 223, "y": 24, "flags": 1},
+            {"matrix": [6, 0], "x": 223, "y": 41, "flags": 1}
         ],
         "sleep": true
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The x coordinate of the three keys in the rightmost column were set to zero, so certain animations were acting funny. For example, any animation that sweeps from left to right, there'd be a pause before the rightmost column. Updating the x coord to a suitable value (so that it as seen as indeed being on the right, not the left) does fix these sweep animations.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #23224

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
