### PR TITLE
[Core] Faster matrix comparison

### DIFF
--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -595,8 +595,13 @@ static bool matrix_task(void) {
         return false;
     }
 
-    matrix_scan();
-    bool matrix_changed = false;
+    // copy current matrix to previous
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        matrix_previous[row] = matrix_get_row(row);
+    }
+
+    uint8_t matrix_changed = matrix_scan();
+
     for (uint8_t row = 0; row < MATRIX_ROWS && !matrix_changed; row++) {
         matrix_changed |= matrix_previous[row] ^ matrix_get_row(row);
     }
@@ -635,8 +640,6 @@ static bool matrix_task(void) {
                 switch_events(row, col, key_pressed);
             }
         }
-
-        matrix_previous[row] = current_row;
     }
 
     return matrix_changed;

--- a/quantum/matrix_common.c
+++ b/quantum/matrix_common.c
@@ -15,8 +15,8 @@
 #endif
 
 /* matrix state(1:on, 0:off) */
-matrix_row_t raw_matrix[MATRIX_ROWS];
-matrix_row_t matrix[MATRIX_ROWS];
+matrix_row_t raw_matrix[MATRIX_ROWS];      // raw values
+matrix_row_t matrix[MATRIX_ROWS];          // debounced values
 
 #ifdef SPLIT_KEYBOARD
 // row offsets for each hand
@@ -171,7 +171,7 @@ __attribute__((weak)) uint8_t matrix_scan(void) {
     matrix_scan_kb();
 #endif
 
-    return changed;
+    return (uint8_t)changed;
 }
 
 __attribute__((weak)) bool peek_matrix(uint8_t row_index, uint8_t col_index, bool raw) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
- Moves `matrix_previous[MATRIX_ROWS]` into the respective `matrix.c` and `matrix_common.c`.
- Consolidate matrix masked right into `matrix_scan()`
- `matrix_scan()` now returns changed, rather than a comparison
- `memcmp` over looping per row

My speed up went from 13800 scans to 14800 scans ~6% increase (with custom matrix) 👍 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
