### PR TITLE
Restrict mouse timer activation to movement keycodes

### DIFF
--- a/quantum/mousekey.c
+++ b/quantum/mousekey.c
@@ -386,7 +386,8 @@ void mousekey_task(void) {
 
 void mousekey_on(uint8_t code) {
 #    ifdef MK_KINETIC_SPEED
-    if (mouse_timer == 0 && !IS_MOUSEKEY_BUTTON(code)) {
+    // Start kinetic timer when movement keycodes are pressed
+    if (mouse_timer == 0 && (IS_MOUSEKEY_MOVE(code) || IS_MOUSEKEY_WHEEL(code))) {
         mouse_timer = timer_read();
     }
 #    endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
The timer used to calculate the speed of the cursor should not be initiated when a **_mousekey button_** is the first **_mousekey_** to be pressed.

Currently, when a **_mousekey button_** is pressed and held, on a **_mousekey cursor_** press, the cursor appears to "jump", it's  moving at a higher speed than expected.

I encountered the issue when trying to select text using only the mouse keys (left click + cursor movement).

I think this is an oversight as #23341 #21494 don't mention anything about **_mousekey buttons_**.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).