### PR TITLE
Recover hhkb ansi rn42

### DIFF
--- a/keyboards/hhkb/ansi/ansi.c
+++ b/keyboards/hhkb/ansi/ansi.c
@@ -1,0 +1,28 @@
+#include "ansi.h"
+#include <avr/io.h>
+
+#ifdef HHKB_RN42_ENABLE
+#   include "../rn42/rn42.h"
+#   include "../rn42/rn42_task.h"
+#endif
+
+void keyboard_post_init_kb(void) {
+#ifdef HHKB_RN42_ENABLE
+    // SUART setup
+    DDRD |= (1<<0);
+    PORTD |= (1<<0);
+    DDRD &= ~(1<<1);
+    PORTD |= (1<<1);
+
+    rn42_init();
+    rn42_task_init();
+#endif
+    keyboard_post_init_user();
+}
+
+void matrix_scan_kb(void) {
+#ifdef HHKB_RN42_ENABLE
+    rn42_task();
+#endif
+    matrix_scan_user();
+}

--- a/keyboards/hhkb/ansi/ansi.h
+++ b/keyboards/hhkb/ansi/ansi.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "quantum.h"

--- a/keyboards/hhkb/ansi/config.h
+++ b/keyboards/hhkb/ansi/config.h
@@ -22,6 +22,53 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_ROWS 8
 #define MATRIX_COLS 8
 
