### PR TITLE
Add `qmk.keymap.write_file` test coverage

### DIFF
--- a/lib/python/qmk/keymap.py
+++ b/lib/python/qmk/keymap.py
@@ -320,7 +320,7 @@ def generate_c(keymap_json):
     return new_keymap
 
 
-def write_file(keymap_filename, keymap_content):
+def write_file(keymap_filename: Path, keymap_content: str) -> Path:
     keymap_filename.parent.mkdir(parents=True, exist_ok=True)
     keymap_filename.write_text(keymap_content)
 

--- a/lib/python/qmk/tests/test_qmk_keymap.py
+++ b/lib/python/qmk/tests/test_qmk_keymap.py
@@ -1,3 +1,6 @@
+import tempfile
+from pathlib import Path
+
 import qmk.keymap
 
 
@@ -44,4 +47,15 @@ def test_parse_keymap_c():
     assert parsed_keymap_c == {'layers': [{'name': '0', 'layout': 'LAYOUT_ortho_1x1', 'keycodes': ['KC_A']}]}
 
 
-# FIXME(skullydazed): Add a test for qmk.keymap.write that mocks up an FD.
+def test_keymap_write():
+    with tempfile.TemporaryDirectory() as directory:
+        keymap_file = Path(directory) / "keymap.c"
+        contents = "some random text for the test"
+
+        path = qmk.keymap.write_file(keymap_file, contents)
+
+        # in case some code uses the argument instead of return value
+        # which, so far is the same filepath, and would be weird to change
+        assert keymap_file == path
+
+        assert path.read_text() == contents


### PR DESCRIPTION
## Description

Im looking around for TODOs/FIXMEs in the codebase, may open similarly-sized PRs if I find something else to tackle

For now, just a tiny test that was easy to add, and took the opportunity to add type-hinting to the function in the process, given that the inputs/output were very obvious.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
