### PR TITLE
Fix pmw33xx sensor initialisation

### DIFF
--- a/drivers/sensors/pmw33xx_common.c
+++ b/drivers/sensors/pmw33xx_common.c
@@ -108,7 +108,7 @@ __attribute__((weak)) bool pmw33xx_check_signature(uint8_t sensor) {
         pmw33xx_read(sensor, REG_Inverse_Product_ID),
     };
 
-    return memcmp(pmw33xx_firmware_signature, signature_dump, sizeof(signature_dump)) == 0;
+    return memcmp(pmw33xx_firmware_signature, signature_dump, sizeof(signature_dump));
 }
 
 bool pmw33xx_upload_firmware(uint8_t sensor) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

removed '== 0' from line 111 of pmw33xx_common.c to resolve issue with flashing firmware disabling pmw3360 sensor in ploopy trackball

This was caused by this commit https://github.com/qmk/qmk_firmware/pull/25315 / the previous set up of the file.  I didn't change any of the code added by that commit but altered the report that already existed.  I'm not particularly confident this is the right resolution but thought I'd take a stab at it, I have verified it resolves the issue with my trackball.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #25769

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
