### PR TITLE
[Core] Speed up matrix common when debounce is zero

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -339,7 +339,7 @@ uint8_t matrix_scan(void) {
 #    if DEBOUNCE > 0
     changed = debounce(raw_matrix, matrix + thisHand, changed) || matrix_post_scan();
 #    else
-    changed = matrix_post_scan();
+    changed = changed || matrix_post_scan();
 #    endif
 #else
 #    if DEBOUNCE > 0

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -172,7 +172,7 @@ __attribute__((weak)) uint8_t matrix_scan(void) {
 #    if DEBOUNCE > 0
     changed = debounce(raw_matrix, matrix + thisHand, changed) || matrix_post_scan();
 #    else
-    changed = matrix_post_scan();
+    changed = changed || matrix_post_scan();
 #    endif
 #else
 #    if DEBOUNCE > 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Fairly minor speed up, but speed up none the less.
Only about 13830 -> 13861 in my testing. 0.2% extra

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
