### PR TITLE
[keyboard] Binepad KnobX1 - refactor `x1_layer_led` function as weak

### DIFF
--- a/keyboards/binepad/knobx1/knobx1.c
+++ b/keyboards/binepad/knobx1/knobx1.c
@@ -9,6 +9,13 @@
 #    define X1_KEYMAP_LAYER_COUNT 4
 #endif
 
+__attribute__((weak)) void x1_layer_led(uint8_t lyr) {
+    gpio_write_pin(IND1_LED, lyr >= 0);
+    gpio_write_pin(IND2_LED, lyr >= 1);
+    gpio_write_pin(IND3_LED, lyr >= 2);
+    gpio_write_pin(IND4_LED, lyr >= 3);
+}
+
 void keyboard_pre_init_kb(void) {
     const pin_t indicator_leds[4] = {IND1_LED, IND2_LED, IND3_LED, IND4_LED};
     for (int i = 0; i < 4; i++) {

--- a/keyboards/binepad/knobx1/knobx1.h
+++ b/keyboards/binepad/knobx1/knobx1.h
@@ -38,12 +38,6 @@ static inline void x1_led_3_off(void) { gpio_write_pin_low(IND3_LED); }
 static inline void x1_led_4_off(void) { gpio_write_pin_low(IND4_LED); }
 // clang-format on
 
-static inline void x1_layer_led(uint8_t lyr) {
-    gpio_write_pin(IND1_LED, lyr >= 0);
-    gpio_write_pin(IND2_LED, lyr >= 1);
-    gpio_write_pin(IND3_LED, lyr >= 2);
-    gpio_write_pin(IND4_LED, lyr >= 3);
-}
-
+void x1_layer_led(uint8_t lyr);
 bool process_x1_layer_up(keyrecord_t *record);
 bool process_x1_layer_down(keyrecord_t *record);


### PR DESCRIPTION
## Description

The initial code for the Binepad KnobX1 had the 4-LED layer indicator functionality as a static inline function `x1_layer_led`. This change refactors that function to a weak function so that down-stream / custom keymap developers can override the default behaviour.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*n/a*

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