+/* RN42 Bluetooth Support */
+#define SUART_OUT_PORT PORTD
+
+#ifdef HHKB_RN42_ENABLE
+   // rn42 support -- acquired from the tmk repo. This is almost certainly not
+   // integrated with qmk in the correct way.
+
+#  define SUART_OUT_BIT 0
+#  define SUART_IN_PIN PIND
+#  define SUART_IN_BIT 1
+
+#  ifdef __AVR_ATmega32U4__
+     /* iom32u4.h has no definition of UCSR1D. copy from iom32u2.h */
+#    define UCSR1D _SFR_MEM8(0xCB)
+#    define RTSEN 0
+#    define CTSEN 1
+
+#    define SERIAL_UART_BAUD 115200
+#    define SERIAL_UART_DATA UDR1
+#    define SERIAL_UART_UBRR ((F_CPU/(16.0*SERIAL_UART_BAUD)-1+0.5))
+#    define SERIAL_UART_RXD_VECT USART1_RX_vect
+#    define SERIAL_UART_TXD_READY (UCSR1A&(1<<UDRE1))
+
+     /* Override serial_uart.c init to ensure correct baud and RX enable */
+#    define SERIAL_UART_INIT_CUSTOM do { \
+         UBRR1L = (uint8_t) SERIAL_UART_UBRR; /* baud rate */ \
+         UBRR1H = ((uint16_t)SERIAL_UART_UBRR>>8); /* baud rate */ \
+         UCSR1B |= (1<<RXCIE1) | (1<<RXEN1); /* RX interrupt, RX: enable */ \
+         UCSR1B |= (0<<TXCIE1) | (1<<TXEN1); /* TX interrupt, TX: enable */ \
+         UCSR1C |= (0<<UPM11) | (0<<UPM10); /* parity: none(00), even(01), odd(11) */ \
+         UCSR1D |= (0<<RTSEN) | (0<<CTSEN); /* RTS, CTS(no flow control by hardware) */ \
+         DDRD |= (1<<5); PORTD &= ~(1<<5); /* RTS for flow control by firmware */ \
+         sei(); \
+     } while(0)
+
+#    define SERIAL_UART_RTS_LO() do { PORTD &= ~(1<<5); } while (0)
+#    define SERIAL_UART_RTS_HI() do { PORTD |= (1<<5); } while (0)
+#  else
+#    error "USART configuration is needed."
+#  endif
+#  define HHKB_POWER_SAVING
+#endif
+
+#define SUART_OUT_BIT 0
+#define SUART_IN_PIN PIND
+#define SUART_IN_BIT 1
+
 /*
  * Feature disable options
  *  These options are also useful to firmware size reduction.

--- a/keyboards/hhkb/ansi/info.json
+++ b/keyboards/hhkb/ansi/info.json
@@ -1,5 +1,5 @@
 {
-  "keyboard_name": "ANSI",
+  "keyboard_name": "HHKB ANSI",
   "manufacturer": "HHKB",
   "maintainer": "qmk",
   "usb": {

--- a/keyboards/hhkb/ansi/post_rules.mk
+++ b/keyboards/hhkb/ansi/post_rules.mk
@@ -1,0 +1,14 @@
+# RN42 Bluetooth Support
+# add HHKB_RN42_ENABLE = yes to rules.mk to enable
+
+ifeq ($(strip $(HHKB_RN42_ENABLE)), yes)
+    OPT_DEFS += -DHHKB_RN42_ENABLE
+    RN42_DIR = keyboards/hhkb/rn42
+    SRC += $(RN42_DIR)/serial_uart.c \
+           $(RN42_DIR)/suart.S \
+           $(RN42_DIR)/rn42.c \
+           $(RN42_DIR)/rn42_task.c \
+           $(RN42_DIR)/battery.c
+    VPATH += $(RN42_DIR)
+    EXTRAINCDIRS += $(RN42_DIR)
+endif

--- a/keyboards/hhkb/ansi/post_rules.mk
+++ b/keyboards/hhkb/ansi/post_rules.mk
@@ -1,5 +1,4 @@
 # RN42 Bluetooth Support
-# add HHKB_RN42_ENABLE = yes to rules.mk to enable
 
 ifeq ($(strip $(HHKB_RN42_ENABLE)), yes)
     OPT_DEFS += -DHHKB_RN42_ENABLE

--- a/keyboards/hhkb/ansi/readme.md
+++ b/keyboards/hhkb/ansi/readme.md
@@ -10,5 +10,17 @@ Hardware Availability: https://geekhack.org/index.php?topic=12047.0
 Make example for this keyboard (after setting up your build environment):
 
     make hhkb/ansi:default
+        or
+    qmk compile -kb hhkb/ansi/32u4 -km default
 
 See [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) then the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information.
+
+## RN-42 Bluetooth Support
+
+This keyboard supports the RN-42 Bluetooth module. To enable this feature, add the following to your `rules.mk`:
+
+```makefile
+HHKB_RN42_ENABLE = yes
+```
+
+The config should also work for jp layout, but I personally do not have a jp version, so no guarantee for it.

--- a/keyboards/hhkb/rn42/MEMO.txt
+++ b/keyboards/hhkb/rn42/MEMO.txt
@@ -1,0 +1,262 @@
+Memo of deveopment
+==================
+just memo, NOT WORTH READING
+
+2015/11/24
+JP Bluetooth:
+    RN-42 cannot send Japanese keys like; henkan, mu-henkan and kana, JPY and RO.
+    It seems HID usage more than 0x65 cannot be send with the module.
+        http://shiki.esrille.com/2014/07/bluetoothnisse.html
+
+
+Bug:
+- Factory Reset PIO4 doesn't work
+    - the reason is unclear - 12/08 NOT LOOK INTO ANY MORE
+    - WORKAROUND: use serial pins(3.3V, GND, RX and TX)
+        - SF,1 and R,1 to set factory defalult
+
+
+Todo:
+- LED cover and switch knob and new Slide Switch
+- RN42 auto configuration
+    - configure the module as HID device every time powering up
+    - this'll reduce work load of assembly
+
+- move rn42 to protocol directory when it becomes reusable stack
+
+- sendchar() in lufa.c no buffer
+    - no buffering. character lost can be caused.
+- LUFA sendchar should be buffered and serial_uart.c buffur size is too large(256).
+
+- BT operations
+    - disconnect
+    - new connection
+    - remove connection
+
+- sendchar() in lufa.c block loop   - DONE 11/29
+    - block loop when powered with AC adapter
+    - FrameNumber is not updated when adapter powered
+
+Improving:
+- ADC resolution
+    AVR120
+    AVR32138
+    - Enhancing ADC resolution by oversampling
+        AVR121  http://www.atmel.com/images/doc8003.pdf
+    - disable digital input buffer DIDR(7.8.6)
+
+Design:
+- suspend.h - DONE 11/26
+    - remove argument from suspend_power_down() for backward compatitibility
+- remove MCU dependent power saving code from core/keyboard - DONE 11/23
+    - it should be located in project matrix.c
+- HHKB matrix.c needs matrix_prev?
+    - is_modified() is obsolete now. really needs?
+- ADC: removing AREF capacitor C10
+    - seems to be better while usb powered
+    - still bad while battery powered
+    http://electronics.stackexchange.com/questions/105849/avcc-and-capacitor-using-adc
+- ADC: smaller resistors for voltage dividor
+    - 1K + 1K: not improved. - 11/27
+
+
+LUFA:
+USB connection check: state of USB deivce
+- USB_DeviceState:
+    USB_Deivce_State_t { Unattached, Powered, Default, Addressed, Configured*, Suspended* }
+    Unattached: unpluged
+    Powered:    pluged with power adapter
+    Default:    enumerate process bigin
+    Addressed:  addressed
+    Configured: enumerated
+    Suspended:  suspended
+
+- USB_IsInitialized: state of LUFA core setup
+    becomes true in USB_Init()  USBController_AVR8.c
+    becomes false in USB_Disable()  USBController_AVR8.c
+- USB_VBUS_GetStatus(): state of VBUS(power/connection)
+- USB_Disable() detaches, disables all interrupts, controller, PLL, regulater.
+
+- When connect to power adapter
+    - event happened: CW or CSW or C or DDC
+    - USB state: not configured
+
+- USB evnets
+    - USB connect: CSWRWRW
+    - USB connect but fail to enumeration: CWRWRWRWS
+    - USB disconnect: D
+    - Power adapter connect: CW, CSW, C
+    - Power adapter disconnect: D
+
+
+Power saving:
+- Pro2 current consumption
+    - active: 138.2mA(no device on Hub)
+    - suspended: 30.9mA(WakeUp enabled DIPSW6)
+    - suspended: 0mA->46.0mA(WakeUp disabled DIPSW6)
+- Pro current consumption
+    - active: 54.0mA
+    - suspended: 40.5mA(WakeUp enabled DIPSW6)
+    - suspended: 0.3mA(WakeUp disabled DIPSW6)
+
+- RN42 3.3V
+    - disconnected(Idle): 5mA (config mode)
+    - connected(Active):
+        SW,0000:  23-26mA
+        SW,0010:  27-29mA worse than 0000 for unknown reason
+        SW,0020:  17-19mA mouse NG
+        SW,0030:  13-16mA laggy mouse NG
+        SW,0050:  10-13mA laggy mouse NG
+
+- matrix power saving
+    - power saving while externally powered and not while unpluged
+- confirm suspend mode lufa.c: matrix_power_*, suspend_wakeup_condition
+- 8MHz clock
+- When not connected in a few minutes get into deep sleep to save battery life
+- CTS is needed for waking up from deep sleep? How deep sleep is activated?
+- firmware controlled 3.3V DC converter to switch on/off BT module
+- sleep MCU and BT module(keyboard is not used)
+- deep sleep MCU and BT module(keyboard is not used for long time)
+- deep sleep MCU and turn off BT module(keyboard is not used and not connected)
+- Battery ADC; switching, high resistance
+    - switching gnd end of divider with PF4
+    - high resistor 100K/1M?
+        capacitor   10nF
+        http://www.eevblog.com/forum/beginners/measuring-battery-voltage-without-consuming-current/
+- During USB suspend change clock source to internal RC from external Xtal(6.8)
+- FRZCLK: you can freeze clock for power saving. still WAKEUPI and VBUSTI interrupts are available while freezing.(21.7.3)
+- Suspend: Clear Suspend Bit, Freeze clock, disable PLL, MCU sleep(21.13)
+- Voltage reference(8.1.1)
+    - to reduce power consumption while power down mode
+- unset ADEN before sleep(24.7)
+
+
+
+
+
+
+
+Lipo
+----
+850mA lasts around 9 hours(07/28)
+
+Sparkfun Polymer Lithium Ion Battery 850mAh:
+https://www.sparkfun.com/products/341
+Lipo Cell spec:
+https://www.sparkfun.com/datasheets/Batteries/063048%20Li-polymer.pdf
+Protection spec:
+http://dlnmh9ip6v2uc.cloudfront.net/datasheets/Prototyping/BatteryProtection.pdf
+                                min     typical max
+    over-charge                 4.255   4.280   4.305
+    over-charge discover?       4.030   4.080   4.130
+    over-discharge              2.827   2.900   2.973
+    over-discharge discover     3.022   3.100   3.178
+
+ADC voltage monitor:    voltage divider 10K+10K(0.5)
+                        ADC=V*0.5/2.56*1024
+
+    V       ADC
+    ------------------
+    4.20    0x347(839)
+    3.10    0x26b(619)
+
+
+
+
+TROUBLE SHOOT
+-------------
+07/16   After fix of voltage dividor on GPIO6, had a trouble that it could not send a char to BT module, though could receive.
+        Found R8 had wrong 1K resistor and changed to 10K, after that it can send to the module again. Not sure how it had sent with the wrong 1K before.
+
+07/18   On Linux, had an USB related trouble; keyboard or console didn't work for some reason. Changing PID cured this problem. Very annoying, took very long time before resolved it.
+
+12/07   rn42_rts() read 1 every time. R12 broke in open mode(no coductive), idk why, too much heat with soldering? and PF1 pin was not soldered.
+        It resolved with resoldering PF1 and new resistor on R12.
+
+
+
+
+Done:
+- low battery alert(solid light) 09/04
+- *** Rev.E BT test *** - DONE
+    - with MCP73832, new Schottky, tantalum caps - DONE 12/07
+        * MCP73832 doesn't leak from Vcc pin when unpluged and battery powered
+            34mV vs 2.07V(MCP73831) at Vcc pin
+            MCP73832 doesn't need revese protection diode D5
+        * PMEG2010ER is very low VF while reverse current/voltage is high
+            VF=0.96 vs 1.98(RB160M-30TR)with Fluke 175
+            Anode of D11 is 680mV vs 20mV(RB160M-30TR)
+            780mV is still low < 1.4V VBUS plugin detection(21.11)
+                this doesn't cause false VBUS detect
+                and 780mV on MCP73832 Vcc pin is also no problem.
+            D5 can be removed.
+    - ADC divider switching - DONE 12/07
+        * Drain and Source of Q4 Pch was reversed wrongly on Rev.E.
+
+    - reverse current from Lipo charger - DONE 12/07
+        * MCP73832 has no recverse current from Vcc pin unlike MCP73831
+
+
+- Rev.F design - DONE
+    - current measure point - DONE 12/08
+    - change value of cap 68->47    - DONE 12/08
+    - PPTC land pattern: no solder jumper, use 0Ohm resistor instead - CANCEL 12/08
+    - Q4 Pch FET: wrong Drain and Source - DONE 12/08
+    - D5 can be removed.    - DONE 12/08
+
+
+
+- BT_INDICATOR LED turns on wrongly when touching line or pin.  -- pull-up enabled on PF6/GPIO2 08/30
+- Lipo charger configuration: fast charge time:  USB charger spec? -- used 2kohm
+- use LED of charger to alarm low battery. LED should be powered directly from Lipo? - cancel; powered from VUSB
+- Use RTS in serial_uart.c to resolve missing chars from help message of RN-42 - done
+- CTS/RTS lines are needed? just connect in loop back if no flow control is needed. - done
+- add IO pin to charger status CHRG; LED control(low) and detect charge status(input HiZ) 07.24
+- LINKED: add trace on PIO2 to PF6   07.24
+- Lipo voltage ADC sensing
+- Lipo charger MCP73831: needs capacitor 4.7uF *2
+- USB connection check - 07.01
+- BT on/off check: whether RX line is pulled up? - checking RTS 07.01
+- USB/BT switching  BT is on -> BT, BT is off -> USB - 07.01
+- Under voltage lock out UVLO for protection of Lipo - Lipo has discharge protection at 3.100V    07.01
+- Power saving: HHKB scan, BT radio control - 9h with 850mAh, this is enough   07.01
+- Power selector doesn't work; Q4 MOSFET leaks from Lipo to USB power line. -- use Schottky instead 07/04
+
+- wrongly suspended when powered from adapter without USB connection - DONE
+    - suspend event may occur when plug into adapter
+    - and never wake until conected to real USB line
+    - without debug print via USB no problem; CSW(wake just after suspend as real USB line)
+    - seems like USB print causes this problem after suspended
+
+- lose USB connection during power-down mode - DONE
+    - USB initialize code in main() causes this - WRONG
+    - Do not power-down during USB connection is active - DONE 11/11
+        (USB_DeviceState == USB_DEVICE_Configured) is used to check USB connection
+        matrix_power_down() matrix.c - 11/23
+
+- with Nexus5 keyboard and mouse are very laggy.
+    Not confirmed. 01/15
+
+- switch BT host connections    - CANCEL 01/15
+    - switch next connection
+        cannot switch connection with version 6.15 at least
+
+- When given power only from wall wart adapter  - DONE? not confirmed 01/15
+    - it sleeps. it should not sleep
+    - Configured state without USB connection?
+
+- timer is slow while power down - DONE 11/26
+    - time out interrupt is lost while power down?
+    - interrupt of watchdog timer compensates timer counter(avr/suspend.c)
+
+- repeated CHARGING/FULL_CHARGED    - No longer problem 01/15
+    - In LTC sharp pulses are observed.
+    - MCP has no pulse but still has a problem.
+    - needs more wait before read pin state? - NO
+
+- USB plug-in fails while BT        - No longer problem 01/15
+    - it ends in suspend state
+    - maybe, not responsive to host enumeration process due to power-down.
+    - matrix_power_down() only when state is unattached - 11/26
+        - need to observe a while
+

--- a/keyboards/hhkb/rn42/PowerSave.txt
+++ b/keyboards/hhkb/rn42/PowerSave.txt
@@ -1,0 +1,88 @@
+Power Saving
+============
+
+
+MCU+HHKB Power Comsumption
+--------------------------
+Battery drive:
+    idle    18.9mA
+    active  35.8mA
+
+USB powered:
+    40.0mA
+    52mA    01/17
+
+Other keyboards:
+HHKB Pro    55mA
+HHKB Pro2   140mA
+HHKB Pro    42mA(Alt)
+HHKB Pro2   52mA(Alt BT controller USB mode)
+HHKB Pro2   88mA(Alt BT controller BT mode connected)
+HHKB Pro2   68mA(Alt BT controller BT mode config mode)
+Poker X     6mA
+Infinity    24mA(TMK)
+            65mA(kiibohd)
+
+
+HHKB key switch power control
+-----------------------------
+MOS FET Nch: BSS138 or IRLML6344T, either works and no apparent difference.
+Normally on(pull-up) or off(pull-down)? interms of power saving it prefers pull-down?
+
+Pull-down will be better for power saving, normally off.
+
+
+
+Used Timer
+----------
+
+8MHz clock
+----------
+1) 16MHz xtal with system prescaler div2: F_CPU=8MHz, F_USB=16MHz
+2) 8MHz xtal with div1: F_CPU=8MHz, F_USB=8MHz
+Hardware USART doesn't work at 115200bps with 8MHz(F_CPU).
+
+workaround:
+a) use Sotwre serial for communcation with RN-42
+b) reduce baud of RN-42 to lower rate;(factory default is 115200bps)
+10/03
+
+
+
+Slave mode
+----------
+Discovery/Inquire
+Connect/Page
+
+SI,0012
+SJ,0012
+InqWindw=0100
+PagWindw=0100
+
+
+Sniff mode
+----------
+0.625ms * <hex>
+SW,0320     Very sluggish. Type is not lost but very slow to register.
+SW,0160     Still sluggish. may transposed? can type but ...
+            Mouse point move intermittently
+SW,0020     feel a bit late like stumble(20ms)
+SW,0010     feel no latency(10ms)
+
+
+Deep sleep
+----------
+SW,8010
+
+
+TX power
+--------
+SY,fff4
+
+
+IO pins
+-------
+S%,1000         status led and connection control don't work
+                GPIO5: status LED
+                GPIO6: Connection control
+                GPIO2: linked status

--- a/keyboards/hhkb/rn42/RN42.txt
+++ b/keyboards/hhkb/rn42/RN42.txt
@@ -1,0 +1,408 @@
+RN-42 Bluetooth Module Support
+==============================
+Bluetooth controller board works with HHKB Pro2, JP, Type-S and Type-S JP and it supports both USB and Bluetooth as keyboard output protocol. Bluetooth module Roving Networks/Microchip RN-42 is installed on the board.
+
+
+RN-42:
+http://www.microchip.com/wwwproducts/Devices.aspx?product=RN42
+
+
+Capabitlities:
+- USB keyboard functions
+    completely equivarent to USB controller including mouse keys and NKRO.
+- Switching between USB and Bluetooth
+    You can switch the two connections with BT switch or key combination.
+- RN-42 config mode
+    You can change power/connection configuration of the module if needed.
+- Low battery alert
+    Red LED turns on when low voltage.
+- RN-42 status indicator
+    LED indicates status of Bluetooth connection.
+- Pairing
+    The module stores up to 8 connections.
+- Auto connect
+    The module connects the last connected device automatically.
+- iOS support
+    works as keyboard with iPhone5. No tested completely.
+- Android support
+    works as keyboard and mouse with Nexus5. No tested completely.
+- Mouse keys over BT
+    Note that iOS doesn't accept mouse device.
+
+
+Limitations:
+- Short battery life
+    Around 12hr with 1000mAh
+- No connection switching
+    RN-42 auto-connects to the last connected device.
+    Some of consumer products can switch between devices, for example Logitech K480.
+        http://www.logitech.com/en-us/product/multi-device-keyboard-k480?crid=26
+- HHKB JP requires case modification for BT switch and LEDs.
+    without switch power controlled by MCU? Probably using 3.3V regulator enable pin power of RN-42 can be controlled.
+
+NOTE:
+- LIPO BATTERY IS VERY DANGEROUS, TAKE EXTRA CARE OF YOUR SAFETY AND PROPERTY.
+- RN-42 version 6.15 is supported.
+- No NKRO over Bluetooth
+- Check you country's wiress regulation and certification of RN-42.
+
+Bugs:
+
+Todos:
+
+
+Lipo Battery
+------------
+You can use 3.7V Lithium Ion battery with JST PH 2pin connector and protection circuit.
+Battery space inside HHKB is around 54mm x 50mm and its height is 7mm.
+
+Sparkfun 850mAh
+https://www.sparkfun.com/products/341
+Sparkfun 1000mAh
+https://www.sparkfun.com/products/339
+
+Sparkfun 2000mAh battery won't fit due to its size.
+
+Learn about Lipo battery:
+https://learn.adafruit.com/li-ion-and-lipoly-batteries
+
+
+
+
+
+LED Status
+----------
+Configuring                     10 times per sec
+Startup/configuration timer     2 times per sec
+Discoverable/Inquiring/Idle     once per sec
+Connected                       solid on
+
+
+RN-42 Magic Command
+--------------------
+Magic key combination is 'LShift+RShift' by default in case of HHKB.
+
+Here is help.
+
+    ----- Bluetooth RN-42 Help -----
+    i:       RN-42 info
+    b:       battery voltage
+    Del:     enter/exit RN-42 config mode
+    Slck:    RN-42 initialize
+    p:       pairing
+    u:       toggle Force USB mode
+
+    RN-42 info:             displays information of the module on console.
+    battery voltage:        displays current voltage of battery and uptime.
+    RN-42 initialize:       does factory reset and configures RN-42
+    pairing:                enters Pairing mode.
+    toggle Force USB mode:  switch between USB and Bluetooth
+
+
+RN-42 Config mode
+-----------------
+You can tune/operate RN-42 yourself with config(command) mode.
+
+1. hook up USB cable
+2. run `hid_listen` command  in console
+3. turn on Bluetooth switch
+4. press LShift+RShift+Delete(Fn+~) you will see output like followings:
+
+    Entering config mode ...
+    CMD
+    v
+    Ver 6.15 04/26/2013
+    (c) Roving Networks
+
+5. do config with RN-42 commands. See documentations of RN-42.
+6. to exit also press LShift+RShift+Delete(Fn+~)
+
+    Exiting config mode ...
+    ---
+    END
+
+
+RN-42 Initial Configuration
+---------------------------
+RN-42 is configured as SPP device at factory reset, you need to configure it as HID device. This is needed just once first time.
+
+1. hook up USB cable
+2. run `hid_listen` command  in console
+3. turn on Bluetooth switch
+4. press LShift+RShift+ScrLk(Fn+O) you will see output like followings:
+
+    Entering config mode ...
+    CMD
+    Ver 6.15 04/26/2013
+    (c) Roving Networks
+    ECHO ON
+    SF,1
+    AOK
+    S-,TmkBT
+    AOK
+    SS,Keyboard/Mouse
+    AOK
+    SM,4
+    AOK
+    SW,8000
+    AOK
+    S~,6
+    AOK
+    SH,003C
+    AOK
+    SY,FFF4
+    AOK
+    R,1
+    Reboot!
+    Exiting config mode ...
+
+5. output of command 'X' after cofiguration
+
+    Ver 6.15 04/26/2013
+    (c) Roving Networks
+    ***Settings***
+    BTA=00066667BBE9
+    BTName=TmkBT-BBE9
+    Baudrt(SW4)=115K
+    Mode  =DTR
+    Authen=1
+    PinCod=1234
+    Bonded=0
+    Rem=NONE SET
+    ***ADVANCED Settings***
+    SrvName= Keyboard/Mouse
+    SrvClass=0000
+    DevClass=1F00
+    InqWindw=0100
+    PagWindw=0100
+    CfgTimer=255
+    StatuStr=NULL
+    HidFlags=3c
+    DTRtimer=8
+    KeySwapr=0
+    ***OTHER Settings***
+    Profile= HID
+    CfgChar= $
+    SniffEna=8000
+    LowPower=0
+    TX Power=fff4
+    IOPorts= 0
+    IOValues=0
+    Sleeptmr=0
+    DebugMod=0
+    RoleSwch=0
+
+
+Switch to USB mode
+------------------
+You can switch between USB and Bluetooth with pressing 'LShift+RShift+u'.
+
+
+Pairing mode
+------------
+This disconnects current connect and enter pairing mode.
+
+
+
+
+For deveropment
+===============
+
+RN-42 Serial Connection
+-----------------------
+UART:           115200bps, 8bit, 1-stopbit, non-parity, no flow control
+SSP:            115200bps, 8bit, 1-stopbit, non-parity, no flow control(via Bluetooth)
+
+To enter command mode disconnect the module from host and type '$$$'.(you will see 'CMD') and type '+' to get local echo. To exit type '---'(you will see 'END').
+
+
+RN-42 Commands
+--------------
+S-,tmkBT            // Device name
+SS,keyboard/mouse   // service name
+SM,4                // Auto Connect DTR mode
+SW,8010             // Sniff enable 0x10*0.625ms=10ms; 50ms is laggish and not much power save
+S~,6                // HID profile
+S~,0                // SPP profile
+SH,003C             // HID register
+SY,0004             // Transmit power
+SC,0000             // COD: 000005C0    (see HID spec/Bluegiga doc)
+SD,05C0             //     bit 12-8         7           6           5-0
+                    //         00101        1           1           0
+                    //         peripheral   pointing    keybaord    joystick, gamepad, ...
+SM,6                // Pairing mode: auto connect
+SM,4                // Master mode: Connection can be controled with GPIO6
+SF,1                // Factroy reset
+R,1                 // reboot
+SR,Z                // removes all remote addresses for reconnecting.
+                    // can be used to connect another host
+SR,I                // registers last inquiry address
+
+
+Operation Modes
+---------------
+SM,3        Auto Connect Master mode
+SM,4        Auto Connect DTR Mode uses GPIO6 to make and break connection(Mode =DTR)
+                confirm: auto connect works and control connection with GPIO6
+SM,5        Auto Connect ANY Mode (Mode =ANY)
+                each time GPIO is set, make inquiry and connect to the first found device
+SM,6        automatically reconnect(Mode =Pair)
+                confirm: auto connect works well but difficult to enter command mode.
+
+
+HID flag register
+-----------------
+SH,0200
+GH
+
+10 0000 0000(0200)  default
+00 0011 1000(0038)  Combo
+|| |  | |\_\____ number of paired devices to which the module can reconnect
+|| |  | \_______ send out reports over UART (0xFF <len> <data>)
+|| \__\_________ descriptor type
+|\______________ toggle virtual keyboard on iOS when first connected
+\_______________ Force HID mode if GPIO11 is high on power-up
+
+    Descriptor type:
+    0000:   keybaord
+    0001:   Game Pad
+    0010:   Mouse
+    0011:   Combo
+    0100:   Joystick
+    1xxx:   reserved
+
+
+Out report - Indicator
+----------------------
+0xFE 0x02 0x01 <LED_state>
+
+
+Apple iOS
+---------
+Keyboard can be used with iPhone, but mouse cannot.
+
+
+Android
+-------
+3.7.1.5 Note: To connect with Android phone the modules must wake up 11ms every 2.5seconds.
+
+
+Power Management
+----------------
+Inquiry and Page window     Idle or Active  (3.1.1)
+    Downside: delay in discovery or connection time
+    SI,         // set inquiry scan window(discovery) on/off duty?
+    SJ,         // set page scan window(connection)
+    This reduces averaege power >20mA to 5mA(3mA in Sniff mode)
+
+Sniff mode                  Transmit
+    Sniff mode is disabled by default and radio is active continuously when connected.(25-30mA)
+    In Sniff mode the radio wakes up intermittently and sleeps in very low power mode.(2mA)
+    SW,<val>    // set interval timer(*0.625ms) 0000-7FFF
+
+Deep sleep                  Idle            (3.1.2)
+    In this mode the module shuts down completly and only draws about 300uA. To enable this set the most signifant bit(0x8000) of Sniff interaval timer.
+    SW,8320     // deep sleep enable(interval=0x320*0.625=500ms)
+    In normal sleep the firmware is still running in idle mode, and wakes up about 20 times per second to check ports, update LEDs, etc. During deep sleep, the firmware actually stops runnig some tasks and the LEDs only update about once per second.
+    To wake from deep sleep there are three ways: (in worst case wake up takes 5ms)
+        *send a charactor to the UART(first charactor will be lost)
+        *toggle CTS low to high and wait 5ms
+        *wake automatically every slot time(<val>*0.625ms)
+    Once the radio is awake it stay active for exactly 1 second of inactivity and then sleeps again.
+    Downside: latency and data loss
+
+Disable Output driver       Idle or Active  (3.1.3)
+    S%,1000     // set all GPIO pins(0-11) to inputs.
+
+Lower Transmit Power        Idle or Active  (3.1.4)
+    SY,<hex>    // transmit power setting(takes effect after a power cycle and reboot)
+    Downside: reducing effective range
+
+
+Optimizig for Latency
+---------------------
+By default the firmware is optimized for throughput.
+SQ,16           // set latency bit
+SQ,0            // unset latency bit
+
+
+Configuration timer settings
+----------------------------
+Remote configuration is used for the module to be configured with various commands over Bluetooth(SPP profile only?).
+
+The module has remote configuration timer to allow remote configuration over Bluetooth after power up in Slave mode. In Master modes the remote configuration timer is set to 0(no remote configuration). (In Trigger Master mode the timer is used as an idle timer to break the connection after time expires with no charactors receive.)
+    ST,0        // no remote, no local when connected
+    ST,<1-252>  // local and remote with timeout in seconds from power up
+    ST,253      // local only       without timeout
+    ST,254      // remote only      without timeout
+    ST,255      // local and remote without timeout
+
+
+Commands
+--------
+S7,                     7bit mode
+SA,                     Authenticaiton
+SB,                     Send break
+SC,                     Service class
+SD,                     Device class
+SM,<val>                Operation mode
+SP,<string>             Pin code(alpahnumeric)
+SQ,<mask>               Special configuration(GPIO, discovery mode, low latency, reboot, UART)
+SR,<hex>                Store remote address
+SR,Z                    Erase all address
+SS,<string>             Set service name(1-20)**
+ST,<val>                Remote configuration timer(Master:0, Slave:0-255, Triger:as idle timer)
+SU,<val>                UART baud rate
+SW,<val>                low-power sniff mode** deep sleep and wake up every 625us * <val>
+SX,<0|1>                bonding enable  only acceps device that matches the stored address
+SY,<hex>                power setting**
+SZ,<val>                non-standard raw baud rate  <val>=baud*0.004096
+S~,<val>                Profile     0:SPP, 5:APL, 6:HID
+S-,<string>             Device name     -15 alphanumeric charactors
+S?,<0|1>                role switch enable
+S$,<char>               command mode char
+$|,<hex>                low-power connect mode  deep sleep/active(discoverable and connectable) cycle
+D                       display basic setting
+E                       display extended setting
+GB                      display the device's Bluetooth address
+GF                      display Bluetooth address of connected device
+GK                      show connection status
+GR                      show remote address for reconnecting
+G&                      show GPIO pin
+G<char>                 show stored setting
++                       toggle local echo on/off
+&                       show GPIO 3,4,6,7(DIP switch)
+C                       connect to stored remote address
+C,<address>             connect last address
+CFI                     connect and go into fast data mode
+CFR                     connect and go into fast data mode
+CT,<address>,<val>      connect to the address and disconnect after val?
+F,1                     fast data mod:
+H                       display help
+I,<time>,<cod>          inquiry scan with <cod>
+IN,<time>,<cod>         inquiry scan with <cod>, return without BT name
+IR                      inquiry scan with 0055AA
+IS                      inquiry scan with 001F00
+J                       hide pin code
+K,                      kill    disconnects current connection
+L                       link quality
+M                       show modem signlal status
+O                       display other settings
+P,<char>                pass through?
+Q                       quiet mode  make the module not discoverable
+Q,0                     discoverable and connectable
+Q,1                     not discoverable and not connectable
+Q,2                     not discoverable and connectable
+Q,?                     display current quiet mode
+R,1                     reboot
+T,<0|1>                 pass received data while in command mode
+U,<baud>,<parity>       change UART setting tentatively
+V                       display firmware version
+W                       wake from quiet mode    enable discovery and connection
+Z                       deep sleep mode(<2mA)
+
+
+Reset to Factory Default
+------------------------
+SF,1
+R,1

--- a/keyboards/hhkb/rn42/battery.c
+++ b/keyboards/hhkb/rn42/battery.c
@@ -1,0 +1,130 @@
+#include <avr/io.h>
+#include <util/delay.h>
+#include "battery.h"
+
+
+/*
+ * Battery
+ */
+void battery_init(void)
+{
+    // blink
+    battery_led(LED_ON);  _delay_ms(100);
+    battery_led(LED_OFF); _delay_ms(100);
+    battery_led(LED_ON);  _delay_ms(100);
+    battery_led(LED_OFF); _delay_ms(100);
+    // LED indicates charger status
+    battery_led(LED_CHARGER);
+
+    // ADC setting for voltage monitor
+    // Ref:2.56V band-gap, Input:ADC0(PF0), Prescale:128(16MHz/128=125KHz)
+    ADMUX = (1<<REFS1) | (1<<REFS0);
+    ADCSRA = (1<<ADPS2) | (1<<ADPS1) | (1<<ADPS0);
+    // digital input buffer disable(24.9.5)
+    DIDR0 = (1<<ADC0D) | (1<<ADC4D) | (1<<ADC7D);
+    DIDR1 = (1<<AIN0D);
+    DIDR2 = (1<<ADC8D) | (1<<ADC9D) | (1<<ADC11D) | (1<<ADC12D) | (1<<ADC13D);
+
+    // ADC disable voltate divider(PF4)
+    DDRF  |=  (1<<4);
+    PORTF &= ~(1<<4);
+}
+
+// Indicator for battery
+void battery_led(battery_led_t val)
+{
+    if (val == LED_TOGGLE) {
+        // Toggle LED
+        DDRF  |=  (1<<5);
+        PINF  |=  (1<<5);
+    } else if (val == LED_ON) {
+        // On overriding charger status
+        DDRF  |=  (1<<5);
+        PORTF &= ~(1<<5);
+    } else if (val == LED_OFF) {
+        // Off overriding charger status
+        DDRF  |=  (1<<5);
+        PORTF |=  (1<<5);
+    } else {
+        // Display charger status
+        DDRF  &= ~(1<<5);
+        PORTF &= ~(1<<5);
+    }
+}
+
+bool battery_charging(void)
+{
+    if (!(USBSTA&(1<<VBUS))) return false;
+
+    // Charger Status:
+    //   MCP73831   MCP73832   LTC4054  Status
+    //   Hi-Z       Hi-Z       Hi-Z     Shutdown/No Battery
+    //   Low        Low        Low      Charging
+    //   Hi         Hi-Z       Hi-Z     Charged
+
+    // preserve last register status
+    uint8_t ddrf_prev  = DDRF;
+    uint8_t portf_prev = PORTF;
+
+    // Input with pullup
+    DDRF  &= ~(1<<5);
+    PORTF |=  (1<<5);
+    _delay_ms(1);
+    bool charging = PINF&(1<<5) ? false : true;
+
+    // restore last register status
+    DDRF  = (DDRF&~(1<<5))  | (ddrf_prev&(1<<5));
+    PORTF = (PORTF&~(1<<5)) | (portf_prev&(1<<5));
+
+    // TODO: With MCP73831 this can not get stable status when charging.
+    // LED is powered from PSEL line(USB or Lipo)
+    // due to weak low output of STAT pin?
+    // due to pull-up'd via resitor and LED?
+    return charging;
+}
+
+// Returns voltage in mV
+uint16_t battery_voltage(void)
+{
+    // ADC disable voltate divider(PF4)
+    DDRF  |=  (1<<4);
+    PORTF |=  (1<<4);
+
+    volatile uint16_t bat;
+    ADCSRA |= (1<<ADEN);
+    _delay_ms(1);   // wait for charging S/H capacitance
+
+    ADCSRA |= (1<<ADSC);
+    while (ADCSRA & (1<<ADSC)) ;
+    bat = ADC;
+
+    ADCSRA &= ~(1<<ADEN);
+
+    // ADC disable voltate divider(PF4)
+    DDRF  |=  (1<<4);
+    PORTF &= ~(1<<4);
+
+    return (bat - BATTERY_ADC_OFFSET) * BATTERY_ADC_RESOLUTION;
+}
+
+static bool low_voltage(void) {
+    static bool low = false;
+    uint16_t v = battery_voltage();
+    if (v < BATTERY_VOLTAGE_LOW_LIMIT) {
+        low = true;
+    } else if (v > BATTERY_VOLTAGE_LOW_RECOVERY) {
+        low = false;
+    }
+    return low;
+}
+
+battery_status_t battery_status(void)
+{
+    if (USBSTA&(1<<VBUS)) {
+        /* powered */
+        return battery_charging() ? CHARGING : FULL_CHARGED;
+    } else {
+        /* not powered */
+        return low_voltage() ? LOW_VOLTAGE : DISCHARGING;
+    }
+}

