### PR TITLE
Simplify hue calculation in raindrops animation

### DIFF
--- a/quantum/rgb_matrix/animations/raindrops_anim.h
+++ b/quantum/rgb_matrix/animations/raindrops_anim.h
@@ -7,14 +7,9 @@ static void raindrops_set_color(uint8_t i, effect_params_t* params) {
     hsv_t hsv = rgb_matrix_config.hsv;
 
     // Take the shortest path between hues
-    int16_t deltaH = ((hsv.h + 180) % 360 - hsv.h) / 4;
-    if (deltaH > 127) {
-        deltaH -= 256;
-    } else if (deltaH < -127) {
-        deltaH += 256;
-    }
-
+    int8_t deltaH = (int8_t)((hsv.h + 128) - hsv.h) / 4;
     hsv.h += (deltaH * random8_max(3));
+
     rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
     rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The `deltaH` calculation in the raindrops animation was based on a 0-360 hue range. This commit simplifies the logic to correctly use 8-bit integer arithmetic, making the code more efficient and accurate for QMK's hue color range.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
