### PR TITLE
Remove deprecated `isLeftHand`

### DIFF
--- a/quantum/split_common/split_util.c
+++ b/quantum/split_common/split_util.c
@@ -56,8 +56,6 @@
 
 static uint8_t connection_errors = 0;
 
-volatile bool isLeftHand = true;
-
 static struct {
     bool master;
     bool left;
@@ -202,8 +200,6 @@ __attribute__((weak)) bool is_keyboard_master(void) {
 void split_pre_init(void) {
     split_config.master = is_keyboard_master_impl();
     split_config.left   = is_keyboard_left_impl();
-
-    isLeftHand = is_keyboard_left(); // TODO: Remove isLeftHand
 
 #if defined(RGBLIGHT_ENABLE) && defined(RGBLED_SPLIT)
     uint8_t num_rgb_leds_split[2] = RGBLED_SPLIT;

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -5,8 +5,6 @@
 
 #include "matrix.h"
 
-extern volatile bool isLeftHand;
-
 void split_pre_init(void);
 void split_post_init(void);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
In tree uses have now been refactored to use `is_keyboard_left()` instead.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