--- a/keyboards/hhkb/rn42/battery.h
+++ b/keyboards/hhkb/rn42/battery.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    FULL_CHARGED,
+    CHARGING,
+    DISCHARGING,
+    LOW_VOLTAGE,
+    UNKNOWN,
+} battery_status_t;
+
+typedef enum {
+    LED_CHARGER = 0,
+    LED_ON,
+    LED_OFF,
+    LED_TOGGLE,
+} battery_led_t;
+
+/* Battery API */
+void battery_init(void);
+void battery_led(battery_led_t val);
+bool battery_charging(void);
+uint16_t battery_voltage(void);
+battery_status_t battery_status(void);
+
+#define BATTERY_VOLTAGE_LOW_LIMIT       3500
+#define BATTERY_VOLTAGE_LOW_RECOVERY    3700
+// ADC offset:16, resolution:5mV
+#define BATTERY_ADC_OFFSET              16
+#define BATTERY_ADC_RESOLUTION          5

--- a/keyboards/hhkb/rn42/main.c
+++ b/keyboards/hhkb/rn42/main.c
@@ -1,0 +1,106 @@
+#include <avr/io.h>
+#include <avr/power.h>
+#include <avr/wdt.h>
+#include "lufa.h"
+#include "print.h"
+#include "sendchar.h"
+#include "rn42.h"
+#include "rn42_task.h"
+#include "serial.h"
+#include "keyboard.h"
+#include "keycode.h"
+#include "action.h"
+#include "action_util.h"
+#include "wait.h"
+#include "suart.h"
+#include "suspend.h"
+#include "matrix.h"
+
+static int8_t sendchar_func(uint8_t c)
+{
+    xmit(c);        // SUART
+    sendchar(c);    // LUFA
+    return 0;
+}
+
+static void SetupHardware(void)
+{
+    /* Disable watchdog if enabled by bootloader/fuses */
+    MCUSR &= ~(1 << WDRF);
+    wdt_disable();
+
+    /* Disable clock division */
+    clock_prescale_set(clock_div_1);
+
+    // Leonardo needs. Without this USB device is not recognized.
+    USB_Disable();
+
+    USB_Init();
+
+    // for Console_Task
+    USB_Device_EnableSOFEvents();
+    print_set_sendchar(sendchar_func);
+
+    // SUART PD0:output, PD1:input
+    DDRD |= (1<<0);
+    PORTD |= (1<<0);
+    DDRD &= ~(1<<1);
+    PORTD |= (1<<1);
+}
+
+int main(void)  __attribute__ ((weak));
+int main(void)
+{
+    SetupHardware();
+    sei();
+
+    /* wait for USB startup to get ready for debug output */
+    uint8_t timeout = 255;  // timeout when USB is not available(Bluetooth)
+    while (timeout-- && USB_DeviceState != DEVICE_STATE_Configured) {
+        wait_ms(4);
+#if defined(INTERRUPT_CONTROL_ENDPOINT)
+        ;
+#else
+        USB_USBTask();
+#endif
+    }
+    print("\nUSB init\n");
+
+    rn42_init();
+    rn42_task_init();
+    print("RN-42 init\n");
+
+    /* init modules */
+    keyboard_init();
+
+#ifdef SLEEP_LED_ENABLE
+    sleep_led_init();
+#endif
+
+    print("Keyboard start\n");
+    while (1) {
+        while (rn42_rts() && // RN42 is off
+                USB_DeviceState == DEVICE_STATE_Suspended) {
+            print("[s]");
+            matrix_power_down();
+            suspend_power_down();
+            suspend_power_down();
+            suspend_power_down();
+            suspend_power_down();
+            suspend_power_down();
+            suspend_power_down();
+            suspend_power_down();
+            if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
+                    USB_Device_SendRemoteWakeup();
+            }
+        }
+
+        keyboard_task();
+
+#if !defined(INTERRUPT_CONTROL_ENDPOINT)
+        USB_USBTask();
+#endif
+
+        rn42_task();
+    }
+}

