### PR TITLE
Fix USER_PATH resolution on case-insensitive filesystems

### DIFF
--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -474,8 +474,10 @@ ifneq ($(wildcard $(QMK_USERSPACE)),)
 endif
 
 # If the equivalent users directory exists in userspace, use that in preference to anything currently in the main repo
-ifneq ($(wildcard $(QMK_USERSPACE)/$(USER_PATH)),)
-    USER_PATH := $(QMK_USERSPACE)/$(USER_PATH)
+ifneq ($(QMK_USERSPACE),)
+	ifneq ($(wildcard $(QMK_USERSPACE)/$(USER_PATH)),)
+    	USER_PATH := $(QMK_USERSPACE)/$(USER_PATH)
+	endif
 endif
 
 # Pull in user level rules.mk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When QMK_USERSPACE is empty, the wildcard check in `build_keyboard.mk` incorrectly matches user home directories on case-insensitive filesystems (macOS/Windows), causing USER_PATH to resolve to an absolute path instead of a relative path.

This only affects users whose username matches their user directory name (e.g., username `psycher` with home `/Users/psycher` and QMK user dir `users/psycher`).

USER_PATH would then be incorrectly resolved to `/users/psycher` instead of `users/psycher`


## Types of Changes
Fix by checking if QMK_USERSPACE is non-empty before performing the wildcard check.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
