### PR TITLE
Add Ergo‑L keycodes and sendstring

### DIFF
--- a/data/constants/keycodes/extras/keycodes_ergol_0.0.1.hjson
+++ b/data/constants/keycodes/extras/keycodes_ergol_0.0.1.hjson
@@ -1,0 +1,527 @@
+{
+    "aliases": {
+/*
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ` │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │ 0 │ / │ = │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ Q │ C │ O │ P │ W │ J │ M │ D │ ★ │ Y │ [ │ ] │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │ A │ S │ E │ N │ F │ L │ R │ T │ I │ U │ ' │ \ │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ < │ Z │ X │ - │ V │ B │ . │ H │ G │ , │ K │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+        "KC_GRV": {
+            "key": "EL_GRV",
+            "label": "`",
+        }
+        "KC_1": {
+            "key": "EL_1",
+            "label": "1",
+        }
+        "KC_2": {
+            "key": "EL_2",
+            "label": "2",
+        }
+        "KC_3": {
+            "key": "EL_3",
+            "label": "3",
+        }
+        "KC_4": {
+            "key": "EL_4",
+            "label": "4",
+        }
+        "KC_5": {
+            "key": "EL_5",
+            "label": "5",
+        }
+        "KC_6": {
+            "key": "EL_6",
+            "label": "6",
+        }
+        "KC_7": {
+            "key": "EL_7",
+            "label": "7",
+        }
+        "KC_8": {
+            "key": "EL_8",
+            "label": "8",
+        }
+        "KC_9": {
+            "key": "EL_9",
+            "label": "9",
+        }
+        "KC_0": {
+            "key": "EL_0",
+            "label": "0",
+        }
+        "KC_MINS": {
+            "key": "EL_SLSH",
+            "label": "/",
+        }
+        "KC_EQL": {
+            "key": "EL_EQL",
+            "label": "=",
+        }
+        "KC_Q": {
+            "key": "EL_Q",
+            "label": "Q",
+        }
+        "KC_W": {
+            "key": "EL_C",
+            "label": "C",
+        }
+        "KC_E": {
+            "key": "EL_O",
+            "label": "O",
+        }
+        "KC_R": {
+            "key": "EL_P",
+            "label": "P",
+        }
+        "KC_T": {
+            "key": "EL_W",
+            "label": "W",
+        }
+        "KC_Y": {
+            "key": "EL_J",
+            "label": "J",
+        }
+        "KC_U": {
+            "key": "EL_M",
+            "label": "M",
+        }
+        "KC_I": {
+            "key": "EL_D",
+            "label": "D",
+        }
+        "KC_O": {
+            "key": "EL_1DK",
+            "label": "★ (one dead key)",
+        }
+        "KC_P": {
+            "key": "EL_Y",
+            "label": "Y",
+        }
+        "KC_LBRC": {
+            "key": "EL_LBRC",
+            "label": "[",
+        }
+        "KC_RBRC": {
+            "key": "EL_RBRC",
+            "label": "]",
+        }
+        "KC_A": {
+            "key": "EL_A",
+            "label": "A",
+        }
+        "KC_S": {
+            "key": "EL_S",
+            "label": "S",
+        }
+        "KC_D": {
+            "key": "EL_E",
+            "label": "E",
+        }
+        "KC_F": {
+            "key": "EL_N",
+            "label": "N",
+        }
+        "KC_G": {
+            "key": "EL_F",
+            "label": "F",
+        }
+        "KC_H": {
+            "key": "EL_L",
+            "label": "L",
+        }
+        "KC_J": {
+            "key": "EL_R",
+            "label": "R",
+        }
+        "KC_K": {
+            "key": "EL_T",
+            "label": "T",
+        }
+        "KC_L": {
+            "key": "EL_I",
+            "label": "I",
+        }
+        "KC_SCLN": {
+            "key": "EL_U",
+            "label": "U",
+        }
+        "KC_QUOT": {
+            "key": "EL_QUOT",
+            "label": "'",
+        }
+        "KC_BSLS": {
+            "key": "EL_BSLS",
+            "label": "\\",
+        }
+        "KC_NUBS": {
+            "key": "EL_LABK",
+            "label": "<",
+        }
+        "KC_Z": {
+            "key": "EL_Z",
+            "label": "Z",
+        }
+        "KC_X": {
+            "key": "EL_X",
+            "label": "X",
+        }
+        "KC_C": {
+            "key": "EL_MINS",
+            "label": "-",
+        }
+        "KC_V": {
+            "key": "EL_V",
+            "label": "V",
+        }
+        "KC_B": {
+            "key": "EL_B",
+            "label": "B",
+        }
+        "KC_N": {
+            "key": "EL_DOT",
+            "label": ".",
+        }
+        "KC_M": {
+            "key": "EL_H",
+            "label": "H",
+        }
+        "KC_COMM": {
+            "key": "EL_G",
+            "label": "G",
+        }
+        "KC_DOT": {
+            "key": "EL_COMM",
+            "label": ",",
+        }
+        "KC_SLSH": {
+            "key": "EL_K",
+            "label": "K",
+        }
+
+/* Shifted symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │ ~ │ € │ « │ » │ $ │ % │ ^ │ & │ * │ # │ @ │ _ │ + │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │   │   │   │   │   │   │   │   │ ! │   │ { │ } │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │   │   │   │   │   │   │   │   │   │   │ " │ | │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │ > │   │   │ ? │   │   │ : │   │   │ ; │   │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+        "S(EL_GRV)": {
+            "key": "EL_TILD",
+            "label": "~",
+        }
+        "S(EL_1)": {
+            "key": "EL_EURO",
+            "label": "€",
+        }
+        "S(EL_2)": {
+            "key": "EL_LDAQ",
+            "label": "«",
+        }
+        "S(EL_3)": {
+            "key": "EL_RDAQ",
+            "label": "»",
+        }
+        "S(EL_4)": {
+            "key": "EL_DLR",
+            "label": "$",
+        }
+        "S(EL_5)": {
+            "key": "EL_PERC",
+            "label": "%",
+        }
+        "S(EL_6)": {
+            "key": "EL_CIRC",
+            "label": "^",
+        }
+        "S(EL_7)": {
+            "key": "EL_AMPR",
+            "label": "&",
+        }
+        "S(EL_8)": {
+            "key": "EL_ASTR",
+            "label": "*",
+        }
+        "S(EL_9)": {
+            "key": "EL_HASH",
+            "label": "#",
+        }
+        "S(EL_0)": {
+            "key": "EL_AT",
+            "label": "@",
+        }
+        "S(EL_SLSH)": {
+            "key": "EL_UNDS",
+            "label": "_",
+        }
+        "S(EL_EQL)": {
+            "key": "EL_PLUS",
+            "label": "+",
+        }
+        "S(EL_1DK)": {
+            "key": "EL_EXLM",
+            "label": "!",
+        }
+        "S(EL_LBRC)": {
+            "key": "EL_LCBR",
+            "label": "{",
+        }
+        "S(EL_RBRC)": {
+            "key": "EL_RCBR",
+            "label": "}",
+        }
+        "S(EL_QUOT)": {
+            "key": "EL_DQUO",
+            "label": "\"",
+        }
+        "S(EL_BSLS)": {
+            "key": "EL_PIPE",
+            "label": "|",
+        }
+        "S(EL_LABK)": {
+            "key": "EL_RABK",
+            "label": ">",
+        }
+        "S(EL_MINS)": {
+            "key": "EL_QUES",
+            "label": "?",
+        }
+        "S(EL_DOT)": {
+            "key": "EL_COLN",
+            "label": ":",
+        }
+        "S(EL_COMM)": {
+            "key": "EL_SCLN",
+            "label": ";",
+        }
+        "S(KC_SPC)": {
+            "key": "EL_NNBS",
+            "label": "(narrow non-breaking space)",
+        }
+
+/* AltGr symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │ ₁ │ ₂ │ ₃ │ ₄ │ ₅ │ ₆ │ ₇ │ ₈ │ ₉ │ ₀ │   │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ ^ │ < │ > │ $ │ % │ @ │ & │ * │ ' │ ` │   │   │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │ { │ ( │ ) │ } │ = │ \ │ + │ - │ / │ " │   │   │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │   │ ~ │ [ │ ] │ _ │ # │ | │ ! │ ; │ : │ ? │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+        "ALGR(EL_1)": {
+            "key": "EL_SUB1",
+            "label": "₁",
+        }
+        "ALGR(EL_2)": {
+            "key": "EL_SUB2",
+            "label": "₂",
+        }
+        "ALGR(EL_3)": {
+            "key": "EL_SUB3",
+            "label": "₃",
+        }
+        "ALGR(EL_4)": {
+            "key": "EL_SUB4",
+            "label": "₄",
+        }
+        "ALGR(EL_5)": {
+            "key": "EL_SUB5",
+            "label": "₅",
+        }
+        "ALGR(EL_6)": {
+            "key": "EL_SUB6",
+            "label": "₆",
+        }
+        "ALGR(EL_7)": {
+            "key": "EL_SUB7",
+            "label": "₇",
+        }
+        "ALGR(EL_8)": {
+            "key": "EL_SUB8",
+            "label": "₈",
+        }
+        "ALGR(EL_9)": {
+            "key": "EL_SUB9",
+            "label": "₉",
+        }
+        "ALGR(EL_0)": {
+            "key": "EL_SUB0",
+            "label": "₀",
+        }
+        "ALGR(EL_S)": {
+            "key": "EL_LPRN",
+            "label": "(",
+        }
+        "ALGR(EL_E)": {
+            "key": "EL_RPRN",
+            "label": ")",
+        }
+
+/* Shift+AltGr symbols
+ * ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───────┐
+ * │   │ ¹ │ ² │ ³ │ ⁴ │ ⁵ │ ⁶ │ ⁷ │ ⁸ │ ⁹ │ ⁰ │   │   │       │
+ * ├───┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─────┤
+ * │     │ ^ │ ≤ │ ≥ │ ¤ │ ‰ │ ° │   │ × │ ´ │ ` │   │   │     │
+ * ├─────┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┐    │
+ * │      │ ˇ │   │   │ ˙ │ ≠ │ / │ ± │ ¯ │ ÷ │ ˝ │   │   │    │
+ * ├────┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴───┴────┤
+ * │    │   │ ~ │ , │ ˛ │   │   │   │ ¬ │ ¸ │   │ ˘ │          │
+ * ├────┼───┴┬──┴─┬─┴───┴───┴───┴───┴───┴──┬┴───┼───┴┬────┬────┤
+ * │    │    │    │                        │    │    │    │    │
+ * └────┴────┴────┴────────────────────────┴────┴────┴────┴────┘
+ */
+        "S(ALGR(EL_1))": {
+            "key": "EL_SUP1",
+            "label": "¹",
+        }
+        "S(ALGR(EL_2))": {
+            "key": "EL_SUP2",
+            "label": "²",
+        }
+        "S(ALGR(EL_3))": {
+            "key": "EL_SUP3",
+            "label": "³",
+        }
+        "S(ALGR(EL_4))": {
+            "key": "EL_SUP4",
+            "label": "⁴",
+        }
+        "S(ALGR(EL_5))": {
+            "key": "EL_SUP5",
+            "label": "⁵",
+        }
+        "S(ALGR(EL_6))": {
+            "key": "EL_SUP6",
+            "label": "⁶",
+        }
+        "S(ALGR(EL_7))": {
+            "key": "EL_SUP7",
+            "label": "⁷",
+        }
+        "S(ALGR(EL_8))": {
+            "key": "EL_SUP8",
+            "label": "⁸",
+        }
+        "S(ALGR(EL_9))": {
+            "key": "EL_SUP9",
+            "label": "⁹",
+        }
+        "S(ALGR(EL_0))": {
+            "key": "EL_SUP0",
+            "label": "⁰",
+        }
+        "S(ALGR(EL_Q))": {
+            "key": "EL_DCIR",
+            "label": "^ (dead)",
+        }
+        "S(ALGR(EL_C))": {
+            "key": "EL_LEQL",
+            "label": "≤",
+        }
+        "S(ALGR(EL_O))": {
+            "key": "EL_GEQL",
+            "label": "≥",
+        }
+        "S(ALGR(EL_P))": {
+            "key": "EL_CURR",
+            "label": "¤ (dead)",
+        }
+        "S(ALGR(EL_W))": {
+            "key": "EL_PERM",
+            "label": "‰",
+        }
+        "S(ALGR(EL_J))": {
+            "key": "EL_RNGA",
+            "label": "° (dead)",
+        }
+        "S(ALGR(EL_D))": {
+            "key": "EL_MUL",
+            "label": "×",
+        }
+        "S(ALGR(EL_1DK))": {
+            "key": "EL_ACUT",
+            "label": "´ (dead)",
+        }
+        "S(ALGR(EL_Y))": {
+            "key": "EL_DGRV",
+            "label": "` (dead)",
+        }
+        "S(ALGR(EL_A))": {
+            "key": "EL_CARN",
+            "label": "ˇ (dead)",
+        }
+        "S(ALGR(EL_N))": {
+            "key": "EL_DOTA",
+            "label": "˙ (dead)",
+        }
+        "S(ALGR(EL_F))": {
+            "key": "EL_NEQL",
+            "label": "≠",
+        }
+        "S(ALGR(EL_L))": {
+            "key": "EL_DSLS",
+            "label": "/ (dead)",
+        }
+        "S(ALGR(EL_R))": {
+            "key": "EL_PLMN",
+            "label": "±",
+        }
+        "S(ALGR(EL_T))": {
+            "key": "EL_MACR",
+            "label": "¯ (dead)",
+        }
+        "S(ALGR(EL_I))": {
+            "key": "EL_DIV",
+            "label": "÷",
+        }
+        "S(ALGR(EL_U))": {
+            "key": "EL_DACU",
+            "label": "” (dead)",
+        }
+        "S(ALGR(EL_Z))": {
+            "key": "EL_DTIL",
+            "label": "~ (dead)",
+        }
+        "S(ALGR(EL_X))": {
+            "key": "EL_DCMM",
+            "label": ", (dead)",
+        }
+        "S(ALGR(EL_MINS))": {
+            "key": "EL_OGON",
+            "label": "˛ (dead)",
+        }
+        "S(ALGR(EL_H))": {
+            "key": "EL_NOT",
+            "label": "¬",
+        }
+        "S(ALGR(EL_G))": {
+            "key": "EL_CEDL",
+            "label": "¸ (dead)",
+        }
+        "S(ALGR(EL_K))": {
+            "key": "EL_BREV",
+            "label": "˘ (dead)",
+        }
+        "S(ALGR(KC_SPC))": {
+            "key": "EL_NBSP",
+            "label": "(non-breaking space)",
+        }
+    }
+}