--- a/keyboards/hhkb/rn42/rn42.c
+++ b/keyboards/hhkb/rn42/rn42.c
@@ -1,0 +1,256 @@
+#include <avr/io.h>
+#include "host.h"
+#include "host_driver.h"
+#include <stddef.h>
+#include "serial.h"
+#include "rn42.h"
+#include "print.h"
+#include "timer.h"
+#include "wait.h"
+
+
+/* Host driver */
+static uint8_t keyboard_leds(void);
+static void send_keyboard(report_keyboard_t *report);
+static void send_mouse(report_mouse_t *report);
+static void send_extra(report_extra_t *report);
+
+host_driver_t rn42_driver = {
+    keyboard_leds,
+    send_keyboard,
+    NULL,
+    send_mouse,
+    send_extra
+};
+
+
+void rn42_init(void)
+{
+    // PF7: BT connection control(high: connect, low: disconnect)
+    rn42_autoconnect();
+
+    // PF6: linked(input without pull-up)
+    DDRF  &= ~(1<<6);
+    PORTF |=  (1<<6);
+
+    // PF1: RTS(low: allowed to send, high: not allowed)
+    DDRF &= ~(1<<1);
+    PORTF &= ~(1<<1);
+
+    // PD5: CTS(low: allow to send, high:not allow)
+    DDRD |= (1<<5);
+    PORTD &= ~(1<<5);
+
+    serial_init();
+}
+
+int16_t rn42_getc(void)
+{
+    return serial_recv2();
+}
+
+const char *rn42_gets(uint16_t timeout)
+{
+    static char s[24];
+    uint16_t t = timer_read();
+    uint8_t i = 0;
+    int16_t c;
+    while (i < 23 && timer_elapsed(t) < timeout) {
+        if ((c = rn42_getc()) != -1) {
+            if ((char)c == '\r') continue;
+            if ((char)c == '\n') break;
+            s[i++] = c;
+        }
+    }
+    s[i] = '\0';
+    return s;
+}
+
+void rn42_putc(uint8_t c)
+{
+    serial_send(c);
+}
+
+void rn42_puts(char *s)
+{
+    while (*s)
+	serial_send(*s++);
+}
+
+bool rn42_autoconnecting(void)
+{
+    // GPIO6 for control connection(high: auto connect, low: disconnect)
+    // Note that this needs config: SM,4(Auto-Connect DTR Mode)
+    return (PORTF & (1<<7) ? true : false);
+}
+
+void rn42_autoconnect(void)
+{
+    // hi to auto connect
+    DDRF |= (1<<7);
+    PORTF |= (1<<7);
+}
+
+void rn42_disconnect(void)
+{
+    // low to disconnect
+    DDRF |= (1<<7);
+    PORTF &= ~(1<<7);
+}
+
+bool rn42_rts(void)
+{
+    // low when RN-42 is powered and ready to receive
+    return PINF&(1<<1);
+}
+
+void rn42_cts_hi(void)
+{
+    // not allow to send
+    PORTD |= (1<<5);
+}
+
+void rn42_cts_lo(void)
+{
+    // allow to send
+    PORTD &= ~(1<<5);
+}
+
+bool rn42_linked(void)
+{
+    // RN-42 GPIO2
+    //   Hi-Z:  Not powered
+    //   High:  Linked
+    //   Low:   Connecting
+    return PINF&(1<<6);
+}
+
+
+static uint8_t leds = 0;
+static uint8_t keyboard_leds(void) { return leds; }
+void rn42_set_leds(uint8_t l) { leds = l; }
+
+
+void rn42_send_str(const char *str)
+{
+    uint8_t c;
+    while ((c = pgm_read_byte(str++)))
+        rn42_putc(c);
+}
+
+const char *rn42_send_command(const char *cmd)
+{
+    static const char *s;
+    rn42_send_str(cmd);
+    wait_ms(500);
+    s = rn42_gets(100);
+    xprintf("%s\r\n", s);
+    rn42_print_response();
+    return s;
+}
+
+void rn42_print_response(void)
+{
+    int16_t c;
+    while ((c = rn42_getc()) != -1) {
+        xprintf("%c", c);
+    }
+}
+
+
+static void send_keyboard(report_keyboard_t *report)
+{
+    // wake from deep sleep
+/*
+    PORTD |= (1<<5);    // high
+    wait_ms(5);
+    PORTD &= ~(1<<5);   // low
+*/
+
+    serial_send(0xFD);  // Raw report mode
+    serial_send(9);     // length
+    serial_send(1);     // descriptor type
+    serial_send(report->mods);
+    serial_send(0x00);
+    serial_send(report->keys[0]);
+    serial_send(report->keys[1]);
+    serial_send(report->keys[2]);
+    serial_send(report->keys[3]);
+    serial_send(report->keys[4]);
+    serial_send(report->keys[5]);
+}
+
+static void send_mouse(report_mouse_t *report)
+{
+    // wake from deep sleep
+/*
+    PORTD |= (1<<5);    // high
+    wait_ms(5);
+    PORTD &= ~(1<<5);   // low
+*/
+
+    serial_send(0xFD);  // Raw report mode
+    serial_send(5);     // length
+    serial_send(2);     // descriptor type
+    serial_send(report->buttons);
+    serial_send(report->x);
+    serial_send(report->y);
+    serial_send(report->v);
+}
+
+
+static uint16_t usage2bits(uint16_t usage)
+{
+    switch (usage) {
+        case AC_HOME:                 return 0x01;
+        case AL_EMAIL:                return 0x02;
+        case AC_SEARCH:               return 0x04;
+        //case AL_KBD_LAYOUT:         return 0x08;  // Apple virtual keybaord toggle
+        case AUDIO_VOL_UP:            return 0x10;
+        case AUDIO_VOL_DOWN:          return 0x20;
+        case AUDIO_MUTE:              return 0x40;
+        case TRANSPORT_PLAY_PAUSE:    return 0x80;
+        case TRANSPORT_NEXT_TRACK:    return 0x100;
+        case TRANSPORT_PREV_TRACK:    return 0x200;
+        case TRANSPORT_STOP:          return 0x400;
+        case TRANSPORT_STOP_EJECT:    return 0x800;
+        case TRANSPORT_FAST_FORWARD:  return 0x1000;
+        case TRANSPORT_REWIND:        return 0x2000;
+        //case return 0x4000;   // Stop/eject
+        //case return 0x8000;   // Internet browser
+    };
+    return 0;
+}
+
+
+static void send_extra(report_extra_t *report)
+{
+    if (report->report_id == REPORT_ID_CONSUMER) {
+        uint16_t bits = usage2bits(report->usage);
+        serial_send(0xFD);  // Raw report mode
+        serial_send(3);     // length
+        serial_send(3);     // descriptor type
+        serial_send(bits&0xFF);
+        serial_send((bits>>8)&0xFF);
+    }
+}
+
+
+/* Null driver for config_mode */
+static uint8_t config_keyboard_leds(void);
+static void config_send_keyboard(report_keyboard_t *report);
+static void config_send_mouse(report_mouse_t *report);
+static void config_send_extra(report_extra_t *report);
+
+host_driver_t rn42_config_driver = {
+    config_keyboard_leds,
+    config_send_keyboard,
+    NULL,
+    config_send_mouse,
+    config_send_extra
+};
+
+static uint8_t config_keyboard_leds(void) { return leds; }
+static void config_send_keyboard(report_keyboard_t *report) {}
+static void config_send_mouse(report_mouse_t *report) {}
+static void config_send_extra(report_extra_t *report) {}

