### PR TITLE
Fix community layout keymap discovery

### DIFF
--- a/builddefs/build_json.mk
+++ b/builddefs/build_json.mk
@@ -19,18 +19,18 @@ endif
 ifneq ($(QMK_USERSPACE),)
     ifneq ("$(wildcard $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_5)/keymap.json)","")
         KEYMAP_JSON := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_5)/keymap.json
-        KEYMAP_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_5)
+        KEYMAP_JSON_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_5)
     else ifneq ("$(wildcard $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_4)/keymap.json)","")
         KEYMAP_JSON := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_4)/keymap.json
-        KEYMAP_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_4)
+        KEYMAP_JSON_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_4)
     else ifneq ("$(wildcard $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_3)/keymap.json)","")
         KEYMAP_JSON := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_3)/keymap.json
-        KEYMAP_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_3)
+        KEYMAP_JSON_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_3)
     else ifneq ("$(wildcard $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_2)/keymap.json)","")
         KEYMAP_JSON := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_2)/keymap.json
-        KEYMAP_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_2)
+        KEYMAP_JSON_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_2)
     else ifneq ("$(wildcard $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_1)/keymap.json)","")
         KEYMAP_JSON := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_1)/keymap.json
-        KEYMAP_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_1)
+        KEYMAP_JSON_PATH := $(QMK_USERSPACE)/$(MAIN_KEYMAP_PATH_1)
     endif
 endif

--- a/builddefs/build_layout.mk
+++ b/builddefs/build_layout.mk
@@ -10,10 +10,10 @@ define SEARCH_LAYOUTS_REPO
     LAYOUT_KEYMAP_JSON := $$(LAYOUT_KEYMAP_PATH)/keymap.json
     LAYOUT_KEYMAP_C := $$(LAYOUT_KEYMAP_PATH)/keymap.c
     ifneq ("$$(wildcard $$(LAYOUT_KEYMAP_JSON))","")
-        -include $$(LAYOUT_KEYMAP_PATH)/rules.mk
         KEYMAP_JSON := $$(LAYOUT_KEYMAP_JSON)
-        KEYMAP_PATH := $$(LAYOUT_KEYMAP_PATH)
-    else ifneq ("$$(wildcard $$(LAYOUT_KEYMAP_C))","")
+        KEYMAP_JSON_PATH := $$(LAYOUT_KEYMAP_PATH)
+    endif
+    ifneq ("$$(wildcard $$(LAYOUT_KEYMAP_C))","")
         -include $$(LAYOUT_KEYMAP_PATH)/rules.mk
         KEYMAP_C := $$(LAYOUT_KEYMAP_C)
         KEYMAP_PATH := $$(LAYOUT_KEYMAP_PATH)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

When searching for keymaps within the community layout folder, it does not check for both `keymap.c` and `keymap.json`. When both exist, where `keymap.c` contains the actual keymap and `keymap.json` contains module configuration, only the `keymap.json` is captured. The later code in `build_keyboard.mk` runs:

```make
# Have we found a keymap.json?
ifneq ("$(wildcard $(KEYMAP_JSON))", "")
    ifneq ("$(wildcard $(KEYMAP_C))", "")
        # Allow a separately-found keymap.c next to keymap.json -- the keymap.c
        # generator will include the other keymap.c in the process, if supplied.
        OTHER_KEYMAP_C := $(KEYMAP_C)
```

`KEYMAP_C` is not set, then `OTHER_KEYMAP_C` is not set and the resulting compilation then complains about the keymap array not existing.

Also:
* Fixes inconsistency in variable setting within `builddefs/build_json.mk`
  * There is no reason for the external userspace path to set different variables
* Fixes `rules.mk` being processed twice for community layouts using `keymap.json`
  * This should be handled by the existing check <https://github.com/qmk/qmk_firmware/blob/master/builddefs/build_keyboard.mk#L227>

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* <https://discord.com/channels/440868230475677696/473506116718952450/1440476385016680559>

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
