### PR TITLE
Have rgblight inc/dec helper passthrough set_speed

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -188,6 +188,7 @@
     "RGBLIGHT_DEFAULT_SAT": {"info_key": "rgblight.default.sat", "value_type": "int"},
     "RGBLIGHT_DEFAULT_VAL": {"info_key": "rgblight.default.val", "value_type": "int"},
     "RGBLIGHT_DEFAULT_SPD": {"info_key": "rgblight.default.speed", "value_type": "int"},
+    "RGBLIGHT_DEFAULT_SPD_MAX": {"info_key": "rgblight.default.speed_max", "value_type": "int"},
 
     // Secure
     "SECURE_IDLE_TIMEOUT": {"info_key": "secure.idle_timeout", "value_type": "int"},

--- a/data/mappings/info_defaults.hjson
+++ b/data/mappings/info_defaults.hjson
@@ -39,7 +39,8 @@
             "hue": 0,
             "sat": 255,
             "val": 255,
-            "speed": 0
+            "speed": 0,
+            "speed_max": 3
         },
         "brightness_steps": 17,
         "hue_steps": 8,

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -728,6 +728,7 @@
                         "sat": {"$ref": "./definitions.jsonschema#/unsigned_int_8"},
                         "val": {"$ref": "./definitions.jsonschema#/unsigned_int_8"},
                         "speed": {"$ref": "./definitions.jsonschema#/unsigned_int_8"}