--- a/keyboards/hhkb/rn42/rn42.h
+++ b/keyboards/hhkb/rn42/rn42.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdbool.h>
+#include "host_driver.h"
+
+host_driver_t rn42_driver;
+host_driver_t rn42_config_driver;
+
+void rn42_init(void);
+int16_t rn42_getc(void);
+const char *rn42_gets(uint16_t timeout);
+void rn42_putc(uint8_t c);
+void rn42_puts(char *s);
+bool rn42_autoconnecting(void);
+void rn42_autoconnect(void);
+void rn42_disconnect(void);
+bool rn42_rts(void);
+void rn42_cts_hi(void);
+void rn42_cts_lo(void);
+bool rn42_linked(void);
+void rn42_set_leds(uint8_t l);
+
+const char *rn42_send_command(const char *cmd);
+void rn42_send_str(const char *str);
+void rn42_print_response(void);
+#define SEND_STR(str)       rn42_send_str(PSTR(str))
+#define SEND_COMMAND(cmd)   rn42_send_command(PSTR(cmd))

--- a/keyboards/hhkb/rn42/rn42_task.c
+++ b/keyboards/hhkb/rn42/rn42_task.c
@@ -1,0 +1,467 @@
+#include <stdint.h>
+#include <string.h>
+#include <avr/pgmspace.h>
+#include <avr/eeprom.h>
+#include "keycode.h"
+#include "serial.h"
+#include "host.h"
+#include "action.h"
+#include "action_util.h"
+#include "lufa.h"
+#include "rn42_task.h"
+#include "print.h"
+#include "debug.h"
+#include "timer.h"
+#include "wait.h"
+#include "command.h"
+#include "battery.h"
+#include "keycode_config.h"
+
+extern keymap_config_t keymap_config;
+
+static bool config_mode = false;
+static bool force_usb = false;
+
+static void status_led(bool on)
+{
+    if (on) {
+        DDRE  |=  (1<<6);
+        PORTE &= ~(1<<6);
+    } else {
+        DDRE  |=  (1<<6);
+        PORTE |=  (1<<6);
+    }
+}
+
+void rn42_task_init(void)
+{
+    battery_init();
+#ifdef NKRO_ENABLE
+    rn42_nkro_last = keymap_config.nkro;
+#endif
+}
+
+void rn42_task(void)
+{
+    int16_t c;
+    // Raw mode: interpret output report of LED state
+    while ((c = rn42_getc()) != -1) {
+        // LED Out report: 0xFE, 0x02, 0x01, <leds>
+        // To get the report over UART set bit3 with SH, command.
+        static enum {LED_INIT, LED_FE, LED_02, LED_01} state = LED_INIT;
+        switch (state) {
+            case LED_INIT:
+                if (c == 0xFE) state = LED_FE;
+                else {
+                    if (0x0 <= c && c <= 0x7f) xprintf("%c", c);
+                    else xprintf(" %02X", c);
+                }
+                break;
+            case LED_FE:
+                if (c == 0x02) state = LED_02;
+                else           state = LED_INIT;
+                break;
+            case LED_02:
+                if (c == 0x01) state = LED_01;
+                else           state = LED_INIT;
+                break;
+            case LED_01:
+                dprintf("LED status: %02X\n", c);
+                rn42_set_leds(c);
+                state = LED_INIT;
+                break;
+            default:
+                state = LED_INIT;
+        }
+    }
+
+    /* Switch between USB and Bluetooth */
+    if (!config_mode) { // not switch while config mode
+        if (!force_usb && !rn42_rts()) {
+            if (host_get_driver() != &rn42_driver) {
+                clear_keyboard();
+#ifdef NKRO_ENABLE
+                rn42_nkro_last = keymap_config.nkro;
+                keymap_config.nkro = false;
+#endif
+                host_set_driver(&rn42_driver);
+            }
+        } else {
+            if (host_get_driver() != &lufa_driver) {
+                clear_keyboard();
+#ifdef NKRO_ENABLE
+                keymap_config.nkro = rn42_nkro_last;
+#endif
+                host_set_driver(&lufa_driver);
+            }
+        }
+    }
+
+
+    static uint16_t prev_timer = 0;
+    uint16_t e = timer_elapsed(prev_timer);
+    if (e > 1000) {
+        /* every second */
+        prev_timer += e/1000*1000;
+
+        /* Low voltage alert */
+        uint8_t bs = battery_status();
+        if (bs == LOW_VOLTAGE) {
+            battery_led(LED_ON);
+        } else {
+            battery_led(LED_CHARGER);
+        }
+
+        /* every minute */
+        uint32_t t = timer_read32()/1000;
+        if (t%60 == 0) {
+            uint16_t v = battery_voltage();
+            uint8_t h = t/3600;
+            uint8_t m = t%3600/60;
+            uint8_t s = t%60;
+            dprintf("%02u:%02u:%02u\t%umV\n", h, m, s, v);
+            /* TODO: xprintf doesn't work for this.
+            xprintf("%02u:%02u:%02u\t%umV\n", (t/3600), (t%3600/60), (t%60), v);
+            */
+        }
+    }
+
+
+    /* Connection monitor */
+    if (!rn42_rts() && rn42_linked()) {
+        status_led(true);
+    } else {
+        status_led(false);
+    }
+}
+
+
+
+/******************************************************************************
+ * Command
+ ******************************************************************************/
+static host_driver_t *prev_driver = &rn42_driver;
+
+static void enter_command_mode(void)
+{
+    prev_driver = host_get_driver();
+    clear_keyboard();
+    host_set_driver(&rn42_config_driver);   // null driver; not to send a key to host
+    rn42_disconnect();
+    while (rn42_linked()) ;
+
+    print("Entering config mode ...\n");
+    wait_ms(1100);          // need 1 sec
+    SEND_COMMAND("$$$");
+    wait_ms(600);           // need 1 sec
+    rn42_print_response();
+    const char *s = SEND_COMMAND("v\r\n");
+    if (strncmp("v", s, 1) != 0) SEND_COMMAND("+\r\n"); // local echo on
+}
+
+static void exit_command_mode(void)
+{
+    print("Exiting config mode ...\n");
+    SEND_COMMAND("---\r\n");    // exit
+
+    rn42_autoconnect();
+    clear_keyboard();
+    host_set_driver(prev_driver);
+}
+
+static void init_rn42(void)
+{
+    // RN-42 configure
+    if (!config_mode) enter_command_mode();
+    SEND_COMMAND("SF,1\r\n");  // factory defaults
+    SEND_COMMAND("S-,TmkBT\r\n");
+    SEND_COMMAND("SS,Keyboard/Mouse\r\n");
+    SEND_COMMAND("SM,4\r\n");  // auto connect(DTR)
+    SEND_COMMAND("SW,8000\r\n");   // Sniff disable
+    SEND_COMMAND("S~,6\r\n");   // HID profile
+    SEND_COMMAND("SH,003C\r\n");   // combo device, out-report, 4-reconnect
+    SEND_COMMAND("SY,FFF4\r\n");   // transmit power -12
+    SEND_COMMAND("R,1\r\n");
+    if (!config_mode) exit_command_mode();
+}
+
+#if 0
+// Switching connections
+// NOTE: Remote Address doesn't work in the way manual says.
+// EEPROM address for link store
+#define RN42_LINK0  (uint8_t *)128
+#define RN42_LINK1  (uint8_t *)140
+#define RN42_LINK2  (uint8_t *)152
+#define RN42_LINK3  (uint8_t *)164
+static void store_link(uint8_t *eeaddr)
+{
+    enter_command_mode();
+    SEND_STR("GR\r\n"); // remote address
+    const char *s = rn42_gets(500);
+    if (strcmp("GR", s) == 0) s = rn42_gets(500);   // ignore local echo
+    xprintf("%s(%d)\r\n", s, strlen(s));
+    if (strlen(s) == 12) {
+        for (int i = 0; i < 12; i++) {
+            eeprom_write_byte(eeaddr+i, *(s+i));
+            dprintf("%c ", *(s+i));
+        }
+        dprint("\r\n");
+    }
+    exit_command_mode();
+}
+
+static void restore_link(const uint8_t *eeaddr)
+{
+    enter_command_mode();
+    SEND_COMMAND("SR,Z\r\n");   // remove remote address
+    SEND_STR("SR,");            // set remote address from EEPROM
+    for (int i = 0; i < 12; i++) {
+        uint8_t c = eeprom_read_byte(eeaddr+i);
+        rn42_putc(c);
+        dprintf("%c ", c);
+    }
+    dprintf("\r\n");
+    SEND_COMMAND("\r\n");
+    SEND_COMMAND("R,1\r\n");    // reboot
+    exit_command_mode();
+}
+
+static const char *get_link(uint8_t * eeaddr)
+{
+    static char s[13];
+    for (int i = 0; i < 12; i++) {
+        uint8_t c = eeprom_read_byte(eeaddr+i);
+        s[i] = c;
+    }
+    s[12] = '\0';
+    return s;
+}
+#endif
+
+static void pairing(void)
+{
+    enter_command_mode();
+    SEND_COMMAND("SR,Z\r\n");   // remove remote address
+    SEND_COMMAND("R,1\r\n");    // reboot
+    exit_command_mode();
+}
+
+bool command_extra(uint8_t code)
+{
+    uint32_t t;
+    uint16_t b;
+    switch (code) {
+        case KC_H:
+        case KC_SLASH: /* ? */
+            print("\n\n----- Bluetooth RN-42 Help -----\n");
+            print("i:       RN-42 info\n");
+            print("b:       battery voltage\n");
+            print("Del:     enter/exit RN-42 config mode\n");
+            print("Slck:    RN-42 initialize\n");
+#if 0
+            print("1-4:     restore link\n");
+            print("F1-F4:   store link\n");
+#endif
+            print("p:       pairing\n");
+
+            if (config_mode) {
+                return true;
+            } else {
+                print("u:       toggle Force USB mode\n");
+                return false;   // to display default command help
+            }
+        case KC_P:
+            pairing();
+            return true;
+#if 0
+        /* Store link address to EEPROM */
+        case KC_F1:
+            store_link(RN42_LINK0);
+            return true;
+        case KC_F2:
+            store_link(RN42_LINK1);
+            return true;
+        case KC_F3:
+            store_link(RN42_LINK2);
+            return true;
+        case KC_F4:
+            store_link(RN42_LINK3);
+            return true;
+        /* Restore link address to EEPROM */
+        case KC_1:
+            restore_link(RN42_LINK0);
+            return true;
+        case KC_2:
+            restore_link(RN42_LINK1);
+            return true;
+        case KC_3:
+            restore_link(RN42_LINK2);
+            return true;
+        case KC_4:
+            restore_link(RN42_LINK3);
+            return true;
+#endif
+        case KC_I:
+            print("\n----- RN-42 info -----\n");
+            xprintf("protocol: %s\n", (host_get_driver() == &rn42_driver) ? "RN-42" : "LUFA");
+            xprintf("force_usb: %X\n", force_usb);
+            xprintf("rn42: %s\n", rn42_rts() ? "OFF" : (rn42_linked() ? "CONN" : "ON"));
+            xprintf("rn42_autoconnecting(): %X\n", rn42_autoconnecting());
+            xprintf("config_mode: %X\n", config_mode);
+            xprintf("USB State: %s\n",
+                    (USB_DeviceState == DEVICE_STATE_Unattached) ? "Unattached" :
+                    (USB_DeviceState == DEVICE_STATE_Powered) ? "Powered" :
+                    (USB_DeviceState == DEVICE_STATE_Default) ? "Default" :
+                    (USB_DeviceState == DEVICE_STATE_Addressed) ? "Addressed" :
+                    (USB_DeviceState == DEVICE_STATE_Configured) ? "Configured" :
+                    (USB_DeviceState == DEVICE_STATE_Suspended) ? "Suspended" : "?");
+            xprintf("battery: ");
+            switch (battery_status()) {
+                case FULL_CHARGED:  xprintf("FULL"); break;
+                case CHARGING:      xprintf("CHARG"); break;
+                case DISCHARGING:   xprintf("DISCHG"); break;
+                case LOW_VOLTAGE:   xprintf("LOW"); break;
+                default:            xprintf("?"); break;
+            };
+            xprintf("\n");
+            xprintf("RemoteWakeupEnabled: %X\n", USB_Device_RemoteWakeupEnabled);
+            xprintf("VBUS: %X\n", USBSTA&(1<<VBUS));
+            t = timer_read32()/1000;
+            uint8_t d = t/3600/24;
+            uint8_t h = t/3600;
+            uint8_t m = t%3600/60;
+            uint8_t s = t%60;
+            xprintf("uptime: %02u %02u:%02u:%02u\n", d, h, m, s);
+#if 0
+            xprintf("LINK0: %s\r\n", get_link(RN42_LINK0));
+            xprintf("LINK1: %s\r\n", get_link(RN42_LINK1));
+            xprintf("LINK2: %s\r\n", get_link(RN42_LINK2));
+            xprintf("LINK3: %s\r\n", get_link(RN42_LINK3));
+#endif
+            return true;
+        case KC_B:
+            // battery monitor
+            t = timer_read32()/1000;
+            b = battery_voltage();
+            xprintf("BAT: %umV\t", b);
+            xprintf("%02u:",   t/3600);
+            xprintf("%02u:",   t%3600/60);
+            xprintf("%02u\n",  t%60);
+            return true;
+        case KC_U:
+            if (config_mode) return false;
+            if (force_usb) {
+                print("Auto mode\n");
+                force_usb = false;
+            } else {
+                print("USB mode\n");
+                force_usb = true;
+            }
+            return true;
+        case KC_DELETE:
+            /* RN-42 Command mode */
+            if (rn42_autoconnecting()) {
+                enter_command_mode();
+
+                command_state = CONSOLE;
+                config_mode = true;
+            } else {
+                exit_command_mode();
+
+                command_state = ONESHOT;
+                config_mode = false;
+            }
+            return true;
+        case KC_SCROLL_LOCK:
+            init_rn42();
+            return true;
+#ifdef NKRO_ENABLE
+        case KC_N:
+            if (host_get_driver() != &lufa_driver) {
+                // ignored unless USB mode
+                return true;
+            }
+            return false;
+#endif
+        default:
+            if (config_mode)
+                return true;
+            else
+                return false;   // yield to default command
+    }
+    return true;
+}
+
+/*
+ * RN-42 Command mode
+ * sends charactors to the module
+ */
+static uint8_t code2asc(uint8_t code);
+bool command_console_extra(uint8_t code)
+{
+    rn42_putc(code2asc(code));
+    return true;
+}
+
+// convert keycode into ascii charactor
+static uint8_t code2asc(uint8_t code)
+{
+    bool shifted = (get_mods() & (MOD_BIT(KC_LSFT)|MOD_BIT(KC_RSFT))) ? true : false;
+    switch (code) {
+        case KC_A: return (shifted ? 'A' : 'a');
+        case KC_B: return (shifted ? 'B' : 'b');
+        case KC_C: return (shifted ? 'C' : 'c');
+        case KC_D: return (shifted ? 'D' : 'd');
+        case KC_E: return (shifted ? 'E' : 'e');
+        case KC_F: return (shifted ? 'F' : 'f');
+        case KC_G: return (shifted ? 'G' : 'g');
+        case KC_H: return (shifted ? 'H' : 'h');
+        case KC_I: return (shifted ? 'I' : 'i');
+        case KC_J: return (shifted ? 'J' : 'j');
+        case KC_K: return (shifted ? 'K' : 'k');
+        case KC_L: return (shifted ? 'L' : 'l');
+        case KC_M: return (shifted ? 'M' : 'm');
+        case KC_N: return (shifted ? 'N' : 'n');
+        case KC_O: return (shifted ? 'O' : 'o');
+        case KC_P: return (shifted ? 'P' : 'p');
+        case KC_Q: return (shifted ? 'Q' : 'q');
+        case KC_R: return (shifted ? 'R' : 'r');
+        case KC_S: return (shifted ? 'S' : 's');
+        case KC_T: return (shifted ? 'T' : 't');
+        case KC_U: return (shifted ? 'U' : 'u');
+        case KC_V: return (shifted ? 'V' : 'v');
+        case KC_W: return (shifted ? 'W' : 'w');
+        case KC_X: return (shifted ? 'X' : 'x');
+        case KC_Y: return (shifted ? 'Y' : 'y');
+        case KC_Z: return (shifted ? 'Z' : 'z');
+        case KC_1: return (shifted ? '!' : '1');
+        case KC_2: return (shifted ? '@' : '2');
+        case KC_3: return (shifted ? '#' : '3');
+        case KC_4: return (shifted ? '$' : '4');
+        case KC_5: return (shifted ? '%' : '5');
+        case KC_6: return (shifted ? '^' : '6');
+        case KC_7: return (shifted ? '&' : '7');
+        case KC_8: return (shifted ? '*' : '8');
+        case KC_9: return (shifted ? '(' : '9');
+        case KC_0: return (shifted ? ')' : '0');
+        case KC_ENTER: return '\n';
+        case KC_ESCAPE: return 0x1B;
+        case KC_BACKSPACE: return '\b';
+        case KC_TAB: return '\t';
+        case KC_SPACE: return ' ';
+        case KC_MINUS: return (shifted ? '_' : '-');
+        case KC_EQUAL: return (shifted ? '+' : '=');
+        case KC_LEFT_BRACKET: return (shifted ? '{' : '[');
+        case KC_RIGHT_BRACKET: return (shifted ? '}' : ']');
+        case KC_BACKSLASH: return (shifted ? '|' : '\\');
+        case KC_NONUS_HASH: return (shifted ? '|' : '\\');
+        case KC_SEMICOLON: return (shifted ? ':' : ';');
+        case KC_QUOTE: return (shifted ? '"' : '\'');
+        case KC_GRAVE: return (shifted ? '~' : '`');
+        case KC_COMMA: return (shifted ? '<' : ',');
+        case KC_DOT: return (shifted ? '>' : '.');
+        case KC_SLASH: return (shifted ? '?' : '/');
+        case KC_DELETE: return '\0';    // Delete to disconnect
+        default: return ' ';
+    }
+}

