### PR TITLE
[Bugfix] QP error handling

### DIFF
--- a/drivers/painter/comms/qp_comms_dummy.c
+++ b/drivers/painter/comms/qp_comms_dummy.c
@@ -15,8 +15,9 @@ static bool dummy_comms_start(painter_device_t device) {
     return true;
 }
 
-static void dummy_comms_stop(painter_device_t device) {
+static bool dummy_comms_stop(painter_device_t device) {
     // No-op.
+    return true;
 }
 
 uint32_t dummy_comms_send(painter_device_t device, const void *data, uint32_t byte_count) {

--- a/drivers/painter/comms/qp_comms_i2c.c
+++ b/drivers/painter/comms/qp_comms_i2c.c
@@ -35,7 +35,9 @@ uint32_t qp_comms_i2c_send_data(painter_device_t device, const void *data, uint3
     return qp_comms_i2c_send_raw(device, data, byte_count);
 }
 
-void qp_comms_i2c_stop(painter_device_t device) {}
+bool qp_comms_i2c_stop(painter_device_t device) {
+    return true;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Command+Data I2C support
@@ -43,9 +45,9 @@ void qp_comms_i2c_stop(painter_device_t device) {}
 static const uint8_t cmd_byte  = 0x00;
 static const uint8_t data_byte = 0x40;
 
-void qp_comms_i2c_cmddata_send_command(painter_device_t device, uint8_t cmd) {
+bool qp_comms_i2c_cmddata_send_command(painter_device_t device, uint8_t cmd) {
     uint8_t buf[2] = {cmd_byte, cmd};
-    qp_comms_i2c_send_raw(device, &buf, 2);
+    return qp_comms_i2c_send_raw(device, &buf, 2);
 }
 
 uint32_t qp_comms_i2c_cmddata_send_data(painter_device_t device, const void *data, uint32_t byte_count) {
@@ -58,7 +60,7 @@ uint32_t qp_comms_i2c_cmddata_send_data(painter_device_t device, const void *dat
     return byte_count;
 }
 
-void qp_comms_i2c_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
+bool qp_comms_i2c_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
     uint8_t buf[32];
     for (size_t i = 0; i < sequence_len;) {
         uint8_t command   = sequence[i];
@@ -67,12 +69,17 @@ void qp_comms_i2c_bulk_command_sequence(painter_device_t device, const uint8_t *
         buf[0]            = cmd_byte;
         buf[1]            = command;
         memcpy(&buf[2], &sequence[i + 3], num_bytes);
-        qp_comms_i2c_send_raw(device, buf, num_bytes + 2);
+        if (!qp_comms_i2c_send_raw(device, buf, num_bytes + 2)) {
+            return false;
+        }
+
         if (delay > 0) {
             wait_ms(delay);
         }
         i += (3 + num_bytes);
     }
+
+    return true;
 }
 
 const painter_comms_with_command_vtable_t i2c_comms_cmddata_vtable = {

--- a/drivers/painter/comms/qp_comms_i2c.h
+++ b/drivers/painter/comms/qp_comms_i2c.h
@@ -19,7 +19,7 @@ typedef struct qp_comms_i2c_config_t {
 bool     qp_comms_i2c_init(painter_device_t device);
 bool     qp_comms_i2c_start(painter_device_t device);
 uint32_t qp_comms_i2c_send_data(painter_device_t device, const void* data, uint32_t byte_count);
-void     qp_comms_i2c_stop(painter_device_t device);
+bool     qp_comms_i2c_stop(painter_device_t device);
 
 extern const painter_comms_with_command_vtable_t i2c_comms_cmddata_vtable;
 

--- a/drivers/painter/comms/qp_comms_spi.c
+++ b/drivers/painter/comms/qp_comms_spi.c
@@ -45,11 +45,12 @@ uint32_t qp_comms_spi_send_data(painter_device_t device, const void *data, uint3
     return byte_count - bytes_remaining;
 }
 
-void qp_comms_spi_stop(painter_device_t device) {
+bool qp_comms_spi_stop(painter_device_t device) {
     painter_driver_t *     driver       = (painter_driver_t *)device;
     qp_comms_spi_config_t *comms_config = (qp_comms_spi_config_t *)driver->comms_config;
     spi_stop();
     gpio_write_pin_high(comms_config->chip_select_pin);
+    return true;
 }
 
 const painter_comms_vtable_t spi_comms_vtable = {
@@ -97,14 +98,15 @@ uint32_t qp_comms_spi_dc_reset_send_data(painter_device_t device, const void *da
     return qp_comms_spi_send_data(device, data, byte_count);
 }
 
-void qp_comms_spi_dc_reset_send_command(painter_device_t device, uint8_t cmd) {
+bool qp_comms_spi_dc_reset_send_command(painter_device_t device, uint8_t cmd) {
     painter_driver_t *              driver       = (painter_driver_t *)device;
     qp_comms_spi_dc_reset_config_t *comms_config = (qp_comms_spi_dc_reset_config_t *)driver->comms_config;
     gpio_write_pin_low(comms_config->dc_pin);
     spi_write(cmd);
+    return true;
 }
 
-void qp_comms_spi_dc_reset_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
+bool qp_comms_spi_dc_reset_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
     painter_driver_t *              driver       = (painter_driver_t *)device;
     qp_comms_spi_dc_reset_config_t *comms_config = (qp_comms_spi_dc_reset_config_t *)driver->comms_config;
     for (size_t i = 0; i < sequence_len;) {
@@ -126,6 +128,8 @@ void qp_comms_spi_dc_reset_bulk_command_sequence(painter_device_t device, const 
         }
         i += (3 + num_bytes);
     }
+
+    return true;
 }
 
 const painter_comms_with_command_vtable_t spi_comms_with_dc_vtable = {

--- a/drivers/painter/comms/qp_comms_spi.h
+++ b/drivers/painter/comms/qp_comms_spi.h
@@ -22,7 +22,7 @@ typedef struct qp_comms_spi_config_t {
 bool     qp_comms_spi_init(painter_device_t device);
 bool     qp_comms_spi_start(painter_device_t device);
 uint32_t qp_comms_spi_send_data(painter_device_t device, const void* data, uint32_t byte_count);
-void     qp_comms_spi_stop(painter_device_t device);
+bool     qp_comms_spi_stop(painter_device_t device);
 
 extern const painter_comms_vtable_t spi_comms_vtable;
 
@@ -39,9 +39,9 @@ typedef struct qp_comms_spi_dc_reset_config_t {
 } qp_comms_spi_dc_reset_config_t;
 
 bool     qp_comms_spi_dc_reset_init(painter_device_t device);
-void     qp_comms_spi_dc_reset_send_command(painter_device_t device, uint8_t cmd);
+bool     qp_comms_spi_dc_reset_send_command(painter_device_t device, uint8_t cmd);
 uint32_t qp_comms_spi_dc_reset_send_data(painter_device_t device, const void* data, uint32_t byte_count);
-void     qp_comms_spi_dc_reset_bulk_command_sequence(painter_device_t device, const uint8_t* sequence, size_t sequence_len);
+bool     qp_comms_spi_dc_reset_bulk_command_sequence(painter_device_t device, const uint8_t* sequence, size_t sequence_len);
 
 extern const painter_comms_with_command_vtable_t spi_comms_with_dc_vtable;
 

--- a/drivers/painter/gc9xxx/qp_gc9107.c
+++ b/drivers/painter/gc9xxx/qp_gc9107.c
@@ -32,7 +32,9 @@ __attribute__((weak)) bool qp_gc9107_init(painter_device_t device, painter_rotat
     };
 
     // clang-format on
-    qp_comms_bulk_command_sequence(device, gc9107_init_sequence, sizeof(gc9107_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, gc9107_init_sequence, sizeof(gc9107_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -41,9 +43,7 @@ __attribute__((weak)) bool qp_gc9107_init(painter_device_t device, painter_rotat
         [QP_ROTATION_180] = GC9XXX_MADCTL_BGR | GC9XXX_MADCTL_MX | GC9XXX_MADCTL_MY,
         [QP_ROTATION_270] = GC9XXX_MADCTL_BGR | GC9XXX_MADCTL_MV | GC9XXX_MADCTL_MY,
     };
-    qp_comms_command_databyte(device, GC9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
-
-    return true;
+    return qp_comms_command_databyte(device, GC9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/gc9xxx/qp_gc9a01.c
+++ b/drivers/painter/gc9xxx/qp_gc9a01.c
@@ -45,7 +45,9 @@ __attribute__((weak)) bool qp_gc9a01_init(painter_device_t device, painter_rotat
     };
     // clang-format on
 
-    qp_comms_bulk_command_sequence(device, gc9a01_init_sequence, sizeof(gc9a01_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, gc9a01_init_sequence, sizeof(gc9a01_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -54,9 +56,7 @@ __attribute__((weak)) bool qp_gc9a01_init(painter_device_t device, painter_rotat
         [QP_ROTATION_180] = GC9XXX_MADCTL_BGR | GC9XXX_MADCTL_MX | GC9XXX_MADCTL_MY,
         [QP_ROTATION_270] = GC9XXX_MADCTL_BGR | GC9XXX_MADCTL_MV | GC9XXX_MADCTL_MY,
     };
-    qp_comms_command_databyte(device, GC9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
-
-    return true;
+    return qp_comms_command_databyte(device, GC9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/ili9xxx/qp_ili9163.c
+++ b/drivers/painter/ili9xxx/qp_ili9163.c
@@ -41,7 +41,9 @@ __attribute__((weak)) bool qp_ili9163_init(painter_device_t device, painter_rota
         ILI9XXX_CMD_DISPLAY_ON,        20,  0
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, ili9163_init_sequence, sizeof(ili9163_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, ili9163_init_sequence, sizeof(ili9163_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -50,9 +52,7 @@ __attribute__((weak)) bool qp_ili9163_init(painter_device_t device, painter_rota
         [QP_ROTATION_180] = ILI9XXX_MADCTL_BGR | ILI9XXX_MADCTL_MX | ILI9XXX_MADCTL_MY,
         [QP_ROTATION_270] = ILI9XXX_MADCTL_BGR | ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY,
     };
-    qp_comms_command_databyte(device, ILI9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
-
-    return true;
+    return qp_comms_command_databyte(device, ILI9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/ili9xxx/qp_ili9341.c
+++ b/drivers/painter/ili9xxx/qp_ili9341.c
@@ -48,7 +48,9 @@ __attribute__((weak)) bool qp_ili9341_init(painter_device_t device, painter_rota
         ILI9XXX_CMD_DISPLAY_ON,        20,  0
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, ili9341_init_sequence, sizeof(ili9341_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, ili9341_init_sequence, sizeof(ili9341_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -57,9 +59,7 @@ __attribute__((weak)) bool qp_ili9341_init(painter_device_t device, painter_rota
         [QP_ROTATION_180] = ILI9XXX_MADCTL_BGR | ILI9XXX_MADCTL_MX | ILI9XXX_MADCTL_MY,
         [QP_ROTATION_270] = ILI9XXX_MADCTL_BGR | ILI9XXX_MADCTL_MV | ILI9XXX_MADCTL_MY,
     };
-    qp_comms_command_databyte(device, ILI9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
-
-    return true;
+    return qp_comms_command_databyte(device, ILI9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/ili9xxx/qp_ili9486.c
+++ b/drivers/painter/ili9xxx/qp_ili9486.c
@@ -37,7 +37,9 @@ bool qp_ili9486_init(painter_device_t device, painter_rotation_t rotation) {
         ILI9XXX_SET_INVERSION_CTL,      0,  1, 0x02,
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, ili9486_init_sequence, sizeof(ili9486_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, ili9486_init_sequence, sizeof(ili9486_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -62,22 +64,22 @@ bool qp_ili9486_init(painter_device_t device, painter_rotation_t rotation) {
         ILI9XXX_CMD_DISPLAY_ON,         5,  0,
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, rotation_sequence, sizeof(rotation_sequence));
-
-    return true;
+    return qp_comms_bulk_command_sequence(device, rotation_sequence, sizeof(rotation_sequence));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Driver vtable
 
 // waveshare variant needs some tweaks due to shift registers
-static void qp_comms_spi_dc_reset_send_command_odd_cs_pulse(painter_device_t device, uint8_t cmd) {
+static bool qp_comms_spi_dc_reset_send_command_odd_cs_pulse(painter_device_t device, uint8_t cmd) {
     painter_driver_t *              driver       = (painter_driver_t *)device;
     qp_comms_spi_dc_reset_config_t *comms_config = (qp_comms_spi_dc_reset_config_t *)driver->comms_config;
 
     gpio_write_pin_low(comms_config->spi_config.chip_select_pin);
     qp_comms_spi_dc_reset_send_command(device, cmd);
     gpio_write_pin_high(comms_config->spi_config.chip_select_pin);
+
+    return true;
 }
 
 static uint32_t qp_comms_spi_send_data_odd_cs_pulse(painter_device_t device, const void *data, uint32_t byte_count) {
@@ -124,7 +126,7 @@ static uint32_t qp_ili9486_send_data_toggling(painter_device_t device, const uin
     return ret;
 }
 
-static void qp_comms_spi_send_command_sequence_odd_cs_pulse(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
+static bool qp_comms_spi_send_command_sequence_odd_cs_pulse(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
     for (size_t i = 0; i < sequence_len;) {
         uint8_t command   = sequence[i];
         uint8_t delay     = sequence[i + 1];
@@ -140,6 +142,8 @@ static void qp_comms_spi_send_command_sequence_odd_cs_pulse(painter_device_t dev
         }
         i += (3 + num_bytes);
     }
+
+    return true;
 }
 
 static bool qp_ili9486_viewport(painter_device_t device, uint16_t left, uint16_t top, uint16_t right, uint16_t bottom) {

--- a/drivers/painter/ili9xxx/qp_ili9488.c
+++ b/drivers/painter/ili9xxx/qp_ili9488.c
@@ -41,7 +41,9 @@ __attribute__((weak)) bool qp_ili9488_init(painter_device_t device, painter_rota
         ILI9XXX_CMD_DISPLAY_ON,        20,  0
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, ili9488_init_sequence, sizeof(ili9488_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, ili9488_init_sequence, sizeof(ili9488_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -50,9 +52,7 @@ __attribute__((weak)) bool qp_ili9488_init(painter_device_t device, painter_rota
         [QP_ROTATION_180] = ILI9XXX_MADCTL_BGR | ILI9XXX_MADCTL_MX,
         [QP_ROTATION_270] = ILI9XXX_MADCTL_BGR | ILI9XXX_MADCTL_MV,
     };
-    qp_comms_command_databyte(device, ILI9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
-
-    return true;
+    return qp_comms_command_databyte(device, ILI9XXX_SET_MEM_ACS_CTL, madctl[rotation]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/ld7032/qp_ld7032.c
+++ b/drivers/painter/ld7032/qp_ld7032.c
@@ -10,7 +10,7 @@
 #include "qp_surface.h"
 #include "qp_surface_internal.h"
 
-typedef void (*ld7032_driver_comms_send_command_and_data_func)(painter_device_t device, uint8_t cmd, uint8_t data);
+typedef bool (*ld7032_driver_comms_send_command_and_data_func)(painter_device_t device, uint8_t cmd, uint8_t data);
 typedef uint32_t (*ld7032_driver_comms_send_command_and_databuf_func)(painter_device_t device, uint8_t cmd, const void *data, uint32_t byte_count);
 
 typedef struct ld7032_comms_with_command_vtable_t {
@@ -25,12 +25,13 @@ typedef struct ld7032_comms_with_command_vtable_t {
 // LD7032 Internal API
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void ld7032_comms_i2c_send_command_and_data(painter_device_t device, uint8_t cmd, uint8_t data) {
+#ifdef QUANTUM_PAINTER_LD7032_I2C_ENABLE
+bool ld7032_comms_i2c_send_command_and_data(painter_device_t device, uint8_t cmd, uint8_t data) {
     uint8_t buf[2] = {cmd, data};
-    qp_comms_i2c_send_data(device, buf, 2);
+    return qp_comms_i2c_send_data(device, buf, 2);
 }
 
-void ld7032_comms_i2c_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
+bool ld7032_comms_i2c_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
     uint8_t buf[32];
     for (size_t i = 0; i < sequence_len;) {
         uint8_t command   = sequence[i];
@@ -38,12 +39,16 @@ void ld7032_comms_i2c_bulk_command_sequence(painter_device_t device, const uint8
         uint8_t num_bytes = sequence[i + 2];
         buf[0]            = command;
         memcpy(&buf[1], &sequence[i + 3], num_bytes);
-        qp_comms_i2c_send_data(device, buf, num_bytes + 1);
+        if (!qp_comms_i2c_send_data(device, buf, num_bytes + 1)) {
+            return false;
+        }
         if (delay > 0) {
             wait_ms(delay);
         }
         i += (3 + num_bytes);
     }
+
+    return true;
 }
 
 uint32_t ld7032_comms_i2c_send_command_and_databuf(painter_device_t device, uint8_t cmd, const void *data, uint32_t byte_count) {
@@ -53,6 +58,7 @@ uint32_t ld7032_comms_i2c_send_command_and_databuf(painter_device_t device, uint
     memcpy(&buf[1], data, byte_count);
     return qp_comms_send(device, buf, byte_count + 1);
 }
+#endif // QUANTUM_PAINTER_LD7032_I2C_ENABLE
 
 // Power control
 bool qp_ld7032_power(painter_device_t device, bool power_on) {
@@ -201,7 +207,9 @@ __attribute__((weak)) bool qp_ld7032_init(painter_device_t device, painter_rotat
     };
     // clang-format on
 
-    qp_comms_bulk_command_sequence(device, ld7032_init_sequence, sizeof(ld7032_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, ld7032_init_sequence, sizeof(ld7032_init_sequence))) {
+        return false;
+    }
 
     uint8_t display_y_start = 40 - driver->oled.base.panel_height;
     uint8_t display_x_start = (128 - driver->oled.base.panel_width) / 2;
@@ -223,7 +231,9 @@ __attribute__((weak)) bool qp_ld7032_init(painter_device_t device, painter_rotat
     ld7032_memory_setup[13] = ld7032_memory_setup[4] + 1;
     ld7032_memory_setup[17] = driver->oled.base.panel_height;
 
-    qp_comms_bulk_command_sequence(device, ld7032_memory_setup, sizeof(ld7032_memory_setup));
+    if (!qp_comms_bulk_command_sequence(device, ld7032_memory_setup, sizeof(ld7032_memory_setup))) {
+        return false;
+    }
 
     uint8_t write_direction = 0;
     switch (rotation) {
@@ -245,7 +255,9 @@ __attribute__((weak)) bool qp_ld7032_init(painter_device_t device, painter_rotat
     painter_driver_t *                  pdriver      = (painter_driver_t *)device;
     ld7032_comms_with_command_vtable_t *comms_vtable = (ld7032_comms_with_command_vtable_t *)pdriver->comms_vtable;
 
-    comms_vtable->send_command_data(device, LD7032_WRITE_DIRECTION, write_direction);
+    if (!comms_vtable->send_command_data(device, LD7032_WRITE_DIRECTION, write_direction)) {
+        return false;
+    }
 
     qp_ld7032_power(device, true);
 

--- a/drivers/painter/sh1106/qp_sh1106.c
+++ b/drivers/painter/sh1106/qp_sh1106.c
@@ -71,8 +71,7 @@ __attribute__((weak)) bool qp_sh1106_init(painter_device_t device, painter_rotat
         sh1106_init_sequence[20] = 0x02;
     }
 
-    qp_comms_bulk_command_sequence(device, sh1106_init_sequence, sizeof(sh1106_init_sequence));
-    return true;
+    return qp_comms_bulk_command_sequence(device, sh1106_init_sequence, sizeof(sh1106_init_sequence));
 }
 
 // Screen flush

--- a/drivers/painter/sh1107/qp_sh1107.c
+++ b/drivers/painter/sh1107/qp_sh1107.c
@@ -73,8 +73,7 @@ __attribute__((weak)) bool qp_sh1107_init(painter_device_t device, painter_rotat
         sh1107_init_sequence[20] = 0x02;
     }
 
-    qp_comms_bulk_command_sequence(device, sh1107_init_sequence, sizeof(sh1107_init_sequence));
-    return true;
+    return qp_comms_bulk_command_sequence(device, sh1107_init_sequence, sizeof(sh1107_init_sequence));
 }
 
 // Screen flush

--- a/drivers/painter/ssd1351/qp_ssd1351.c
+++ b/drivers/painter/ssd1351/qp_ssd1351.c
@@ -44,7 +44,9 @@ __attribute__((weak)) bool qp_ssd1351_init(painter_device_t device, painter_rota
         SSD1351_DISPLAYON,             5,  0,
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, ssd1351_init_sequence, sizeof(ssd1351_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, ssd1351_init_sequence, sizeof(ssd1351_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -53,10 +55,10 @@ __attribute__((weak)) bool qp_ssd1351_init(painter_device_t device, painter_rota
         [QP_ROTATION_180] = SSD1351_MADCTL_BGR | SSD1351_MADCTL_MX,
         [QP_ROTATION_270] = SSD1351_MADCTL_BGR | SSD1351_MADCTL_MV,
     };
-    qp_comms_command_databyte(device, SSD1351_SETREMAP, madctl[rotation]);
-    qp_comms_command_databyte(device, SSD1351_STARTLINE, (rotation == QP_ROTATION_0 || rotation == QP_ROTATION_90) ? driver->base.panel_height : 0);
-
-    return true;
+    if (!qp_comms_command_databyte(device, SSD1351_SETREMAP, madctl[rotation])) {
+        return false;
+    }
+    return qp_comms_command_databyte(device, SSD1351_STARTLINE, (rotation == QP_ROTATION_0 || rotation == QP_ROTATION_90) ? driver->base.panel_height : 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/painter/st77xx/qp_st7735.c
+++ b/drivers/painter/st77xx/qp_st7735.c
@@ -63,7 +63,9 @@ __attribute__((weak)) bool qp_st7735_init(painter_device_t device, painter_rotat
         ST77XX_CMD_DISPLAY_ON,        20,  0
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, st7735_init_sequence, sizeof(st7735_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, st7735_init_sequence, sizeof(st7735_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -72,7 +74,9 @@ __attribute__((weak)) bool qp_st7735_init(painter_device_t device, painter_rotat
         [QP_ROTATION_180] = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MX | ST77XX_MADCTL_MY,
         [QP_ROTATION_270] = ST77XX_MADCTL_BGR | ST77XX_MADCTL_MV | ST77XX_MADCTL_MY,
     };
-    qp_comms_command_databyte(device, ST77XX_SET_MADCTL, madctl[rotation]);
+    if (!qp_comms_command_databyte(device, ST77XX_SET_MADCTL, madctl[rotation])) {
+        return false;
+    }
 
 #ifndef ST7735_NO_AUTOMATIC_VIEWPORT_OFFSETS
     st7735_automatic_viewport_offsets(device, rotation);

--- a/drivers/painter/st77xx/qp_st7789.c
+++ b/drivers/painter/st77xx/qp_st7789.c
@@ -60,7 +60,9 @@ __attribute__((weak)) bool qp_st7789_init(painter_device_t device, painter_rotat
         ST77XX_CMD_DISPLAY_ON,        20,  0
     };
     // clang-format on
-    qp_comms_bulk_command_sequence(device, st7789_init_sequence, sizeof(st7789_init_sequence));
+    if (!qp_comms_bulk_command_sequence(device, st7789_init_sequence, sizeof(st7789_init_sequence))) {
+        return false;
+    }
 
     // Configure the rotation (i.e. the ordering and direction of memory writes in GRAM)
     const uint8_t madctl[] = {
@@ -69,7 +71,9 @@ __attribute__((weak)) bool qp_st7789_init(painter_device_t device, painter_rotat
         [QP_ROTATION_180] = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MX | ST77XX_MADCTL_MY,
         [QP_ROTATION_270] = ST77XX_MADCTL_RGB | ST77XX_MADCTL_MV | ST77XX_MADCTL_MY,
     };
-    qp_comms_command_databyte(device, ST77XX_SET_MADCTL, madctl[rotation]);
+    if (!qp_comms_command_databyte(device, ST77XX_SET_MADCTL, madctl[rotation])) {
+        return false;
+    }
 
 #ifndef ST7789_NO_AUTOMATIC_VIEWPORT_OFFSETS
     st7789_automatic_viewport_offsets(device, rotation);

--- a/quantum/painter/qp_comms.c
+++ b/quantum/painter/qp_comms.c
@@ -49,15 +49,15 @@ uint32_t qp_comms_send(painter_device_t device, const void *data, uint32_t byte_
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Comms APIs that use a D/C pin
 
-void qp_comms_command(painter_device_t device, uint8_t cmd) {
+bool qp_comms_command(painter_device_t device, uint8_t cmd) {
     painter_driver_t *                   driver       = (painter_driver_t *)device;
     painter_comms_with_command_vtable_t *comms_vtable = (painter_comms_with_command_vtable_t *)driver->comms_vtable;
-    comms_vtable->send_command(device, cmd);
+    return comms_vtable->send_command(device, cmd);
 }
 
-void qp_comms_command_databyte(painter_device_t device, uint8_t cmd, uint8_t data) {
+bool qp_comms_command_databyte(painter_device_t device, uint8_t cmd, uint8_t data) {
     qp_comms_command(device, cmd);
-    qp_comms_send(device, &data, sizeof(data));
+    return qp_comms_send(device, &data, sizeof(data));
 }
 
 uint32_t qp_comms_command_databuf(painter_device_t device, uint8_t cmd, const void *data, uint32_t byte_count) {
@@ -65,8 +65,8 @@ uint32_t qp_comms_command_databuf(painter_device_t device, uint8_t cmd, const vo
     return qp_comms_send(device, data, byte_count);
 }
 
-void qp_comms_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
+bool qp_comms_bulk_command_sequence(painter_device_t device, const uint8_t *sequence, size_t sequence_len) {
     painter_driver_t *                   driver       = (painter_driver_t *)device;
     painter_comms_with_command_vtable_t *comms_vtable = (painter_comms_with_command_vtable_t *)driver->comms_vtable;
-    comms_vtable->bulk_command_sequence(device, sequence, sequence_len);
+    return comms_vtable->bulk_command_sequence(device, sequence, sequence_len);
 }

--- a/quantum/painter/qp_comms.h
+++ b/quantum/painter/qp_comms.h
@@ -19,7 +19,7 @@ uint32_t qp_comms_send(painter_device_t device, const void* data, uint32_t byte_
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Comms APIs that use a D/C pin
 
-void     qp_comms_command(painter_device_t device, uint8_t cmd);
-void     qp_comms_command_databyte(painter_device_t device, uint8_t cmd, uint8_t data);
+bool     qp_comms_command(painter_device_t device, uint8_t cmd);
+bool     qp_comms_command_databyte(painter_device_t device, uint8_t cmd, uint8_t data);
 uint32_t qp_comms_command_databuf(painter_device_t device, uint8_t cmd, const void* data, uint32_t byte_count);
-void     qp_comms_bulk_command_sequence(painter_device_t device, const uint8_t* sequence, size_t sequence_len);
+bool     qp_comms_bulk_command_sequence(painter_device_t device, const uint8_t* sequence, size_t sequence_len);

--- a/quantum/painter/qp_internal_driver.h
+++ b/quantum/painter/qp_internal_driver.h
@@ -36,7 +36,7 @@ typedef struct painter_driver_vtable_t {
 
 typedef bool (*painter_driver_comms_init_func)(painter_device_t device);
 typedef bool (*painter_driver_comms_start_func)(painter_device_t device);
-typedef void (*painter_driver_comms_stop_func)(painter_device_t device);
+typedef bool (*painter_driver_comms_stop_func)(painter_device_t device);
 typedef uint32_t (*painter_driver_comms_send_func)(painter_device_t device, const void *data, uint32_t byte_count);
 
 typedef struct painter_comms_vtable_t {
@@ -46,8 +46,8 @@ typedef struct painter_comms_vtable_t {
     painter_driver_comms_send_func  comms_send;
 } painter_comms_vtable_t;
 
-typedef void (*painter_driver_comms_send_command_func)(painter_device_t device, uint8_t cmd);
-typedef void (*painter_driver_comms_bulk_command_sequence)(painter_device_t device, const uint8_t *sequence, size_t sequence_len);
+typedef bool (*painter_driver_comms_send_command_func)(painter_device_t device, uint8_t cmd);
+typedef bool (*painter_driver_comms_bulk_command_sequence)(painter_device_t device, const uint8_t *sequence, size_t sequence_len);
 
 typedef struct painter_comms_with_command_vtable_t {
     painter_comms_vtable_t                     base; // must be first, so this object can be cast from the painter_comms_vtable_t* type


### PR DESCRIPTION
## Description

Change QP so that any function can return an error. This fixes the case for `qp_init` returning `true` on a disconnected OLED (should have returned `false` because I2C transaction times out)

Essentially, a few `void` return types are now `bool`. Might perhaps want to add `__attribute__((__warn_unused_result__))` to functions to make sure callsites don't forget to check the result, but i haven't done so for now.

Will un-draft after testing on my hardware (some cleanup is required first). So far, i've checked it compiles and @Cipulot has run it on OLED screens fine

## Types of Changes
- [X] Core
- [X] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).