### PR TITLE
[Sat75x] Adjust the oled i2c timeout value to 1000 from the default 100.

### DIFF
--- a/keyboards/cannonkeys/satisfaction75_hs/config.h
+++ b/keyboards/cannonkeys/satisfaction75_hs/config.h
@@ -23,6 +23,9 @@
 #define I2C1_TIMINGR_SCLH 0x03U
 #define I2C1_TIMINGR_SCLL 0x09U
 
+// Fixes oled_init erroring out
+#define OLED_I2C_TIMEOUT 1000
+
 // configure oled driver for the 128x32 oled
 #define OLED_UPDATE_INTERVAL 66 // ~15fps
 


### PR DESCRIPTION
This seemingly fixes the oled module failing oled_init.

## Description

On current master the oled doesn't initialize properly while the rest of the keyboard works fine. I spent a while debugging the firmware with a lot of printfs, and mostly trial and error. This was the only change that worked.

I don't understand the cause here, but I figure it's a fairly harmless change since it's just a timeout value. Happy to do some more testing if needed though!

I've only tested with the [Sat75x](https://cannonkeys.com/products/sat75-x) as I don't have the original Sat75 board to test, so I only adjusted the one config.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