--- a/keyboards/hhkb/rn42/rn42_task.h
+++ b/keyboards/hhkb/rn42/rn42_task.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdbool.h>
+#include "rn42.h"
+
+#ifdef NKRO_ENABLE
+bool rn42_nkro_last;
+#endif
+
+void rn42_task_init(void);
+void rn42_task(void);

--- a/keyboards/hhkb/rn42/serial.h
+++ b/keyboards/hhkb/rn42/serial.h
@@ -1,0 +1,46 @@
+/*
+Copyright 2012 Jun WAKO <wakojun@gmail.com>
+
+This software is licensed with a Modified BSD License.
+All of this is supposed to be Free Software, Open Source, DFSG-free,
+GPL-compatible, and OK to use in both free and proprietary applications.
+Additions and corrections to this file are welcome.
+
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in
+  the documentation and/or other materials provided with the
+  distribution.
+
+* Neither the name of the copyright holders nor the names of
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#define SERIAL_UART_DATA UDR1
+
+/* host role */
+void    serial_init(void);
+uint8_t serial_recv(void);
+int16_t serial_recv2(void);
+void    serial_send(uint8_t data);

--- a/keyboards/hhkb/rn42/serial_uart.c
+++ b/keyboards/hhkb/rn42/serial_uart.c
@@ -1,0 +1,139 @@
+/*
+Copyright 2013 Jun WAKO <wakojun@gmail.com>
+
+This software is licensed with a Modified BSD License.
+All of this is supposed to be Free Software, Open Source, DFSG-free,
+GPL-compatible, and OK to use in both free and proprietary applications.
+Additions and corrections to this file are welcome.
+
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in
+  the documentation and/or other materials provided with the
+  distribution.
+
+* Neither the name of the copyright holders nor the names of
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdbool.h>
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include "serial.h"
+
+#ifndef SERIAL_UART_BAUD
+#    define SERIAL_UART_BAUD 9600
+#endif
+
+#ifndef SERIAL_UART_UBRR
+#define SERIAL_UART_UBRR (F_CPU / (16UL * SERIAL_UART_BAUD) - 1)
+#endif
+#ifndef SERIAL_UART_TXD_READY
+#define SERIAL_UART_TXD_READY (UCSR1A & _BV(UDRE1))
+#endif
+#ifndef SERIAL_UART_RXD_VECT
+#define SERIAL_UART_RXD_VECT USART1_RX_vect
+#endif
+
+#ifndef SERIAL_UART_INIT_CUSTOM
+#    define SERIAL_UART_INIT_CUSTOM \
+        /* enable TX */             \
+        UCSR1B = _BV(TXEN1);        \
+        /* 8-bit data */            \
+        UCSR1C = _BV(UCSZ11) | _BV(UCSZ10);
+#endif
+
+#if defined(SERIAL_UART_RTS_LO) && defined(SERIAL_UART_RTS_HI)
+// Buffer state
+//   Empty:           RBUF_SPACE == RBUF_SIZE(head==tail)
+//   Last 1 space:    RBUF_SPACE == 2
+//   Full:            RBUF_SPACE == 1(last cell of rbuf be never used.)
+#    define RBUF_SPACE() (rbuf_head < rbuf_tail ? (rbuf_tail - rbuf_head) : (RBUF_SIZE - rbuf_head + rbuf_tail))
+// allow to send
+#    define rbuf_check_rts_lo()                         \
+        do {                                            \
+            if (RBUF_SPACE() > 2) SERIAL_UART_RTS_LO(); \
+        } while (0)
+// prohibit to send
+#    define rbuf_check_rts_hi()                          \
+        do {                                             \
+            if (RBUF_SPACE() <= 2) SERIAL_UART_RTS_HI(); \
+        } while (0)
+#else
+#    define rbuf_check_rts_lo()
+#    define rbuf_check_rts_hi()
+#endif
+
+void serial_init(void) {
+    do {
+        // Set baud rate
+        // UBRR1L = SERIAL_UART_UBRR;
+        // UBRR1L = SERIAL_UART_UBRR >> 8;
+        SERIAL_UART_INIT_CUSTOM;
+    } while (0);
+}
+
+// RX ring buffer
+#define RBUF_SIZE 256
+static uint8_t rbuf[RBUF_SIZE];
+static uint8_t rbuf_head = 0;
+static uint8_t rbuf_tail = 0;
+
+uint8_t serial_recv(void) {
+    uint8_t data = 0;
+    if (rbuf_head == rbuf_tail) {
+        return 0;
+    }
+
+    data      = rbuf[rbuf_tail];
+    rbuf_tail = (rbuf_tail + 1) % RBUF_SIZE;
+    rbuf_check_rts_lo();
+    return data;
+}
+
+int16_t serial_recv2(void) {
+    uint8_t data = 0;
+    if (rbuf_head == rbuf_tail) {
+        return -1;
+    }
+
+    data      = rbuf[rbuf_tail];
+    rbuf_tail = (rbuf_tail + 1) % RBUF_SIZE;
+    rbuf_check_rts_lo();
+    return data;
+}
+
+void serial_send(uint8_t data) {
+    while (!SERIAL_UART_TXD_READY)
+        ;
+    SERIAL_UART_DATA = data;
+}
+
+// USART RX complete interrupt
+ISR(SERIAL_UART_RXD_VECT) {
+    uint8_t next = (rbuf_head + 1) % RBUF_SIZE;
+    if (next != rbuf_tail) {
+        rbuf[rbuf_head] = SERIAL_UART_DATA;
+        rbuf_head       = next;
+    }
+    rbuf_check_rts_hi();
+}

