### PR TITLE
Either output Unicode or insert in Leader sequence

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -395,11 +395,11 @@ bool process_record_quantum(keyrecord_t *record) {
 #ifdef TAP_DANCE_ENABLE
             process_tap_dance(keycode, record) &&
 #endif
-#if defined(UNICODE_COMMON_ENABLE)
-            process_unicode_common(keycode, record) &&
-#endif
 #ifdef LEADER_ENABLE
             process_leader(keycode, record) &&
+#endif
+#if defined(UNICODE_COMMON_ENABLE)
+            process_unicode_common(keycode, record) &&
 #endif
 #ifdef AUTO_SHIFT_ENABLE
             process_auto_shift(keycode, record) &&


### PR DESCRIPTION
## Description

### Goals
1. While `leader_sequence_active()`, any key should be inserted into the leader sequence to then produce some user defined effect.
2. Unicode keycodes `UC(L'x')` should use the user defined unicode input method to insert `x`.

### Old behavior
When pressing a key assigned `UC(L'x')` during `leader_sequence_active()`, both 1. and 2. happen, since 2. does not stop key processing.

### New behavior
Because 1. does stop key processing, the unicode character is then handled by whatever method the user defined in `leader_end_user`, and is not immediatly processed on key press.

### Possible alternative
* Unicode handling could stop key processing on successful write. I did not consider if this has any other effects.
* Document old behavior as feature.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).