### PR TITLE
Fix Slovak and Lithuanian (QWERTY) sendstring LUTs

### DIFF
--- a/quantum/keymap_extras/sendstring_lithuanian_qwerty.h
+++ b/quantum/keymap_extras/sendstring_lithuanian_qwerty.h
@@ -54,13 +54,13 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
 
     //       !        "        #        $        %        &        '
-    KC_SPC,  LT_1,    LT_QUOT, LT_3,    LT_4,    LT_5,    LT_7,    LT_QUOT,
+    KC_SPC,  LT_AOGO, LT_QUOT, LT_EOGO, LT_EDOT, LT_IOGO, LT_UOGO, LT_QUOT,
     // (     )        *        +        ,        -        .        /
-    LT_9,    LT_0,    LT_8,    LT_ZCAR, LT_COMM, LT_MINS, LT_DOT,  LT_SLSH,
+    LT_9,    LT_0,    LT_UMAC, LT_ZCAR, LT_COMM, LT_MINS, LT_DOT,  LT_SLSH,
     // 0     1        2        3        4        5        6        7
     LT_0,    LT_AOGO, LT_CCAR, LT_EOGO, LT_EDOT, LT_IOGO, LT_SCAR, LT_UOGO,
     // 8     9        :        ;        <        =        >        ?
-    LT_UMAC, LT_9,    LT_SCLN, LT_SCLN, LT_COMM, LT_PLUS, LT_DOT,  LT_SLSH,
+    LT_UMAC, LT_9,    LT_SCLN, LT_SCLN, LT_COMM, LT_ZCAR, LT_DOT,  LT_SLSH,
     // @     A        B        C        D        E        F        G
     LT_CCAR, LT_A,    LT_B,    LT_C,    LT_D,    LT_E,    LT_F,    LT_G,
     // H     I        J        K        L        M        N        O

--- a/quantum/keymap_extras/sendstring_slovak.h
+++ b/quantum/keymap_extras/sendstring_slovak.h
@@ -108,13 +108,13 @@ const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
     // P     Q        R        S        T        U        V        W
     SK_P,    SK_Q,    SK_R,    SK_S,    SK_T,    SK_U,    SK_V,    SK_W,
     // X     Y        Z        [        \        ]        ^        _
-    SK_X,    SK_Y,    SK_Z,    SK_F,    SK_Q,    SK_G,    SK_3,    SK_MINS,
+    SK_X,    SK_Y,    SK_Z,    SK_F,    SK_Q,    SK_G,    SK_SCAR, SK_MINS,
     // `     a        b        c        d        e        f        g
-    SK_7,    SK_A,    SK_B,    SK_C,    SK_D,    SK_E,    SK_F,    SK_G,
+    SK_YACU, SK_A,    SK_B,    SK_C,    SK_D,    SK_E,    SK_F,    SK_G,
     // h     i        j        k        l        m        n        o
     SK_H,    SK_I,    SK_J,    SK_K,    SK_L,    SK_M,    SK_N,    SK_O,
     // p     q        r        s        t        u        v        w
     SK_P,    SK_Q,    SK_R,    SK_S,    SK_T,    SK_U,    SK_V,    SK_W,
     // x     y        z        {        |        }        ~        DEL
-    SK_X,    SK_Y,    SK_Z,    SK_B,    SK_W,    SK_N,    SK_1,    KC_DEL
+    SK_X,    SK_Y,    SK_Z,    SK_B,    SK_W,    SK_N,    SK_PLUS, KC_DEL
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

> `ascii_to_keycode_lut` is an array of `uint8_t`, but apparently I wasn't paying attention when I wrote some of these and used keycodes that were already modified (> 255) here.

~~There may well be more that have gone unnoticed; for now I'm just fixing these two that were flagged. I'll look into unit tests or at least just going through all of them to make sure they compile - checking the output is correct will be even more tedious.~~

As noted in linked issue, the rest of the headers work fine, but just to be sure I checked them all myself as well. Still can't speak to whether they output correctly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #25696

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
