### PR TITLE
Short term fix for skip_converter KeyError in 'qmk userspace-add'

### DIFF
--- a/lib/python/qmk/cli/userspace/add.py
+++ b/lib/python/qmk/cli/userspace/add.py
@@ -47,6 +47,7 @@ def userspace_add(cli):
             from qmk.cli.new.keymap import new_keymap
             cli.config.new_keymap.keyboard = cli.args.keyboard
             cli.config.new_keymap.keymap = cli.args.keymap
+            cli.args.skip_converter = True
             if new_keymap(cli) is not False:
                 userspace.add_target(keyboard=cli.args.keyboard, keymap=cli.args.keymap, build_env=build_env)
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Calling qmk userspace-add' when the keymap does not exist, will throw the following error:
```
<class 'KeyError'>
☒ 'skip_converter'
Traceback (most recent call last):
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.13.3/lib/python3.13/site-packages/milc/milc.py", line 609, in __call__
    return self.__call__()
           ~~~~~~~~~~~~~^^
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.13.3/lib/python3.13/site-packages/milc/milc.py", line 614, in __call__
    return self._subcommand(self)
           ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/cli/userspace/add.py", line 51, in userspace_add
    if new_keymap(cli) is not False:
       ~~~~~~~~~~^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/decorators.py", line 43, in wrapper
    return func(*args, **kwargs)
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/decorators.py", line 65, in wrapper
    return func(*args, **kwargs)
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/cli/new/keymap.py", line 105, in new_keymap
    converter = cli.config.new_keymap.converter if cli.args.skip_converter or cli.config.new_keymap.converter else prompt_converter(kb_name)
                                                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.13.3/lib/python3.13/site-packages/milc/attrdict.py", line 32, in __getattr__
    return self.__getitem__(key)
           ~~~~~~~~~~~~~~~~^^^^^
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.13.3/lib/python3.13/site-packages/milc/attrdict.py", line 37, in __getitem__
    return self._data[key]
           ~~~~~~~~~~^^^^^
KeyError: 'skip_converter'

```

Longer term, I plan to refactor `qmk userspace-add` to not call the CLI subcommand directly (and also fix a few things like avoiding the double save of userspace settings).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
