### PR TITLE
Handle building of XAP keymaps on master/develop

### DIFF
--- a/.github/workflows/ci_build_major_branch_keymap.yml
+++ b/.github/workflows/ci_build_major_branch_keymap.yml
@@ -105,7 +105,12 @@ jobs:
         continue-on-error: true
         run: |
           export NCPUS=$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null) -1 ))
-          qmk mass-compile -t -j $NCPUS -e DUMP_CI_METADATA=yes $(jq -r '.["${{ matrix.target }}"].targets' targets.json) || touch .failed
+          targets=$(jq -r '.["${{ matrix.target }}"].targets' targets.json | tr ' ' '\n' | sort)
+          if [[ -z ${targets} ]]; then
+            echo "Zero build targets detected"
+            exit 0
+          fi
+          qmk mass-compile -t -j $NCPUS -e DUMP_CI_METADATA=yes $targets || touch .failed
 
       - name: Upload binaries
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

When the `CI Build Major Branch` workflow runs on master/develop, it attempts to find xap keymaps. As the feature is still on its own branch, zero keymaps are found. These targets are then passed to `qmk mass-compile`. In the case of zero keymaps, `qmk mass-compile` is then given zero additional target arguments and in turn builds **everything**.

This additional build should be avoided as it is both extremely slow, and completely unnecessary due to it already building in batches.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
