### PR TITLE
Fix Magic GUI masking logic

### DIFF
--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -162,8 +162,9 @@ __attribute__((weak)) uint8_t mod_config(uint8_t mod) {
         }
     }
     if (keymap_config.no_gui) {
-        mod &= ~MOD_LGUI;
-        mod &= ~MOD_RGUI;
+        if (mod & MOD_LGUI) {
+            mod &= ~MOD_RGUI;
+        }
     }
 
 #endif // MAGIC_ENABLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Change the no_gui modifier handling to only clear RGUI when either modifier is active. This will prevent any right side modifier flag from being removed unconditionally when this flag is active.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #25680

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
