### PR TITLE
Add the Cirrus40 keyboard

### DIFF
--- a/keyboards/cirrus40/cirrus40.c
+++ b/keyboards/cirrus40/cirrus40.c
@@ -1,0 +1,54 @@
+// Copyright 2025 Jakob Linke
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+#ifdef ENCODER_ENABLE
+static bool encoder_pins_are_initialized = false;  // Whether custom initialization ran.
+static pin_t encoders_pad_a_l[] = ENCODER_A_PINS;
+static pin_t encoders_pad_b_l[] = ENCODER_B_PINS;
+static pin_t encoders_pad_a_r[] = ENCODER_A_PINS_RIGHT;
+static pin_t encoders_pad_b_r[] = ENCODER_B_PINS_RIGHT;
+static pin_t* encoders_pad_a = NULL;
+static pin_t* encoders_pad_b = NULL;
+
+// This function overrides the weak implementation in the core code.
+void encoder_wait_pullup_charge(void) {
+  wait_us(10);  // QMK is conservative and waits 100us.
+}
+
+// We use external pullups and thus have to implement custom initialization.
+// This function overrides the weak implementation in the core code.
+void encoder_quadrature_init_pin(uint8_t index, bool pad_b) {
+  if (!encoder_pins_are_initialized) {
+    // We cannot hook in earlier than this, so do side initialization here.
+    static_assert(sizeof(encoders_pad_a_l) / sizeof(encoders_pad_a_l[0]) == 1);
+    static_assert(sizeof(encoders_pad_b_l) / sizeof(encoders_pad_b_l[0]) == 1);
+    static_assert(sizeof(encoders_pad_a_r) / sizeof(encoders_pad_a_r[0]) == 1);
+    static_assert(sizeof(encoders_pad_b_r) / sizeof(encoders_pad_b_r[0]) == 1);
+    encoders_pad_a = is_keyboard_left() ? encoders_pad_a_l : encoders_pad_a_r;
+    encoders_pad_b = is_keyboard_left() ? encoders_pad_b_l : encoders_pad_b_r;
+    encoder_pins_are_initialized = true;
+  }
+  assert(index == 0);
+  pin_t pin = pad_b ? encoders_pad_b[index] : encoders_pad_a[index];
+  assert(pin != NO_PIN);
+  gpio_set_pin_input(pin);  // No pullup.
+}
+
+// Optimize by reading both pins at once.
+// This function overrides the weak implementation in the core code.
+void encoder_driver_task(void) {
+  extern void encoder_quadrature_handle_read(uint8_t index, uint8_t pin_a_state, uint8_t pin_b_state);
+  static const int i = 0;
+  pin_t pin_a = encoders_pad_a[i];
+  pin_t pin_b = encoders_pad_b[i];
+  // Read both pins at the same time since they are on the same port.
+  assert(PAL_PORT(pin_a) == PAL_PORT(pin_b));
+  ioportmask_t port_state = palReadPort(PAL_PORT(pin_a));
+  uint8_t pin_a_state, pin_b_state;
+  pin_a_state = (port_state >> PAL_PAD(pin_a)) & 1;
+  pin_b_state = (port_state >> PAL_PAD(pin_b)) & 1;
+  encoder_quadrature_handle_read(i, pin_a_state, pin_b_state);
+}
+#endif

