### PR TITLE
Refactor combos for consistent triggering, with tests

### DIFF
--- a/docs/features/combo.md
+++ b/docs/features/combo.md
@@ -28,7 +28,7 @@ A combo will trigger if and only if
         - A hold, tap, ordering, contiguity, or generic `combo_should_trigger` condition prevents it from firing (see below). By default, this constraints all combos to be *contiguous*. That means that if a key that doesn't belong to the combo is pressed between the first and last triggers, then the combo will not fire. (However, irrelevant key *releases* will not interrupt combos.)
         - An overlapping combo with higher priority triggers instead
  
-Combos, and key presses/releases not consumed by combos, will always be released in their event order. The event time of a combo is that of its FIRST trigger key press (so that the relevant keys are still in the buffer for combos requiring detailed event processing)
+Combos, and key presses/releases not consumed by combos, will always be released in their event order. The event time of a combo is that of its FIRST trigger key press.
 
 Each key press will be consumed by at most one combo. That means that when overlapping combos have all trigger keys pressed, we need to decide which one will fire. By default, we prioritize combos as follows:
 - first, we prioritize combos whose first trigger key was pressed earliest

--- a/docs/features/combo.md
+++ b/docs/features/combo.md
@@ -146,7 +146,7 @@ To configure the maximum amount of keys a combo can be composed of, change the f
 | 32   | `#define EXTRA_EXTRA_LONG_COMBOS` |
 
 
-A larger maximum combo length will cause a (pretty negligible) increase in memory usage. Another cost of longer combos is limiting the maximum number of combos that can be defined. The maximum combo count is `(65536 / MAX_COMBO_LENGTH) - 1`. If you really need more, you can `#define MANY_COMBOS`, but this will increase the memory usage of each combo.
+A larger maximum combo length will cause a (pretty negligible) increase in memory usage. Another cost of longer combos is limiting the maximum number of combos that can be defined. The maximum combo count is `(65536 / MAX_COMBO_LENGTH) - 1`.
 
 If you have a modest number of combos that aren't too large, you can save additional memory by defining `COMBO_COMPRESSED`. This compresses the internal state of each combo to a single byte. However, this should ONLY be set if you have fewer than `(256/MAX_COMBO_LENGTH) -1` combos, where `MAX_COMBO_LENGTH` is inferred from the flags above.
 
