### PR TITLE
feat: implement PS2 power-on reset functionality and support enabling…

### DIFF
--- a/drivers/ps2/ps2.h
+++ b/drivers/ps2/ps2.h
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "wait.h"
 #include "ps2_io.h"
 #include "print.h"
+#include "gpio.h"
 
 /*
  * Primitive PS/2 Library for AVR
@@ -83,6 +84,17 @@ POSSIBILITY OF SUCH DAMAGE.
 #define PS2_LED_CAPS_LOCK 2
 
 extern uint8_t ps2_error;
+
+#define PS2_POWER_ON_RESET_TIME 600
+
+static inline void ps2_host_power_on_reset(void) {
+#ifdef PS2_RESET_PIN
+    setPinOutput(PS2_RESET_PIN);
+    writePinHigh(PS2_RESET_PIN);
+    wait_ms(PS2_POWER_ON_RESET_TIME);
+    writePinLow(PS2_RESET_PIN);
+#endif
+}
 
 void    ps2_host_init(void);
 uint8_t ps2_host_send(uint8_t data);

--- a/drivers/ps2/ps2.h
+++ b/drivers/ps2/ps2.h
@@ -89,10 +89,10 @@ extern uint8_t ps2_error;
 
 static inline void ps2_host_power_on_reset(void) {
 #ifdef PS2_RESET_PIN
-    setPinOutput(PS2_RESET_PIN);
-    writePinHigh(PS2_RESET_PIN);
+    gpio_set_pin_output(PS2_RESET_PIN);
+    gpio_write_pin_high(PS2_RESET_PIN);
     wait_ms(PS2_POWER_ON_RESET_TIME);
-    writePinLow(PS2_RESET_PIN);
+    gpio_write_pin_low(PS2_RESET_PIN);
 #endif
 }
 

--- a/drivers/ps2/ps2_mouse.c
+++ b/drivers/ps2/ps2_mouse.c
@@ -40,11 +40,13 @@ static inline void ps2_mouse_scroll_button_task(report_mouse_t *mouse_report);
 
 /* supports only 3 button mouse at this time */
 void ps2_mouse_init(void) {
+    ps2_host_power_on_reset();
     ps2_host_init();
 
     wait_ms(PS2_MOUSE_INIT_DELAY); // wait for powering up
 
-    PS2_MOUSE_SEND(PS2_MOUSE_RESET, "ps2_mouse_init: sending reset");
+    // Resetting is not required and it is causing errors
+    // PS2_MOUSE_SEND(PS2_MOUSE_RESET, "ps2_mouse_init: sending reset");
 
     PS2_MOUSE_RECEIVE("ps2_mouse_init: read BAT");
     PS2_MOUSE_RECEIVE("ps2_mouse_init: read DevID");

--- a/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
+++ b/platforms/chibios/drivers/vendor/RP/RP2040/ps2_vendor.c
@@ -145,6 +145,9 @@ void ps2_host_init(void) {
     // clang-format off
     iomode_t pin_mode = PAL_RP_PAD_IE |
                         PAL_RP_GPIO_OE |
+#ifdef PS2_PINMODE_PULL_UP
+                        PAL_RP_PAD_PUE |
+#endif
                         PAL_RP_PAD_SLEWFAST |
                         PAL_RP_PAD_DRIVE12 |
                         // Invert output enable so that pindirs=1 means input


### PR DESCRIPTION
## Description

This PR introduces two enhancements to the PS/2 driver subsystem (specifically targeting the RP2040 implementation and general PS/2 initialization):

1. **Power-On Reset Feature**: Adds support for a dedicated PS/2 reset pin interaction during initialization. Some PS/2 devices, such as specific TrackPoint modules, require a specific power-on reset timing sequence to initialize correctly. This feature allows a GPIO pin to drive the device reset line without requiring external RC timing circuits.
   - Enabled by defining `PS2_RESET_PIN` in `config.h`.
   - The reset timing is governed by `PS2_POWER_ON_RESET_TIME` (default 600ms).

2. **RP2040 Internal Pull-Up Support**: Adds an option to enable the RP2040's internal pull-up resistors for the PS/2 PIO implementation. This simplifies hardware design by removing the requirement for external pull-up resistors on the Clock and Data lines.
   - Enabled by defining `PS2_PINMODE_PULL_UP` in `config.h`.


### Demo
https://www.reddit.com/r/ErgoMechKeyboards/comments/1q4gclk/comment/ny5281b/?%24deep_link=true&correlation_id=6af70a64-da03-5a96-b5a7-56fa05153a22&ref=email_post_reply&ref_campaign=email_post_reply&ref_source=email


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
