### PR TITLE
Correction for Drop CSTM80

### DIFF
--- a/keyboards/drop/cstm80/cstm80.c
+++ b/keyboards/drop/cstm80/cstm80.c
@@ -4,7 +4,7 @@
 #    include "rgb_matrix.h"
 
 const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT] = {
-    { 0, SW5_CS1,  SW4_CS1,  SW6_CS1  },
+    { 0, SW5_CS1,  SW4_CS1,  SW6_CS1  }, // Row 1
     { 0, SW5_CS2,  SW4_CS2,  SW6_CS2  },
     { 0, SW5_CS3,  SW4_CS3,  SW6_CS3  },
     { 0, SW5_CS4,  SW4_CS4,  SW6_CS4  },
@@ -20,7 +20,9 @@ const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT] = {
     { 0, SW5_CS14, SW4_CS14, SW6_CS14 },
     { 0, SW5_CS15, SW4_CS15, SW6_CS15 },
     { 0, SW5_CS16, SW4_CS16, SW6_CS16 },
-    { 0, SW8_CS1,  SW7_CS1,  SW9_CS1  },
+    { 1, SW2_CS14, SW1_CS14, SW3_CS14 },
+
+    { 0, SW8_CS1,  SW7_CS1,  SW9_CS1  }, // Row 2
     { 0, SW8_CS2,  SW7_CS2,  SW9_CS2  },
     { 0, SW8_CS3,  SW7_CS3,  SW9_CS3  },
     { 0, SW8_CS4,  SW7_CS4,  SW9_CS4  },
@@ -36,7 +38,9 @@ const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT] = {
     { 0, SW8_CS14, SW7_CS14, SW9_CS14 },
     { 0, SW8_CS15, SW7_CS15, SW9_CS15 },
     { 0, SW8_CS16, SW7_CS16, SW9_CS16 },
-    { 0, SW11_CS1,  SW10_CS1,  SW12_CS1  },
+    { 1, SW2_CS15, SW1_CS15, SW3_CS15 },
+
+    { 0, SW11_CS1,  SW10_CS1,  SW12_CS1  }, // Row 3
     { 0, SW11_CS2,  SW10_CS2,  SW12_CS2  },
     { 0, SW11_CS3,  SW10_CS3,  SW12_CS3  },
     { 0, SW11_CS4,  SW10_CS4,  SW12_CS4  },
@@ -52,7 +56,9 @@ const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT] = {
     { 0, SW11_CS14, SW10_CS14, SW12_CS14 },
     { 0, SW11_CS15, SW10_CS15, SW12_CS15 },
     { 0, SW11_CS16, SW10_CS16, SW12_CS16 },
-    { 1, SW2_CS1,  SW1_CS1,  SW3_CS1  },
+    { 1, SW2_CS16, SW1_CS16, SW3_CS16 },
+
+    { 1, SW2_CS1,  SW1_CS1,  SW3_CS1  }, // Row 4
     { 1, SW2_CS2,  SW1_CS2,  SW3_CS2  },
     { 1, SW2_CS3,  SW1_CS3,  SW3_CS3  },
     { 1, SW2_CS4,  SW1_CS4,  SW3_CS4  },
@@ -65,10 +71,8 @@ const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT] = {
     { 1, SW2_CS11, SW1_CS11, SW3_CS11 },
     { 1, SW2_CS12, SW1_CS12, SW3_CS12 },
     { 1, SW2_CS13, SW1_CS13, SW3_CS13 },
-    { 1, SW2_CS14, SW1_CS14, SW3_CS14 },
-    { 1, SW2_CS15, SW1_CS15, SW3_CS15 },
-    { 1, SW2_CS16, SW1_CS16, SW3_CS16 },
-    { 1, SW5_CS1,  SW4_CS1,  SW6_CS1  },
+
+    { 1, SW5_CS1,  SW4_CS1,  SW6_CS1  }, // Row 5
     { 1, SW5_CS2,  SW4_CS2,  SW6_CS2  },
     { 1, SW5_CS3,  SW4_CS3,  SW6_CS3  },
     { 1, SW5_CS4,  SW4_CS4,  SW6_CS4  },
@@ -81,7 +85,8 @@ const is31fl3733_led_t PROGMEM g_is31fl3733_leds[IS31FL3733_LED_COUNT] = {
     { 1, SW5_CS11, SW4_CS11, SW6_CS11 },
     { 1, SW5_CS12, SW4_CS12, SW6_CS12 },
     { 1, SW5_CS13, SW4_CS13, SW6_CS13 },
-    { 1, SW8_CS1,  SW7_CS1,  SW9_CS1  },
+
+    { 1, SW8_CS1,  SW7_CS1,  SW9_CS1  }, // Row 6
     { 1, SW8_CS2,  SW7_CS2,  SW9_CS2  },
     { 1, SW8_CS3,  SW7_CS3,  SW9_CS3  },
     { 1, SW8_CS4,  SW7_CS4,  SW9_CS4  },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Problem:
Drop CSTM80 laid out the LED definitions but laid in them out in logical hardware order.   This caused problems in two areas:

1) Users wanting to create custom keymaps while depending on the stock driver had no way to overcome the hardware order defined when needing LEDs in logical key map order. 2) RGB effects that were row defined for specific patterns were always off as traversing the LED definitions was always off.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Solutions
The LED hardware array definitions are now laid out in row order, matching the key switch order in the driver.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ X ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ X ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ X ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ X ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