@@ -322,7 +322,7 @@ If the default prioritization of combos described above doesn't work for you, yo
 ```c
 /* Return true if combo1 is preferred to combo2 if they could both activate.
  * Default behavior: prefer longer combos, and break ties by preferring combos with higher indices */
-bool is_combo_preferred(combo_state_t combo_index1, combo_state_t combo_index2, uint8_t combo_length1) {
+bool is_combo_preferred(uint16_t combo_index1, uint16_t combo_index2, uint8_t combo_length1) {
     uint8_t combo_length2 = _get_combo_length(combo_get(combo_index2));
     if (combo_length1 > combo_length2) {
         return true;

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -541,6 +541,9 @@ void keyboard_init(void) {
 #ifdef HAPTIC_ENABLE
     haptic_init();
 #endif
+#ifdef COMBO_ENABLE
+    combo_enable();
+#endif
 
 #if defined(DEBUG_MATRIX_SCAN_RATE) && defined(CONSOLE_ENABLE)
     debug_enable = true;

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -202,7 +202,7 @@ __attribute__((weak)) bool combo_should_trigger(uint16_t combo_index, combo_t *c
 #endif
 
 #ifdef COMBO_PROCESS_KEY_RELEASE
-__attribute__((weak)) bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode, keyevent_t *event) { return false; }
+__attribute__((weak)) bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) { return false; }
 #endif
 
 #ifdef COMBO_PROCESS_KEY_REPRESS

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -331,8 +331,12 @@ __attribute__((weak)) bool is_combo_preferred(combo_state_t combo_index1, combo_
     return combo_index1 > combo_index2;
 }
 
+__attribute__((weak)) bool is_combo_contiguous(uint16_t index, combo_t *combo, uint16_t keycode, keyrecord_t *record, uint8_t n_unpressed_keys) {
+    return true;
+}
+
 /* Default behavior (if none of COMBO_MUST_PRESS_IN_ORDER, COMBO_MUST_PRESS_IN_ORDER_PER_COMBO, or COMBO_SHOULD_TRIGGER are defined)
- * is to be interrupted by any key not contained in a combo, and otherwise to not be interrupted (require contiguous presses) */
+ * is to be interrupted by any key not contained in a combo, and otherwise to not be interrupted (require contiguous presses). */
 __attribute__((weak)) bool is_combo_interrupted(uint16_t index, combo_t *combo, uint16_t keycode, keyrecord_t *record, uint8_t n_unpressed_keys, bool combo_has_key) {
     if (combo_has_key) {
 #ifdef COMBO_MUST_PRESS_IN_ORDER_PER_COMBO
@@ -356,7 +360,7 @@ __attribute__((weak)) bool is_combo_interrupted(uint16_t index, combo_t *combo, 
         return false;
 #endif
     }
-    return true;
+    return is_combo_contiguous(index, combo, keycode, record, n_unpressed_keys);
 }
 
 /*************************

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -1039,7 +1039,7 @@ void reset_combos(void) {
     SET_NEXT_COMBO(combo, COMBO_NULL_INDEX);
 
     active_combo_count = 0;
-    for (uint8_t i = 0; i < COMBO_BUFFER_LENGTH - 1; i++) {
+    for (uint8_t i = 0; i < COMBO_BUFFER_LENGTH; i++) {
         active_buffer[i].combo_index = COMBO_NULL_INDEX;
         active_buffer[i].state       = 0;
     }

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -291,7 +291,7 @@ bool does_combo_overlap(combo_t *combo1, combo_t *combo2) {
 
 /* Return true if combo1 is preferred to combo2 if they could both activate.
  * Default behavior: prefer longer combos, and break ties by preferring combos with higher indices */
-__attribute__((weak)) bool is_combo_preferred(combo_state_t combo_index1, combo_state_t combo_index2, uint8_t combo_length1) {
+__attribute__((weak)) bool is_combo_preferred(uint16_t combo_index1, uint16_t combo_index2, uint8_t combo_length1) {
     uint8_t combo_length2 = _get_combo_length(combo_get(combo_index2));
     if (combo_length1 > combo_length2) {
         return true;

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -94,7 +94,7 @@ static bool b_combo_enable = false;
  * separate buffer.
  */
 
-#define COMBO_NULL_INDEX (((combo_state_t)-1) >> COMBO_STATE_BITS)
+#define COMBO_NULL_INDEX (((combo_state_t) - 1) >> COMBO_STATE_BITS)
 #define COMBO_NULL_STATE ((COMBO_NULL_INDEX << COMBO_STATE_BITS))
 
 /* Used by combo queue iterators */
@@ -167,7 +167,9 @@ static uint16_t        next_expiration = 0;
 #define GET_QUEUED_RECORD(i) &key_buffer[(key_buffer_head + i) % COMBO_KEY_BUFFER_LENGTH]
 
 /* Returns true if this key is ready to be dumped from the buffer */
-static inline bool is_key_resolved(queued_record_t *qrecord) { return ((qrecord->state == COMBO_NULL_STATE) || GET_STATE(qrecord) >= COMBO_KEY_CONSUMED); }
+static inline bool is_key_resolved(queued_record_t *qrecord) {
+    return ((qrecord->state == COMBO_NULL_STATE) || GET_STATE(qrecord) >= COMBO_KEY_CONSUMED);
+}
 
 __attribute__((weak)) void process_combo_event(uint16_t combo_index, bool pressed) {}
 
@@ -178,15 +180,21 @@ __attribute__((weak)) uint8_t combo_ref_from_layer(uint8_t layer) {
 #endif
 
 #ifdef COMBO_MUST_HOLD_PER_COMBO
-__attribute__((weak)) bool get_combo_must_hold(uint16_t index, combo_t *combo) { return false; }
+__attribute__((weak)) bool get_combo_must_hold(uint16_t index, combo_t *combo) {
+    return false;
+}
 #endif
 
 #ifdef COMBO_MUST_TAP_PER_COMBO
-__attribute__((weak)) bool get_combo_must_tap(uint16_t index, combo_t *combo) { return false; }
+__attribute__((weak)) bool get_combo_must_tap(uint16_t index, combo_t *combo) {
+    return false;
+}
 #endif
 
 #ifdef COMBO_TERM_PER_COMBO
-__attribute__((weak)) uint16_t get_combo_term(uint16_t index, combo_t *combo) { return COMBO_TERM; }
+__attribute__((weak)) uint16_t get_combo_term(uint16_t index, combo_t *combo) {
+    return COMBO_TERM;
+}
 #endif
 
 #ifdef COMBO_MUST_PRESS_IN_ORDER_PER_COMBO
@@ -202,7 +210,9 @@ __attribute__((weak)) bool combo_should_trigger(uint16_t combo_index, combo_t *c
 #endif
 
 #ifdef COMBO_PROCESS_KEY_RELEASE
-__attribute__((weak)) bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) { return false; }
+__attribute__((weak)) bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) {
+    return false;
+}
 #endif
 
 #ifdef COMBO_PROCESS_KEY_REPRESS
@@ -317,7 +327,7 @@ bool is_combo_interrupted(uint16_t index, combo_t *combo, uint16_t keycode, keyr
         if (false) {
 #endif
             /* If the combo must be pressed in order, it is interrupted if this key is not the next key in sequence */
-            uint8_t combo_length = _get_combo_length(combo);
+            uint8_t  combo_length = _get_combo_length(combo);
             uint16_t expected_key = pgm_read_word(&(combo->keys)[combo_length - n_unpressed_keys]);
             if (expected_key != keycode) {
                 return true;
@@ -350,7 +360,9 @@ typedef struct {
 } combo_iterator_t;
 
 /* Have we reached the end of the iteration; usually used only through convenience macro below */
-static inline bool combo_iter_is_complete(combo_iterator_t *iter) { return (iter->combo_index == COMBO_NULL_INDEX); }
+static inline bool combo_iter_is_complete(combo_iterator_t *iter) {
+    return (iter->combo_index == COMBO_NULL_INDEX);
+}
 
 /* Move to next iterator; usually used only through convenience macro below */
 void combo_iter_next(combo_iterator_t *iter) {
@@ -441,8 +453,8 @@ void process_active_buffer_overflow(void) {
             break;
         }
     }
-    uint16_t       combo_index = iter.combo_index;
-    combo_t       *combo       = iter.combo;
+    uint16_t              combo_index = iter.combo_index;
+    combo_t              *combo       = iter.combo;
     combo_active_state_t *combo_state = NULL;
     if (combo != NULL) {
         combo_state = get_combo_active_state(iter.combo_index);
@@ -467,7 +479,7 @@ void process_active_buffer_overflow(void) {
             keyrecord_t fake_release = {
                 .event =
                     {
-                        .key     = MAKE_KEYPOS(0,0),
+                        .key     = MAKE_KEYPOS(0, 0),
                         .time    = timer_read() | 1,
                         .type    = KEY_EVENT,
                         .pressed = false,
@@ -504,7 +516,7 @@ combo_active_state_t *init_combo_active_state(combo_state_t combo_index) {
 /* Insert into ripe queue, maintaining sort in order of decreasing priority */
 void ripen_combo(combo_state_t combo_index, combo_t *combo) {
     combo_iterator_t iter;
-    uint8_t combo_length = _get_combo_length(combo);
+    uint8_t          combo_length = _get_combo_length(combo);
     for (ALL_COMBOS_IN_QUEUE(&ripe_head, &iter)) {
         if (is_combo_preferred(combo_index, iter.combo_index, combo_length)) {
             break;
@@ -563,8 +575,8 @@ void resolve_conflicts(void) {
         /* Overlapping partial and unripe complete combos that have lower
          * priority or don't fully contain this combo are inactivated */
         for (uint8_t i = 0; i < key_buffer_size; i++) {
-            queued_record_t *qrecord = GET_QUEUED_RECORD(i);
-            bool combo_has_key = _combo_has_key(ripe_iter.combo, qrecord->record.keycode);
+            queued_record_t *qrecord       = GET_QUEUED_RECORD(i);
+            bool             combo_has_key = _combo_has_key(ripe_iter.combo, qrecord->record.keycode);
             if (combo_has_key) {
                 SET_STATE(qrecord, COMBO_KEY_RIPE);
             } else if (is_key_resolved(qrecord)) {
@@ -730,8 +742,8 @@ void dump_keyrecord(keyrecord_t *record) {
 
 /* Insert combo into active queue and process the combo's outcome */
 void activate_combo(queued_record_t *qrecord) {
-    combo_state_t  combo_index = GET_NEXT_COMBO(qrecord);
-    combo_t       *combo       = combo_get(combo_index);
+    combo_state_t         combo_index = GET_NEXT_COMBO(qrecord);
+    combo_t              *combo       = combo_get(combo_index);
     combo_active_state_t *combo_state = init_combo_active_state(combo_index);
     if (combo_state == NULL) {
         /* This should never happen! */
@@ -742,15 +754,16 @@ void activate_combo(queued_record_t *qrecord) {
     combo_queue_insert(&active_head, combo_index, combo);
 
     if (!combo->keycode) {
-            process_combo_event(combo_index, true);
+        process_combo_event(combo_index, true);
     } else {
         keyrecord_t record = {
-            .event = {
-                .key     = MAKE_KEYPOS(0, 0),
-                .time    = qrecord->record.event.time,
-                .type    = COMBO_EVENT,
-                .pressed = true,
-            },
+            .event =
+                {
+                    .key     = MAKE_KEYPOS(0, 0),
+                    .time    = qrecord->record.event.time,
+                    .type    = COMBO_EVENT,
+                    .pressed = true,
+                },
             .keycode = combo->keycode,
         };
         dump_keyrecord(&record);
@@ -786,7 +799,7 @@ bool release_from_active(keyrecord_t *record) {
                         process_combo_event(iter.combo_index, false);
                     } else {
                         keyrecord_t release_record = {
-                            .event = MAKE_COMBOEVENT(false),
+                            .event   = MAKE_COMBOEVENT(false),
                             .keycode = iter.combo->keycode,
                         };
                         dump_keyrecord(&release_record);
@@ -906,8 +919,8 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
     /* Only check keycodes from one layer. */
     keycode = keymap_key_to_keycode(COMBO_ONLY_FROM_LAYER, record->event.key);
 #else
-    uint8_t  highest_layer = get_highest_layer(layer_state | default_layer_state);
-    uint8_t  ref_layer     = combo_ref_from_layer(highest_layer);
+    uint8_t highest_layer = get_highest_layer(layer_state | default_layer_state);
+    uint8_t ref_layer     = combo_ref_from_layer(highest_layer);
     if (ref_layer != highest_layer) {
         keycode = keymap_key_to_keycode(ref_layer, record->event.key);
     }
@@ -951,13 +964,13 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
     key_buffer_size++;
 
     if (record->event.pressed
-        /* Key presses can:
-         * - be consumed by an active combo repress if COMBO_PROCESS_KEY_REPRESS is defined, OR
-         * - contribute to partial combos, possibly completing them;
-         * - contribute to inactive combos, moving them to partial state (or
-         *   completing them, if user has defined a combo of length 1);
-         * - inactivate partial combos that are contiguous but lack this key
-         */
+    /* Key presses can:
+     * - be consumed by an active combo repress if COMBO_PROCESS_KEY_REPRESS is defined, OR
+     * - contribute to partial combos, possibly completing them;
+     * - contribute to inactive combos, moving them to partial state (or
+     *   completing them, if user has defined a combo of length 1);
+     * - inactivate partial combos that are contiguous but lack this key
+     */
 #ifdef COMBO_PROCESS_KEY_REPRESS
         && !try_repress(qrecord, keycode)
 #endif
@@ -984,7 +997,7 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
                 continue;
             }
             for (ALL_COMBOS_IN_KEY(old_record, &iter)) {
-                bool combo_has_key = _combo_has_key(iter.combo, keycode);
+                bool    combo_has_key  = _combo_has_key(iter.combo, keycode);
                 uint8_t keys_remaining = GET_STATE(iter.combo);
                 /* If already complete, can't be interrupted */
                 if (0 != keys_remaining) {
@@ -1002,7 +1015,7 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
     } /* Key releases are handled by the process_expiration call above */
 
     /* Store the keycode so we can notice overlaps later */
-    qrecord->record.keycode  = keycode;
+    qrecord->record.keycode = keycode;
     dump_safely();
     set_next_expiration();
     return false; /* Key events can only be released from buffer when safe */
@@ -1066,4 +1079,6 @@ void combo_toggle(void) {
     }
 }
 
-bool is_combo_enabled(void) { return b_combo_enable; }
+bool is_combo_enabled(void) {
+    return b_combo_enable;
+}

--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -27,144 +27,200 @@
 #include "action_util.h"
 #include "keymap_introspection.h"
 
+/* Enabled at matrix initialization, when linked lists are initialized */
+static bool b_combo_enable = false;
+
+/* Combo guarantees:
+ * A combo will trigger if and only if
+ *  - all of its keys are pressed within its combo term, and
+ *  - none of the following occurs
+ *      - One of the combo's keys was released before the final key was
+ *        pressed
+ *      - Two events (press and/or release) for the same keycode occur
+ *        between the first and last triggering key presses
+ *      - The combo has the "contiguous" requirement, and an unrelated key
+ *        was pressed between the first and last triggering key presses
+ *      - The combo has the "tap" requirement, but no triggering key is
+ *        released within the hold term
+ *      - The combo has the "hold" requirement, but a triggering key is
+ *        released within the hold term
+ *      - An overlapping combo with higher priority triggers instead
+ *      - The key buffer overflows between the first and last key presses of
+ *        the combo
+ *
+ * Combos, and key presses/releases not consumed by combos, will always be
+ * released in their event order. The event time of a combo is that of its
+ * FIRST trigger key press (so that the relevant keys are still in the
+ * buffer for combos requiring detailed event processing)
+ */
+
+/* Combo statuses:
+ * Inactive: no triggering key presses are available for legal assignment to
+ * this combo
+ *  - moves to partial status on the next triggering key press
+ *
+ * Partial: some, but not all, triggering key presses are available for
+ * legal assignment to this combo
+ *  - moves to inactive status if any triggering key is released, if any
+ *    triggering key press expires, or if any non-triggering key is pressed
+ *    and the combo is not contiguous
+ *  - moves to complete status if all triggering keys are pressed
+ *
+ * Complete: all triggering keys have been pressed, but either the combo
+ * term has not yet elapsed, or a tap is required has not yet occurred, or a
+ * hold is required but the hold term has not yet elapsed
+ *  - moves to ripe status if combo/hold term elapses or tap occurs,
+ *    according to combo requirements
+ *  - moves to inactive status if tap occurs for "must hold" combos, or
+ *    combo term elapses with no tap for "must tap" combos
+ *
+ * Ripe: all triggering keys have been pressed, the combo term or hold term
+ * has elapsed if required, and a tap has occurred if required
+ *  - moves to ready status if this is the highest priority combo among all
+ *    overlapping ripe combos, and if there is no higher-priority complete
+ *    (but unripe) combo whose keys form a superset
+ *  - moves to inactive status if a higher priority overlapping combo is
+ *    ripened
+ *
+ * Ready: the combo is ready to be activated at the appropriate point in the
+ * key sequence. Trigger keys are committed to this combo
+ *  - moves to active status when the first triggering key press is the
+ *    oldest key press in the buffer
+ *
+ * Active: the combo's event has already been processed, and some its keys
+ * have not yet been released
+ *  - moves to inactive status when the last of its keys is released
+ *
+ * Combo status is not recorded directly in the combo_t structure. Instead,
+ * all combos of each status are organized into linked lists. There are
+ * separate linked lists for inactive, active, and ripe combos. In addition,
+ * each queued key record in the key buffer gives the index of any ready
+ * combo that will consume that key. Alternatively, if the key record has
+ * not (yet) been assigned to a ready combo, then the record has a linked
+ * list of all the (partial and complete, but unripe) combos for which that
+ * record is the oldest relevant press event.
+ *
+ * For combos that are partial or complete, the low bits of the combo state
+ * give the number of remaining triggering key presses until the combo
+ * activates.
+ *
+ * We use linked lists to organize combos by state, instead of recording
+ * state directly in the combo_t structure, because we generally want to do
+ * something with all combos of a particular state, rather than determine
+ * what the state is of a particular combo. In particular, in order
+ * handle expiration and ripening of combos, it is convenient to already
+ * have each combo organized according to its oldest key press, rather than
+ * having to iterate over all combo/key pairs. It is also convenient to be
+ * able to sort ripe combos by priority.
+ *
+ * For the small number of active combos, more detailed state recording the
+ * identity of each still-pressed key is required; this is stored in a
+ * separate buffer.
+ */
+
+#define COMBO_NULL_INDEX (((combo_state_t)-1) >> COMBO_STATE_BITS)
+#define COMBO_NULL_STATE ((COMBO_NULL_INDEX << COMBO_STATE_BITS))
+
+/* Used by combo queue iterators */
+#define GET_NEXT_COMBO_DIRECT(state_ptr) ((*state_ptr) >> COMBO_STATE_BITS)
+#define SET_NEXT_COMBO_DIRECT(state_ptr, index) *state_ptr = ((index << COMBO_STATE_BITS) | ((*state_ptr) & ((1 << COMBO_STATE_BITS) - 1)))
+
+/* Used when we have a combo_t or keyrecord_t */
+#define GET_STATE(key_or_combo) (key_or_combo->state & ((1 << COMBO_STATE_BITS) - 1))
+#define SET_STATE(key_or_combo, value) key_or_combo->state = ((key_or_combo->state & ~((1 << COMBO_STATE_BITS) - 1)) | value)
+#define GET_NEXT_COMBO(key_or_combo) (key_or_combo->state >> COMBO_STATE_BITS)
+#define SET_NEXT_COMBO(key_or_combo, index) key_or_combo->state = (GET_STATE(key_or_combo) | (index << COMBO_STATE_BITS))
+/* DANGER: no guard against underflow on the state bits */
+#define DECREMENT_STATE(key_or_combo) key_or_combo->state--;
+
+static combo_state_t inactive_head;
+static combo_state_t ripe_head;
+static combo_state_t active_head;
+
+/* Detailed state of active combos, i.e., which keys are still unpressed, is
+ * recorded here as a bit array for each active combo.
+ */
+typedef struct {
+    combo_state_t        combo_index;
+    combo_active_state_t state;
+} active_combo_t;
+
+static active_combo_t active_buffer[COMBO_BUFFER_LENGTH];
+static uint8_t        active_combo_count = 0;
+
+/* Queued key record state is given by a combo_state_t. Like the
+ * combo_state_t that holds combo_t state, its high bits give a combo index,
+ * which can be used for a linked list of combos. Its low bits (the "state"
+ * bits) encode the following possible statuses:
+ *      COMBO_KEY_BASE - any key release. Also, presses that might help
+ *          activate a combo, but require additional presses or ripening
+ *          conditions. If this is the oldest key press in the buffer, and
+ *          the high bits encode COMBO_NULL_INDEX, then the key press is not
+ *          used by any combo and can be emitted as an ordinary press
+ *      COMBO_KEY_RIPE - presses that will be used to activate a combo, but
+ *          for which the specific combo has not yet been determined (e.g.,
+ *          because we are waiting for an unripe high priority combo)
+ *      COMBO_KEY_CONSUMED - presses that are being used to activate a
+ *          combo, but will not trigger its event. The high bits indicate
+ *          the combo being activated.
+ *      COMBO_KEY_TRIGGER - the key press that actually triggers a combo
+ *          event. The high bits indicate the combo being activated.
+ *
+ * Keys with status COMBO_KEY_CONSUMED or COMBO_KEY_TRIGGER can safely be
+ * used in the appropriate manner when they reach the front of the key
+ * buffer, as can keys with status COMBO_KEY_BASE whose high state bits
+ * encode COMBO_NULL_INDEX.
+ */
+enum queued_record_state {
+    COMBO_KEY_BASE,
+    COMBO_KEY_RIPE,
+    COMBO_KEY_CONSUMED,
+    COMBO_KEY_TRIGGER,
+};
+
+typedef struct {
+    keyrecord_t   record;
+    combo_state_t state;
+} queued_record_t;
+
+static queued_record_t key_buffer[COMBO_KEY_BUFFER_LENGTH];
+static uint8_t         key_buffer_head = 0;
+static uint8_t         key_buffer_size = 0;
+static uint16_t        next_expiration = 0;
+
+#define GET_QUEUED_RECORD(i) &key_buffer[(key_buffer_head + i) % COMBO_KEY_BUFFER_LENGTH]
+
+/* Returns true if this key is ready to be dumped from the buffer */
+bool is_key_resolved(queued_record_t *qrecord) { return ((qrecord->state == COMBO_NULL_STATE) || GET_STATE(qrecord) >= COMBO_KEY_CONSUMED); }
+
 __attribute__((weak)) void process_combo_event(uint16_t combo_index, bool pressed) {}
 
-#ifndef COMBO_ONLY_FROM_LAYER
-__attribute__((weak)) uint8_t combo_ref_from_layer(uint8_t layer) {
-    return layer;
-}
-#endif
-
 #ifdef COMBO_MUST_HOLD_PER_COMBO
-__attribute__((weak)) bool get_combo_must_hold(uint16_t combo_index, combo_t *combo) {
-    return false;
-}
+__attribute__((weak)) bool get_combo_must_hold(uint16_t index, combo_t *combo) { return false; }
 #endif
 
 #ifdef COMBO_MUST_TAP_PER_COMBO
-__attribute__((weak)) bool get_combo_must_tap(uint16_t combo_index, combo_t *combo) {
-    return false;
-}
+__attribute__((weak)) bool get_combo_must_tap(uint16_t index, combo_t *combo) { return false; }
 #endif
 
 #ifdef COMBO_TERM_PER_COMBO
-__attribute__((weak)) uint16_t get_combo_term(uint16_t combo_index, combo_t *combo) {
-    return COMBO_TERM;
-}
+__attribute__((weak)) uint16_t get_combo_term(uint16_t index, combo_t *combo) { return COMBO_TERM; }
 #endif
 
-#ifdef COMBO_MUST_PRESS_IN_ORDER_PER_COMBO
-__attribute__((weak)) bool get_combo_must_press_in_order(uint16_t combo_index, combo_t *combo) {
-    return true;
-}
+#ifdef COMBO_CONTIGUOUS_PER_COMBO
+__attribute__((weak)) bool get_combo_interrupted(uint16_t index, combo_t *combo, keyrecord_t *record) { return true; }
+#endif
+
+#ifdef COMBO_DETAILED_EVENTS_PER_COMBO
+__attribute__((weak)) bool get_combo_needs_details(uint16_t index, combo_t *combo) { return false; }
+__attribute__((weak)) void process_combo_detailed_press(uint16_t index, combo_t *combo, keyrecord_t *triggers) {}
+__attribute__((weak)) bool process_combo_detailed_release(uint16_t index, combo_t *combo, uint8_t key_index, uint16_t keycode, keyevent_t *event) { return false; }
+static keyrecord_t         triggers[MAX_COMBO_LENGTH];
 #endif
 
 #ifdef COMBO_PROCESS_KEY_RELEASE
-__attribute__((weak)) bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) {
-    return false;
-}
+__attribute__((weak)) bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) { return false; }
 #endif
-
-#ifdef COMBO_PROCESS_KEY_REPRESS
-__attribute__((weak)) bool process_combo_key_repress(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) {
-    return false;
-}
-#endif
-
-#ifdef COMBO_SHOULD_TRIGGER
-__attribute__((weak)) bool combo_should_trigger(uint16_t combo_index, combo_t *combo, uint16_t keycode, keyrecord_t *record) {
-    return true;
-}
-#endif
-
-typedef enum { COMBO_KEY_NOT_PRESSED, COMBO_KEY_PRESSED, COMBO_KEY_REPRESSED } combo_key_action_t;
-
-#ifndef COMBO_NO_TIMER
-static uint16_t timer = 0;
-#endif
-static bool     b_combo_enable = true; // defaults to enabled
-static uint16_t longest_term   = 0;
-
-typedef struct {
-    keyrecord_t record;
-    uint16_t    combo_index;
-    uint16_t    keycode;
-} queued_record_t;
-static uint8_t         key_buffer_size = 0;
-static queued_record_t key_buffer[COMBO_KEY_BUFFER_LENGTH];
-
-typedef struct {
-    uint16_t combo_index;
-} queued_combo_t;
-static uint8_t        combo_buffer_write = 0;
-static uint8_t        combo_buffer_read  = 0;
-static queued_combo_t combo_buffer[COMBO_BUFFER_LENGTH];
-
-#define INCREMENT_MOD(i) i = (i + 1) % COMBO_BUFFER_LENGTH
-
-#ifndef EXTRA_SHORT_COMBOS
-/* flags are their own elements in combo_t struct. */
-#    define COMBO_ACTIVE(combo) (combo->active)
-#    define COMBO_DISABLED(combo) (combo->disabled)
-#    define COMBO_STATE(combo) (combo->state)
-
-#    define ACTIVATE_COMBO(combo) \
-        do {                      \
-            combo->active = true; \
-        } while (0)
-#    define DEACTIVATE_COMBO(combo) \
-        do {                        \
-            combo->active = false;  \
-        } while (0)
-#    define DISABLE_COMBO(combo)    \
-        do {                        \
-            combo->disabled = true; \
-        } while (0)
-#    define RESET_COMBO_STATE(combo) \
-        do {                         \
-            combo->disabled = false; \
-            combo->state    = 0;     \
-        } while (0)
-#else
-/* flags are at the two high bits of state. */
-#    define COMBO_ACTIVE(combo) (combo->state & 0x80)
-#    define COMBO_DISABLED(combo) (combo->state & 0x40)
-#    define COMBO_STATE(combo) (combo->state & 0x3F)
-
-#    define ACTIVATE_COMBO(combo) \
-        do {                      \
-            combo->state |= 0x80; \
-        } while (0)
-#    define DEACTIVATE_COMBO(combo) \
-        do {                        \
-            combo->state &= ~0x80;  \
-        } while (0)
-#    define DISABLE_COMBO(combo)  \
-        do {                      \
-            combo->state |= 0x40; \
-        } while (0)
-#    define RESET_COMBO_STATE(combo) \
-        do {                         \
-            combo->state &= ~0x7F;   \
-        } while (0)
-#endif
-
-static inline void release_combo(uint16_t combo_index, combo_t *combo) {
-    if (combo->keycode) {
-        keyrecord_t record = {
-            .event   = MAKE_COMBOEVENT(false),
-            .keycode = combo->keycode,
-        };
-#ifndef NO_ACTION_TAPPING
-        action_tapping_process(record);
-#else
-        process_record(&record);
-#endif
-    } else {
-        process_combo_event(combo_index, false);
-    }
-    DEACTIVATE_COMBO(combo);
-}
 
 static inline bool _get_combo_must_hold(uint16_t combo_index, combo_t *combo) {
 #ifdef COMBO_NO_TIMER
@@ -177,20 +233,6 @@ static inline bool _get_combo_must_hold(uint16_t combo_index, combo_t *combo) {
     return false;
 }
 
-static inline uint16_t _get_wait_time(uint16_t combo_index, combo_t *combo) {
-    if (_get_combo_must_hold(combo_index, combo)
-#ifdef COMBO_MUST_TAP_PER_COMBO
-        || get_combo_must_tap(combo_index, combo)
-#endif
-    ) {
-        if (longest_term < COMBO_HOLD_TERM) {
-            return COMBO_HOLD_TERM;
-        }
-    }
-
-    return longest_term;
-}
-
 static inline uint16_t _get_combo_term(uint16_t combo_index, combo_t *combo) {
 #if defined(COMBO_TERM_PER_COMBO)
     return get_combo_term(combo_index, combo);
@@ -199,362 +241,599 @@ static inline uint16_t _get_combo_term(uint16_t combo_index, combo_t *combo) {
     return COMBO_TERM;
 }
 
-void clear_combos(void) {
-    uint16_t index = 0;
-    longest_term   = 0;
-    for (index = 0; index < combo_count(); ++index) {
-        combo_t *combo = combo_get(index);
-        if (!COMBO_ACTIVE(combo)) {
-            RESET_COMBO_STATE(combo);
-        }
-    }
-}
-
-static inline void dump_key_buffer(void) {
-    /* First call start from 0 index; recursive calls need to start from i+1 index */
-    static uint8_t key_buffer_next = 0;
-#if TAP_CODE_DELAY > 0
-    bool delay_done = false;
-#endif
-
-    if (key_buffer_size == 0) {
-        return;
-    }
-
-    for (uint8_t key_buffer_i = key_buffer_next; key_buffer_i < key_buffer_size; key_buffer_i++) {
-        key_buffer_next = key_buffer_i + 1;
-
-        queued_record_t *qrecord = &key_buffer[key_buffer_i];
-        keyrecord_t *    record  = &qrecord->record;
-
-        if (IS_NOEVENT(record->event)) {
-            continue;
-        }
-
-        if (!record->keycode && qrecord->combo_index != (uint16_t)-1) {
-            process_combo_event(qrecord->combo_index, true);
-        } else {
-#ifndef NO_ACTION_TAPPING
-            action_tapping_process(*record);
-#else
-            process_record(record);
-#endif
-        }
-        record->event.type = TICK_EVENT;
-
-#if defined(CAPS_WORD_ENABLE) && defined(AUTO_SHIFT_ENABLE)
-        // Edge case: preserve the weak Left Shift mod if both Caps Word and
-        // Auto Shift are on. Caps Word capitalizes by setting the weak Left
-        // Shift mod during the press event, but Auto Shift doesn't send the
-        // key until it receives the release event.
-        del_weak_mods((is_caps_word_on() && get_autoshift_state()) ? ~MOD_BIT(KC_LSFT) : 0xff);
-#else
-        clear_weak_mods();
-#endif // defined(CAPS_WORD_ENABLE) && defined(AUTO_SHIFT_ENABLE)
-
-#if TAP_CODE_DELAY > 0
-        // only delay once and for a non-tapping key
-        if (!delay_done && !is_tap_record(record)) {
-            delay_done = true;
-            wait_ms(TAP_CODE_DELAY);
-        }
-#endif
-    }
-
-    key_buffer_next = key_buffer_size = 0;
-}
-
-#define NO_COMBO_KEYS_ARE_DOWN (0 == COMBO_STATE(combo))
-#define ALL_COMBO_KEYS_ARE_DOWN(state, key_count) (((1 << key_count) - 1) == state)
-#define ONLY_ONE_KEY_IS_DOWN(state) !(state & (state - 1))
-#define KEY_NOT_YET_RELEASED(state, key_index) ((1 << key_index) & state)
-#define KEY_STATE_DOWN(state, key_index) \
-    do {                                 \
-        state |= (1 << key_index);       \
-    } while (0)
-#define KEY_STATE_UP(state, key_index) \
-    do {                               \
-        state &= ~(1 << key_index);    \
-    } while (0)
-
-static inline void _find_key_index_and_count(const uint16_t *keys, uint16_t keycode, uint16_t *key_index, uint8_t *key_count) {
-    while (true) {
-        uint16_t key = pgm_read_word(&keys[*key_count]);
-        if (keycode == key) *key_index = *key_count;
-        if (COMBO_END == key) break;
-        (*key_count)++;
-    }
-}
-
-void drop_combo_from_buffer(uint16_t combo_index) {
-    /* Mark a combo as processed from the buffer. If the buffer is in the
-     * beginning of the buffer, drop it.  */
-    uint8_t i = combo_buffer_read;
-    while (i != combo_buffer_write) {
-        queued_combo_t *qcombo = &combo_buffer[i];
-
-        if (qcombo->combo_index == combo_index) {
-            combo_t *combo = combo_get(combo_index);
-            DISABLE_COMBO(combo);
-
-            if (i == combo_buffer_read) {
-                INCREMENT_MOD(combo_buffer_read);
-            }
-            break;
-        }
-        INCREMENT_MOD(i);
-    }
-}
-
-void apply_combo(uint16_t combo_index, combo_t *combo) {
-    /* Apply combo's result keycode to the last chord key of the combo and
-     * disable the other keys. */
-
-    if (COMBO_DISABLED(combo)) {
-        return;
-    }
-
-    // state to check against so we find the last key of the combo from the buffer
-#if defined(EXTRA_EXTRA_LONG_COMBOS)
-    uint32_t state = 0;
-#elif defined(EXTRA_LONG_COMBOS)
-    uint16_t state         = 0;
-#else
-    uint8_t state = 0;
-#endif
-
-    for (uint8_t key_buffer_i = 0; key_buffer_i < key_buffer_size; key_buffer_i++) {
-        queued_record_t *qrecord = &key_buffer[key_buffer_i];
-        keyrecord_t *    record  = &qrecord->record;
-        uint16_t         keycode = qrecord->keycode;
-
-        uint8_t  key_count = 0;
-        uint16_t key_index = -1;
-        _find_key_index_and_count(combo->keys, keycode, &key_index, &key_count);
-
-        if (-1 == (int16_t)key_index) {
-            // key not part of this combo
-            continue;
-        }
-
-        KEY_STATE_DOWN(state, key_index);
-        if (ALL_COMBO_KEYS_ARE_DOWN(state, key_count)) {
-            // this in the end executes the combo when the key_buffer is dumped.
-            record->keycode    = combo->keycode;
-            record->event.type = COMBO_EVENT;
-            record->event.key  = MAKE_KEYPOS(0, 0);
-
-            qrecord->combo_index = combo_index;
-            ACTIVATE_COMBO(combo);
-
-            break;
-        } else {
-            // key was part of the combo but not the last one, "disable" it
-            // by making it a TICK event.
-            record->event.type = TICK_EVENT;
-        }
-    }
-    drop_combo_from_buffer(combo_index);
-}
-
-static inline void apply_combos(void) {
-    // Apply all buffered normal combos.
-    for (uint8_t i = combo_buffer_read; i != combo_buffer_write; INCREMENT_MOD(i)) {
-        queued_combo_t *buffered_combo = &combo_buffer[i];
-        combo_t *       combo          = combo_get(buffered_combo->combo_index);
-
+static inline uint16_t _get_hold_term(uint16_t combo_index, combo_t *combo) {
+    if (_get_combo_must_hold(combo_index, combo)
 #ifdef COMBO_MUST_TAP_PER_COMBO
-        if (get_combo_must_tap(buffered_combo->combo_index, combo)) {
-            // Tap-only combos are applied on key release only, so let's drop 'em here.
-            drop_combo_from_buffer(buffered_combo->combo_index);
-            continue;
-        }
+        || get_combo_must_tap(combo_index, combo)
 #endif
-        apply_combo(buffered_combo->combo_index, combo);
-    }
-    dump_key_buffer();
-    clear_combos();
-}
-
-combo_t *overlaps(combo_t *combo1, combo_t *combo2) {
-    /* Checks if the combos overlap and returns the combo that should be
-     * dropped from the combo buffer.
-     * The combo that has less keys will be dropped. If they have the same
-     * amount of keys, drop combo1. */
-
-    uint8_t  idx1 = 0, idx2 = 0;
-    uint16_t key1, key2;
-    bool     overlaps = false;
-
-    while ((key1 = pgm_read_word(&combo1->keys[idx1])) != COMBO_END) {
-        idx2 = 0;
-        while ((key2 = pgm_read_word(&combo2->keys[idx2])) != COMBO_END) {
-            if (key1 == key2) overlaps = true;
-            idx2 += 1;
-        }
-        idx1 += 1;
-    }
-
-    if (!overlaps) return NULL;
-    if (idx2 < idx1) return combo2;
-    return combo1;
-}
-
-#if defined(COMBO_MUST_PRESS_IN_ORDER) || defined(COMBO_MUST_PRESS_IN_ORDER_PER_COMBO)
-static bool keys_pressed_in_order(uint16_t combo_index, combo_t *combo, uint16_t key_index, uint16_t keycode, keyrecord_t *record) {
-#    ifdef COMBO_MUST_PRESS_IN_ORDER_PER_COMBO
-    if (!get_combo_must_press_in_order(combo_index, combo)) {
-        return true;
-    }
-#    endif
-    if (
-        // The `state` bit for the key being pressed.
-        (1 << key_index) ==
-        // The *next* combo key's bit.
-        (COMBO_STATE(combo) + 1)
-        // E.g. two keys already pressed: `state == 11`.
-        // Next possible `state` is `111`.
-        // So the needed bit is `100` which we get with `11 + 1`.
     ) {
-        return true;
+        return COMBO_HOLD_TERM;
     }
-    return false;
+    return _get_combo_term(combo_index, combo);
 }
-#endif
 
-static combo_key_action_t process_single_combo(combo_t *combo, uint16_t keycode, keyrecord_t *record, uint16_t combo_index) {
-    uint8_t  key_count = 0;
-    uint16_t key_index = -1;
-    _find_key_index_and_count(combo->keys, keycode, &key_index, &key_count);
+bool _combo_has_key(combo_t *combo, uint16_t keycode) {
+    const uint16_t *keys = combo->keys;
+    for (uint8_t i = 0;; i++) {
+        uint16_t key = pgm_read_word(&keys[i]);
+        if (keycode == key) {
+            return true;
+        } else if (COMBO_END == key) {
+            return false;
+        }
+    }
+}
 
-    /* Continue processing if key isn't part of current combo. */
-    if (-1 == (int16_t)key_index) {
-        return COMBO_KEY_NOT_PRESSED;
+uint8_t _get_combo_keycode_index(combo_t *combo, uint16_t keycode) {
+    const uint16_t *keys = combo->keys;
+    for (uint8_t i = 0;; i++) {
+        uint16_t key = pgm_read_word(&keys[i]);
+        if (keycode == key) {
+            return i;
+        } else if (COMBO_END == key) {
+            return (uint8_t)-1;
+        }
+    }
+}
+
+uint8_t _get_combo_length(combo_t *combo) {
+    const uint16_t *keys = combo->keys;
+    for (uint8_t i = 0;; i++) {
+        uint16_t key = pgm_read_word(&keys[i]);
+        if (COMBO_END == key) {
+            return i;
+        }
+    }
+}
+
+uint8_t get_combo_overlap(combo_t *combo1, combo_t *combo2) {
+    const uint16_t *keys    = combo1->keys;
+    uint8_t         overlap = 0;
+    for (uint8_t i = 0;; i++) {
+        uint16_t key = pgm_read_word(&keys[i]);
+        if (COMBO_END == key) {
+            break;
+        }
+        if (_combo_has_key(combo2, key)) {
+            overlap++;
+        }
+    }
+    return overlap;
+}
+
+/*************************
+ * COMBO QUEUE ITERATION *
+ *************************/
+
+typedef struct {
+    combo_t       *combo;
+    combo_state_t  combo_index;
+    combo_state_t *prev_combo;
+    bool           removed;
+} combo_iterator_t;
+
+/* Have we reached the end of the iteration; usually used only through convenience macro below */
+static inline bool combo_iter_is_complete(combo_iterator_t *iter) { return (iter->combo_index == COMBO_NULL_INDEX); }
+
+/* Move to next iterator; usually used only through convenience macro below */
+void combo_iter_next(combo_iterator_t *iter) {
+    if (combo_iter_is_complete(iter)) {
+        return;
+    }
+    if (!iter->removed) {
+        iter->prev_combo = &iter->combo->state;
+    } else {
+        iter->removed = false;
+    }
+    iter->combo_index = GET_NEXT_COMBO_DIRECT(iter->prev_combo);
+    if (iter->combo_index == COMBO_NULL_INDEX) {
+        iter->combo = NULL;
+    } else {
+        iter->combo = combo_get(iter->combo_index);
+    }
+}
+
+/* Intialize new iterator; usually used only through convenience macro below */
+void combo_iter_init(combo_iterator_t *iter, combo_state_t *head) {
+    iter->prev_combo  = head;
+    iter->combo_index = 0;
+    iter->removed     = true;
+    combo_iter_next(iter);
+}
+
+#define ALL_COMBOS_IN_QUEUE(queue, iter) \
+    combo_iter_init(iter, queue);        \
+    !combo_iter_is_complete(iter);       \
+    combo_iter_next(iter)
+#define ALL_COMBOS_IN_KEY(qrecord, iter) ALL_COMBOS_IN_QUEUE(&qrecord->state, iter)
+
+/* Remove from its queue the combo currently accessed by the iterator */
+static inline void combo_iter_remove(combo_iterator_t *iter) {
+    if (!iter->removed && !combo_iter_is_complete(iter)) {
+        SET_NEXT_COMBO_DIRECT(iter->prev_combo, GET_NEXT_COMBO(iter->combo));
+        iter->removed = true;
+    }
+}
+
+/* Insert combo immediately before current entry in iterator */
+static inline void combo_iter_insert(combo_iterator_t *iter, combo_state_t combo_index, combo_t *combo) {
+    SET_NEXT_COMBO(combo, iter->combo_index);
+    SET_NEXT_COMBO_DIRECT(iter->prev_combo, combo_index);
+}
+
+/* Insert combo at head of queue */
+static inline void combo_queue_insert(combo_state_t *head, combo_state_t combo_index, combo_t *combo) {
+    SET_NEXT_COMBO(combo, GET_NEXT_COMBO_DIRECT(head));
+    SET_NEXT_COMBO_DIRECT(head, combo_index);
+}
+
+/****************************
+ * ACTIVE BUFFER MANAGEMENT *
+ ****************************/
+
+bool release_from_active(keyrecord_t *record);
+
+/* Search for active combo state with given combo index and return pointer */
+combo_active_state_t *get_combo_active_state(combo_state_t combo_index) {
+    for (uint8_t i = 0; i < COMBO_BUFFER_LENGTH; i++) {
+        active_combo_t *buffer_entry = &active_buffer[i];
+        if (buffer_entry->combo_index == combo_index) {
+            return &buffer_entry->state;
+        }
+    }
+    return NULL;
+}
+
+/* Free active state buffer space currently allocated to a particular combo */
+void free_combo_active_state(combo_state_t combo_index) {
+    for (uint8_t i = 0; i < COMBO_BUFFER_LENGTH; i++) {
+        active_combo_t *buffer_entry = &active_buffer[i];
+        if (buffer_entry->combo_index == combo_index) {
+            buffer_entry->combo_index = COMBO_NULL_INDEX;
+            active_combo_count--;
+            return;
+        }
+    }
+}
+
+void process_active_buffer_overflow(void) {
+    /* Get oldest active combo (tail of active queue) */
+    combo_iterator_t iter;
+    for (ALL_COMBOS_IN_QUEUE(&active_head, &iter)) {
+        if (COMBO_NULL_INDEX == GET_NEXT_COMBO(iter.combo)) {
+            break;
+        }
+    }
+    uint16_t       combo_index = iter.combo_index;
+    combo_t       *combo       = iter.combo;
+    combo_active_state_t *combo_state = NULL;
+    if (combo != NULL) {
+        combo_state = get_combo_active_state(iter.combo_index);
+    }
+    if (combo_state == NULL) {
+        /* Called overflow even though there aren't any active combos, or
+           oldest active combo doesn't have active state...
+           This should never happen. */
+        combo_index = active_buffer[0].combo_index;
+        if (combo_index == COMBO_NULL_INDEX) {
+            return;
+        }
+        combo       = combo_get(combo_index);
+        combo_state = &active_buffer[0].state;
     }
 
-    bool key_is_part_of_combo = (!COMBO_DISABLED(combo) && is_combo_enabled()
-#if defined(COMBO_MUST_PRESS_IN_ORDER) || defined(COMBO_MUST_PRESS_IN_ORDER_PER_COMBO)
-                                 && keys_pressed_in_order(combo_index, combo, key_index, keycode, record)
-#endif
-#ifdef COMBO_SHOULD_TRIGGER
-                                 && combo_should_trigger(combo_index, combo, keycode, record)
-#endif
-    );
+    /* Release the active combo, key by key */
+    uint16_t keycode;
+    for (uint8_t combo_key = 0; (keycode = pgm_read_word(&combo->keys[combo_key])) != COMBO_END; combo_key++) {
+        if (*combo_state & (1 << combo_key)) {
+            /* Key is still present in the combo; simulate its release */
+            keyrecord_t fake_release = {
+                .event =
+                    {
+                        .key     = MAKE_KEYPOS(0,0),
+                        .time    = timer_read() | 1,
+                        .type    = KEY_EVENT,
+                        .pressed = false,
+                    },
+                .keycode = keycode,
+            };
+            release_from_active(&fake_release); /*free_combo_active_state called on final release */
+        }
+    }
+}
 
-    if (record->event.pressed && key_is_part_of_combo) {
-        uint16_t time = _get_combo_term(combo_index, combo);
-        if (!COMBO_ACTIVE(combo)) {
-            KEY_STATE_DOWN(combo->state, key_index);
-            if (longest_term < time) {
-                longest_term = time;
+/* Search for unused active combo state buffer space, allocate to specified
+ * combo, and return pointer */
+combo_active_state_t *init_combo_active_state(combo_state_t combo_index) {
+    if (active_combo_count == COMBO_BUFFER_LENGTH) {
+        process_active_buffer_overflow();
+    }
+    for (uint8_t i = 0; i < COMBO_BUFFER_LENGTH; i++) {
+        active_combo_t *buffer_entry = &active_buffer[i];
+        if (buffer_entry->combo_index == COMBO_NULL_INDEX) {
+            buffer_entry->combo_index = combo_index;
+            buffer_entry->state       = 0;
+            active_combo_count++;
+            return &buffer_entry->state;
+        }
+    }
+    return NULL;
+}
+
+/********************************
+ * RIPENING AND READYING COMBOS *
+ ********************************/
+
+/* Insert into ripe queue, maintaining sort in order of increasing combo index */
+void ripen_combo(combo_state_t combo_index, combo_t *combo) {
+    combo_iterator_t iter;
+    if (combo_index > GET_NEXT_COMBO_DIRECT(&ripe_head)) {
+        combo_queue_insert(&ripe_head, combo_index, combo);
+        return;
+    }
+    for (ALL_COMBOS_IN_QUEUE(&ripe_head, &iter)) {
+        if (combo_index > iter.combo_index) {
+            break;
+        }
+    }
+    combo_iter_insert(&iter, combo_index, combo);
+}
+
+/* Prepare to activate a ripened combo by transferring it to the ready queue
+ * and committing its triggering key records
+ *
+ * Should only be called by resolve_conflicts() */
+void ready_combo(combo_state_t combo_index, combo_t *combo) {
+    bool triggered = false;
+    SET_NEXT_COMBO(combo, COMBO_NULL_INDEX);
+    for (uint8_t i = 0; i < key_buffer_size; i++) {
+        queued_record_t *qrecord = GET_QUEUED_RECORD(i);
+        if ((COMBO_KEY_RIPE == GET_STATE(qrecord)) && _combo_has_key(combo, qrecord->record.keycode)) {
+            /* This function is only called by resolve_conflicts(), so the key queue should already
+             * be empty */
+            if (!triggered) {
+                SET_STATE(qrecord, COMBO_KEY_TRIGGER);
+                SET_NEXT_COMBO(qrecord, combo_index);
+                triggered = true;
+            } else {
+                qrecord->state = COMBO_KEY_CONSUMED;
+                SET_NEXT_COMBO(qrecord, combo_index);
             }
         }
-        if (ALL_COMBO_KEYS_ARE_DOWN(COMBO_STATE(combo), key_count)) {
-            /* Combo was fully pressed */
-            /* Buffer the combo so we can fire it after COMBO_TERM */
+    }
+}
 
-#ifndef COMBO_NO_TIMER
-            /* Don't buffer this combo if its combo term has passed. */
-            if (timer && timer_elapsed(timer) > time) {
-                DISABLE_COMBO(combo);
-                return COMBO_KEY_PRESSED;
-            } else
-#endif
-            {
-
-                // disable readied combos that overlap with this combo
-                combo_t *drop = NULL;
-                for (uint8_t combo_buffer_i = combo_buffer_read; combo_buffer_i != combo_buffer_write; INCREMENT_MOD(combo_buffer_i)) {
-                    queued_combo_t *qcombo         = &combo_buffer[combo_buffer_i];
-                    combo_t *       buffered_combo = combo_get(qcombo->combo_index);
-
-                    if ((drop = overlaps(buffered_combo, combo))) {
-                        DISABLE_COMBO(drop);
-                        if (drop == combo) {
-                            // stop checking for overlaps if dropped combo was current combo.
-                            break;
-                        } else if (combo_buffer_i == combo_buffer_read && drop == buffered_combo) {
-                            /* Drop the disabled buffered combo from the buffer if
-                             * it is in the beginning of the buffer. */
-                            INCREMENT_MOD(combo_buffer_read);
-                        }
+/* Ensure that there are no overlapping combos in the ripe queue by
+ * inactivating lower-priority combos.
+ *
+ * For surviving ripe combos, mark every key including the combo as
+ * COMBO_KEY_RIPE
+ *
+ * Also ensure that any remaining ripe combos have no overlap with combos in
+ * the key queues, except in the case of higher-priority combos with a
+ * superset of triggers */
+void resolve_conflicts(void) {
+    combo_iterator_t ripe_iter;
+    for (ALL_COMBOS_IN_QUEUE(&ripe_head, &ripe_iter)) {
+        bool             blocked      = false;
+        uint8_t          combo_length = _get_combo_length(ripe_iter.combo);
+        combo_iterator_t conflict_iter;
+        /* Overlapping ripe combos (after this one) are lower priority; inactivate them */
+        for (ALL_COMBOS_IN_QUEUE(&ripe_iter.combo->state, &conflict_iter)) {
+            if (get_combo_overlap(ripe_iter.combo, conflict_iter.combo)) {
+                combo_iter_remove(&conflict_iter);
+                combo_queue_insert(&inactive_head, conflict_iter.combo_index, conflict_iter.combo);
+            }
+        }
+        /* Overlapping partial and unripe complete combos that have lower
+         * priority or don't fully contain this combo are inactivated */
+        for (uint8_t i = 0; i < key_buffer_size; i++) {
+            queued_record_t *qrecord = GET_QUEUED_RECORD(i);
+            if (_combo_has_key(ripe_iter.combo, qrecord->record.keycode)) {
+                SET_STATE(qrecord, COMBO_KEY_RIPE);
+            } else if (is_key_resolved(qrecord)) {
+                /* This key might have temporarily appeared resolved until
+                 * this call to resolve_conflicts(), if this combo was the
+                 * only remaining combo for the key, so it's important to
+                 * first check for presence of the key in the combo */
+                continue;
+            }
+            for (ALL_COMBOS_IN_KEY(qrecord, &conflict_iter)) {
+                uint8_t overlap = get_combo_overlap(ripe_iter.combo, conflict_iter.combo);
+                if (overlap) {
+                    if ((ripe_iter.combo_index > conflict_iter.combo_index) || (overlap < combo_length)) {
+                        combo_iter_remove(&conflict_iter);
+                        combo_queue_insert(&inactive_head, conflict_iter.combo_index, conflict_iter.combo);
+                    } else {
+                        blocked = true;
                     }
                 }
-
-                if (drop != combo) {
-                    // save this combo to buffer
-                    combo_buffer[combo_buffer_write] = (queued_combo_t){
-                        .combo_index = combo_index,
-                    };
-                    INCREMENT_MOD(combo_buffer_write);
-
-                    // get possible longer waiting time for tap-/hold-only combos.
-                    longest_term = _get_wait_time(combo_index, combo);
-                }
-            } // if timer elapsed end
-        }
-#ifdef COMBO_PROCESS_KEY_REPRESS
-    } else if (record->event.pressed) {
-        if (COMBO_ACTIVE(combo)) {
-            if (process_combo_key_repress(combo_index, combo, key_index, keycode)) {
-                KEY_STATE_DOWN(combo->state, key_index);
-                return COMBO_KEY_REPRESSED;
             }
         }
-#endif
-    } else {
-        // chord releases
-        if (!COMBO_ACTIVE(combo) && ALL_COMBO_KEYS_ARE_DOWN(COMBO_STATE(combo), key_count)) {
-            /* First key quickly released */
-            if (COMBO_DISABLED(combo) || _get_combo_must_hold(combo_index, combo)) {
-                // combo wasn't tappable, disable it and drop it from buffer.
-                drop_combo_from_buffer(combo_index);
-                key_is_part_of_combo = false;
-            }
-#ifdef COMBO_MUST_TAP_PER_COMBO
-            else if (get_combo_must_tap(combo_index, combo)) {
-                // immediately apply tap-only combo
-                apply_combo(combo_index, combo);
-                apply_combos(); // also apply other prepared combos and dump key buffer
-#    ifdef COMBO_PROCESS_KEY_RELEASE
-                if (process_combo_key_release(combo_index, combo, key_index, keycode)) {
-                    release_combo(combo_index, combo);
-                }
-#    endif
-            }
-#endif
-        } else if (COMBO_ACTIVE(combo) && ONLY_ONE_KEY_IS_DOWN(COMBO_STATE(combo)) && KEY_NOT_YET_RELEASED(COMBO_STATE(combo), key_index)) {
-            /* last key released */
-            release_combo(combo_index, combo);
-            key_is_part_of_combo = true;
-
-#ifdef COMBO_PROCESS_KEY_RELEASE
-            process_combo_key_release(combo_index, combo, key_index, keycode);
-#endif
-        } else if (COMBO_ACTIVE(combo) && KEY_NOT_YET_RELEASED(COMBO_STATE(combo), key_index)) {
-            /* first or middle key released */
-            key_is_part_of_combo = true;
-
-#ifdef COMBO_PROCESS_KEY_RELEASE
-            if (process_combo_key_release(combo_index, combo, key_index, keycode)) {
-                release_combo(combo_index, combo);
-            }
-#endif
-        } else {
-            /* The released key was part of an incomplete combo */
-            key_is_part_of_combo = false;
+        if (!blocked) {
+            combo_iter_remove(&ripe_iter);
+            ready_combo(ripe_iter.combo_index, ripe_iter.combo);
         }
-
-        KEY_STATE_UP(combo->state, key_index);
     }
-
-    return key_is_part_of_combo ? COMBO_KEY_PRESSED : COMBO_KEY_NOT_PRESSED;
 }
 
-bool process_combo(uint16_t keycode, keyrecord_t *record) {
-    uint8_t is_combo_key          = COMBO_KEY_NOT_PRESSED;
-    bool    no_combo_keys_pressed = true;
+/**********************************
+ * COMBO AND HOLD TERM EXPIRATION *
+ **********************************/
 
+/* Process expiration of a queued key record until a particular limit time.
+ * May cause completed combos to ripen, ready, or inactivate, or cause
+ * partial combos to inactivate. All incomplete or unripe combos for which
+ * this key record was the first press are held in the combo queue of this
+ * queued key record, so the relevant expiration time is easy to compute.
+ *
+ * If until!=0, any combo whose hold or combo term expired before `until` is
+ * processed. If tap!=0, then additionally, any combo containing the key
+ * `tap` is processed. If until==0, all combos are processed.
+ *
+ * If tap==0, then hold requirements are satisfied and tap requirements are
+ * unsatisfied. If tap!=0, the opposite holds only for combos including the
+ * key `tap`. */
+void expire_key(queued_record_t *qrecord, uint16_t until, uint16_t tap) {
+    if (is_key_resolved(qrecord)) {
+        return;
+    }
+
+    combo_iterator_t iter;
+    for (ALL_COMBOS_IN_KEY(qrecord, &iter)) {
+        bool combo_complete = (0 == GET_STATE(iter.combo));
+        bool combo_expired  = true;
+        bool combo_tapped   = false;
+        if (tap && _combo_has_key(iter.combo, tap)) {
+            combo_tapped = true;
+        }
+        if (!combo_tapped && until) {
+            uint16_t term = combo_complete ? _get_hold_term(iter.combo_index, iter.combo) : _get_combo_term(iter.combo_index, iter.combo);
+            if (!timer_expired(until, (qrecord->record.event.time + term))) {
+                combo_expired = false;
+            }
+        }
+        if (combo_expired) {
+            combo_iter_remove(&iter);
+            if (!combo_complete
+#ifdef COMBO_MUST_TAP_PER_COMBO
+                || (!combo_tapped && get_combo_must_tap(iter.combo_index, iter.combo))
+#endif
+#if defined(COMBO_MUST_HOLD_PER_COMBO) || defined(COMBO_MUST_HOLD_MODS)
+                || (combo_tapped && _get_combo_must_hold(iter.combo_index, iter.combo))
+#endif
+            ) {
+                combo_queue_insert(&inactive_head, iter.combo_index, iter.combo);
+            } else {
+                ripen_combo(iter.combo_index, iter.combo);
+            }
+        }
+    }
+
+    resolve_conflicts();
+}
+
+/* Forces expiration (with specified keycode tap if tap!=0) of all combos
+ * associated with oldest `force` records in the key buffer. Additionally,
+ * if until != 0, handles expiration of all combos expiring before the limit
+ * `until` (using the specified keycode tap if tap!=0). */
+void process_expiration(uint16_t until, uint16_t tap, uint8_t force) {
+    for (uint8_t i = 0; i < key_buffer_size; i++) {
+        queued_record_t *qrecord = GET_QUEUED_RECORD(i);
+        if (i < force) {
+            expire_key(qrecord, 0, tap);
+        } else if (until) {
+            expire_key(qrecord, until, tap);
+        } else {
+            break;
+        }
+    }
+}
+
+/* Compute when the next expiration should be performed. Should only be
+ * called after calling dump_safely() (since that calls resolve_conflicts(),
+ * which affects the result of this computation)
+ *
+ * If there are unripe complete combos, the next expiration is the soonest
+ * time when one will ripen. (The order of ripening is important for
+ * consistent triggering, since combos can inactivate higher priority
+ * completed combos when they ripen, as long as the higher priority combos
+ * do not have a superset of the combo triggers.)
+ *
+ * If there are no unripe complete combos, the next expiration is determined
+ * by the longest combo term among partial combos containing the oldest
+ * (unresolved) key in the buffer, since this determines the soonest time
+ * when we can safely dump a key. */
+void set_next_expiration(void) {
+    next_expiration             = 0;
+    uint16_t partial_expiration = 0;
+    bool     oldest             = true;
+    for (uint8_t i = 0; i < key_buffer_size; i++) {
+        queued_record_t *qrecord = GET_QUEUED_RECORD(i);
+        if (is_key_resolved(qrecord)) {
+            continue;
+        }
+        combo_iterator_t iter;
+        for (ALL_COMBOS_IN_KEY(qrecord, &iter)) {
+            if (0 == GET_STATE(iter.combo)) {
+                uint16_t ripening = qrecord->record.event.time + _get_hold_term(iter.combo_index, iter.combo);
+                if (!next_expiration || ripening < next_expiration) {
+                    next_expiration = ripening;
+                }
+            } else if (oldest && !next_expiration) {
+                uint16_t inactivation = qrecord->record.event.time + _get_combo_term(iter.combo_index, iter.combo);
+                if (inactivation > partial_expiration) {
+                    partial_expiration = inactivation;
+                }
+            }
+        }
+        oldest = false;
+    }
+    if (!next_expiration) {
+        next_expiration = partial_expiration;
+    }
+}
+
+/****************************
+ * DUMPING KEYS FROM BUFFER *
+ ****************************/
+
+/* Release a key record for processing by later steps of QMK pipeline */
+void dump_keyrecord(keyrecord_t *record) {
+#ifndef NO_ACTION_TAPPING
+    action_tapping_process(*record);
+#else
+    process_record(record);
+#endif
+}
+
+/* Insert combo into active queue, process the combo's outcome, and
+ * initialize detailed active state */
+void activate_combo(queued_record_t *qrecord) {
+    combo_state_t  combo_index = GET_NEXT_COMBO(qrecord);
+    combo_t       *combo       = combo_get(combo_index);
+    combo_active_state_t *combo_state = init_combo_active_state(combo_index);
+    if (combo_state == NULL) {
+        /* This should never happen! */
+        return;
+    }
+    uint8_t combo_length = _get_combo_length(combo);
+    *combo_state         = (1 << combo_length) - 1;
+    combo_queue_insert(&active_head, combo_index, combo);
+
+    if (!combo->keycode) {
+#ifdef COMBO_DETAILED_EVENTS_PER_COMBO
+        if (get_combo_needs_details(combo_index, combo)) {
+            triggers[0]                  = qrecord->record;
+            uint8_t       trigger_index  = 1;
+            combo_state_t consumed_state = ((combo_index << COMBO_STATE_BITS) & COMBO_KEY_CONSUMED);
+            for (uint8_t i = 0; i < key_buffer_size; i++) {
+                queued_record_t *buffer_entry = GET_QUEUED_RECORD(i);
+                if (qrecord->state == consumed_state) {
+                    triggers[trigger_index] = buffer_entry->record;
+                    trigger_index++;
+                }
+            }
+            process_combo_detailed_press(combo_index, combo, triggers);
+        } else
+#endif
+        {
+            process_combo_event(combo_index, true);
+        }
+    } else {
+        keyrecord_t record = {
+            .event = {
+                .key     = MAKE_KEYPOS(0, 0),
+                .time    = qrecord->record.event.time,
+                .type    = COMBO_EVENT,
+                .pressed = true,
+            },
+            .keycode = combo->keycode,
+        };
+        dump_keyrecord(&record);
+    }
+}
+
+/* Try releasing a key from any active combos in which it is present.
+ * Returns true if it was in fact released from an active combo, false
+ * otherwise. */
+bool release_from_active(keyrecord_t *record) {
+    bool             released = false;
+    combo_iterator_t iter;
+    for (ALL_COMBOS_IN_QUEUE(&active_head, &iter)) {
+        uint8_t key_index = _get_combo_keycode_index(iter.combo, record->keycode);
+        if (key_index != (uint8_t)-1) {
+            combo_active_state_t *combo_state = get_combo_active_state(iter.combo_index);
+            if (combo_state == NULL) {
+                /* Shouldn't happen... */
+                continue;
+            }
+            if (*combo_state & (1 << key_index)) {
+                /* Key is still pressed for this combo */
+                released = true;
+                *combo_state &= ~(1 << key_index);
+#ifdef COMBO_PROCESS_KEY_RELEASE
+#    ifdef COMBO_DETAILED_EVENTS_PER_COMBO
+                if (get_combo_needs_details(iter.combo_index, iter.combo)) {
+                    if (process_combo_detailed_release(iter.combo_index, iter.combo, key_index, record->keycode, &record->event)) {
+                        *combo_state = 0;
+                    }
+                }
+#    endif
+                if (process_combo_key_release(iter.combo_index, iter.combo, key_index, record->keycode)) {
+                    *combo_state = 0;
+                }
+#endif
+                if (*combo_state == 0) {
+                    if (!iter.combo->keycode) {
+                        process_combo_event(iter.combo_index, false);
+                    } else {
+                        keyrecord_t release_record = {
+                            .event = MAKE_COMBOEVENT(false),
+                            .keycode = iter.combo->keycode,
+                        };
+                        dump_keyrecord(&release_record);
+                    }
+                    free_combo_active_state(iter.combo_index);
+                    combo_iter_remove(&iter);
+                    combo_queue_insert(&inactive_head, iter.combo_index, iter.combo);
+                }
+            }
+        }
+    }
+    return released;
+}
+
+/* Releases key records from the buffer and combos from their queues for as
+ * long as we have enough information to fully resolve the next item in the
+ * sequence */
+void dump_safely(void) {
+    resolve_conflicts();
+    while (key_buffer_size > 0) {
+        queued_record_t *qrecord = GET_QUEUED_RECORD(0);
+        if (!is_key_resolved(qrecord)) {
+            break;
+        }
+        /* We advance the buffer here, in case dump_safely() gets called
+         * recursively as a side-effect of user code */
+        key_buffer_head = (key_buffer_head + 1) % COMBO_KEY_BUFFER_LENGTH;
+        key_buffer_size--;
+        switch (GET_STATE(qrecord)) {
+            case COMBO_KEY_CONSUMED:
+                qrecord->record.event.type = TICK_EVENT;
+                dump_keyrecord(&qrecord->record);
+                break;
+            case COMBO_KEY_TRIGGER:
+                activate_combo(qrecord);
+                break;
+            default:
+                if (!qrecord->record.event.pressed) {
+                    if (release_from_active(&qrecord->record)) {
+                        qrecord->record.event.type = TICK_EVENT;
+                        dump_keyrecord(&qrecord->record);
+                        break;
+                    }
+                }
+                /* Remove our cached keycode so that the proper keycode can
+                 * be inferred from matrix position */
+                qrecord->record.keycode = 0;
+                dump_keyrecord(&qrecord->record);
+        }
+    }
+}
+
+/* Force oldest key in the buffer to be released, as though all combos
+ * involving it had already been resolved */
+void process_key_buffer_overflow(void) {
+    process_expiration(0, 0, 1);
+    dump_safely();
+}
+
+/***************************
+ * MAIN COMBO ENTRY POINTS *
+ ***************************/
+
+bool process_combo(uint16_t keycode, keyrecord_t *record) {
     if (keycode == QK_COMBO_ON && record->event.pressed) {
         combo_enable();
         return true;
@@ -570,95 +849,155 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
         return true;
     }
 
+    if (!is_combo_enabled()) {
+        return true;
+    }
+
+    if (IS_NOEVENT(record->event)) {
+        return true;
+    }
+
 #ifdef COMBO_ONLY_FROM_LAYER
     /* Only check keycodes from one layer. */
     keycode = keymap_key_to_keycode(COMBO_ONLY_FROM_LAYER, record->event.key);
-#else
-    uint8_t  highest_layer = get_highest_layer(layer_state | default_layer_state);
-    uint8_t  ref_layer     = combo_ref_from_layer(highest_layer);
-    if (ref_layer != highest_layer) {
-        keycode = keymap_key_to_keycode(ref_layer, record->event.key);
-    }
 #endif
 
-    for (uint16_t idx = 0; idx < combo_count(); ++idx) {
-        combo_t *combo = combo_get(idx);
-        is_combo_key |= process_single_combo(combo, keycode, record, idx);
-        no_combo_keys_pressed = no_combo_keys_pressed && (NO_COMBO_KEYS_ARE_DOWN || COMBO_ACTIVE(combo) || COMBO_DISABLED(combo));
-    }
+    /* We first check the key buffer for duplicate keycodes. When we
+     * encounter a new event for a keycode already in the buffer, everything
+     * preceding the older event immediately resolves, allowing the older
+     * keyrecord to be dumped.
+     *
+     * Regardless of whether we encounter a duplicate keycode, we first
+     * expire everything until the event time of the new keyrecord, so that
+     * we don't end up, e.g., completing partial combos that should have
+     * already expired. If the new keyrecord is a key release, it is
+     * processed during this expiration to appropriately ripen or inactivate
+     * completed combos (depending on tap/hold requirements) and to
+     * inactivate overlapping partial combos.
+     *
+     * After expiration, we dump anything that has resolved from the
+     * keybuffer. */
 
-    if (record->event.pressed && is_combo_key) {
-#ifndef COMBO_NO_TIMER
-#    ifdef COMBO_STRICT_TIMER
-        if (!timer) {
-            // timer is set only on the first key
-            timer = timer_read();
+    uint8_t  force = 0;
+    uint16_t tap   = record->event.pressed ? 0 : keycode;
+    for (uint8_t i = 0; i < key_buffer_size; i++) {
+        queued_record_t *old_record = GET_QUEUED_RECORD(i);
+        if (keycode == old_record->record.keycode) {
+            force = i + 1;
+            break;
         }
-#    else
-        timer = timer_read();
-#    endif
-#endif
+    }
+    process_expiration(record->event.time, tap, force);
+    dump_safely();
 
-#ifdef COMBO_PROCESS_KEY_REPRESS
-        if (is_combo_key == COMBO_KEY_PRESSED)
-#endif
-        {
-            if (key_buffer_size < COMBO_KEY_BUFFER_LENGTH) {
-                key_buffer[key_buffer_size++] = (queued_record_t){
-                    .record      = *record,
-                    .keycode     = keycode,
-                    .combo_index = -1, // this will be set when applying combos
-                };
+    if (key_buffer_size == COMBO_KEY_BUFFER_LENGTH) {
+        process_key_buffer_overflow();
+    }
+
+    queued_record_t *qrecord = GET_QUEUED_RECORD(key_buffer_size);
+    qrecord->record          = *record;
+    qrecord->record.keycode  = keycode;
+    qrecord->state           = COMBO_NULL_STATE;
+    key_buffer_size++;
+
+    if (record->event.pressed) {
+        /* Key presses can:
+         * - contribute to partial combos, possibly completing them;
+         * - contribute to inactive combos, moving them to partial state (or
+         *   completing them, if user has defined a combo of length 1);
+         * - inactivate partial combos that are contiguous but lack this key
+         */
+
+        /* Add key to inactive combos */
+        combo_iterator_t iter;
+        for (ALL_COMBOS_IN_QUEUE(&inactive_head, &iter)) {
+            if (_combo_has_key(iter.combo, keycode)) {
+                /* Remove from inactive queue and add to this key's queue */
+                uint8_t combo_length = _get_combo_length(iter.combo);
+                SET_STATE(iter.combo, (combo_length - 1));
+                combo_iter_remove(&iter);
+                combo_queue_insert(&qrecord->state, iter.combo_index, iter.combo);
             }
         }
-    } else {
-        if (combo_buffer_read != combo_buffer_write) {
-            // some combo is prepared
-            apply_combos();
-        } else {
-            // reset state if there are no combo keys pressed at all
-            dump_key_buffer();
-#ifndef COMBO_NO_TIMER
-            timer = 0;
+
+        /* Add key to partial combos of other keys */
+        for (uint8_t i = 0; i < key_buffer_size - 1; i++) {
+            queued_record_t *old_record = GET_QUEUED_RECORD(i);
+            if (is_key_resolved(old_record)) {
+                continue;
+            }
+            for (ALL_COMBOS_IN_KEY(old_record, &iter)) {
+                if (_combo_has_key(iter.combo, keycode)) {
+                    DECREMENT_STATE(iter.combo);
+                } else
+#ifdef COMBO_CONTIGUOUS_PER_COMBO
+                    if (get_combo_interrupted(iter.combo_index, iter.combo, &qrecord->record))
 #endif
-            clear_combos();
+                {
+                    /* Inactivate partial combos that don't include this key
+                     * but are required to be contiguous */
+                    if (0 != GET_STATE(iter.combo)) {
+                        combo_iter_remove(&iter);
+                        combo_queue_insert(&inactive_head, iter.combo_index, iter.combo);
+                    }
+                }
+            }
         }
-    }
-    return !is_combo_key;
+    } /* Key releases are handled by the process_expiration call above */
+
+    dump_safely();
+    set_next_expiration();
+    return false; /* Key events can only be released from buffer when safe */
 }
 
 void combo_task(void) {
-    if (!b_combo_enable) {
+    if (!is_combo_enabled() || !next_expiration) {
         return;
     }
-
-#ifndef COMBO_NO_TIMER
-    if (timer && timer_elapsed(timer) > longest_term) {
-        if (combo_buffer_read != combo_buffer_write) {
-            apply_combos();
-            longest_term = 0;
-            timer        = 0;
-        } else {
-            dump_key_buffer();
-            timer = 0;
-            clear_combos();
-        }
+    uint16_t time = timer_read();
+    if (timer_expired(time, next_expiration)) {
+        process_expiration(time, 0, key_buffer_size);
+        dump_safely();
+        set_next_expiration();
     }
-#endif
+}
+
+/************************
+ * COMBO FEATURE SET-UP *
+ ************************/
+
+/* Initializes combo state when keyboard matrix is initialized, and when
+ * combo feature is re-enabled after having been disabled */
+void reset_combos(void) {
+    key_buffer_head = key_buffer_size = 0;
+    ripe_head = active_head = COMBO_NULL_STATE;
+
+    inactive_head  = 0;
+    combo_t *combo = combo_get(0);
+    for (combo_state_t i = 0; i < combo_count(); i++) {
+        combo = combo_get(i);
+        SET_NEXT_COMBO(combo, (i + 1));
+    }
+    SET_NEXT_COMBO(combo, COMBO_NULL_INDEX);
+
+    active_combo_count = 0;
+    for (uint8_t i = 0; i < COMBO_BUFFER_LENGTH - 1; i++) {
+        active_buffer[i].combo_index = COMBO_NULL_INDEX;
+        active_buffer[i].state       = 0;
+    }
 }
 
 void combo_enable(void) {
-    b_combo_enable = true;
+    if ((!b_combo_enable) && combo_count() > 0) {
+        reset_combos();
+        b_combo_enable = true;
+    }
 }
 
 void combo_disable(void) {
-#ifndef COMBO_NO_TIMER
-    timer = 0;
-#endif
-    b_combo_enable    = false;
-    combo_buffer_read = combo_buffer_write;
-    clear_combos();
-    dump_key_buffer();
+    b_combo_enable = false;
+    process_expiration(0, 0, key_buffer_size);
+    dump_safely();
 }
 
 void combo_toggle(void) {
@@ -669,6 +1008,4 @@ void combo_toggle(void) {
     }
 }
 
-bool is_combo_enabled(void) {
-    return b_combo_enable;
-}
+bool is_combo_enabled(void) { return b_combo_enable; }

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -48,8 +48,6 @@ typedef uint8_t combo_active_state_t;
 #ifdef COMBO_COMPRESSED
 /* If combo_count() < (256/MAX_COMBO_LENGTH) - 1, this can be defined to save some space */
 typedef uint8_t combo_state_t;
-#elif defined(MANY_COMBOS)
-typedef uint32_t combo_state_t;
 #else
 typedef uint16_t combo_state_t;
 #endif

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -46,8 +46,10 @@ typedef uint8_t combo_active_state_t;
 #endif
 
 #ifdef COMBO_COMPRESSED
-/* If (combo_count() + 1) * MAX_COMBO_LENGTH < 256, this can be defined to save some space */
+/* If combo_count() < (256/MAX_COMBO_LENGTH) - 1, this can be defined to save some space */
 typedef uint8_t combo_state_t;
+#elif defined(MANY_COMBOS)
+typedef uint32_t combo_state_t;
 #else
 typedef uint16_t combo_state_t;
 #endif

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -22,39 +22,44 @@
 #include "keycodes.h"
 #include "quantum_keycodes.h"
 
-#ifdef EXTRA_SHORT_COMBOS
-#    define MAX_COMBO_LENGTH 6
-#elif defined(EXTRA_EXTRA_LONG_COMBOS)
+/* COMBO_BUFFER_LENGTH defines the maximum number of simulatenously active combos. */
+#ifndef COMBO_BUFFER_LENGTH
+#    define COMBO_BUFFER_LENGTH 4
+#endif
+
+#if defined(EXTRA_EXTRA_LONG_COMBOS)
 #    define MAX_COMBO_LENGTH 32
+#    define COMBO_STATE_BITS 5
+typedef uint32_t combo_active_state_t;
 #elif defined(EXTRA_LONG_COMBOS)
 #    define MAX_COMBO_LENGTH 16
+#    define COMBO_STATE_BITS 4
+typedef uint16_t combo_active_state_t;
+#elif defined(EXTRA_SMALL_COMBOS)
+#    define MAX_COMBO_LENGTH 4
+#    define COMBO_STATE_BITS 2
+typedef uint8_t combo_active_state_t;
 #else
 #    define MAX_COMBO_LENGTH 8
+#    define COMBO_STATE_BITS 3
+typedef uint8_t combo_active_state_t;
+#endif
+
+/* Must be defined if (COMBO_COUNT + 1) * MAX_COMBO_LENGTH >= 256 */
+#ifdef MANY_COMBOS
+typedef uint16_t combo_state_t;
+#else
+typedef uint8_t  combo_state_t;
 #endif
 
 #ifndef COMBO_KEY_BUFFER_LENGTH
-#    define COMBO_KEY_BUFFER_LENGTH MAX_COMBO_LENGTH
-#endif
-#ifndef COMBO_BUFFER_LENGTH
-#    define COMBO_BUFFER_LENGTH 4
+#    define COMBO_KEY_BUFFER_LENGTH (MAX_COMBO_LENGTH + 4)
 #endif
 
 typedef struct combo_t {
     const uint16_t *keys;
     uint16_t        keycode;
-#ifdef EXTRA_SHORT_COMBOS
-    uint8_t state;
-#else
-    bool     disabled;
-    bool     active;
-#    if defined(EXTRA_EXTRA_LONG_COMBOS)
-    uint32_t state;
-#    elif defined(EXTRA_LONG_COMBOS)
-    uint16_t state;
-#    else
-    uint8_t state;
-#    endif
-#endif
+    combo_state_t   state;
 } combo_t;
 
 #define COMBO(ck, ca) \
@@ -71,7 +76,7 @@ typedef struct combo_t {
 #endif
 
 /* check if keycode is only modifiers */
-#define KEYCODE_IS_MOD(code) (IS_MODIFIER_KEYCODE(code) || (IS_QK_MODS(code) && !QK_MODS_GET_BASIC_KEYCODE(code)))
+#define KEYCODE_IS_MOD(code) (IS_MOD(code) || (code >= QK_MODS && code <= QK_MODS_MAX && !(code & QK_BASIC_MAX)))
 
 bool process_combo(uint16_t keycode, keyrecord_t *record);
 void combo_task(void);

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -45,11 +45,11 @@ typedef uint8_t combo_active_state_t;
 typedef uint8_t combo_active_state_t;
 #endif
 
-/* Must be defined if (COMBO_COUNT + 1) * MAX_COMBO_LENGTH >= 256 */
-#ifdef MANY_COMBOS
-typedef uint16_t combo_state_t;
+#ifdef COMBO_COMPRESSED
+/* If (combo_count() + 1) * MAX_COMBO_LENGTH < 256, this can be defined to save some space */
+typedef uint8_t combo_state_t;
 #else
-typedef uint8_t  combo_state_t;
+typedef uint16_t combo_state_t;
 #endif
 
 #ifndef COMBO_KEY_BUFFER_LENGTH
@@ -69,7 +69,7 @@ typedef struct combo_t {
 
 #define COMBO_END 0
 #ifndef COMBO_TERM
-#    define COMBO_TERM 50
+#    define COMBO_TERM 150
 #endif
 #ifndef COMBO_HOLD_TERM
 #    define COMBO_HOLD_TERM TAPPING_TERM

--- a/tests/combo/combo_active_buffer/config.h
+++ b/tests/combo/combo_active_buffer/config.h
@@ -1,0 +1,8 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define COMBO_BUFFER_LENGTH 2

--- a/tests/combo/combo_active_buffer/test.mk
+++ b/tests/combo/combo_active_buffer/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2025 @johnwilmes
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+COMBO_ENABLE = yes
+
+INTROSPECTION_KEYMAP_C = test_combo_buffer.c

--- a/tests/combo/combo_active_buffer/test_combo.cpp
+++ b/tests/combo/combo_active_buffer/test_combo.cpp
@@ -1,0 +1,37 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.h"
+#include "test_common.hpp"
+#include "test_driver.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+extern bool combo_override;
+
+class ComboBuffer : public TestFixture {};
+
+TEST_F(ComboBuffer, combo_active_buffer_overflow) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_c(0, 2, 0, KC_C);
+    KeymapKey  key_d(0, 3, 0, KC_D);
+    KeymapKey  key_e(0, 4, 0, KC_E);
+    KeymapKey  key_f(0, 5, 0, KC_F);
+    set_keymap({key_a, key_b, key_c, key_d, key_e, key_f});
+
+    EXPECT_REPORT(driver, (KC_1));
+    EXPECT_REPORT(driver, (KC_1, KC_2));
+    EXPECT_REPORT(driver, (KC_2));
+    EXPECT_REPORT(driver, (KC_2, KC_3));
+    EXPECT_REPORT(driver, (KC_3));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_b, key_c, key_d, key_e, key_f});
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/combo/combo_active_buffer/test_combo_buffer.c
+++ b/tests/combo/combo_active_buffer/test_combo_buffer.c
@@ -1,0 +1,18 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+#include "stdio.h"
+
+enum combos {ab_1, cd_2, ef_3};
+
+uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
+uint16_t const cd_2_combo[]     = {KC_C, KC_D, COMBO_END};
+uint16_t const ef_3_combo[]     = {KC_E, KC_F, COMBO_END};
+
+// clang-format off
+combo_t key_combos[] = {
+    [ab_1]     = COMBO(ab_1_combo, KC_1),
+    [cd_2]    = COMBO(cd_2_combo, KC_2),
+    [ef_3]    = COMBO(ef_3_combo, KC_3),
+};
+// clang-format on

--- a/tests/combo/combo_active_buffer/test_combo_buffer.c
+++ b/tests/combo/combo_active_buffer/test_combo_buffer.c
@@ -3,11 +3,11 @@
 #include "quantum.h"
 #include "stdio.h"
 
-enum combos {ab_1, cd_2, ef_3};
+enum combos { ab_1, cd_2, ef_3 };
 
-uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
-uint16_t const cd_2_combo[]     = {KC_C, KC_D, COMBO_END};
-uint16_t const ef_3_combo[]     = {KC_E, KC_F, COMBO_END};
+uint16_t const ab_1_combo[] = {KC_A, KC_B, COMBO_END};
+uint16_t const cd_2_combo[] = {KC_C, KC_D, COMBO_END};
+uint16_t const ef_3_combo[] = {KC_E, KC_F, COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {

--- a/tests/combo/combo_conflicts/config.h
+++ b/tests/combo/combo_conflicts/config.h
@@ -4,3 +4,5 @@
 #pragma once
 
 #include "test_common.h"
+
+#define COMBO_CONTIGUOUS_PER_COMBO

--- a/tests/combo/combo_conflicts/config.h
+++ b/tests/combo/combo_conflicts/config.h
@@ -1,0 +1,8 @@
+// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define COMBO_CONTIGUOUS_PER_COMBO

--- a/tests/combo/combo_conflicts/config.h
+++ b/tests/combo/combo_conflicts/config.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// Copyright 2025 @johnwilmes
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/tests/combo/combo_conflicts/config.h
+++ b/tests/combo/combo_conflicts/config.h
@@ -4,5 +4,3 @@
 #pragma once
 
 #include "test_common.h"
-
-#define COMBO_CONTIGUOUS_PER_COMBO

--- a/tests/combo/combo_conflicts/test.mk
+++ b/tests/combo/combo_conflicts/test.mk
@@ -1,4 +1,4 @@
-# Copyright 2023 Stefan Kerkmann (@KarlK90)
+# Copyright 2025 @johnwilmes
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 COMBO_ENABLE = yes

--- a/tests/combo/combo_conflicts/test.mk
+++ b/tests/combo/combo_conflicts/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2023 Stefan Kerkmann (@KarlK90)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+COMBO_ENABLE = yes
+
+INTROSPECTION_KEYMAP_C = test_combo_conflicts.c

--- a/tests/combo/combo_conflicts/test_combo.cpp
+++ b/tests/combo/combo_conflicts/test_combo.cpp
@@ -26,21 +26,9 @@ TEST_F(ComboConflicts, combo_irrelevant_press) {
     EXPECT_REPORT(driver, (KC_1)).Times(2);
     EXPECT_REPORT(driver, (KC_1, KC_Z));
     EXPECT_EMPTY_REPORT(driver);
-    // Press A, Z, B in that order; release B, Z, A
+    // Press A, Z, B in that order
     // Combo for A+B should be triggered since it does not require contiguity
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_z.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_z.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
+    tap_combo({key_a, key_z, key_b});
     VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_A)).Times(3);
@@ -64,25 +52,15 @@ TEST_F(ComboConflicts, combo_irrelevant_press) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_X)).Times(2);
-    EXPECT_REPORT(driver, (KC_X, KC_Z)).Times(2);
+    EXPECT_REPORT(driver, (KC_X));
+    EXPECT_REPORT(driver, (KC_X, KC_Z));
     EXPECT_REPORT(driver, (KC_X, KC_Z, KC_Y));
+    EXPECT_REPORT(driver, (KC_Z, KC_Y));
+    EXPECT_REPORT(driver, (KC_Y));
     EXPECT_EMPTY_REPORT(driver);
-    // Press X, Z, Y in that order; release Y, Z, X
+    // Press X, Z, Y in that order; release X, Z, Y
     // Combo for X+Y should not be triggered since it requires contiguity
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_z.press();
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
-    key_z.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
+    tap_combo({key_x, key_z, key_y});
     VERIFY_AND_CLEAR(driver);
 }
 
@@ -97,49 +75,17 @@ TEST_F(ComboConflicts, combo_priority) {
     EXPECT_REPORT(driver, (KC_4)).Times(2);
     EXPECT_REPORT(driver, (KC_4, KC_A));
     EXPECT_EMPTY_REPORT(driver);
-    // Press X, A, B, Y in that order; release Y, B, A, X
+    // Press X, A, B, Y in that order
     // Combo for X+B+Y should be triggered since it has higher priority (index)
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
+    tap_combo({key_x, key_a, key_b, key_y});
     VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_4)).Times(2);
     EXPECT_REPORT(driver, (KC_4, KC_A));
     EXPECT_EMPTY_REPORT(driver);
-    // Press X, Y, A, B in that order; release B, A, Y, X
+    // Press X, Y, A, B in that order
     // Combo for X+B+Y should be triggered since it has higher priority (index)
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
+    tap_combo({key_x, key_y, key_a, key_b});
     VERIFY_AND_CLEAR(driver);
 }
 
@@ -154,25 +100,9 @@ TEST_F(ComboConflicts, combo_priority_trigger) {
     EXPECT_REPORT(driver, (KC_3)).Times(2);
     EXPECT_REPORT(driver, (KC_3, KC_B));
     EXPECT_EMPTY_REPORT(driver);
-    // Press A, X, B, Y in that order; release Y, B, X, A
+    // Press A, X, B, Y in that order
     // Combo for X+A+Y should be triggered since it has earlier trigger
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
+    tap_combo({key_a, key_x, key_b, key_y});
     VERIFY_AND_CLEAR(driver);
 }
 
@@ -188,51 +118,15 @@ TEST_F(ComboConflicts, combo_wait_for_preferred) {
     EXPECT_REPORT(driver, (KC_4)).Times(2);
     EXPECT_REPORT(driver, (KC_4, KC_A));
     EXPECT_EMPTY_REPORT(driver);
-    // Press X, A, Y, B in that order; release B, Y, A, X
+    // Press X, A, Y, B in that order
     // Combo for X+B+Y should be triggered since it has higher priority (index), even though X+A+Y completed before it
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
+    tap_combo({key_x, key_a, key_y, key_b});
     VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_6));
     EXPECT_EMPTY_REPORT(driver);
-    // Press X, Y, A, B, C in that order; release C, B, A, Y, X
+    // Press X, Y, A, B, C in that order
     // Combo for X+A+B+C+Y should be triggered sice it has higher priority than the others
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_c.press();
-    run_one_scan_loop();
-    key_c.release();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
+    tap_combo({key_x, key_y, key_a, key_b, key_c});
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/combo/combo_conflicts/test_combo.cpp
+++ b/tests/combo/combo_conflicts/test_combo.cpp
@@ -1,5 +1,4 @@
-// Copyright 2023 Stefan Kerkmann (@KarlK90)
-// Copyright 2023 @filterpaper
+// Copyright 2025 @johnwilmes
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "keyboard_report_util.hpp"

--- a/tests/combo/combo_conflicts/test_combo.cpp
+++ b/tests/combo/combo_conflicts/test_combo.cpp
@@ -1,0 +1,239 @@
+// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// Copyright 2023 @filterpaper
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.h"
+#include "test_common.hpp"
+#include "test_driver.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+class ComboConflicts : public TestFixture {};
+
+TEST_F(ComboConflicts, combo_irrelevant_press) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_x(0, 2, 0, KC_X);
+    KeymapKey  key_y(0, 3, 0, KC_Y);
+    KeymapKey  key_z(0, 4, 0, KC_Z);
+    set_keymap({key_a, key_b, key_x, key_y, key_z});
+
+    EXPECT_REPORT(driver, (KC_1)).Times(2);
+    EXPECT_REPORT(driver, (KC_1, KC_Z));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press A, Z, B in that order; release B, Z, A
+    // Combo for A+B should be triggered since it does not require contiguity
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_z.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_z.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A)).Times(3);
+    EXPECT_REPORT(driver, (KC_A, KC_Z));
+    EXPECT_REPORT(driver, (KC_A, KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press A, press and release Z, press B in that order; release B then A
+    // Combo for A+B should not be triggered since there was a press+release of Z in between
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_z.press();
+    run_one_scan_loop();
+    key_z.release();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_X)).Times(2);
+    EXPECT_REPORT(driver, (KC_X, KC_Z)).Times(2);
+    EXPECT_REPORT(driver, (KC_X, KC_Z, KC_Y));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press X, Z, Y in that order; release Y, Z, X
+    // Combo for X+Y should not be triggered since it requires contiguity
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_z.press();
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    key_z.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboConflicts, combo_priority) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_x(0, 2, 0, KC_X);
+    KeymapKey  key_y(0, 3, 0, KC_Y);
+    set_keymap({key_a, key_b, key_x, key_y});
+
+    EXPECT_REPORT(driver, (KC_4)).Times(2);
+    EXPECT_REPORT(driver, (KC_4, KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press X, A, B, Y in that order; release Y, B, A, X
+    // Combo for X+B+Y should be triggered since it has higher priority (index)
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_4)).Times(2);
+    EXPECT_REPORT(driver, (KC_4, KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press X, Y, A, B in that order; release B, A, Y, X
+    // Combo for X+B+Y should be triggered since it has higher priority (index)
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboConflicts, combo_priority_trigger) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_x(0, 2, 0, KC_X);
+    KeymapKey  key_y(0, 3, 0, KC_Y);
+    set_keymap({key_a, key_b, key_x, key_y});
+
+    EXPECT_REPORT(driver, (KC_3)).Times(2);
+    EXPECT_REPORT(driver, (KC_3, KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press A, X, B, Y in that order; release Y, B, X, A
+    // Combo for X+A+Y should be triggered since it has earlier trigger
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboConflicts, combo_wait_for_preferred) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_x(0, 2, 0, KC_X);
+    KeymapKey  key_y(0, 3, 0, KC_Y);
+    KeymapKey  key_c(0, 4, 0, KC_C);
+    set_keymap({key_a, key_b, key_x, key_y, key_c});
+
+    EXPECT_REPORT(driver, (KC_4)).Times(2);
+    EXPECT_REPORT(driver, (KC_4, KC_A));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press X, A, Y, B in that order; release B, Y, A, X
+    // Combo for X+B+Y should be triggered since it has higher priority (index), even though X+A+Y completed before it
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_6));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press X, Y, A, B, C in that order; release C, B, A, Y, X
+    // Combo for X+A+B+C+Y should be triggered sice it has higher priority than the others
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_c.press();
+    run_one_scan_loop();
+    key_c.release();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/combo/combo_conflicts/test_combo_conflicts.c
+++ b/tests/combo/combo_conflicts/test_combo_conflicts.c
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "quantum.h"
 
-enum combos {ab_1, xy_2, axy_3, bxy_4, cxy_5, abcxy_6};
+enum combos { ab_1, xy_2, axy_3, bxy_4, cxy_5, abcxy_6 };
 
-uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
-uint16_t const xy_2_combo[]     = {KC_X, KC_Y,  COMBO_END};
-uint16_t const axy_3_combo[]     = {KC_A, KC_X, KC_Y, COMBO_END};
+uint16_t const ab_1_combo[]    = {KC_A, KC_B, COMBO_END};
+uint16_t const xy_2_combo[]    = {KC_X, KC_Y, COMBO_END};
+uint16_t const axy_3_combo[]   = {KC_A, KC_X, KC_Y, COMBO_END};
 uint16_t const bxy_4_combo[]   = {KC_B, KC_X, KC_Y, COMBO_END};
 uint16_t const cxy_5_combo[]   = {KC_C, KC_X, KC_Y, COMBO_END};
 uint16_t const abcxy_6_combo[] = {KC_A, KC_B, KC_C, KC_X, KC_Y, COMBO_END};

--- a/tests/combo/combo_conflicts/test_combo_conflicts.c
+++ b/tests/combo/combo_conflicts/test_combo_conflicts.c
@@ -24,16 +24,12 @@ combo_t key_combos[] = {
 };
 // clang-format on
 
-/* Return true if the keypress in record interrupts the given combo with the given index,
- * preventing it from firing. */
-bool is_combo_interrupted(uint16_t index, combo_t *combo, keyrecord_t *record, uint8_t n_unpressed_keys, bool combo_has_key) {
+bool is_combo_contiguous(uint16_t index, combo_t *combo, keyrecord_t *record, uint8_t n_unpressed_keys) {
     switch (index) {
         case xy_2:
         case cxy_5:
-            // Require contiguous
-            return !combo_has_key;
+            return true; // xy_2 and cxy_5 are contiguous combos
         default:
-            return false;
+            return false; // no other combos are contiguous
     }
 }
-

--- a/tests/combo/combo_conflicts/test_combo_conflicts.c
+++ b/tests/combo/combo_conflicts/test_combo_conflicts.c
@@ -25,16 +25,15 @@ combo_t key_combos[] = {
 // clang-format on
 
 /* Return true if the keypress in record interrupts the given combo with the given index,
- * preventing it from firing. The key in record is not contained in the combo.
- */
-bool get_combo_interrupted(uint16_t index, combo_t *combo, keyrecord_t *record) {
+ * preventing it from firing. */
+bool is_combo_interrupted(uint16_t index, combo_t *combo, keyrecord_t *record, uint8_t n_unpressed_keys, bool combo_has_key) {
     switch (index) {
         case xy_2:
         case cxy_5:
-            return true;
+            // Require contiguous
+            return !combo_has_key;
         default:
             return false;
     }
 }
-
 

--- a/tests/combo/combo_conflicts/test_combo_conflicts.c
+++ b/tests/combo/combo_conflicts/test_combo_conflicts.c
@@ -1,6 +1,4 @@
-// Copyright 2023 Stefan Kerkmann (@KarlK90)
-// Copyright 2023 @filterpaper
-// Copyright 2023 Nick Brassel (@tzarc)
+// Copyright 2025 @johnwilmes
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "quantum.h"
 

--- a/tests/combo/combo_conflicts/test_combo_conflicts.c
+++ b/tests/combo/combo_conflicts/test_combo_conflicts.c
@@ -1,0 +1,40 @@
+// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// Copyright 2023 @filterpaper
+// Copyright 2023 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+
+enum combos {ab_1, xy_2, axy_3, bxy_4, cxy_5, abcxy_6};
+
+uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
+uint16_t const xy_2_combo[]     = {KC_X, KC_Y,  COMBO_END};
+uint16_t const axy_3_combo[]     = {KC_A, KC_X, KC_Y, COMBO_END};
+uint16_t const bxy_4_combo[]   = {KC_B, KC_X, KC_Y, COMBO_END};
+uint16_t const cxy_5_combo[]   = {KC_C, KC_X, KC_Y, COMBO_END};
+uint16_t const abcxy_6_combo[] = {KC_A, KC_B, KC_C, KC_X, KC_Y, COMBO_END};
+
+// clang-format off
+combo_t key_combos[] = {
+    [ab_1]     = COMBO(ab_1_combo, KC_1),
+    [xy_2]     = COMBO(xy_2_combo, KC_2),
+    [axy_3]     = COMBO(axy_3_combo, KC_3),
+    [bxy_4]   = COMBO(bxy_4_combo, KC_4),
+    [cxy_5]   = COMBO(cxy_5_combo, KC_5),
+    [abcxy_6] = COMBO(abcxy_6_combo, KC_6)
+};
+// clang-format on
+
+/* Return true if the keypress in record interrupts the given combo with the given index,
+ * preventing it from firing. The key in record is not contained in the combo.
+ */
+bool get_combo_interrupted(uint16_t index, combo_t *combo, keyrecord_t *record) {
+    switch (index) {
+        case xy_2:
+        case cxy_5:
+            return true;
+        default:
+            return false;
+    }
+}
+
+

--- a/tests/combo/combo_events/config.h
+++ b/tests/combo/combo_events/config.h
@@ -1,0 +1,9 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define COMBO_PROCESS_KEY_RELEASE
+#define COMBO_SHOULD_TRIGGER

--- a/tests/combo/combo_events/test.mk
+++ b/tests/combo/combo_events/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2025 @johnwilmes
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+COMBO_ENABLE = yes
+
+INTROSPECTION_KEYMAP_C = test_combo_events.c

--- a/tests/combo/combo_events/test_combo.cpp
+++ b/tests/combo/combo_events/test_combo.cpp
@@ -42,7 +42,6 @@ TEST_F(ComboEvents, combo_release) {
     tap_combo({key_x, key_y});
     VERIFY_AND_CLEAR(driver);
 
-
     // Combo deactivates early when y is released
     EXPECT_REPORT(driver, (KC_1)).Times(2);
     EXPECT_REPORT(driver, (KC_1, KC_3));

--- a/tests/combo/combo_events/test_combo.cpp
+++ b/tests/combo/combo_events/test_combo.cpp
@@ -1,0 +1,68 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.h"
+#include "test_common.hpp"
+#include "test_driver.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+extern bool combo_override;
+
+class ComboEvents : public TestFixture {};
+
+TEST_F(ComboEvents, combo_action) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 1, KC_A);
+    KeymapKey  key_b(0, 0, 2, KC_B);
+    set_keymap({key_a, key_b});
+
+    EXPECT_REPORT(driver, (KC_1));
+    EXPECT_REPORT(driver, (KC_2));
+    EXPECT_EMPTY_REPORT(driver).Times(2);
+    tap_combo({key_a, key_b});
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboEvents, combo_release) {
+    TestDriver driver;
+    KeymapKey  key_x(0, 0, 1, KC_X);
+    KeymapKey  key_y(0, 0, 2, KC_Y);
+    set_keymap({key_x, key_y});
+
+    EXPECT_REPORT(driver, (KC_1)).Times(3);
+    EXPECT_REPORT(driver, (KC_1, KC_2));
+    EXPECT_REPORT(driver, (KC_1, KC_3));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_x, key_y});
+    VERIFY_AND_CLEAR(driver);
+
+
+    // Combo deactivates early when y is released
+    EXPECT_REPORT(driver, (KC_1)).Times(2);
+    EXPECT_REPORT(driver, (KC_1, KC_3));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_y, key_x});
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboEvents, combo_should_trigger) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 1, KC_A);
+    KeymapKey  key_b(0, 0, 2, KC_B);
+    set_keymap({key_a, key_b});
+
+    combo_override = true;
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_REPORT(driver, (KC_A, KC_B));
+    EXPECT_REPORT(driver, (KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_b});
+    VERIFY_AND_CLEAR(driver);
+    combo_override = false;
+}

--- a/tests/combo/combo_events/test_combo_events.c
+++ b/tests/combo/combo_events/test_combo_events.c
@@ -3,10 +3,10 @@
 #include "quantum.h"
 #include "stdio.h"
 
-enum combos {ab_action, xy_123};
+enum combos { ab_action, xy_123 };
 
-uint16_t const ab_action_combo[]     = {KC_A, KC_B, COMBO_END};
-uint16_t const xy_123_combo[]     = {KC_X, KC_Y, COMBO_END};
+uint16_t const ab_action_combo[] = {KC_A, KC_B, COMBO_END};
+uint16_t const xy_123_combo[]    = {KC_X, KC_Y, COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {
@@ -30,7 +30,7 @@ void process_combo_event(uint16_t combo_index, bool pressed) {
 bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) {
     switch (combo_index) {
         case xy_123:
-            switch(keycode) {
+            switch (keycode) {
                 case KC_X:
                     tap_code(KC_2);
                     break;

--- a/tests/combo/combo_events/test_combo_events.c
+++ b/tests/combo/combo_events/test_combo_events.c
@@ -1,0 +1,50 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+#include "stdio.h"
+
+enum combos {ab_action, xy_123};
+
+uint16_t const ab_action_combo[]     = {KC_A, KC_B, COMBO_END};
+uint16_t const xy_123_combo[]     = {KC_X, KC_Y, COMBO_END};
+
+// clang-format off
+combo_t key_combos[] = {
+    [ab_action]     = COMBO_ACTION(ab_action_combo),
+    [xy_123]     = COMBO(xy_123_combo, KC_1),
+};
+// clang-format on
+
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    switch (combo_index) {
+        case ab_action:
+            if (pressed) {
+                tap_code(KC_1);
+            } else {
+                tap_code(KC_2);
+            }
+            break;
+    }
+}
+
+bool process_combo_key_release(uint16_t combo_index, combo_t *combo, uint8_t key_index, uint16_t keycode) {
+    switch (combo_index) {
+        case xy_123:
+            switch(keycode) {
+                case KC_X:
+                    tap_code(KC_2);
+                    break;
+                case KC_Y:
+                    tap_code(KC_3);
+                    return true; // deactivate combo
+                    break;
+            }
+    }
+    return false;
+}
+
+bool combo_override = false;
+
+bool combo_should_trigger(uint16_t combo_index, combo_t *combo, uint16_t keycode, keyrecord_t *record) {
+    return !combo_override;
+}

--- a/tests/combo/combo_hold_tap/config.h
+++ b/tests/combo/combo_hold_tap/config.h
@@ -1,0 +1,10 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define COMBO_MUST_HOLD_PER_COMBO
+#define COMBO_MUST_TAP_PER_COMBO
+#define COMBO_HOLD_TERM 100

--- a/tests/combo/combo_hold_tap/test.mk
+++ b/tests/combo/combo_hold_tap/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2025 @johnwilmes
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+COMBO_ENABLE = yes
+
+INTROSPECTION_KEYMAP_C = test_combo_hold_tap.c

--- a/tests/combo/combo_hold_tap/test_combo.cpp
+++ b/tests/combo/combo_hold_tap/test_combo.cpp
@@ -12,9 +12,9 @@
 using testing::_;
 using testing::InSequence;
 
-class ComboConflicts : public TestFixture {};
+class ComboHoldTap : public TestFixture {};
 
-TEST_F(ComboConflicts, combo_hold) {
+TEST_F(ComboHoldTap, combo_hold) {
     TestDriver driver;
     KeymapKey  key_a(0, 0, 1, KC_A);
     KeymapKey  key_b(0, 0, 2, KC_B);
@@ -33,7 +33,7 @@ TEST_F(ComboConflicts, combo_hold) {
     VERIFY_AND_CLEAR(driver);
 }
 
-TEST_F(ComboConflicts, combo_tap) {
+TEST_F(ComboHoldTap, combo_tap) {
     TestDriver driver;
     KeymapKey  key_x(0, 0, 1, KC_X);
     KeymapKey  key_y(0, 0, 2, KC_Y);

--- a/tests/combo/combo_hold_tap/test_combo.cpp
+++ b/tests/combo/combo_hold_tap/test_combo.cpp
@@ -1,0 +1,53 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.h"
+#include "test_common.hpp"
+#include "test_driver.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+class ComboConflicts : public TestFixture {};
+
+TEST_F(ComboConflicts, combo_hold) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 1, KC_A);
+    KeymapKey  key_b(0, 0, 2, KC_B);
+    set_keymap({key_a, key_b});
+
+    EXPECT_REPORT(driver, (KC_1));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_b}, COMBO_HOLD_TERM + 1);
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_REPORT(driver, (KC_A, KC_B));
+    EXPECT_REPORT(driver, (KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_b}, COMBO_HOLD_TERM - 1);
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboConflicts, combo_tap) {
+    TestDriver driver;
+    KeymapKey  key_x(0, 0, 1, KC_X);
+    KeymapKey  key_y(0, 0, 2, KC_Y);
+    set_keymap({key_x, key_y});
+
+    EXPECT_REPORT(driver, (KC_2));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_x, key_y}, COMBO_HOLD_TERM - 1);
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_X));
+    EXPECT_REPORT(driver, (KC_X, KC_Y));
+    EXPECT_REPORT(driver, (KC_Y));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_x, key_y}, COMBO_HOLD_TERM + 1);
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/combo/combo_hold_tap/test_combo_hold_tap.c
+++ b/tests/combo/combo_hold_tap/test_combo_hold_tap.c
@@ -1,0 +1,34 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+#include "stdio.h"
+
+enum combos {ab_1, xy_2};
+
+uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
+uint16_t const xy_2_combo[]     = {KC_X, KC_Y, COMBO_END};
+
+// clang-format off
+combo_t key_combos[] = {
+    [ab_1]     = COMBO(ab_1_combo, KC_1),
+    [xy_2]     = COMBO(xy_2_combo, KC_2),
+};
+// clang-format on
+
+bool get_combo_must_hold(uint16_t combo_index, combo_t *combo) {
+    switch (combo_index) {
+        case ab_1:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool get_combo_must_tap(uint16_t combo_index, combo_t *combo) {
+    switch (combo_index) {
+        case xy_2:
+            return true;
+        default:
+            return false;
+    }
+}

--- a/tests/combo/combo_hold_tap/test_combo_hold_tap.c
+++ b/tests/combo/combo_hold_tap/test_combo_hold_tap.c
@@ -3,10 +3,10 @@
 #include "quantum.h"
 #include "stdio.h"
 
-enum combos {ab_1, xy_2};
+enum combos { ab_1, xy_2 };
 
-uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
-uint16_t const xy_2_combo[]     = {KC_X, KC_Y, COMBO_END};
+uint16_t const ab_1_combo[] = {KC_A, KC_B, COMBO_END};
+uint16_t const xy_2_combo[] = {KC_X, KC_Y, COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {

--- a/tests/combo/combo_key_buffer/config.h
+++ b/tests/combo/combo_key_buffer/config.h
@@ -1,0 +1,9 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define COMBO_KEY_BUFFER_LENGTH 4
+#define COMBO_CONTIGUOUS_PER_COMBO

--- a/tests/combo/combo_key_buffer/test.mk
+++ b/tests/combo/combo_key_buffer/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2025 @johnwilmes
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+COMBO_ENABLE = yes
+
+INTROSPECTION_KEYMAP_C = test_combo_key_buffer.c

--- a/tests/combo/combo_key_buffer/test_combo.cpp
+++ b/tests/combo/combo_key_buffer/test_combo.cpp
@@ -1,0 +1,103 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.h"
+#include "test_common.hpp"
+#include "test_driver.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+extern bool combo_override;
+
+class ComboKeyBuffer : public TestFixture {};
+
+TEST_F(ComboKeyBuffer, combo_key_buffer) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_i(0, 2, 0, KC_I);
+    KeymapKey  key_j(0, 3, 0, KC_J);
+    KeymapKey  key_k(0, 4, 0, KC_K);
+    KeymapKey  key_a2(0, 5, 0, KC_A);
+    set_keymap({key_a, key_b, key_i, key_j, key_k, key_a2});
+
+    EXPECT_REPORT(driver, (KC_1)).Times(2);
+    EXPECT_REPORT(driver, (KC_1, KC_I));
+    EXPECT_REPORT(driver, (KC_1, KC_I, KC_J));
+    EXPECT_REPORT(driver, (KC_1, KC_J));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_i, key_j, key_b});
+    VERIFY_AND_CLEAR(driver);
+
+    // buffer overflow prevents combo from firing
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_REPORT(driver, (KC_A, KC_I));
+    EXPECT_REPORT(driver, (KC_A, KC_I, KC_J));
+    EXPECT_REPORT(driver, (KC_A, KC_I, KC_J, KC_K));
+    EXPECT_REPORT(driver, (KC_A, KC_I, KC_J, KC_K, KC_B));
+    EXPECT_REPORT(driver, (KC_I, KC_J, KC_K, KC_B));
+    EXPECT_REPORT(driver, (KC_J, KC_K, KC_B));
+    EXPECT_REPORT(driver, (KC_K, KC_B));
+    EXPECT_REPORT(driver, (KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_i, key_j, key_k, key_b});
+    VERIFY_AND_CLEAR(driver);
+
+    // buffer overflow prevents combo from firing initially, fires with a second key press
+    EXPECT_REPORT(driver, (KC_A)).Times(2);
+    EXPECT_REPORT(driver, (KC_A, KC_I));
+    EXPECT_REPORT(driver, (KC_A, KC_I, KC_J));
+    EXPECT_REPORT(driver, (KC_A, KC_I, KC_J, KC_K));
+    EXPECT_REPORT(driver, (KC_A, KC_I, KC_J, KC_K, KC_1));
+    // the first KC_A release is consumed by the active combo even though it is a different position
+    EXPECT_REPORT(driver, (KC_A, KC_J, KC_K, KC_1));
+    EXPECT_REPORT(driver, (KC_A, KC_K, KC_1));
+    EXPECT_REPORT(driver, (KC_A, KC_1));
+    EXPECT_EMPTY_REPORT(driver);
+    for (KeymapKey key : {key_a, key_i, key_j, key_k, key_b, key_a2}) {
+        key.press();
+        run_one_scan_loop();
+    }
+    for (KeymapKey key : {key_a, key_i, key_j, key_k, key_b, key_a2}) {
+        key.release();
+        run_one_scan_loop();
+    }
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboKeyBuffer, combo_key_buffer_blocked) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_i(0, 2, 0, KC_I);
+    KeymapKey  key_j(0, 3, 0, KC_J);
+    KeymapKey  key_k(0, 4, 0, KC_K);
+    KeymapKey  key_x(0, 5, 0, KC_X);
+    set_keymap({key_a, key_b, key_i, key_j, key_k, key_x});
+
+    // If the key buffer doesn't overflow, we wait for ABX to fire
+    EXPECT_REPORT(driver, (KC_2)).Times(2);
+    EXPECT_REPORT(driver, (KC_I, KC_2));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_b, key_i, key_x});
+    VERIFY_AND_CLEAR(driver);
+
+    // If the key buffer overflows, we just use AB
+    EXPECT_REPORT(driver, (KC_1));
+    EXPECT_REPORT(driver, (KC_1, KC_I));
+    EXPECT_REPORT(driver, (KC_1, KC_I, KC_J));
+    EXPECT_REPORT(driver, (KC_1, KC_I, KC_J, KC_K));
+    EXPECT_REPORT(driver, (KC_1, KC_I, KC_J, KC_K, KC_X));
+    EXPECT_REPORT(driver, (KC_I, KC_J, KC_K, KC_X));
+    EXPECT_REPORT(driver, (KC_J, KC_K, KC_X));
+    EXPECT_REPORT(driver, (KC_K, KC_X));
+    EXPECT_REPORT(driver, (KC_X));
+    EXPECT_EMPTY_REPORT(driver);
+    tap_combo({key_a, key_b, key_i, key_j, key_k, key_x});
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/combo/combo_key_buffer/test_combo_key_buffer.c
+++ b/tests/combo/combo_key_buffer/test_combo_key_buffer.c
@@ -3,10 +3,10 @@
 #include "quantum.h"
 #include "stdio.h"
 
-enum combos {ab_1, abx_2};
+enum combos { ab_1, abx_2 };
 
-uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
-uint16_t const abx_2_combo[]    = {KC_A, KC_B, KC_X, COMBO_END};
+uint16_t const ab_1_combo[]  = {KC_A, KC_B, COMBO_END};
+uint16_t const abx_2_combo[] = {KC_A, KC_B, KC_X, COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {
@@ -15,9 +15,6 @@ combo_t key_combos[] = {
 };
 // clang-format on
 
-
 bool is_combo_contiguous(uint16_t index, combo_t *combo, keyrecord_t *record, uint8_t n_unpressed_keys) {
     return false; // No combos are contiguous in this test
 }
-
-

--- a/tests/combo/combo_key_buffer/test_combo_key_buffer.c
+++ b/tests/combo/combo_key_buffer/test_combo_key_buffer.c
@@ -1,0 +1,23 @@
+// Copyright 2025 @johnwilmes
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+#include "stdio.h"
+
+enum combos {ab_1, abx_2};
+
+uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
+uint16_t const abx_2_combo[]    = {KC_A, KC_B, KC_X, COMBO_END};
+
+// clang-format off
+combo_t key_combos[] = {
+    [ab_1]     = COMBO(ab_1_combo, KC_1),
+    [abx_2]    = COMBO(abx_2_combo, KC_2),
+};
+// clang-format on
+
+
+bool is_combo_contiguous(uint16_t index, combo_t *combo, keyrecord_t *record, uint8_t n_unpressed_keys) {
+    return false; // No combos are contiguous in this test
+}
+
+

--- a/tests/combo/combo_order/config.h
+++ b/tests/combo/combo_order/config.h
@@ -1,0 +1,8 @@
+// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define COMBO_MUST_PRESS_IN_ORDER_PER_COMBO

--- a/tests/combo/combo_order/config.h
+++ b/tests/combo/combo_order/config.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// Copyright 2025 @johnwilmes
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/tests/combo/combo_order/test.mk
+++ b/tests/combo/combo_order/test.mk
@@ -1,4 +1,4 @@
-# Copyright 2023 Stefan Kerkmann (@KarlK90)
+# Copyright 2025 @johnwilmes
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 COMBO_ENABLE = yes

--- a/tests/combo/combo_order/test.mk
+++ b/tests/combo/combo_order/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2023 Stefan Kerkmann (@KarlK90)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+COMBO_ENABLE = yes
+
+INTROSPECTION_KEYMAP_C = test_combo_order.c

--- a/tests/combo/combo_order/test_combo.cpp
+++ b/tests/combo/combo_order/test_combo.cpp
@@ -12,9 +12,9 @@
 using testing::_;
 using testing::InSequence;
 
-class ComboConflicts : public TestFixture {};
+class ComboOrder : public TestFixture {};
 
-TEST_F(ComboConflicts, combo_requires_order) {
+TEST_F(ComboOrder, combo_requires_order) {
     TestDriver driver;
     KeymapKey  key_a(0, 0, 0, KC_A);
     KeymapKey  key_b(0, 1, 0, KC_B);
@@ -81,7 +81,7 @@ TEST_F(ComboConflicts, combo_requires_order) {
     VERIFY_AND_CLEAR(driver);
 }
 
-TEST_F(ComboConflicts, combo_doesnt_require_order) {
+TEST_F(ComboOrder, combo_doesnt_require_order) {
     TestDriver driver;
     KeymapKey  key_x(0, 0, 0, KC_X);
     KeymapKey  key_y(0, 1, 0, KC_Y);

--- a/tests/combo/combo_order/test_combo.cpp
+++ b/tests/combo/combo_order/test_combo.cpp
@@ -1,5 +1,4 @@
-// Copyright 2023 Stefan Kerkmann (@KarlK90)
-// Copyright 2023 @filterpaper
+// Copyright 2025 @johnwilmes
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "keyboard_report_util.hpp"

--- a/tests/combo/combo_order/test_combo.cpp
+++ b/tests/combo/combo_order/test_combo.cpp
@@ -61,7 +61,6 @@ TEST_F(ComboOrder, combo_doesnt_require_order) {
     tap_combo({key_x, key_y, key_z});
     VERIFY_AND_CLEAR(driver);
 
-
     EXPECT_REPORT(driver, (KC_3));
     EXPECT_EMPTY_REPORT(driver);
     // Press Y, X, Z in that order

--- a/tests/combo/combo_order/test_combo.cpp
+++ b/tests/combo/combo_order/test_combo.cpp
@@ -1,0 +1,130 @@
+// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// Copyright 2023 @filterpaper
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.h"
+#include "test_common.hpp"
+#include "test_driver.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+class ComboConflicts : public TestFixture {};
+
+TEST_F(ComboConflicts, combo_requires_order) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_c(0, 2, 0, KC_C);
+    set_keymap({key_a, key_b, key_c});
+
+    EXPECT_REPORT(driver, (KC_1));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press A, B, C in that order; release C, B, A
+    // triggers ABC combo in order
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_c.press();
+    run_one_scan_loop();
+    key_c.release();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_2));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press C, A, B in that order; release B, A, C
+    // triggers CAB combo in order
+    run_one_scan_loop();
+    key_c.press();
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    key_c.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_A)).Times(2);
+    EXPECT_REPORT(driver, (KC_A, KC_C)).Times(2);
+    EXPECT_REPORT(driver, (KC_A, KC_C, KC_B));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press A, C, B; release B, C, A
+    // does not trigger any combo
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_c.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_c.release();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(ComboConflicts, combo_doesnt_require_order) {
+    TestDriver driver;
+    KeymapKey  key_x(0, 0, 0, KC_X);
+    KeymapKey  key_y(0, 1, 0, KC_Y);
+    KeymapKey  key_z(0, 2, 0, KC_Z);
+    set_keymap({key_x, key_y, key_z});
+
+    EXPECT_REPORT(driver, (KC_3));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press X, Y, Z in that order; release Z, Y, X
+    // triggers XYZ combo
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_z.press();
+    run_one_scan_loop();
+    key_z.release();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+
+    EXPECT_REPORT(driver, (KC_3));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press Y, X, Z in that order; release Z, X, Y
+    // triggers XYZ combo
+    run_one_scan_loop();
+    key_y.press();
+    run_one_scan_loop();
+    key_x.press();
+    run_one_scan_loop();
+    key_z.press();
+    run_one_scan_loop();
+    key_z.release();
+    run_one_scan_loop();
+    key_x.release();
+    run_one_scan_loop();
+    key_y.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/combo/combo_order/test_combo.cpp
+++ b/tests/combo/combo_order/test_combo.cpp
@@ -23,61 +23,27 @@ TEST_F(ComboOrder, combo_requires_order) {
 
     EXPECT_REPORT(driver, (KC_1));
     EXPECT_EMPTY_REPORT(driver);
-    // Press A, B, C in that order; release C, B, A
-    // triggers ABC combo in order
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_c.press();
-    run_one_scan_loop();
-    key_c.release();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
+    // Press A, B, C in that order
+    // triggers ABC combo
+    tap_combo({key_a, key_b, key_c});
     VERIFY_AND_CLEAR(driver);
 
     EXPECT_REPORT(driver, (KC_2));
     EXPECT_EMPTY_REPORT(driver);
     // Press C, A, B in that order; release B, A, C
     // triggers CAB combo in order
-    run_one_scan_loop();
-    key_c.press();
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
-    key_c.release();
-    run_one_scan_loop();
+    tap_combo({key_c, key_a, key_b});
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_A)).Times(2);
-    EXPECT_REPORT(driver, (KC_A, KC_C)).Times(2);
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_REPORT(driver, (KC_A, KC_C));
     EXPECT_REPORT(driver, (KC_A, KC_C, KC_B));
+    EXPECT_REPORT(driver, (KC_C, KC_B));
+    EXPECT_REPORT(driver, (KC_B));
     EXPECT_EMPTY_REPORT(driver);
-    // Press A, C, B; release B, C, A
+    // Press A, C, B
     // does not trigger any combo
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_c.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_c.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
+    tap_combo({key_a, key_c, key_b});
     VERIFY_AND_CLEAR(driver);
 }
 
@@ -90,40 +56,16 @@ TEST_F(ComboOrder, combo_doesnt_require_order) {
 
     EXPECT_REPORT(driver, (KC_3));
     EXPECT_EMPTY_REPORT(driver);
-    // Press X, Y, Z in that order; release Z, Y, X
+    // Press X, Y, Z in that order
     // triggers XYZ combo
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_z.press();
-    run_one_scan_loop();
-    key_z.release();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
+    tap_combo({key_x, key_y, key_z});
     VERIFY_AND_CLEAR(driver);
 
 
     EXPECT_REPORT(driver, (KC_3));
     EXPECT_EMPTY_REPORT(driver);
-    // Press Y, X, Z in that order; release Z, X, Y
+    // Press Y, X, Z in that order
     // triggers XYZ combo
-    run_one_scan_loop();
-    key_y.press();
-    run_one_scan_loop();
-    key_x.press();
-    run_one_scan_loop();
-    key_z.press();
-    run_one_scan_loop();
-    key_z.release();
-    run_one_scan_loop();
-    key_x.release();
-    run_one_scan_loop();
-    key_y.release();
-    run_one_scan_loop();
+    tap_combo({key_y, key_x, key_z});
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/combo/combo_order/test_combo_order.c
+++ b/tests/combo/combo_order/test_combo_order.c
@@ -1,6 +1,4 @@
-// Copyright 2023 Stefan Kerkmann (@KarlK90)
-// Copyright 2023 @filterpaper
-// Copyright 2023 Nick Brassel (@tzarc)
+// Copyright 2025 @johnwilmes
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "quantum.h"
 #include "stdio.h"

--- a/tests/combo/combo_order/test_combo_order.c
+++ b/tests/combo/combo_order/test_combo_order.c
@@ -3,11 +3,11 @@
 #include "quantum.h"
 #include "stdio.h"
 
-enum combos {abc_1, cab_2, xyz_3};
+enum combos { abc_1, cab_2, xyz_3 };
 
-uint16_t const abc_1_combo[]     = {KC_A, KC_B, KC_C, COMBO_END};
-uint16_t const cab_2_combo[]     = {KC_C, KC_A, KC_B, COMBO_END};
-uint16_t const xyz_3_combo[]     = {KC_X, KC_Y, KC_Z, COMBO_END};
+uint16_t const abc_1_combo[] = {KC_A, KC_B, KC_C, COMBO_END};
+uint16_t const cab_2_combo[] = {KC_C, KC_A, KC_B, COMBO_END};
+uint16_t const xyz_3_combo[] = {KC_X, KC_Y, KC_Z, COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {
@@ -24,7 +24,7 @@ bool get_combo_must_press_in_order(uint16_t combo_index, combo_t *combo) {
         case cab_2:
             return true;
         default:
-        // xyz does not require pressing in order
+            // xyz does not require pressing in order
             return false;
     }
 }

--- a/tests/combo/combo_order/test_combo_order.c
+++ b/tests/combo/combo_order/test_combo_order.c
@@ -1,0 +1,32 @@
+// Copyright 2023 Stefan Kerkmann (@KarlK90)
+// Copyright 2023 @filterpaper
+// Copyright 2023 Nick Brassel (@tzarc)
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "quantum.h"
+#include "stdio.h"
+
+enum combos {abc_1, cab_2, xyz_3};
+
+uint16_t const abc_1_combo[]     = {KC_A, KC_B, KC_C, COMBO_END};
+uint16_t const cab_2_combo[]     = {KC_C, KC_A, KC_B, COMBO_END};
+uint16_t const xyz_3_combo[]     = {KC_X, KC_Y, KC_Z, COMBO_END};
+
+// clang-format off
+combo_t key_combos[] = {
+    [abc_1]     = COMBO(abc_1_combo, KC_1),
+    [cab_2]     = COMBO(cab_2_combo, KC_2),
+    [xyz_3]     = COMBO(xyz_3_combo, KC_3)
+};
+// clang-format on
+
+bool get_combo_must_press_in_order(uint16_t combo_index, combo_t *combo) {
+    switch (combo_index) {
+        // these two must be pressed in order
+        case abc_1:
+        case cab_2:
+            return true;
+        default:
+        // xyz does not require pressing in order
+            return false;
+    }
+}

--- a/tests/combo/config.h
+++ b/tests/combo/config.h
@@ -7,4 +7,3 @@
 
 #define TAPPING_TERM 200
 #define COMBO_TERM 40
-#define COMBO_STRICT_TIMER

--- a/tests/combo/config.h
+++ b/tests/combo/config.h
@@ -7,3 +7,4 @@
 
 #define TAPPING_TERM 200
 #define COMBO_TERM 40
+#define COMBO_COMPRESSED

--- a/tests/combo/config.h
+++ b/tests/combo/config.h
@@ -6,3 +6,5 @@
 #include "test_common.h"
 
 #define TAPPING_TERM 200
+#define COMBO_TERM 40
+#define COMBO_STRICT_TIMER

--- a/tests/combo/test_combo.cpp
+++ b/tests/combo/test_combo.cpp
@@ -58,6 +58,33 @@ TEST_F(Combo, combo_too_slow) {
     VERIFY_AND_CLEAR(driver);
 }
 
+TEST_F(Combo, combo_release_interrupt) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_c(0, 2, 0, KC_C);
+    KeymapKey  key_d(0, 3, 0, KC_D);
+    set_keymap({key_a, key_c, key_d});
+
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_REPORT(driver, (KC_A, KC_2));
+    EXPECT_REPORT(driver, (KC_2));
+    EXPECT_EMPTY_REPORT(driver);
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_c.press();
+    run_one_scan_loop();
+    key_a.release();
+    run_one_scan_loop();
+    key_d.press();
+    run_one_scan_loop();
+    key_c.release();
+    run_one_scan_loop();
+    key_d.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
 TEST_F(Combo, combo_disjoint) {
     TestDriver driver;
     KeymapKey  key_a(0, 0, 0, KC_A);
@@ -70,13 +97,13 @@ TEST_F(Combo, combo_disjoint) {
     EXPECT_REPORT(driver, (KC_1, KC_2));
     EXPECT_REPORT(driver, (KC_2));
     EXPECT_EMPTY_REPORT(driver);
-    // Press A, C, B, D in that order; trigger combos for A+B and C+D
+    // Press A, B, C, D in that order; trigger combos for A+B and C+D
     run_one_scan_loop();
     key_a.press();
     run_one_scan_loop();
-    key_c.press();
-    run_one_scan_loop();
     key_b.press();
+    run_one_scan_loop();
+    key_c.press();
     run_one_scan_loop();
     key_d.press();
     run_one_scan_loop();
@@ -99,6 +126,7 @@ TEST_F(Combo, combo_modtest_tapped) {
 
     EXPECT_REPORT(driver, (KC_SPACE));
     EXPECT_EMPTY_REPORT(driver);
+    run_one_scan_loop(); // Ensure that combo timer is > 0
     tap_combo({key_y, key_u});
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/combo/test_combo.cpp
+++ b/tests/combo/test_combo.cpp
@@ -100,23 +100,7 @@ TEST_F(Combo, combo_disjoint) {
     EXPECT_REPORT(driver, (KC_2));
     EXPECT_EMPTY_REPORT(driver);
     // Press A, B, C, D in that order; trigger combos for A+B and C+D
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_c.press();
-    run_one_scan_loop();
-    key_d.press();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_c.release();
-    run_one_scan_loop();
-    key_d.release();
-    run_one_scan_loop();
+    tap_combo({key_a, key_b, key_c, key_d});
     VERIFY_AND_CLEAR(driver);
 }
 
@@ -128,29 +112,16 @@ TEST_F(Combo, combo_noncontiguous) {
     KeymapKey  key_d(0, 3, 0, KC_D);
     set_keymap({key_a, key_b, key_c, key_d});
 
-    EXPECT_REPORT(driver, (KC_A)).Times(2);
-    EXPECT_REPORT(driver, (KC_A, KC_C)).Times(2);
-    EXPECT_REPORT(driver, (KC_A, KC_C, KC_B)).Times(2);
+    EXPECT_REPORT(driver, (KC_A));
+    EXPECT_REPORT(driver, (KC_A, KC_C));
+    EXPECT_REPORT(driver, (KC_A, KC_C, KC_B));
     EXPECT_REPORT(driver, (KC_A, KC_C, KC_B, KC_D));
+    EXPECT_REPORT(driver, (KC_C, KC_B, KC_D));
+    EXPECT_REPORT(driver, (KC_B, KC_D));
+    EXPECT_REPORT(driver, (KC_D));
     EXPECT_EMPTY_REPORT(driver);
     // Press A, C, B, D in that order; don't trigger any combos
-    run_one_scan_loop();
-    key_a.press();
-    run_one_scan_loop();
-    key_c.press();
-    run_one_scan_loop();
-    key_b.press();
-    run_one_scan_loop();
-    key_d.press();
-    run_one_scan_loop();
-    key_d.release();
-    run_one_scan_loop();
-    key_b.release();
-    run_one_scan_loop();
-    key_c.release();
-    run_one_scan_loop();
-    key_a.release();
-    run_one_scan_loop();
+    tap_combo({key_a, key_c, key_b, key_d});
     VERIFY_AND_CLEAR(driver);
 }
 
@@ -162,7 +133,6 @@ TEST_F(Combo, combo_modtest_tapped) {
 
     EXPECT_REPORT(driver, (KC_SPACE));
     EXPECT_EMPTY_REPORT(driver);
-    run_one_scan_loop(); // Ensure that combo timer is > 0
     tap_combo({key_y, key_u});
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/combo/test_combo.cpp
+++ b/tests/combo/test_combo.cpp
@@ -25,7 +25,7 @@ TEST_F(Combo, combo_basic) {
     // Press key A, wait for less than COMBO_TERM, then press key B
     run_one_scan_loop(); // Ensure that combo timer is > 0
     key_a.press();
-    idle_for(COMBO_TERM-2);
+    idle_for(COMBO_TERM-1);
     key_b.press();
     run_one_scan_loop();
     key_a.release();
@@ -69,6 +69,8 @@ TEST_F(Combo, combo_release_interrupt) {
     EXPECT_REPORT(driver, (KC_A, KC_2));
     EXPECT_REPORT(driver, (KC_2));
     EXPECT_EMPTY_REPORT(driver);
+    // Press A, C, D in that order; release A after C
+    // Should still trigger combo for C+D
     run_one_scan_loop();
     key_a.press();
     run_one_scan_loop();
@@ -114,6 +116,40 @@ TEST_F(Combo, combo_disjoint) {
     key_c.release();
     run_one_scan_loop();
     key_d.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(Combo, combo_noncontiguous) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    KeymapKey  key_b(0, 1, 0, KC_B);
+    KeymapKey  key_c(0, 2, 0, KC_C);
+    KeymapKey  key_d(0, 3, 0, KC_D);
+    set_keymap({key_a, key_b, key_c, key_d});
+
+    EXPECT_REPORT(driver, (KC_A)).Times(2);
+    EXPECT_REPORT(driver, (KC_A, KC_C)).Times(2);
+    EXPECT_REPORT(driver, (KC_A, KC_C, KC_B)).Times(2);
+    EXPECT_REPORT(driver, (KC_A, KC_C, KC_B, KC_D));
+    EXPECT_EMPTY_REPORT(driver);
+    // Press A, C, B, D in that order; don't trigger any combos
+    run_one_scan_loop();
+    key_a.press();
+    run_one_scan_loop();
+    key_c.press();
+    run_one_scan_loop();
+    key_b.press();
+    run_one_scan_loop();
+    key_d.press();
+    run_one_scan_loop();
+    key_d.release();
+    run_one_scan_loop();
+    key_b.release();
+    run_one_scan_loop();
+    key_c.release();
+    run_one_scan_loop();
+    key_a.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/combo/test_combo.cpp
+++ b/tests/combo/test_combo.cpp
@@ -4,8 +4,7 @@
 
 #include "keyboard_report_util.hpp"
 #include "keycode.h"
-#include "test_common.h"
-#include "test_driver.hpp"
+#include "test_common.hpp"
 #include "test_fixture.hpp"
 #include "test_keymap_key.hpp"
 
@@ -25,7 +24,7 @@ TEST_F(Combo, combo_basic) {
     // Press key A, wait for less than COMBO_TERM, then press key B
     run_one_scan_loop(); // Ensure that combo timer is > 0
     key_a.press();
-    idle_for(COMBO_TERM-1);
+    idle_for(COMBO_TERM - 1);
     key_b.press();
     run_one_scan_loop();
     key_a.release();
@@ -163,5 +162,19 @@ TEST_F(Combo, combo_osmshift_tapped) {
     EXPECT_REPORT(driver, (KC_I, KC_LEFT_SHIFT));
     EXPECT_EMPTY_REPORT(driver);
     tap_key(key_i);
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(Combo, combo_single_key) {
+    // https://github.com/qmk/qmk_firmware/issues/25197
+    TestDriver driver;
+    KeymapKey  key_t(0, 0, 0, KC_T);
+    set_keymap({key_t});
+
+    EXPECT_REPORT(driver, (KC_3)).Times(3);
+    EXPECT_EMPTY_REPORT(driver).Times(3);
+    tap_combo({key_t}, 1);
+    tap_combo({key_t}, 1);
+    tap_combo({key_t}, 1);
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/combo/test_combos.c
+++ b/tests/combo/test_combos.c
@@ -2,20 +2,22 @@
 // Copyright 2023 @filterpaper
 // Copyright 2023 Nick Brassel (@tzarc)
 // SPDX-License-Identifier: GPL-2.0-or-later
-#include "quantum.h"
+#include <quantum.h>
 
-enum combos { modtest, osmshift, ab_1, cd_2 };
+enum combos { modtest, osmshift, ab_1, cd_2, t_3 };
 
 uint16_t const modtest_combo[]  = {KC_Y, KC_U, COMBO_END};
 uint16_t const osmshift_combo[] = {KC_Z, KC_X, COMBO_END};
 uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
-uint16_t const cd_2_combo[]     = {KC_C, KC_D,  COMBO_END};
+uint16_t const cd_2_combo[]     = {KC_C, KC_D, COMBO_END};
+uint16_t const t_3_combo[]      = {KC_T, COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {
     [modtest]  = COMBO(modtest_combo, RSFT_T(KC_SPACE)),
     [osmshift] = COMBO(osmshift_combo, OSM(MOD_LSFT)),
     [ab_1]     = COMBO(ab_1_combo, KC_1),
-    [cd_2]     = COMBO(cd_2_combo, KC_2)
+    [cd_2]     = COMBO(cd_2_combo, KC_2),
+    [t_3]      = COMBO(t_3_combo, KC_3),
 };
 // clang-format on

--- a/tests/combo/test_combos.c
+++ b/tests/combo/test_combos.c
@@ -4,14 +4,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include "quantum.h"
 
-enum combos { modtest, osmshift };
+enum combos { modtest, osmshift, ab_1, cd_2 };
 
 uint16_t const modtest_combo[]  = {KC_Y, KC_U, COMBO_END};
 uint16_t const osmshift_combo[] = {KC_Z, KC_X, COMBO_END};
+uint16_t const ab_1_combo[]     = {KC_A, KC_B, COMBO_END};
+uint16_t const cd_2_combo[]     = {KC_C, KC_D,  COMBO_END};
 
 // clang-format off
 combo_t key_combos[] = {
     [modtest]  = COMBO(modtest_combo, RSFT_T(KC_SPACE)),
-    [osmshift] = COMBO(osmshift_combo, OSM(MOD_LSFT))
+    [osmshift] = COMBO(osmshift_combo, OSM(MOD_LSFT)),
+    [ab_1]     = COMBO(ab_1_combo, KC_1),
+    [cd_2]     = COMBO(cd_2_combo, KC_2)
 };
 // clang-format on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
- Resolves #15911 
- Resolves #19446 
- Resolves #24973 
- Resolves https://github.com/qmk/qmk_firmware/issues/25197

There was [a previous version of this PR](https://github.com/qmk/qmk_firmware/pull/16006) some years ago that was closed because I never got around to writing tests. Compared with that version, this PR
- adds many tests
- adds documentation
- updates to include features that were added to current combo code since then
- tries to conform more closely to current behavior, where possible. (E.g., combo preference is determined by length before using index as a tiebreaker.)

There are still some breaking changes:
- Combos are required to be pressed contiguously by default
- Combo timers now work in a more intuitive fashion, so COMBO_STRICT_TIMER is removed. So is COMBO_NO_TIMER. The default COMBO_TERM is increased since the new behavior is more similar to what was formerly the COMBO_STRICT_TIMER variant, and since the default contiguity requirement means that there should be fewer accidental triggers
- EXTRA_SHORT_COMBOS is renamed to EXTRA_SMALL_COMBOS, and is now limited to length 4 rather than 6 (renaming means that existing code will get pushed up to length 8)
- Combos now trigger in sequence with their first key press rather than last (makes combo mods more reliable)

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This is a complete rewrite of the combo code in order to fix the above issues. See #15911 and [the previous PR discussion](https://github.com/qmk/qmk_firmware/pull/16006) for details. At a high-level, the issue with current combo code is that it is all or nothing:  there is no way to release some key presses or combos while keeping other key presses in the buffer and preserving partial activation state of other combos. This causes issues such as:
- irrelevant key releases interrupt combos, making it difficult to use combos while typing fast
- the actual combo timing interval depends on irrelevant key presses before or after your combo is pressed

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [X] Documentation

## Issues Fixed or Closed by This PR
- Resolves #15911 
- Resolves #19446 
- Resolves #24973 
- Resolves https://github.com/qmk/qmk_firmware/issues/25197

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