--- a/keyboards/cirrus40/keyboard.json
+++ b/keyboards/cirrus40/keyboard.json
@@ -1,0 +1,100 @@
+{
+  "keyboard_name": "cirrus40",
+  "manufacturer": "schuay",
+  "maintainer": "schuay",
+  "url": "https://github.com/schuay/cirrus40",
+  "usb": {
+    "device_version": "1.0.1",
+    "pid": "0x23B7",
+    "vid": "0xFAAD"
+  },
+  "development_board": "promicro_rp2040",
+  "diode_direction": "COL2ROW",
+  "features": {
+    "bootmagic": true,
+    "encoder": true,
+    "extrakey": true,
+    "nkro": true
+  },
+  "build": {
+    "lto": true
+  },
+  "host": {
+    "default": {
+      "nkro": true
+    }
+  },
+  "matrix_pins": {
+    "cols": ["GP20", "GP22", "GP26", "GP27", "GP28"],
+    "rows": ["GP3", "GP4", "GP5", "GP6"]
+  },
+  "encoder": {
+    "rotary": [
+      {"pin_a": "GP9", "pin_b": "GP8", "resolution": 2}
+    ]
+  },
+  "split": {
+    "enabled": true,
+    "encoder": {
+      "right": {
+        "rotary": [
+          {"pin_a": "GP8", "pin_b": "GP9", "resolution": 2}
+        ]
+      }
+    },
+    "serial": {
+      "driver": "vendor",
+      "pin": "GP1"
+    },
+    "handedness": {
+      "pin": "GP0"
+    }
+  },
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {"label": "Q", "matrix": [0, 0], "hand": "L", "x": 0, "y": 0.5},
+        {"label": "W", "matrix": [0, 1], "hand": "L", "x": 1, "y": 0.25},
+        {"label": "E", "matrix": [0, 2], "hand": "L", "x": 2, "y": 0},
+        {"label": "R", "matrix": [0, 3], "hand": "L", "x": 3, "y": 0.25},
+        {"label": "T", "matrix": [0, 4], "hand": "L", "x": 4, "y": 0.5},
+        {"label": "Y", "matrix": [4, 4], "hand": "R", "x": 8, "y": 0.5},
+        {"label": "U", "matrix": [4, 3], "hand": "R", "x": 9, "y": 0.25},
+        {"label": "I", "matrix": [4, 2], "hand": "R", "x": 10, "y": 0},
+        {"label": "O", "matrix": [4, 1], "hand": "R", "x": 11, "y": 0.25},
+        {"label": "P", "matrix": [4, 0], "hand": "R", "x": 12, "y": 0.5},
+
+        {"label": "A", "matrix": [1, 0], "hand": "L", "x": 0, "y": 1.5},
+        {"label": "S", "matrix": [1, 1], "hand": "L", "x": 1, "y": 1.25},
+        {"label": "D", "matrix": [1, 2], "hand": "L", "x": 2, "y": 1},
+        {"label": "F", "matrix": [1, 3], "hand": "L", "x": 3, "y": 1.25},
+        {"label": "G", "matrix": [1, 4], "hand": "L", "x": 4, "y": 1.5},
+        {"label": "H", "matrix": [5, 4], "hand": "R", "x": 8, "y": 1.5},
+        {"label": "J", "matrix": [5, 3], "hand": "R", "x": 9, "y": 1.25},
+        {"label": "K", "matrix": [5, 2], "hand": "R", "x": 10, "y": 1},
+        {"label": "L", "matrix": [5, 1], "hand": "R", "x": 11, "y": 1.25},
+        {"label": ":", "matrix": [5, 0], "hand": "R", "x": 12, "y": 1.5},
+
+        {"label": "Z", "matrix": [2, 0], "hand": "L", "x": 0, "y": 2.5},
+        {"label": "X", "matrix": [2, 1], "hand": "L", "x": 1, "y": 2.25},
+        {"label": "C", "matrix": [2, 2], "hand": "L", "x": 2, "y": 2},
+        {"label": "V", "matrix": [2, 3], "hand": "L", "x": 3, "y": 2.25},
+        {"label": "B", "matrix": [2, 4], "hand": "L", "x": 4, "y": 2.5},
+        {"label": "N", "matrix": [6, 4], "hand": "R", "x": 8, "y": 2.5},
+        {"label": "M", "matrix": [6, 3], "hand": "R", "x": 9, "y": 2.25},
+        {"label": ",", "matrix": [6, 2], "hand": "R", "x": 10, "y": 2},
+        {"label": ".", "matrix": [6, 1], "hand": "R", "x": 11, "y": 2.25},
+        {"label": "?", "matrix": [6, 0], "hand": "R", "x": 12, "y": 2.5},
+
+        {"label": "Left ENC",     "matrix": [3, 1], "hand": "*", "encoder": 0, "x": 0.5, "y": 3.5},
+        {"label": "Left Thumb1",  "matrix": [3, 2], "hand": "*", "x": 1.5, "y": 3.25},
+        {"label": "Left Thumb2",  "matrix": [3, 3], "hand": "*", "x": 2.5, "y": 3.25},
+        {"label": "Left Thumb3",  "matrix": [3, 4], "hand": "*", "x": 3.5, "y": 3.5},
+        {"label": "Right Thumb3", "matrix": [7, 4], "hand": "*", "x": 8.5, "y": 3.5},
+        {"label": "Right Thumb2", "matrix": [7, 3], "hand": "*", "x": 9.5, "y": 3.25},
+        {"label": "Right Thumb1", "matrix": [7, 2], "hand": "*", "x": 10.5, "y": 3.25},
+        {"label": "Right ENC",    "matrix": [7, 1], "hand": "*", "encoder": 1, "x": 11.5, "y": 3.5}
+      ]
+    }
+  }
+}