--- a/docs/reference_keymap_extras.md
+++ b/docs/reference_keymap_extras.md
@@ -63,6 +63,7 @@ These headers are located in [`quantum/keymap_extras/`](https://github.com/qmk/q
 |French (BÉPO)                    |`keymap_bepo.h`                  |`sendstring_bepo.h`                 |
 |French (Belgium)                 |`keymap_belgian.h`               |`sendstring_belgian.h`              |
 |French (Canada)                  |`keymap_canadian_french.h`       |`sendstring_canadian_french.h`      |
+|French (Ergo‑L)                  |`keymap_ergol.h`                 |`sendstring_ergol.h`                |
 |French (Switzerland)             |`keymap_swiss_fr.h`              |`sendstring_swiss_fr.h`             |
 |French (macOS, ISO)              |`keymap_french_mac_iso.h`        |`sendstring_french_mac_iso.h`       |
 |German                           |`keymap_german.h`                |`sendstring_german.h`               |

--- a/quantum/keymap_extras/keymap_ergol.h
+++ b/quantum/keymap_extras/keymap_ergol.h
@@ -1,0 +1,154 @@
+// Copyright 2025 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*******************************************************************************
+  88888888888 888      d8b                .d888 d8b 888               d8b
+      888     888      Y8P               d88P"  Y8P 888               Y8P
+      888     888                        888        888
+      888     88888b.  888 .d8888b       888888 888 888  .d88b.       888 .d8888b
+      888     888 "88b 888 88K           888    888 888 d8P  Y8b      888 88K
+      888     888  888 888 "Y8888b.      888    888 888 88888888      888 "Y8888b.
+      888     888  888 888      X88      888    888 888 Y8b.          888      X88
+      888     888  888 888  88888P'      888    888 888  "Y8888       888  88888P'
+                                                        888                 888
+                                                        888                 888
+                                                        888                 888
+     .d88b.   .d88b.  88888b.   .d88b.  888d888 8888b.  888888 .d88b.   .d88888
+    d88P"88b d8P  Y8b 888 "88b d8P  Y8b 888P"      "88b 888   d8P  Y8b d88" 888
+    888  888 88888888 888  888 88888888 888    .d888888 888   88888888 888  888
+    Y88b 888 Y8b.     888  888 Y8b.     888    888  888 Y88b. Y8b.     Y88b 888
+     "Y88888  "Y8888  888  888  "Y8888  888    "Y888888  "Y888 "Y8888   "Y88888
+         888
+    Y8b d88P
+     "Y88P"
+*******************************************************************************/
+
+#pragma once
+#include "keycodes.h"
+// clang-format off
+
+#define QMK_ERGOL_KEYCODES_VERSION "0.0.1"
+#define QMK_ERGOL_KEYCODES_VERSION_BCD 0x00000001
+#define QMK_ERGOL_KEYCODES_VERSION_MAJOR 0
+#define QMK_ERGOL_KEYCODES_VERSION_MINOR 0
+#define QMK_ERGOL_KEYCODES_VERSION_PATCH 1
+
+// Aliases
+#define EL_GRV  KC_GRV  // `
+#define EL_1    KC_1    // 1
+#define EL_2    KC_2    // 2
+#define EL_3    KC_3    // 3
+#define EL_4    KC_4    // 4
+#define EL_5    KC_5    // 5
+#define EL_6    KC_6    // 6
+#define EL_7    KC_7    // 7
+#define EL_8    KC_8    // 8
+#define EL_9    KC_9    // 9
+#define EL_0    KC_0    // 0
+#define EL_SLSH KC_MINS // /
+#define EL_EQL  KC_EQL  // =
+#define EL_Q    KC_Q    // Q
+#define EL_C    KC_W    // C
+#define EL_O    KC_E    // O
+#define EL_P    KC_R    // P
+#define EL_W    KC_T    // W
+#define EL_J    KC_Y    // J
+#define EL_M    KC_U    // M
+#define EL_D    KC_I    // D
+#define EL_1DK  KC_O    // ★ (one dead key)
+#define EL_Y    KC_P    // Y
+#define EL_LBRC KC_LBRC // [
+#define EL_RBRC KC_RBRC // ]
+#define EL_A    KC_A    // A
+#define EL_S    KC_S    // S
+#define EL_E    KC_D    // E
+#define EL_N    KC_F    // N
+#define EL_F    KC_G    // F
+#define EL_L    KC_H    // L
+#define EL_R    KC_J    // R
+#define EL_T    KC_K    // T
+#define EL_I    KC_L    // I
+#define EL_U    KC_SCLN // U
+#define EL_QUOT KC_QUOT // '
+#define EL_BSLS KC_BSLS // (backslash)
+#define EL_LABK KC_NUBS // <
+#define EL_Z    KC_Z    // Z
+#define EL_X    KC_X    // X
+#define EL_MINS KC_C    // -
+#define EL_V    KC_V    // V
+#define EL_B    KC_B    // B
+#define EL_DOT  KC_N    // .
+#define EL_H    KC_M    // H
+#define EL_G    KC_COMM // G
+#define EL_COMM KC_DOT  // ,
+#define EL_K    KC_SLSH // K
+#define EL_TILD S(EL_GRV)  // ~
+#define EL_EURO S(EL_1)    // €
+#define EL_LDAQ S(EL_2)    // «
+#define EL_RDAQ S(EL_3)    // »
+#define EL_DLR  S(EL_4)    // $
+#define EL_PERC S(EL_5)    // %
+#define EL_CIRC S(EL_6)    // ^
+#define EL_AMPR S(EL_7)    // &
+#define EL_ASTR S(EL_8)    // *
+#define EL_HASH S(EL_9)    // #
+#define EL_AT   S(EL_0)    // @
+#define EL_UNDS S(EL_SLSH) // _
+#define EL_PLUS S(EL_EQL)  // +
+#define EL_EXLM S(EL_1DK)  // !
+#define EL_LCBR S(EL_LBRC) // {
+#define EL_RCBR S(EL_RBRC) // }
+#define EL_DQUO S(EL_QUOT) // "
+#define EL_PIPE S(EL_BSLS) // |
+#define EL_RABK S(EL_LABK) // >
+#define EL_QUES S(EL_MINS) // ?
+#define EL_COLN S(EL_DOT)  // :
+#define EL_SCLN S(EL_COMM) // ;
+#define EL_NNBS S(KC_SPC)  // (narrow non-breaking space)
+#define EL_SUB1 ALGR(EL_1)    // ₁
+#define EL_SUB2 ALGR(EL_2)    // ₂
+#define EL_SUB3 ALGR(EL_3)    // ₃
+#define EL_SUB4 ALGR(EL_4)    // ₄
+#define EL_SUB5 ALGR(EL_5)    // ₅
+#define EL_SUB6 ALGR(EL_6)    // ₆
+#define EL_SUB7 ALGR(EL_7)    // ₇
+#define EL_SUB8 ALGR(EL_8)    // ₈
+#define EL_SUB9 ALGR(EL_9)    // ₉
+#define EL_SUB0 ALGR(EL_0)    // ₀
+#define EL_LPRN ALGR(EL_S)    // (
+#define EL_RPRN ALGR(EL_E)    // )
+#define EL_SUP1 S(ALGR(EL_1))    // ¹
+#define EL_SUP2 S(ALGR(EL_2))    // ²
+#define EL_SUP3 S(ALGR(EL_3))    // ³
+#define EL_SUP4 S(ALGR(EL_4))    // ⁴
+#define EL_SUP5 S(ALGR(EL_5))    // ⁵
+#define EL_SUP6 S(ALGR(EL_6))    // ⁶
+#define EL_SUP7 S(ALGR(EL_7))    // ⁷
+#define EL_SUP8 S(ALGR(EL_8))    // ⁸
+#define EL_SUP9 S(ALGR(EL_9))    // ⁹
+#define EL_SUP0 S(ALGR(EL_0))    // ⁰
+#define EL_DCIR S(ALGR(EL_Q))    // ^ (dead)
+#define EL_LEQL S(ALGR(EL_C))    // ≤
+#define EL_GEQL S(ALGR(EL_O))    // ≥
+#define EL_CURR S(ALGR(EL_P))    // ¤ (dead)
+#define EL_PERM S(ALGR(EL_W))    // ‰
+#define EL_RNGA S(ALGR(EL_J))    // ° (dead)
+#define EL_MUL  S(ALGR(EL_D))    // ×
+#define EL_ACUT S(ALGR(EL_1DK))  // ´ (dead)
+#define EL_DGRV S(ALGR(EL_Y))    // ` (dead)
+#define EL_CARN S(ALGR(EL_A))    // ˇ (dead)
+#define EL_DOTA S(ALGR(EL_N))    // ˙ (dead)
+#define EL_NEQL S(ALGR(EL_F))    // ≠
+#define EL_DSLS S(ALGR(EL_L))    // / (dead)
+#define EL_PLMN S(ALGR(EL_R))    // ±
+#define EL_MACR S(ALGR(EL_T))    // ¯ (dead)
+#define EL_DIV  S(ALGR(EL_I))    // ÷
+#define EL_DACU S(ALGR(EL_U))    // ” (dead)
+#define EL_DTIL S(ALGR(EL_Z))    // ~ (dead)
+#define EL_DCMM S(ALGR(EL_X))    // , (dead)
+#define EL_OGON S(ALGR(EL_MINS)) // ˛ (dead)
+#define EL_NOT  S(ALGR(EL_H))    // ¬
+#define EL_CEDL S(ALGR(EL_G))    // ¸ (dead)
+#define EL_BREV S(ALGR(EL_K))    // ˘ (dead)
+#define EL_NBSP S(ALGR(KC_SPC))  // (non-breaking space)
+

--- a/quantum/keymap_extras/sendstring_ergol.h
+++ b/quantum/keymap_extras/sendstring_ergol.h
@@ -1,0 +1,100 @@
+/* Copyright 2025 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Sendstring lookup tables for Ergo‑L layouts
+
+#pragma once
+
+#include "send_string.h"
+#include "keymap_ergol.h"
+
+// clang-format off
+
+const uint8_t ascii_to_shift_lut[16] PROGMEM = {
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+
+    KCLUT_ENTRY(0, 1, 1, 1, 1, 1, 1, 0),
+    KCLUT_ENTRY(0, 0, 1, 1, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 1, 1, 0, 0, 1, 1),
+    KCLUT_ENTRY(1, 1, 1, 1, 1, 1, 1, 1),
+    KCLUT_ENTRY(1, 1, 1, 1, 1, 1, 1, 1),
+    KCLUT_ENTRY(1, 1, 1, 1, 1, 1, 1, 1),
+    KCLUT_ENTRY(1, 1, 1, 0, 0, 0, 1, 1),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 1, 1, 1, 1, 0)
+};
+
+const uint8_t ascii_to_altgr_lut[16] PROGMEM = {
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(1, 1, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0),
+    KCLUT_ENTRY(0, 0, 0, 0, 0, 0, 0, 0)
+};
+
+const uint8_t ascii_to_keycode_lut[128] PROGMEM = {
+    // NUL   SOH      STX      ETX      EOT      ENQ      ACK      BEL
+    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    // BS    TAB      LF       VT       FF       CR       SO       SI
+    KC_BSPC, KC_TAB,  KC_ENT,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    // DLE   DC1      DC2      DC3      DC4      NAK      SYN      ETB
+    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+    // CAN   EM       SUB      ESC      FS       GS       RS       US
+    XXXXXXX, XXXXXXX, XXXXXXX, KC_ESC,  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,
+
+    //       !        "        #        $        %        &        '
+    KC_SPC,  EL_1DK,  EL_QUOT, EL_9,    EL_4,    EL_5,    EL_7,    EL_QUOT,
+    // (     )        *        +        ,        -        .        /
+    EL_S,    EL_E,    EL_8,    EL_EQL,  EL_COMM, EL_MINS, EL_DOT,  EL_SLSH,
+    // 0     1        2        3        4        5        6        7
+    EL_0,    EL_1,    EL_2,    EL_3,    EL_4,    EL_5,    EL_6,    EL_7,
+    // 8     9        :        ;        <        =        >        ?
+    EL_8,    EL_9,    EL_DOT,  EL_COMM, EL_LABK, EL_EQL,  EL_LABK, EL_MINS,
+    // @     A        B        C        D        E        F        G
+    EL_0,    EL_A,    EL_B,    EL_C,    EL_D,    EL_E,    EL_F,    EL_G,
+    // H     I        J        K        L        M        N        O
+    EL_H,    EL_I,    EL_J,    EL_K,    EL_L,    EL_M,    EL_N,    EL_O,
+    // P     Q        R        S        T        U        V        W
+    EL_P,    EL_Q,    EL_R,    EL_S,    EL_T,    EL_U,    EL_V,    EL_W,
+    // X     Y        Z        [        \        ]        ^        _
+    EL_X,    EL_Y,    EL_Z,    EL_LBRC, EL_BSLS, EL_RBRC, EL_6,    EL_SLSH,
+    // `     a        b        c        d        e        f        g
+    EL_GRV,  EL_A,    EL_B,    EL_C,    EL_D,    EL_E,    EL_F,    EL_G,
+    // h     i        j        k        l        m        n        o
+    EL_H,    EL_I,    EL_J,    EL_K,    EL_L,    EL_M,    EL_N,    EL_O,
+    // p     q        r        s        t        u        v        w
+    EL_P,    EL_Q,    EL_R,    EL_S,    EL_T,    EL_U,    EL_V,    EL_W,
+    // x     y        z        {        |        }        ~        DEL
+    EL_X,    EL_Y,    EL_Z,    EL_LBRC, EL_BSLS, EL_RBRC, EL_GRV,  KC_DEL
+};


### PR DESCRIPTION
## Description

Add keycodes and sendstring for the French [Ergo‑L](https://ergol.org/) layout.

I used this command to generate the `keymap_ergol.h`:
```sh
qmk generate-keycode-extras --version latest --lang ergol -o quantum/keymap_extras/keymap_ergol.h
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
