### PR TITLE
Fixes for is31fl3729 LED matrix driver off-by-one errors

### DIFF
--- a/drivers/led/issi/is31fl3729-mono.c
+++ b/drivers/led/issi/is31fl3729-mono.c
@@ -107,7 +107,7 @@ void is31fl3729_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 11 transfers of 13 bytes.
 
     // Iterate over the pwm_buffer contents at 13 byte intervals.
-    for (uint8_t i = 0; i <= IS31FL3729_PWM_REGISTER_COUNT; i += 13) {
+    for (uint8_t i = 0; i < IS31FL3729_PWM_REGISTER_COUNT; i += 13) {
 #if IS31FL3729_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3729_I2C_PERSISTENCE; j++) {
             if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 13, IS31FL3729_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
@@ -182,7 +182,7 @@ void is31fl3729_set_scaling_register(uint8_t index, uint8_t value) {
     // need to do a bit of checking here since 3729 scaling is per CS pin.
     // not the usual per single LED key as per other ISSI drivers
     // only enable them, since they should be default disabled
-    int cs_value = (led.v & 0x0F) - 1;
+    int cs_value = (led.v & 0x0F);
 
     driver_buffers[led.driver].scaling_buffer[cs_value] = value;
     driver_buffers[led.driver].scaling_buffer_dirty     = true;

--- a/drivers/led/issi/is31fl3729.c
+++ b/drivers/led/issi/is31fl3729.c
@@ -107,7 +107,7 @@ void is31fl3729_write_pwm_buffer(uint8_t index) {
     // Transmit PWM registers in 11 transfers of 13 bytes.
 
     // Iterate over the pwm_buffer contents at 13 byte intervals.
-    for (uint8_t i = 0; i <= IS31FL3729_PWM_REGISTER_COUNT; i += 13) {
+    for (uint8_t i = 0; i < IS31FL3729_PWM_REGISTER_COUNT; i += 13) {
 #if IS31FL3729_I2C_PERSISTENCE > 0
         for (uint8_t j = 0; j < IS31FL3729_I2C_PERSISTENCE; j++) {
             if (i2c_write_register(i2c_addresses[index] << 1, IS31FL3729_REG_PWM + i, driver_buffers[index].pwm_buffer + i, 13, IS31FL3729_I2C_TIMEOUT) == I2C_STATUS_SUCCESS) break;
@@ -184,9 +184,9 @@ void is31fl3729_set_scaling_register(uint8_t index, uint8_t red, uint8_t green, 
     // need to do a bit of checking here since 3729 scaling is per CS pin.
     // not the usual per RGB key as per other ISSI drivers
     // only enable them, since they should be default disabled
-    int cs_red   = (led.r & 0x0F) - 1;
-    int cs_green = (led.g & 0x0F) - 1;
-    int cs_blue  = (led.b & 0x0F) - 1;
+    int cs_red   = (led.r & 0x0F);
+    int cs_green = (led.g & 0x0F);
+    int cs_blue  = (led.b & 0x0F);
 
     driver_buffers[led.driver].scaling_buffer[cs_red]   = red;
     driver_buffers[led.driver].scaling_buffer[cs_green] = green;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This PR fixes a couple latent bugs within the is31fl3729 matrix driver since #23109 and #21944, resulting in LEDs on sink line CS1 and the last sink line defined by the user to not light up.

## Description

<!--- Describe your changes in detail here. -->
First, within ```is31fl3729_write_pwm_buffer```, less or equal in the for loop causes the write to overrun the bounds of ```pwm_buffer```, as well as clobbering the scaling register due to the address auto-increment on concurrent bytes. Changing to less-than results in keeping in bounds, from 0x00 to 0x8E.

Second, within ```is31fl3729_set_scaling_register```, the calculation for the scaling register address hadn't changed after the changes to the pin definitions, causing scaling register writes for LEDs to be written starting at 0x8F (effectively setting SW9_CS16 LED to max bright by default) through to 0x9E , with writes stopping one short of the highest CS value register, as well as never being able to write to scaling register 0x9F.

These issues were noticed as I'm building my own custom split keeb using this matrix driver; If needed, I would be happy to provide schematics, PCB layout, and pictures as well 😊

Thank you, QMK team!

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
