### PR TITLE
Handle broken symlinks in `qmk doctor` udev checks

### DIFF
--- a/lib/python/qmk/cli/doctor/linux.py
+++ b/lib/python/qmk/cli/doctor/linux.py
@@ -87,7 +87,7 @@ def check_udev_rules():
                     line = line.strip()
                     if not line.startswith("#") and len(line):
                         current_rules.add(line)
-            except PermissionError:
+            except (PermissionError, FileNotFoundError):
                 cli.log.debug("Failed to read: %s", rule_file)
 
         # Check if the desired rules are among the currently present rules


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Within 25933, `qmk doctor` fails with the following:

```
Ψ QMK Doctor is checking your environment.
Ψ Python version: 3.13.11
Ψ CLI version: 1.1.8
Ψ QMK home: /home/roland/development/qmk_firmware
Ψ Detected Linux (Arch Linux).
<class 'FileNotFoundError'>
☒ [Errno 2] No such file or directory: '/etc/udev/rules.d/45-ddcutil-i2c.rules'
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/milc/milc.py", line 606, in __call__
    return self.__call__()
           ~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/milc/milc.py", line 611, in __call__
    return self._subcommand(self)
           ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/roland/development/qmk_firmware/lib/python/qmk/cli/doctor/main.py", line 184, in doctor
    status = os_status = os_tests()
                         ~~~~~~~~^^
  File "/home/roland/development/qmk_firmware/lib/python/qmk/cli/doctor/main.py", line 82, in os_tests
    return os_test_linux()
  File "/home/roland/development/qmk_firmware/lib/python/qmk/cli/doctor/linux.py", line 151, in os_test_linux
    rc = check_udev_rules()
  File "/home/roland/development/qmk_firmware/lib/python/qmk/cli/doctor/linux.py", line 86, in check_udev_rules
    for line in rule_file.read_text(encoding='utf-8').split('\n'):
                ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/pathlib/_local.py", line 546, in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/pathlib/_abc.py", line 632, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/pathlib/_local.py", line 537, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/etc/udev/rules.d/45-ddcutil-i2c.rules'
```

Through some testing, a broken symlink was able to trigger the issue.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
