### PR TITLE
Align use of keymap level `_kb` callbacks

### DIFF
--- a/keyboards/3w6/rev2/keymaps/default_pimoroni/pimoroni_trackball.c
+++ b/keyboards/3w6/rev2/keymaps/default_pimoroni/pimoroni_trackball.c
@@ -72,14 +72,7 @@ __attribute__((weak)) void trackball_check_click(bool pressed, report_mouse_t* m
     }
 }
 
-bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
-    if (true) {
-        xprintf("KL: kc: %u, col: %u, row: %u, pressed: %u\n", keycode, record->event.key.col, record->event.key.row, record->event.pressed);
-    }
-
-
-    if (!process_record_user(keycode, record)) { return false; }
-
+bool process_record_user(uint16_t keycode, keyrecord_t* record) {
 /* If Mousekeys is disabled, then use handle the mouse button
  * keycodes.  This makes things simpler, and allows usage of
  * the keycodes in a consistent manner.  But only do this if
@@ -95,6 +88,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
         }
         pointing_device_set_report(currentReport);
         pointing_device_send();
+        return false;
     }
 #endif
 

--- a/keyboards/bastardkb/dilemma/dilemma.c
+++ b/keyboards/bastardkb/dilemma/dilemma.c
@@ -176,7 +176,6 @@ void dilemma_set_pointer_dragscroll_enabled(bool enable) {
 
 void pointing_device_init_kb(void) {
     maybe_update_pointing_device_cpi(&g_dilemma_config);
-    pointing_device_init_user();
 }
 
 /**

--- a/keyboards/handwired/xealous/keymaps/default/keymap.c
+++ b/keyboards/handwired/xealous/keymaps/default/keymap.c
@@ -87,7 +87,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 float tone_qwerty[][2]     = TONE_QWERTY;
 float tone_numpad[][2]     = TONE_NUMPAD;
 
-layer_state_t default_layer_state_set_kb(layer_state_t state) {
+layer_state_t default_layer_state_set_user(layer_state_t state) {
     if (state == 1UL<<_QWERTY) {
       PLAY_SONG(tone_qwerty);
     } else if (state == 1UL<<_NUMPAD) {

--- a/keyboards/lime/keymaps/default/keymap.c
+++ b/keyboards/lime/keymaps/default/keymap.c
@@ -172,7 +172,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 #   endif
 
     /* Joystick + Encoder fix */
-    void keyboard_post_init_kb(void) {
+    void keyboard_post_init_user(void) {
         if (is_keyboard_master()) {
             gpio_write_pin_low(JOYSTICK_X_PIN);
             gpio_write_pin_low(JOYSTICK_Y_PIN);

--- a/keyboards/lostdotfish/rp2040_orbweaver/keymaps/default/keymap.c
+++ b/keyboards/lostdotfish/rp2040_orbweaver/keymaps/default/keymap.c
@@ -76,15 +76,13 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     }
     return state;
 }
-void suspend_power_down_kb(void) {
+void suspend_power_down_user(void) {
     // code will run multiple times while keyboard is suspended
     gpio_write_pin_high(GP23);
     gpio_write_pin_high(GP24);
     gpio_write_pin_high(GP25);
-    suspend_power_down_user();
 }
 
-void suspend_wakeup_init_kb(void) {
+void suspend_wakeup_init_user(void) {
     layer_state_set_kb(layer_state);
-    suspend_wakeup_init_user();
 }

--- a/keyboards/rmi_kb/tkl_ff/keymaps/default/keymap.c
+++ b/keyboards/rmi_kb/tkl_ff/keymaps/default/keymap.c
@@ -42,25 +42,19 @@ const rgblight_segment_t PROGMEM ll_sl[] = RGBLIGHT_LAYER_SEGMENTS(
 
 const rgblight_segment_t* const PROGMEM rgb_layers[] = RGBLIGHT_LAYERS_LIST(ll_none, ll_cl, ll_sl);
 
-void keyboard_post_init_kb(void) {
+void keyboard_post_init_user(void) {
     rgblight_layers = rgb_layers;
-
-    keyboard_post_init_user();
 }
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-
-    if (res) {
-        uint8_t lock_bits = led_state.scroll_lock << 1 | led_state.caps_lock;
-        for (uint8_t i=0; i<3; i++) {
-            rgblight_set_layer_state(i, false);
-        }
-        if (lock_bits < 3) {
-            rgblight_set_layer_state(lock_bits, true);
-        }
+bool led_update_user(led_t led_state) {
+    uint8_t lock_bits = led_state.scroll_lock << 1 | led_state.caps_lock;
+    for (uint8_t i=0; i<3; i++) {
+        rgblight_set_layer_state(i, false);
+    }
+    if (lock_bits < 3) {
+        rgblight_set_layer_state(lock_bits, true);
     }
 
-    return res;
+    return false;
 }
 #endif

--- a/keyboards/rmi_kb/tkl_ff/keymaps/iso/keymap.c
+++ b/keyboards/rmi_kb/tkl_ff/keymaps/iso/keymap.c
@@ -42,25 +42,19 @@ const rgblight_segment_t PROGMEM ll_sl[] = RGBLIGHT_LAYER_SEGMENTS(
 
 const rgblight_segment_t* const PROGMEM rgb_layers[] = RGBLIGHT_LAYERS_LIST(ll_none, ll_cl, ll_sl);
 
-void keyboard_post_init_kb(void) {
+void keyboard_post_init_user(void) {
     rgblight_layers = rgb_layers;
-
-    keyboard_post_init_user();
 }
 
-bool led_update_kb(led_t led_state) {
-    bool res = led_update_user(led_state);
-
-    if (res) {
-        uint8_t lock_bits = led_state.scroll_lock << 1 | led_state.caps_lock;
-        for (uint8_t i=0; i<3; i++) {
-            rgblight_set_layer_state(i, false);
-        }
-        if (lock_bits < 3) {
-            rgblight_set_layer_state(lock_bits, true);
-        }
+bool led_update_user(led_t led_state) {
+    uint8_t lock_bits = led_state.scroll_lock << 1 | led_state.caps_lock;
+    for (uint8_t i=0; i<3; i++) {
+        rgblight_set_layer_state(i, false);
+    }
+    if (lock_bits < 3) {
+        rgblight_set_layer_state(lock_bits, true);
     }
 
-    return res;
+    return false;
 }
 #endif

--- a/keyboards/rmi_kb/wete/v2/keymaps/default/keymap.c
+++ b/keyboards/rmi_kb/wete/v2/keymaps/default/keymap.c
@@ -73,25 +73,19 @@ const rgblight_segment_t* const PROGMEM rgb_layers[] = RGBLIGHT_LAYERS_LIST(
     ll_slcl
 );
 
-void keyboard_post_init_kb(void) {
+void keyboard_post_init_user(void) {
     rgblight_layers = rgb_layers;
-
-    keyboard_post_init_user();
 }
 
-bool led_update_kb (led_t led_state) {
-    bool res = led_update_user(led_state);
-
-    if (res) {
-        uint8_t lock_bits = led_state.scroll_lock << 2 | led_state.caps_lock << 1 | led_state.num_lock;
-        for (uint8_t i=0; i<7; i++) {
-            rgblight_set_layer_state(i, false);
-        }
-        if (lock_bits < 7) {
-            rgblight_set_layer_state(lock_bits, true);
-        }
+bool led_update_user (led_t led_state) {
+    uint8_t lock_bits = led_state.scroll_lock << 2 | led_state.caps_lock << 1 | led_state.num_lock;
+    for (uint8_t i=0; i<7; i++) {
+        rgblight_set_layer_state(i, false);
+    }
+    if (lock_bits < 7) {
+        rgblight_set_layer_state(lock_bits, true);
     }
 
-    return res;
+    return false;
 }
 #endif

--- a/keyboards/rmi_kb/wete/v2/keymaps/iso/keymap.c
+++ b/keyboards/rmi_kb/wete/v2/keymaps/iso/keymap.c
@@ -73,25 +73,19 @@ const rgblight_segment_t* const PROGMEM rgb_layers[] = RGBLIGHT_LAYERS_LIST(
     ll_slcl
 );
 
-void keyboard_post_init_kb(void) {
+void keyboard_post_init_user(void) {
     rgblight_layers = rgb_layers;
-
-    keyboard_post_init_user();
 }
 
-bool led_update_kb (led_t led_state) {
-    bool res = led_update_user(led_state);
-
-    if (res) {
-        uint8_t lock_bits = led_state.scroll_lock << 2 | led_state.caps_lock << 1 | led_state.num_lock;
-        for (uint8_t i=0; i<7; i++) {
-            rgblight_set_layer_state(i, false);
-        }
-        if (lock_bits < 7) {
-            rgblight_set_layer_state(lock_bits, true);
-        }
+bool led_update_user (led_t led_state) {
+    uint8_t lock_bits = led_state.scroll_lock << 2 | led_state.caps_lock << 1 | led_state.num_lock;
+    for (uint8_t i=0; i<7; i++) {
+        rgblight_set_layer_state(i, false);
+    }
+    if (lock_bits < 7) {
+        rgblight_set_layer_state(lock_bits, true);
     }
 
-    return res;
+    return false;
 }
 #endif

--- a/keyboards/spleeb/spleeb.c
+++ b/keyboards/spleeb/spleeb.c
@@ -283,7 +283,6 @@ void pointing_device_init_kb(void) {
     cirque_pinnacle_enable_cursor_glide(false);
 
     set_auto_mouse_enable(true);
-    pointing_device_init_user();
 }
 
 /**

--- a/keyboards/steelseries/prime/keymaps/default/keymap.c
+++ b/keyboards/steelseries/prime/keymaps/default/keymap.c
@@ -18,7 +18,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
-void pointing_device_init_kb(void) {
+void pointing_device_init_user(void) {
     pointing_device_set_cpi(1600);
 }
 

--- a/keyboards/steelseries/prime_plus/keymaps/default/keymap.c
+++ b/keyboards/steelseries/prime_plus/keymaps/default/keymap.c
@@ -18,7 +18,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
-void pointing_device_init_kb(void) {
+void pointing_device_init_user(void) {
     pointing_device_set_cpi(1600);
 }
 

--- a/keyboards/synthlabs/solo/keymaps/gamepad/keymap.c
+++ b/keyboards/synthlabs/solo/keymaps/gamepad/keymap.c
@@ -20,11 +20,11 @@ joystick_config_t joystick_axes[JOYSTICK_AXIS_COUNT] = {
     [0] = JOYSTICK_AXIS_VIRTUAL
 };
 
-bool encoder_update_kb(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
     joystick_position += (clockwise ? 2 : -2) * (full_joystick_value / pulses_per_revolution);  // +2 and -2 are used, since +1.0 and -1.0 axis output refers to positions at half of a full rotation
     joystick_set_axis(0, joystick_position);
 
-    return true;
+    return false;
 }
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Keymaps should use the `_user` callbacks where possible.

Also `pointing_device_init_kb` should not call `pointing_device_init_user` as this is handled by core.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
