### PR TITLE
 Fix functions layer_debug and default_layer_debug

### DIFF
--- a/quantum/action_layer.c
+++ b/quantum/action_layer.c
@@ -231,7 +231,7 @@ void layer_xor(layer_state_t state) {
  * Print out the hex value of the 32-bit layer state, as well as the value of the highest bit.
  */
 void layer_debug(void) {
-    ac_dprintf("%08X(%u)", layer_state, get_highest_layer(layer_state));
+    ac_dprintf("%08lX(%u)", (uint32_t)layer_state, get_highest_layer(layer_state));
 }
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Correct display of the debug functions 'layer_debug' and 'default_layer_debug'.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
In the file action_layer.c, the debug functions 'layer_debug' and 'default_layer_debug' where not properly displaying the layer (used an unsigned short int instead of a 32 bit unsigned int). 

The issue is described in the associated issue: [https://github.com/qmk/qmk_firmware/issues/25911](https://github.com/qmk/qmk_firmware/issues/25911)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #25911

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
