### PR TITLE
Fix pmw33xx sensor initialisation

### DIFF
--- a/drivers/sensors/pmw33xx_common.c
+++ b/drivers/sensors/pmw33xx_common.c
@@ -108,7 +108,7 @@ __attribute__((weak)) bool pmw33xx_check_signature(uint8_t sensor) {
         pmw33xx_read(sensor, REG_Inverse_Product_ID),
     };
 
-    return memcmp(pmw33xx_firmware_signature, signature_dump, sizeof(signature_dump)) == 0;
+    return memcmp_P(signature_dump, pmw33xx_firmware_signature, sizeof(signature_dump)) == 0;
 }
 
 bool pmw33xx_upload_firmware(uint8_t sensor) {

--- a/platforms/progmem.h
+++ b/platforms/progmem.h
@@ -7,6 +7,7 @@
 #    define PROGMEM
 #    define PSTR(x) x
 #    define PGM_P const char*
+#    define memcmp_P(s1, s2, n) memcmp(s1, s2, n)
 #    define memcpy_P(dest, src, n) memcpy(dest, src, n)
 #    define pgm_read_byte(address_short) *((uint8_t*)(address_short))
 #    define pgm_read_word(address_short) *((uint16_t*)(address_short))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

As reported in 25769, #25315 changed the driver to return the status of `pmw33xx_check_signature`. On AVR, this was always silently failing due to the check asserting values against PROGMEM without using any corresponding functions.

This PR updates the check to correctly use the PROGMEM variant of `memcmp`, along with using its correct order of parameters. Non AVR compatibility has been maintained by updating the wrapper header with the additional `memcmp_P` function.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* fixes #25769

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