+                        "speed_max": {"$ref": "./definitions.jsonschema#/unsigned_int_8"}
                     }
                 },
                 "driver": {

--- a/docs/features/rgblight.md
+++ b/docs/features/rgblight.md
@@ -108,6 +108,7 @@ Your RGB lighting can be configured by placing these `#define`s in your `config.
 |`RGBLIGHT_DEFAULT_SAT`     |`UINT8_MAX` (255)           |The default saturation to use upon clearing the EEPROM                                                                     |
 |`RGBLIGHT_DEFAULT_VAL`     |`RGBLIGHT_LIMIT_VAL`        |The default value (brightness) to use upon clearing the EEPROM                                                             |
 |`RGBLIGHT_DEFAULT_SPD`     |`0`                         |The default speed to use upon clearing the EEPROM                                                                          |
+|`RGBLIGHT_DEFAULT_SPD_MAX` |`3`                         |The default max speed to use upon clearing the EEPROM                                                                      |
 |`RGBLIGHT_DEFAULT_ON`      |`true`                      |Enable RGB lighting upon clearing the EEPROM                                                                               |
 
 ## Effects and Animations

--- a/quantum/rgblight/rgblight.c
+++ b/quantum/rgblight/rgblight.c
@@ -84,6 +84,10 @@ static uint8_t mode_base_table[] = {
 #    define RGBLIGHT_DEFAULT_SPD 0
 #endif
 
+#if !defined(RGBLIGHT_DEFAULT_SPD_MAX)
+#    define RGBLIGHT_DEFAULT_SPD_MAX 3
+#endif
+
 #if !defined(RGBLIGHT_DEFAULT_ON)
 #    define RGBLIGHT_DEFAULT_ON true
 #endif
@@ -187,6 +191,7 @@ void eeconfig_update_rgblight_default(void) {
     rgblight_config.sat       = RGBLIGHT_DEFAULT_SAT;
     rgblight_config.val       = RGBLIGHT_DEFAULT_VAL;
     rgblight_config.speed     = RGBLIGHT_DEFAULT_SPD;
+    rgblight_config.speed_max = RGBLIGHT_DEFAULT_SPD_MAX;
     RGBLIGHT_SPLIT_SET_CHANGE_MODEHSVS;
     eeconfig_update_rgblight(&rgblight_config);
 }
@@ -200,6 +205,7 @@ void eeconfig_debug_rgblight(void) {
     dprintf("rgblight_config.sat = %d\n", rgblight_config.sat);
     dprintf("rgblight_config.val = %d\n", rgblight_config.val);
     dprintf("rgblight_config.speed = %d\n", rgblight_config.speed);
+    dprintf("rgblight_config.speed_max = %d\n", rgblight_config.speed_max);
 }
 
 void rgblight_init(void) {
@@ -467,10 +473,8 @@ void rgblight_decrease_val(void) {
 }
 
 void rgblight_increase_speed_helper(bool write_to_eeprom) {
-    if (rgblight_config.speed < 3) rgblight_config.speed++;
-    // RGBLIGHT_SPLIT_SET_CHANGE_HSVS; // NEED?
-    if (write_to_eeprom) {
-        eeconfig_update_rgblight(&rgblight_config);
+    if (rgblight_config.speed < rgblight_config.speed_max) {
+        rgblight_set_speed_eeprom_helper(qadd8(rgblight_config.speed, 1), write_to_eeprom);
     }
 }
 void rgblight_increase_speed(void) {
@@ -481,11 +485,7 @@ void rgblight_increase_speed_noeeprom(void) {
 }
 
 void rgblight_decrease_speed_helper(bool write_to_eeprom) {
-    if (rgblight_config.speed > 0) rgblight_config.speed--;
-    // RGBLIGHT_SPLIT_SET_CHANGE_HSVS; // NEED??
-    if (write_to_eeprom) {
-        eeconfig_update_rgblight(&rgblight_config);
-    }
+    rgblight_set_speed_eeprom_helper(qsub8(rgblight_config.speed, 1), write_to_eeprom);
 }
 void rgblight_decrease_speed(void) {
     rgblight_decrease_speed_helper(true);
@@ -588,14 +588,26 @@ uint8_t rgblight_get_speed(void) {
     return rgblight_config.speed;
 }
 
+uint8_t rgblight_get_speed_max(void) {
+    return rgblight_config.speed_max;
+}
+
 void rgblight_set_speed_eeprom_helper(uint8_t speed, bool write_to_eeprom) {
     rgblight_config.speed = speed;
+
     if (write_to_eeprom) {
         eeconfig_update_rgblight(&rgblight_config);
-        dprintf("rgblight set speed [EEPROM]: %u\n", rgblight_config.speed);
-    } else {
-        dprintf("rgblight set speed [NOEEPROM]: %u\n", rgblight_config.speed);
     }
+    dprintf("rgblight set speed [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgblight_config.speed);
+}
+
+void rgblight_set_speed_max_eeprom_helper(uint8_t speed_max, bool write_to_eeprom) {
+    rgblight_config.speed_max = speed_max;
+
+    if (write_to_eeprom) {
+        eeconfig_update_rgblight(&rgblight_config);
+    }
+    dprintf("rgblight set speed max [%s]: %u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgblight_config.speed_max);
 }
 
 void rgblight_set_speed(uint8_t speed) {

--- a/quantum/rgblight/rgblight.h
+++ b/quantum/rgblight/rgblight.h
@@ -256,6 +256,7 @@ typedef union rgblight_config_t {
         uint8_t sat : 8;
         uint8_t val : 8;
         uint8_t speed : 8;
+        uint8_t speed_max : 8;
     };
 } rgblight_config_t;
 
@@ -350,6 +351,7 @@ void rgblight_sethsv_noeeprom(uint8_t hue, uint8_t sat, uint8_t val);
 uint8_t rgblight_get_speed(void);
 void    rgblight_set_speed(uint8_t speed);
 void    rgblight_set_speed_noeeprom(uint8_t speed);
+void    rgblight_set_speed_eeprom_helper(uint8_t speed, bool write_to_eeprom);
 
 /*   reset */
 void rgblight_reload_from_eeprom(void);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

I'm unsure if these changes are at all wanted/desired. Currently, this has no actual effect any `rgblight` modes, afaict. However, I believe this is a prerequisite to add the capability to adjust `rgblight` pattern speeds independently of `tmp_dynamic` modes, e.g. https://github.com/qmk/qmk_firmware/blob/ddeaa26fefa7b43a28ce583e39dbf43b7234dd24/quantum/rgblight/rgblight_modes.h#L4-L7 (which I figured should be a different PR, but happy to add here too)

---

* Add missing header for `rgblight_set_eeprom_helper`
* Have `rgb_light_{in,de}crease_speed_helper` pass-through `rgblight_set_speed_eeprom_helper`.
    * De-dup some code
    * Utilizes debug messaging
* Update helper functions to act more similarily to `rbg_matrix` equivalents
    * Using qadd8/qsub8
    * Ternary for debug messaging
* Allow `rgblight_config.speed` "max" to be configurable by adding `RGBLIGHT_DEFAULT_SPD_MAX` and corresponding template values

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

I didn't see a test suite for this feature. Ad hoc tested against some existing keyboards which had `rgblight.default.speed` defined. E.g., added `speed_max: 10` to `keycapsss/3w6_2040` and ran `qmk compile -kb keycapsss/3w6_2040 -km default`