--- a/keyboards/cirrus40/keymaps/default/keymap.c
+++ b/keyboards/cirrus40/keymaps/default/keymap.c
@@ -1,0 +1,97 @@
+// Copyright 2025 Jakob Linke
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+enum Layers {
+  kBase = 0,
+  kOneHand,
+  kNavigation,
+  kNumbers,
+  kFnKeys,
+  kSymbols,
+};
+
+enum CustomKeycodes {
+  HRM_A   = LGUI_T(KC_A),
+  HRM_R   = LALT_T(KC_R),
+  HRM_S   = LCTL_T(KC_S),
+  HRM_T   = LSFT_T(KC_T),
+  HRM_N   = LSFT_T(KC_N),
+  HRM_E   = LCTL_T(KC_E),
+  HRM_I   = LALT_T(KC_I),
+  HRM_O   = LGUI_T(KC_O),
+  BTN_ESC = LT(kOneHand, KC_ESC),
+  NAV_SPC = LT(kNavigation, KC_SPC),
+  NM2_TAB = LT(kNumbers, KC_TAB),
+  NUM_DEL = KC_DEL,
+  FUN_ENT = LT(kFnKeys, KC_ENT),
+  SYM_BSP = LT(kSymbols, KC_BSPC),
+  WSP_L   = G(KC_PGUP),
+  WSP_R   = G(KC_PGDN),
+  TAB_L   = C(KC_PGUP),
+  TAB_R   = C(KC_PGDN),
+};
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [kBase] = LAYOUT(
+        KC_Q,     KC_W,     KC_F,     KC_P,     KC_B,          KC_J,     KC_L,     KC_U,     KC_Y,     KC_SCLN,
+        HRM_A,    HRM_R,    HRM_S,    HRM_T,    KC_G,          KC_M,     HRM_N,    HRM_E,    HRM_I,    HRM_O,
+        KC_Z,     KC_X,     KC_C,     KC_D,     KC_V,          KC_K,     KC_H,     KC_COMM,  KC_DOT,   KC_UNDS,
+                  _______,  BTN_ESC,  NAV_SPC,  NM2_TAB,       FUN_ENT,  SYM_BSP,  NUM_DEL,  _______
+    ),
+
+    [kOneHand] = LAYOUT(
+        C(KC_A),  C(KC_W),  A(KC_TAB),C(KC_T),  XXXXXXX,       XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,
+        WSP_L,    TAB_L,    TAB_R,    WSP_R,    KC_ENT,        XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,
+        C(KC_Z),  C(KC_X),  C(KC_C),  XXXXXXX,  C(KC_V),       XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,
+                  _______,  _______,  _______,  _______,       _______,  _______,  _______,  _______
+    ),
+
+    [kNavigation] = LAYOUT(
+        XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,       KC_PGUP,  _______,  _______,  _______,  XXXXXXX,
+        KC_LGUI,  KC_LALT,  KC_LCTL,  KC_LSFT,  XXXXXXX,       KC_PGDN,  KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,
+        _______,  _______,  _______,  _______,  XXXXXXX,       _______,  KC_HOME,  _______,  _______,  KC_END,
+                  _______,  _______,  _______,  _______,       KC_ENT,   KC_BSPC,  KC_DEL,   _______
+    ),
+
+    [kNumbers] = LAYOUT(
+        QK_BOOT,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,       XXXXXXX,  KC_7,     KC_8,     KC_9,     XXXXXXX,
+        KC_LGUI,  KC_LALT,  KC_LCTL,  KC_LSFT,  XXXXXXX,       S(KC_G),  KC_1,     KC_2,     KC_3,     KC_0,
+        QK_RBT,   XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,       XXXXXXX,  KC_4,     KC_5,     KC_6,     _______,
+                  _______,  _______,  _______,  _______,       KC_ENT,   KC_BSPC,  KC_DEL,   _______
+    ),
+
+    [kFnKeys] = LAYOUT(
+        KC_F10,   KC_F9,    KC_F8,    KC_F7,    XXXXXXX,       XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,
+        KC_F11,   KC_F3,    KC_F2,    KC_F1,    XXXXXXX,       XXXXXXX,  KC_LSFT,  KC_LCTL,  KC_LALT,  KC_LGUI,
+        KC_F12,   KC_F6,    KC_F5,    KC_F4,    XXXXXXX,       XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,  XXXXXXX,
+                  _______,  KC_ESC,   KC_SPC,   KC_TAB,        _______,  _______,  _______,  _______
+    ),
+
+    [kSymbols] = LAYOUT(
+        KC_QUOT,  KC_LPRN,  KC_RPRN,  KC_SCLN,  KC_PERC,       KC_TILD,  KC_PIPE,  KC_AMPR,  KC_GRV,   KC_DQT,
+        KC_EXLM,  KC_EQL,   KC_SLSH,  KC_PLUS,  KC_HASH,       KC_ASTR,  KC_LSFT,  KC_LCTL,  KC_LALT,  KC_LGUI,
+        KC_CIRC,  KC_LCBR,  KC_RCBR,  KC_DLR,   XXXXXXX,       KC_BSLS,  KC_AT,    KC_LBRC,  KC_RBRC,  KC_QUES,
+                  _______,  KC_ESC,   KC_SPC,   KC_TAB,        _______,  _______,  _______,  _______
+    ),
+};
+// clang-format on
+
+#if defined(ENCODER_MAP_ENABLE)
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [kBase] = {ENCODER_CCW_CW(KC_PGUP, KC_PGDN),
+               ENCODER_CCW_CW(KC_LEFT, KC_RIGHT)},
+
+    [kNavigation] = {ENCODER_CCW_CW(KC_UP, KC_DOWN), ENCODER_CCW_CW(KC_BSPC, KC_DEL)},
+    [kSymbols] = {ENCODER_CCW_CW(KC_UP, KC_DOWN), ENCODER_CCW_CW(KC_BSPC, KC_DEL)},
+
+    [kOneHand] = {ENCODER_CCW_CW(KC_PGUP, KC_PGDN),
+                  ENCODER_CCW_CW(KC_LEFT, KC_RIGHT)},
+    [kNumbers] = {ENCODER_CCW_CW(KC_PGUP, KC_PGDN),
+                  ENCODER_CCW_CW(KC_LEFT, KC_RIGHT)},
+    [kFnKeys]    = {ENCODER_CCW_CW(KC_PGUP, KC_PGDN),
+                  ENCODER_CCW_CW(KC_LEFT, KC_RIGHT)},
+};
+#endif

