### PR TITLE
Add cachyos as pattern when installing dependencies

### DIFF
--- a/util/qmk_install.sh
+++ b/util/qmk_install.sh
@@ -24,7 +24,7 @@ case $(uname -a) in
         . "$QMK_FIRMWARE_UTIL_DIR/install/linux_shared.sh"
 
         case $(grep ID /etc/os-release) in
-            *arch*|*manjaro*)
+            *arch*|*manjaro*|*cachyos*)
                 . "$QMK_FIRMWARE_UTIL_DIR/install/arch.sh";;
             *debian*|*ubuntu*)
                 . "$QMK_FIRMWARE_UTIL_DIR/install/debian.sh";;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

This PR is a one-liner changes to add `*cachyos*` pattern so that it's using arch installation script instead of being unrecognized.

## Description

CachyOS is an arch-based linux distribution, so it should be safe to use arch installation script for it. This PR adds a pattern so that cachyos is recognized by the dependency installation script.

As further info, the following is the output of `grep ID / etc/os-release` in my CachyOS machine:
```sh
$ grep ID /etc/os-release
ID=cachyos
BUILD_ID=rolling
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #25578 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
