### PR TITLE
Fix docs for Key Overrides array type

### DIFF
--- a/docs/features/key_overrides.md
+++ b/docs/features/key_overrides.md
@@ -14,7 +14,7 @@ You can use key overrides in a similar way to momentary layer/fn keys to activat
 
 To enable this feature, you need to add `KEY_OVERRIDE_ENABLE = yes` to your `rules.mk`.
 
-Then, in your `keymap.c` file, you'll need to define the array `key_overrides`, which defines all key overrides to be used. Each override is a value of type `key_override_t`. The array `key_overrides`contains pointers to `key_override_t` values (`const key_override_t *`).
+Then, in your `keymap.c` file, you'll need to define the `key_overrides` config. See below for more details.
 
 ## Creating Key Overrides {#creating-key-overrides}
 


### PR DESCRIPTION
## Description

In #24120, the `key_overrides` array type was change **from**:

- `const key_override_t **key_overrides = (const key_override_t *[]){`

**to**:

- `const key_override_t *key_overrides[] = {`, 

..but a spot was missed in the docs to reflect the new data type. This PR updates the docs to match the latest source code, where each element should be of type `key_override_t*` as shown below:

https://github.com/qmk/qmk_firmware/blob/ed343ddad4832a0a48c8ad794e949a595dcf3cfb/quantum/keymap_introspection.c#L167-L172

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

n/a

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
    - tested by running `qmk docs -b` as described [here](https://docs.qmk.fm/contributing#previewing-the-documentation)