--- a/keyboards/cirrus40/keymaps/default/rules.mk
+++ b/keyboards/cirrus40/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+ENCODER_MAP_ENABLE = yes

--- a/keyboards/cirrus40/readme.md
+++ b/keyboards/cirrus40/readme.md
@@ -1,0 +1,25 @@
+# Cirrus40
+
+![Cirrus40](https://i.imgur.com/LmCXtwU.jpeg)
+
+A 40% (3x5+3) split ortholinear keyboard with a focus on usable encoders. [More info](https://github.com/schuay/cirrus40)
+
+* Keyboard Maintainer: [Jakob Linke](https://github.com/schuay)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make cirrus40:default
+
+Flashing example for this keyboard:
+
+    make cirrus40:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+* **Physical reset button**: Briefly press the RESET button the PCB
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/quantum/action_layer.c
+++ b/quantum/action_layer.c
@@ -276,7 +276,7 @@ uint8_t read_source_layers_cache_impl(uint16_t entry_number, uint8_t cache[][MAX
  *
  * Updates the cached encoders when changing layers
  */
-void update_source_layers_cache(keypos_t key, uint8_t layer) {
+void update_source_layers_cache_default(keypos_t key, uint8_t layer) {
     if (key.row < MATRIX_ROWS && key.col < MATRIX_COLS) {
         const uint16_t entry_number = (uint16_t)(key.row * MATRIX_COLS) + key.col;
         update_source_layers_cache_impl(layer, entry_number, source_layers_cache);
@@ -289,11 +289,15 @@ void update_source_layers_cache(keypos_t key, uint8_t layer) {
 #    endif // ENCODER_MAP_ENABLE
 }
 
+__attribute__((weak)) void update_source_layers_cache(keypos_t key, uint8_t layer) {
+    update_source_layers_cache_default(key, layer);
+}
+
 /** \brief read source layers cache
  *
  * reads the cached keys stored when the layer was changed
  */
-uint8_t read_source_layers_cache(keypos_t key) {
+uint8_t read_source_layers_cache_default(keypos_t key) {
     if (key.row < MATRIX_ROWS && key.col < MATRIX_COLS) {
         const uint16_t entry_number = (uint16_t)(key.row * MATRIX_COLS) + key.col;
         return read_source_layers_cache_impl(entry_number, source_layers_cache);
@@ -305,6 +309,10 @@ uint8_t read_source_layers_cache(keypos_t key) {
     }
 #    endif // ENCODER_MAP_ENABLE
     return 0;
+}
+
+__attribute__((weak)) uint8_t read_source_layers_cache(keypos_t key) {
+    return read_source_layers_cache_default(key);
 }
 #endif
 

--- a/quantum/action_layer.h
+++ b/quantum/action_layer.h
@@ -163,6 +163,14 @@ layer_state_t update_tri_layer_state(layer_state_t state, uint8_t layer1, uint8_
 
 void    update_source_layers_cache(keypos_t key, uint8_t layer);
 uint8_t read_source_layers_cache(keypos_t key);
+
+/* Default bodies for the cache functions above. The cache functions
+ * are weak, so callers can strong-override them to add cache buffers
+ * for additional keypos types (e.g. community modules adding new
+ * KEYLOC_* sentinels); the overrides delegate the existing
+ * matrix/encoder cases by calling these. */
+void    update_source_layers_cache_default(keypos_t key, uint8_t layer);
+uint8_t read_source_layers_cache_default(keypos_t key);
 #endif
 action_t store_or_get_action(bool pressed, keypos_t key);
 

--- a/tests/mousekeys/test_mousekeys.cpp
+++ b/tests/mousekeys/test_mousekeys.cpp
@@ -63,6 +63,27 @@ TEST_F(Mousekey, PressAndHoldButtonOneCorrectlyReported) {
     VERIFY_AND_CLEAR(driver);
 }
 
+TEST_F(Mousekey, HostLastMouseButtonsTracksLatestReport) {
+    TestDriver driver;
+    KeymapKey  mouse_key = KeymapKey{0, 0, 0, QK_MOUSE_BUTTON_1};
+
+    set_keymap({mouse_key});
+
+    EXPECT_EQ(host_last_mouse_buttons(), 0);
+
+    EXPECT_MOUSE_REPORT(driver, (0, 0, 0, 0, 1));
+    mouse_key.press();
+    run_one_scan_loop();
+    EXPECT_EQ(host_last_mouse_buttons(), 1);
+
+    EXPECT_MOUSE_REPORT(driver, (0, 0, 0, 0, 0));
+    mouse_key.release();
+    run_one_scan_loop();
+    EXPECT_EQ(host_last_mouse_buttons(), 0);
+
+    VERIFY_AND_CLEAR(driver);
+}
+
 TEST_P(MousekeyParametrized, PressAndReleaseIsCorrectlyReported) {
     TestDriver           driver;
     KeymapKey            mouse_key    = GetParam().first;

--- a/tmk_core/protocol/host.c
+++ b/tmk_core/protocol/host.c
@@ -70,6 +70,7 @@ extern keymap_config_t keymap_config;
 static host_driver_t *driver;
 static uint16_t       last_system_usage   = 0;
 static uint16_t       last_consumer_usage = 0;
+static uint8_t        last_mouse_buttons  = 0;
 
 void host_set_driver(host_driver_t *d) {
     driver = d;
@@ -220,6 +221,7 @@ void host_mouse_send(report_mouse_t *report) {
     report->boot_x = (report->x > 127) ? 127 : ((report->x < -127) ? -127 : report->x);
     report->boot_y = (report->y > 127) ? 127 : ((report->y < -127) ? -127 : report->y);
 #endif
+    last_mouse_buttons = report->buttons;
     (*driver->send_mouse)(report);
 }
 
@@ -357,4 +359,8 @@ uint16_t host_last_system_usage(void) {
 
 uint16_t host_last_consumer_usage(void) {
     return last_consumer_usage;
+}
+
+uint8_t host_last_mouse_buttons(void) {
+    return last_mouse_buttons;
 }

--- a/tmk_core/protocol/host.h
+++ b/tmk_core/protocol/host.h
@@ -48,6 +48,7 @@ void    host_raw_hid_send(uint8_t *data, uint8_t length);
 
 uint16_t host_last_system_usage(void);
 uint16_t host_last_consumer_usage(void);
+uint8_t  host_last_mouse_buttons(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A 40% keyboard with focus on usable encoders. The PCB uses external pullups for encoder pins, hence the custom initialization logic.

https://github.com/schuay/cirrus40

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
