### PR TITLE
Fix detection of hid bootloader flashing tool

### DIFF
--- a/lib/python/qmk/flashers.py
+++ b/lib/python/qmk/flashers.py
@@ -153,6 +153,7 @@ def _flash_atmel_dfu(mcu, file):
 
 
 def _flash_hid_bootloader(mcu, details, file):
+    cmd = None
     if details == 'halfkay':
         if shutil.which('teensy-loader-cli'):
             cmd = 'teensy-loader-cli'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
From Discord:
![](https://media.discordapp.net/attachments/867530222407778344/1439451278286782666/image.png?ex=691a90f8&is=69193f78&hm=40187a6f7ad0cc2a4531f2869dd44286127c6b4446dde548e8671c6a9c49921c&=&format=webp&quality=lossless)


When attempting to flash a teensy device with the flashing tool missing, it will produce the above error.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
