### PR TITLE
Add resolution information to digitizer

### DIFF
--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -332,6 +332,11 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
             HID_RI_USAGE(8, 0x44),         // Barrel Switch
             HID_RI_LOGICAL_MINIMUM(8, 0x00),
             HID_RI_LOGICAL_MAXIMUM(8, 0x01),
+            HID_RI_PHYSICAL_MINIMUM(8, 0),
+            // Semi-random value (actual claimed physical size is not important)
+            HID_RI_PHYSICAL_MAXIMUM(8, 0xCB),
+            HID_RI_UNIT(8, 0x13),          // Inch, English Linear
+            HID_RI_UNIT_EXPONENT(8, 0x0E), // -2
             HID_RI_REPORT_COUNT(8, 0x03),
             HID_RI_REPORT_SIZE(8, 0x01),
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),


### PR DESCRIPTION
This fixes an issue where libinput refuses to accept the QMK digitizer because of missing information.

## Description

I'm surprised to not find an issue in the QMK issue tracker, but the digitizer will currently fail with libinput with `libinput bug: missing tablet capabilities: resolution. Ignoring this device.`. There is more information and a workaround in [Evidlo/remarkable_mouse#18](https://github.com/Evidlo/remarkable_mouse/issues/18#issuecomment-576887912).

This PR adds resolution information by adding physical size to the digitizer. The size doesn't really matter, as far as I can tell, but libinput won't play if it's missing. <!--- The size was chosen to be 2", because most users has two thumbs. Dumb joke, but I had to choose a number. -->


Note that I'm not at all familiar with HID or USB protocols, but as far as I can tell from [HID Usage Tables 1.12](https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf) (page 134), my changes seem to conform to the protocol. I have also verified that libinput is happy with the extra information in the descriptor.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

This issue had not been reported.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
