### PR TITLE
Indicate <keyboard>.h LAYOUT() deprecation in understanding_qmk.md

### DIFF
--- a/docs/understanding_qmk.md
+++ b/docs/understanding_qmk.md
@@ -51,7 +51,7 @@ Matrix Scanning runs many times per second. The exact rate varies but typically 
 
 Once we know the state of every switch on our keyboard we have to map that to a keycode. In QMK this is done by making use of C macros to allow us to separate the definition of the physical layout from the definition of keycodes.
 
-At the keyboard level, QMK will generate a macro (typically named `LAYOUT()`) from your `<keyboard>.json/info.json` file, which then maps our keyboard's matrix to physical keys. Sometimes the matrix does not have a switch in every location, and QMK will use this macro to pre-populate those with KC_NO, making the keymap definition easier to work with. Here's an example `LAYOUT()` macro for a numpad:
+At the keyboard level, QMK will generate a macro (typically named `LAYOUT()`) from our configuration file `info.json`, which then maps our keyboard's matrix to physical keys. Sometimes the matrix does not have a switch in every location, and QMK will use this macro to pre-populate those with KC_NO, making the keymap definition easier to work with. Here's an example `LAYOUT()` macro for a numpad:
 
 ```c
 #define LAYOUT( \


### PR DESCRIPTION
Standard practice is to use the matrix: [0, 1] inside .json file, instead of defining it in a .h file. Documentation update is exactly as follows. 

## Description

Initial documentation uses <keyboard>.json to define matrix pin definitions, rather than having users #define the LAYOUT() macro in <keyboard>.h  -  This change brings this docs inline with the [porting_guidelines](https://docs.qmk.fm/porting_your_keyboard_to_qmk),  QMK MSYS will also throw an error if this is attempted.
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

*  Misleading Docs, fixed build errors due to my formatting :( 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
