### PR TITLE
Fix broken compilation when OS_DETECTION_DEBUG_ENABLE is defined

### DIFF
--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -23,7 +23,7 @@
 #endif
 
 #ifdef OS_DETECTION_DEBUG_ENABLE
-#    include "eeconfig.h"
+#    include "nvm_eeprom_eeconfig_internal.h"
 #    include "eeprom.h"
 #    include "print.h"
 


### PR DESCRIPTION
## Description

Since https://github.com/qmk/qmk_firmware/pull/24356, os_detection.c fails to compile if we have `#define OS_DETECTION_DEBUG_ENABLE`.

The required definitions moved to `nvm_eeprom_eeconfig_internal.h`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
