### PR TITLE
Match Key override index type to bounds type to prevent overflow

### DIFF
--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -250,7 +250,7 @@ static bool try_activating_override(const uint16_t keycode, const uint8_t layer,
         return true;
     }
 
-    for (uint8_t i = 0; i < key_override_count(); i++) {
+    for (uint16_t i = 0; i < key_override_count(); i++) {
         const key_override_t *const override = key_override_get(i);
 
         // End of array


### PR DESCRIPTION

## Description

By changing the index type (previously uint8_t) to be the same as bounds type (uint16_t), the index will not overflow and always return false in the `(uint16_t) index < size` check.
This stops the code from entering an infinite loop checking the first 254 key overrides. This is only observable if both there are more than 255 key overrides (there is one NULL terminator) and the first 255 overrides do not activate.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).