### PR TITLE
Allow community modules to depend on UNICODE_COMMON

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -815,6 +815,10 @@ ifeq ($(strip $(UNICODE_ENABLE)), yes)
     SRC += $(QUANTUM_DIR)/process_keycode/process_unicode.c
 endif
 
+ifeq ($(strip $(UNICODE_COMMON_ENABLE)), yes)
+    UNICODE_COMMON := yes
+endif
+
 ifeq ($(strip $(UNICODE_COMMON)), yes)
     OPT_DEFS += -DUNICODE_COMMON_ENABLE
     COMMON_VPATH += $(QUANTUM_DIR)/unicode


### PR DESCRIPTION
## Description

In some cases, a community module may depend on the Unicode infrastructure (UNICODE_COMMON), but not want to specify any of UNICODE, UNICODEMAP, or UCIS.

In  `common_features.mk`,  we look for `UNICODE_COMMON = yes` to enable the common Unicode infrastructure - but there is no way to set that in `qmk_module.json`; feature names there have `_enabled` appended - which in this case would yield `UNICODE_COMMON_ENABLED = yes` (which is incorrect).

This change essentially adds `UNICODE_COMMON_ENABLED = yes` as a synonym for `UNICODE_COMMON = yes`. That maintains backward compatibility, while allowing modules to specify a dependency only on the common Unicode infrastructure.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
