### PR TITLE
Fixed missing "split": true for sofle keyboard's info.json

### DIFF
--- a/keyboards/sofle/info.json
+++ b/keyboards/sofle/info.json
@@ -34,6 +34,7 @@
     },
     "rgblight": {
         "led_count": 72,
+        "split": true,
         "split_count": [36, 36],
         "sleep": true
     },

--- a/keyboards/sofle/readme.md
+++ b/keyboards/sofle/readme.md
@@ -25,7 +25,7 @@ Flashing example for this keyboard:
     make sofle/rev1:default:flash
     make sofle/keyhive:default:flash
 
-Press reset button on he keyboard when asked.
+Press reset button on the keyboard when asked.
 
 Disconnect the first half, connect the second one and repeat the process.
 
@@ -38,3 +38,14 @@ Enter the bootloader in 3 ways:
 * **Bootmagic reset**: Hold down the key at (0,0) in the matrix
 * **Physical reset button**: Briefly press the button near the TRRS connector. Quickly double-tap if you are using Pro Micro.
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available
+
+## Troubleshooting
+
+If left/right halves are not communicating or broken when connected:
+
+- double check TRRS cable connection
+- add `#define SPLIT_USB_DETECT` to `config.h` to enable handedness detection on both halves and reflash firmware.
+
+If RGBs and/or keyboard are frozen:
+
+- Clear EEPROM using QMK Toolbox.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Fix missing `"split": true` for sofle keyboard's `info.json`.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Without this flag, host_keyboard_led_state() causes weird crashes when two halves are connected and the host LED flags (especially num lock/scroll lock) are updated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* perhaps related to #24725

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
