### PR TITLE
Key Overrides: Fix Ghost Modifier Bug on macOS (with Karabiner Elements)

### DIFF
--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -366,13 +366,13 @@ static bool try_activating_override(const uint16_t keycode, const uint8_t layer,
                 schedule_deferred_register(mod_free_replacement);
                 send_keyboard_report();
             } else {
+                send_keyboard_report();
+                // On macOS there seems to be a race condition when it comes to the keyboard report and consumer keycodes. It seems the OS may recognize a consumer keycode before an updated keyboard report, even if the keyboard report is actually sent before the consumer key. I assume it is some sort of race condition because it happens infrequently and very irregularly. Waiting for about at least 10ms between sending the keyboard report and sending the consumer code has shown to fix this.
+                wait_ms(10);
                 if (IS_BASIC_KEYCODE(mod_free_replacement)) {
                     add_key(mod_free_replacement);
                 } else {
                     key_override_printf("NOT KEY 2\n");
-                    send_keyboard_report();
-                    // On macOS there seems to be a race condition when it comes to the keyboard report and consumer keycodes. It seems the OS may recognize a consumer keycode before an updated keyboard report, even if the keyboard report is actually sent before the consumer key. I assume it is some sort of race condition because it happens infrequently and very irregularly. Waiting for about at least 10ms between sending the keyboard report and sending the consumer code has shown to fix this.
-                    wait_ms(10);
                     register_code(mod_free_replacement);
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
## Description

Key Overrides seem to have a bug where sometimes Modifiers are pressed when not wanted, or not pressed when wanted.

This issue seems to already be known about and was partly fixed, judging by this line of code (also in the diff of this pr):
```c
// On macOS there seems to be a race condition when it comes to the keyboard report and consumer keycodes. It seems the OS may recognize a consumer keycode before an updated keyboard report, even if the keyboard report is actually sent before the consumer key. I assume it is some sort of race condition because it happens infrequently and very irregularly. Waiting for about at least 10ms between sending the keyboard report and sending the consumer code has shown to fix this.
wait_ms(10);
```
But apparently, this wait does not fix the bug fully, judging by this issue https://github.com/qmk/qmk_firmware/issues/24688 and also by the bug I observed (describe in my comment to that issue https://github.com/qmk/qmk_firmware/issues/24688#issuecomment-3674708876), which is basically shift being held down, even though it should be suppressed.
To summarize it seems to happen rarely on macOS (judging by the quoted code comment above), and always for me and the issue creator when Karabiner Elements is used.

And QMK currently seems to handle/fix that edge case only for non-basic keycodes, not for basic ones.
And thats exactly what this PR addresses. I added the "send keyboard report with modifiers, then wait, only then send the key press" also in the case of basic key codes. I decided to then move it out of the if statement to reduce code duplication, with the downside of the printf now happening slightly later. I hope that's okay, else I can of course also move it back into the if statement by duplicating it to both branches.

But im not really into the inner workings of QMK, so I cant really judge whether its a good or appropriate fix, all i can say that this change makes it work for me :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk/qmk_firmware/issues/24688

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
