### PR TITLE
Report permission issues in `qmk doctor`

### DIFF
--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -24,7 +24,7 @@ def git_get_version(repo_dir='.', check_dir='.'):
 
         else:
             cli.log.warning(f'"{" ".join(git_describe_cmd)}" returned error code {git_describe.returncode}')
-            print(git_describe.stderr)
+            cli.log.warning(git_describe.stderr)
             return None
 
     return None
@@ -116,6 +116,18 @@ def git_check_repo():
     dot_git_dir = QMK_FIRMWARE / '.git'
 
     return dot_git_dir.is_dir()
+
+
+def git_check_safe(repo_dir='.'):
+    """Checks if a directory passes the git safe.directory checks
+    """
+    if repo_dir != '.':
+        git_cmd = ['git', '-C', repo_dir, 'status']
+    else:
+        git_cmd = ['git', 'status']
+
+    status = cli.run(git_cmd)
+    return '--add safe.directory' not in status.stderr
 
 
 def git_check_deviation(active_branch):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the only way to infer problems is the absence of `Git branch...` in the `qmk doctor` output. As no error is actually reported, its not directly obvious that anything is wrong. Compilation then spits out the following errors when running `qmk generate-version-h`:

```
⚠ "git describe --abbrev=6 --dirty --always --tags" returned error code 128
⚠ "git describe --abbrev=6 --dirty --always --tags" returned error code 128
builddefs/build_keyboard.mk:291: *** multiple target patterns.  Stop.
```

Where users have previously then questioned "well doctor isnt reporting anything?".

The printing of the "safe.directory" git message to stdout causes the makefile to fall over and mask the actual error message.


Doctor now reports the following when the `qmk_firmware` repo has issue

```
Ψ Userspace enabled: False
⚠ Detected dubious ownership in repository!
Ψ CLI installed in virtualenv.
Ψ All dependencies are installed.
```

And the following when its just a single submodule:

```
Ψ Submodule status:
☒ - lib/chibios: <<< dubious ownership in repository >>>
Ψ - lib/chibios-contrib: 2025-10-03 18:22:15 +0200 --  (8d863d9e)
Ψ - lib/googletest: 2021-06-11 06:37:43 -0700 --  (e2239ee)
Ψ - lib/lufa: 2022-08-26 12:09:55 +1000 --  (549b973)
Ψ - lib/vusb: 2022-06-13 09:18:17 +1000 --  (819dbc1)
Ψ - lib/printf: 2022-06-29 23:59:58 +0300 --  (c2e3b4e)
Ψ - lib/pico-sdk: 2025-04-20 21:24:29 +1000 --  (d0c5cac)
Ψ - lib/lvgl: 2022-04-11 04:44:53 -0600 --  (e19410f)
Ψ QMK is ready to go
```

And compilation no longer falls over, producing:
```
make clean drop/cstm65:default
QMK Firmware 0.31.3
Deleting .build/ ... done.
Making drop/cstm65 with keymap default

⚠ "git describe --abbrev=6 --dirty --always --tags" returned error code 128
⚠ fatal: detected dubious ownership in repository at '/home/zvecr/zv_firmware_clean/lib/chibios'
To add an exception for this directory, call:

	git config --global --add safe.directory /home/zvecr/zv_firmware_clean/lib/chibios

Generating: .build/obj_drop_cstm65_default/src/info_deps.d                                          [OK]
⚠ "git describe --abbrev=6 --dirty --always --tags" returned error code 128
⚠ fatal: detected dubious ownership in repository at '/home/zvecr/zv_firmware_clean/lib/chibios'
To add an exception for this directory, call:

	git config --global --add safe.directory /home/zvecr/zv_firmware_clean/lib/chibios

arm-none-eabi-gcc (Arch Repository) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Generating: .build/obj_drop_cstm65_default/src/info_config.h                                       Generating: .build/obj_drop_cstm65_default/src/default_keyboard.c                                  Generating: .build/obj_drop_cstm65_default/src/default_keyboard.h  
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
