### PR TITLE
Move shutdown delay to audio feature

### DIFF
--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -71,6 +71,10 @@
 #    define AUDIO_DEFAULT_CLICKY_ON true
 #endif
 
+#ifndef AUDIO_SHUTDOWN_DELAY
+#    define AUDIO_SHUTDOWN_DELAY 250
+#endif
+
 #ifndef AUDIO_TONE_STACKSIZE
 #    define AUDIO_TONE_STACKSIZE 8
 #endif
@@ -114,9 +118,14 @@ extern uint16_t voices_timer;
 #ifndef AUDIO_OFF_SONG
 #    define AUDIO_OFF_SONG SONG(AUDIO_OFF_SOUND)
 #endif
+#ifndef GOODBYE_SONG
+#    define GOODBYE_SONG SONG(GOODBYE_SOUND)
+#endif
+
 float startup_song[][2]   = STARTUP_SONG;
 float audio_on_song[][2]  = AUDIO_ON_SONG;
 float audio_off_song[][2] = AUDIO_OFF_SONG;
+float goodbye_song[][2]   = GOODBYE_SONG;
 
 static bool    audio_initialized    = false;
 static bool    audio_driver_stopped = true;
@@ -208,6 +217,18 @@ void audio_startup(void) {
     }
 
     last_timestamp = timer_read();
+}
+
+void audio_shutdown(void) {
+    uint16_t timer_start = timer_read();
+
+    PLAY_SONG(goodbye_song);
+
+    while (timer_elapsed(timer_start) < AUDIO_SHUTDOWN_DELAY) {
+        wait_ms(1);
+    }
+
+    stop_all_notes();
 }
 
 void audio_toggle(void) {

--- a/quantum/audio/audio.h
+++ b/quantum/audio/audio.h
@@ -218,6 +218,8 @@ uint16_t audio_ms_to_duration(uint16_t duration_ms);
 
 void audio_startup(void);
 
+void audio_shutdown(void);
+
 // hardware interface
 
 // implementation in the driver_avr/arm_* respective parts

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -94,10 +94,6 @@
 #endif
 
 #ifdef AUDIO_ENABLE
-#    ifndef GOODBYE_SONG
-#        define GOODBYE_SONG SONG(GOODBYE_SOUND)
-#    endif
-float goodbye_song[][2] = GOODBYE_SONG;
 #    ifdef DEFAULT_LAYER_SONGS
 float default_layer_songs[][16][2] = DEFAULT_LAYER_SONGS;
 #    endif
@@ -218,18 +214,16 @@ void shutdown_quantum(bool jump_to_bootloader) {
 #    ifndef NO_MUSIC_MODE
     music_all_notes_off();
 #    endif
-    uint16_t timer_start = timer_read();
-    PLAY_SONG(goodbye_song);
-    shutdown_modules(jump_to_bootloader);
-    shutdown_kb(jump_to_bootloader);
-    while (timer_elapsed(timer_start) < 250)
-        wait_ms(1);
-    stop_all_notes();
-#else
-    shutdown_modules(jump_to_bootloader);
-    shutdown_kb(jump_to_bootloader);
-    wait_ms(250);
+    audio_shutdown();
 #endif
+
+    shutdown_modules(jump_to_bootloader);
+    shutdown_kb(jump_to_bootloader);
+
+#if SHUTDOWN_DELAY > 0
+    wait_ms(SHUTDOWN_DELAY);
+#endif
+
 #ifdef HAPTIC_ENABLE
     haptic_shutdown();
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Current assumption is that the 250ms delay in `shutdown_quantum` is primarily for audio to finish processing songs.

This PR adds a `audio_shutdown` to encapsulate the shutdown logic within the audio feature, and can be configured with the `AUDIO_SHUTDOWN_DELAY` define.

Just in case a shutdown delay is required, the `SHUTDOWN_DELAY` define can bring back the current overall behaviour.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