--- a/keyboards/hhkb/rn42/suart.S
+++ b/keyboards/hhkb/rn42/suart.S
@@ -1,0 +1,156 @@
+;---------------------------------------------------------------------------;
+; Software implemented UART module                                          ;
+; (C)ChaN, 2005 (http://elm-chan.org/)                                      ;
+;---------------------------------------------------------------------------;
+; Bit rate settings:
+;
+;            1MHz  2MHz  4MHz  6MHz  8MHz  10MHz  12MHz  16MHz  20MHz
+;   2.4kbps   138     -     -     -     -      -      -      -      -
+;   4.8kbps    68   138     -     -     -      -      -      -      -
+;   9.6kbps    33    68   138   208     -      -      -      -      -
+;  19.2kbps     -    33    68   102   138    173    208      -      -
+;  38.4kbps     -     -    33    50    68     85    102    138    172
+;  57.6kbps     -     -    21    33    44     56     68     91    114
+; 115.2kbps     -     -     -     -    21     27     33     44     56
+
+.nolist
+#include <avr/io.h>
+.list
+
+#define	BPS	44 	/* Bit delay. (see above table) */
+#define	BIDIR	0	/* 0:Separated Tx/Rx, 1:Shared Tx/Rx */
+
+#define	OUT_1		sbi _SFR_IO_ADDR(SUART_OUT_PORT), SUART_OUT_BIT	/* Output 1 */
+#define	OUT_0		cbi _SFR_IO_ADDR(SUART_OUT_PORT), SUART_OUT_BIT	/* Output 0 */
+#define	SKIP_IN_1	sbis _SFR_IO_ADDR(SUART_IN_PIN), SUART_IN_BIT	/* Skip if 1 */
+#define	SKIP_IN_0	sbic _SFR_IO_ADDR(SUART_IN_PIN), SUART_IN_BIT	/* Skip if 0 */
+
+
+
+#ifdef SPM_PAGESIZE
+.macro	_LPMI	reg
+	lpm	\reg, Z+
+.endm
+.macro	_MOVW	dh,dl, sh,sl
+	movw	\dl, \sl
+.endm
+#else
+.macro	_LPMI	reg
+	lpm
+	mov	\reg, r0
+	adiw	ZL, 1
+.endm
+.macro	_MOVW	dh,dl, sh,sl
+	mov	\dl, \sl
+	mov	\dh, \sh
+.endm
+#endif
+
+
+
+;---------------------------------------------------------------------------;
+; Transmit a byte in serial format of N81
+;
+;Prototype: void xmit (uint8_t data);
+;Size: 16 words
+
+.global xmit
+.func xmit
+xmit:
+#if BIDIR
+	ldi	r23, BPS-1	;Pre-idle time for bidirectional data line
+5:	dec	r23     	;
+	brne	5b		;/
+#endif
+	in	r0, _SFR_IO_ADDR(SREG)	;Save flags
+
+	com	r24		;C = start bit
+	ldi	r25, 10		;Bit counter
+	cli			;Start critical section
+
+1:	ldi	r23, BPS-1	;----- Bit transferring loop
+2:	dec	r23     	;Wait for a bit time
+	brne	2b		;/
+	brcs	3f		;MISO = bit to be sent
+	OUT_1			;
+3:	brcc	4f		;
+	OUT_0			;/
+4:	lsr	r24     	;Get next bit into C
+	dec	r25     	;All bits sent?
+	brne	1b	     	;  no, coutinue
+
+	out	_SFR_IO_ADDR(SREG), r0	;End of critical section
+	ret
+.endfunc
+
+
+
+;---------------------------------------------------------------------------;
+; Receive a byte
+;
+;Prototype: uint8_t rcvr (void);
+;Size: 19 words
+
+.global rcvr
+.func rcvr
+rcvr:
+	in	r0, _SFR_IO_ADDR(SREG)	;Save flags
+
+	ldi	r24, 0x80	;Receiving shift reg
+	cli			;Start critical section
+
+1:	SKIP_IN_1		;Wait for idle
+	rjmp	1b
+2:	SKIP_IN_0		;Wait for start bit
+	rjmp	2b
+	ldi	r25, BPS/2	;Wait for half bit time
+3:	dec	r25
+	brne	3b
+
+4:	ldi	r25, BPS	;----- Bit receiving loop
+5:	dec	r25     	;Wait for a bit time
+	brne	5b		;/
+	lsr	r24     	;Next bit
+	SKIP_IN_0		;Get a data bit into r24.7
+	ori	r24, 0x80
+	brcc	4b	     	;All bits received?  no, continue
+
+	out	_SFR_IO_ADDR(SREG), r0	;End of critical section
+	ret
+.endfunc
+
+
+; Not wait for start bit. This should be called after detecting start bit.
+.global recv
+.func recv
+recv:
+	in	r0, _SFR_IO_ADDR(SREG)	;Save flags
+
+	ldi	r24, 0x80	;Receiving shift reg
+	cli			;Start critical section
+
+;1:	SKIP_IN_1		;Wait for idle
+;	rjmp	1b
+;2:	SKIP_IN_0		;Wait for start bit
+;	rjmp	2b
+	ldi	r25, BPS/2	;Wait for half bit time
+3:	dec	r25
+	brne	3b
+
+4:	ldi	r25, BPS	;----- Bit receiving loop
+5:	dec	r25     	;Wait for a bit time
+	brne	5b		;/
+	lsr	r24     	;Next bit
+	SKIP_IN_0		;Get a data bit into r24.7
+	ori	r24, 0x80
+	brcc	4b	     	;All bits received?  no, continue
+
+	ldi	r25, BPS/2	;Wait for half bit time
+6:	dec	r25
+	brne	6b
+7:	SKIP_IN_1		;Wait for stop bit
+	rjmp	7b
+
+	out	_SFR_IO_ADDR(SREG), r0	;End of critical section
+	ret
+.endfunc

--- a/keyboards/hhkb/rn42/suart.h
+++ b/keyboards/hhkb/rn42/suart.h
@@ -1,0 +1,8 @@
+#ifndef SUART
+#define SUART
+
+void xmit(uint8_t);
+uint8_t rcvr(void);
+uint8_t recv(void);
+
+#endif	/* SUART */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This PR restores support for the RN-42 Bluetooth module on the HHKB keyboard, which is removed in 0.21 for lack of maintain. It re-introduces the necessary driver files and configuration under rn42 and updates the ANSI variant configuration.

Require `HHKB_RN42_ENABLE=yes` to be set.

The original issue https://github.com/qmk/qmk_firmware/issues/1096 and pr  https://github.com/qmk/qmk_firmware/pull/2693

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
