### PR TITLE
Allow json keymaps to include a user provided keymap.h

### DIFF
--- a/lib/python/qmk/cli/generate/keymap_h.py
+++ b/lib/python/qmk/cli/generate/keymap_h.py
@@ -43,6 +43,13 @@ def generate_keymap_h(cli):
 
     keymap_h_lines = [GPL2_HEADER_C_LIKE, GENERATED_HEADER_C_LIKE, '#pragma once', '// clang-format off']
 
+    # Allow a potential keymap level keymap.h for items like user defined keycode aliases used within a keymap.json keymap
+    keymap_h_lines += [
+        '#if __has_include_next("keymap.h")',
+        '#    include_next "keymap.h"',
+        '#endif',
+    ]
+
     keymap_json = parse_configurator_json(cli.args.filename)
 
     if 'keycodes' in keymap_json and keymap_json['keycodes'] is not None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This will allow a `keymap.json` to generate its `keymap.c` and `keymap.h` into the build dir, but still include a `keymap.h` from within the keymap.

The content could be something like <https://github.com/mikybars/qmk_userspace/blob/ea87bbb7a4106f418ea458d734774eeb2c0f519c/mikybars.h#L6> (where the user has attempted to bodge inclusion via other methods).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
