### PR TITLE
Fix RGB Matrix Typing Heatmap overflow

### DIFF
--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -32,7 +32,7 @@ void process_rgb_matrix_typing_heatmap(uint8_t row, uint8_t col) {
             if (i_row == row && i_col == col) {
                 g_rgb_frame_buffer[row][col] = qadd8(g_rgb_frame_buffer[row][col], RGB_MATRIX_TYPING_HEATMAP_INCREASE_STEP);
             } else {
-#            define LED_DISTANCE(led_a, led_b) sqrt16(((int16_t)(led_a.x - led_b.x) * (int16_t)(led_a.x - led_b.x)) + ((int16_t)(led_a.y - led_b.y) * (int16_t)(led_a.y - led_b.y)))
+#            define LED_DISTANCE(led_a, led_b) sqrt16(((int32_t)(led_a.x - led_b.x) * (int32_t)(led_a.x - led_b.x)) + ((int32_t)(led_a.y - led_b.y) * (int32_t)(led_a.y - led_b.y)))
                 uint8_t distance = LED_DISTANCE(g_led_config.point[g_led_config.matrix_co[row][col]], g_led_config.point[g_led_config.matrix_co[i_row][i_col]]);
 #            undef LED_DISTANCE
                 if (distance <= RGB_MATRIX_TYPING_HEATMAP_SPREAD) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

The RGB heatmap effect currently has an issue where pressing the leftmost keys on the keyboard may light up the rightmost keys on the keyboard as well.

#18410 fixed it by increasing the value of the intermediate distance calculations from an `int8_t` to an `int16_t`, but this value is still insufficient.

The macro calculates the distance by taking the `sqrt16` of the difference of positions between the keys. The range of the positions is recommended to be in the range `{ 0..224, 0..64 }`, even in this range, when keys are at opposite sides, the difference of positions squared can overflow an `int16_t`:
224^2 = 50,176 which is bigger than the maximum `int16_t` (+32,767).

The solution is to increase the intermediate values size to an `int32_t`. As this value is going to be positive, when it's cast to an `uint16_t` to calculate the `sqrt16` it's not going to overflow.

I've found the error on a `crkbrd/rev1` and checked the solution on it as well.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
