### PR TITLE
Fix `USER_PRINT` stripping out `uprintf`

### DIFF
--- a/platforms/avr/_print.h
+++ b/platforms/avr/_print.h
@@ -24,3 +24,9 @@
 #pragma once
 
 #include "avr/xprintf.h"
+
+// TODO: Remove xprintf due to conflicts/assumptions on direct library usage
+#undef xprintf
+
+// Export main print function
+#define print_printf(fmt, ...) __xprintf(PSTR(fmt), ##__VA_ARGS__)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
By introducing a new intermediate define, we can correctly stub out `xprintf` when `USER_PRINT` is defined.
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #24987

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
