### PR TITLE
Add converter support to `evyd13/pockettype`

### DIFF
--- a/keyboards/evyd13/pockettype/keyboard.json
+++ b/keyboards/evyd13/pockettype/keyboard.json
@@ -15,6 +15,7 @@
   "diode_direction": "COL2ROW",
   "processor": "atmega32u4",
   "bootloader": "atmel-dfu",
+  "pin_compatible": "promicro",
   "features": {
     "bootmagic": true,
     "mousekey": false,


### PR DESCRIPTION
added pin compatiblity for "promicro" to allow rp2040_ce conversion

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added pro-micro pin compatibilty to the pockettype keyboard.json, this was to allow me to use a pro-micro form factor rp2040 board from mechboards in my pockettype build. see: https://github.com/mechboardsguides/flashing-rp2040-promicro/
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
