### PR TITLE
Honor BUILD_DIR in mass_compile.py

### DIFF
--- a/lib/python/qmk/cli/mass_compile.py
+++ b/lib/python/qmk/cli/mass_compile.py
@@ -23,7 +23,7 @@ def mass_compile_targets(targets: List[BuildTarget], clean: bool, dry_run: bool,
     os.environ.setdefault('SKIP_SCHEMA_VALIDATION', '1')
 
     make_cmd = find_make()
-    builddir = Path(QMK_FIRMWARE) / '.build'
+    builddir = Path(env.get("BUILD_DIR")) if env.get("BUILD_DIR") is not None else Path(QMK_FIRMWARE) / '.build'
     makefile = builddir / 'parallel_kb_builds.mk'
 
     if dry_run:
@@ -47,8 +47,8 @@ def mass_compile_targets(targets: List[BuildTarget], clean: bool, dry_run: bool,
                 command = target.compile_command(**env)
                 command[0] = '+@$(MAKE)'  # Override the make so that we can use jobserver to handle parallelism
                 extra_args = '_'.join([f"{k}_{v}" for k, v in target.extra_args.items()])
-                build_log = f"{QMK_FIRMWARE}/.build/build.log.{os.getpid()}.{keyboard_safe}.{keymap_name}"
-                failed_log = f"{QMK_FIRMWARE}/.build/failed.log.{os.getpid()}.{keyboard_safe}.{keymap_name}"
+                build_log = f"{builddir}/build.log.{os.getpid()}.{keyboard_safe}.{keymap_name}"
+                failed_log = f"{builddir}/failed.log.{os.getpid()}.{keyboard_safe}.{keymap_name}"
                 target_suffix = ''
                 if len(extra_args) > 0:
                     build_log += f".{extra_args}"
@@ -77,9 +77,9 @@ all: {target_filename}{target_suffix}_binary
                     # yapf: disable
                     f.write(
                         f"""\
-	@rm -rf "{QMK_FIRMWARE}/.build/{target_filename}.elf" 2>/dev/null || true
-	@rm -rf "{QMK_FIRMWARE}/.build/{target_filename}.map" 2>/dev/null || true
-	@rm -rf "{QMK_FIRMWARE}/.build/obj_{target_filename}" || true
+	@rm -rf "{builddir}/{target_filename}.elf" 2>/dev/null || true
+	@rm -rf "{builddir}/{target_filename}.map" 2>/dev/null || true
+	@rm -rf "{builddir}/obj_{target_filename}" || true
 """# noqa
                     )
                     # yapf: enable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
When building through a read only qmk_firmware directory and trying to set BUILD_DIR for example to do `qmk userspace-compile -e BUILD_DIR="my_custom_path"` as the default fails, mass_compile will still try to write to the QMK_HOME/.build.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I used `**env` instead of `os.environ` like it's defined in `constant.py` to make the usage simpler, if using the `os.environ`:
```bash
BUILD_DIR="path" qmk userspace-compile -e BUILD_DIR="$BUILD_DIR"
```
instead of just
```bash
qmk userspace-compile -e BUILD_DIR="path"
```

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
