### PR TITLE
Handle split keyboard watchdog and os detection resets in a unified way.

### DIFF
--- a/quantum/os_detection.h
+++ b/quantum/os_detection.h
@@ -49,3 +49,5 @@ void slave_update_detected_host_os(os_variant_t os);
 void print_stored_setups(void);
 void store_setups_in_eeprom(void);
 #endif
+
+bool os_detection_mcu_reset_is_pending(void);

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -274,6 +274,7 @@ void     post_process_record_user(uint16_t keycode, keyrecord_t *record);
 
 void reset_keyboard(void);
 void soft_reset_keyboard(void);
+void pre_mcu_reset_user(void);
 
 bool shutdown_kb(bool jump_to_bootloader);
 bool shutdown_user(bool jump_to_bootloader);

--- a/quantum/split_common/split_util.h
+++ b/quantum/split_common/split_util.h
@@ -16,3 +16,4 @@ bool is_transport_connected(void);
 void split_watchdog_update(bool done);
 void split_watchdog_task(void);
 bool split_watchdog_check(void);
+bool split_mcu_reset_is_pending(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

* reset delegated to the main task.
* user code from `pre_mcu_reset_user` is executed before a reset.

Additionally, I've taken similar approaches in other firmware that I'm a maintainer or author of, it allows graceful shutdown in a single place.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None, but was developed due to this: https://github.com/qmk/qmk_firmware/issues/19420#issuecomment-3775315623

It allowed me to hook into the reset code and set the backlight color on an ErgodoxInfinity, and also to update the display with the reason prior to the reset.  It was invaluable for debugging.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
