### PR TITLE
Fix avrdude version check logic

### DIFF
--- a/lib/python/qmk/cli/doctor/check.py
+++ b/lib/python/qmk/cli/doctor/check.py
@@ -152,8 +152,10 @@ def _check_avr_gcc_installation():
 
 
 def _check_avrdude_version():
-    last_line = ESSENTIAL_BINARIES['avrdude']['output'].split('\n')[-2]
-    version_number = last_line.split()[2][:-1]
+    lines = ESSENTIAL_BINARIES['avrdude']['output'].split('\n')
+    # avrdude version text is currently not translated, however we fall back to old behaviour of assuming a line
+    version_line = next((line for line in lines if 'version' in line), lines[-2])
+    version_number = version_line.split()[2][:-1]
     cli.log.info('Found avrdude version %s', version_number)
 
     return CheckStatus.OK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When the `avrdude` output is:

```
Avrdude version 8.1-20250625 (b440362)
Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS
Use https://github.com/avrdudes/avrdude/issues to report bugs and ask questions
```

`qmk doctor` incorrectly reports:
```
Ψ Found avrdude version t
```

This PR updates the avrdude version check to search for the` version` token in output to get the correct line. This is locale independent as the `avrdude`  output is currently untranslated.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
