### PR TITLE
Add silly_group/meowy_pad

### DIFF
--- a/keyboards/silly_group/meowy_pad/config.h
+++ b/keyboards/silly_group/meowy_pad/config.h
@@ -5,8 +5,8 @@
 
 // I2C config for OLED (SSD1306)
 #define I2C_DRIVER I2CD1
-#define I2C1_SDA_PIN GP26
-#define I2C1_SCL_PIN GP27
+#define I2C1_SDA_PIN GP6
+#define I2C1_SCL_PIN GP7
 
 // OLED config
 #define OLED_DISPLAY_128X64

--- a/keyboards/silly_group/meowy_pad/config.h
+++ b/keyboards/silly_group/meowy_pad/config.h
@@ -1,0 +1,13 @@
+// Copyright 2026 silly group (@stwupid)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// I2C config for OLED (SSD1306)
+#define I2C_DRIVER I2CD1
+#define I2C1_SDA_PIN GP26
+#define I2C1_SCL_PIN GP27
+
+// OLED config
+#define OLED_DISPLAY_128X64
+#define OLED_TIMEOUT 60000

--- a/keyboards/silly_group/meowy_pad/halconf.h
+++ b/keyboards/silly_group/meowy_pad/halconf.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define HAL_USE_I2C TRUE
+
+#include_next <halconf.h>

--- a/keyboards/silly_group/meowy_pad/info.json
+++ b/keyboards/silly_group/meowy_pad/info.json
@@ -1,0 +1,38 @@
+{
+    "keyboard_name": "MeowyPad",
+    "manufacturer": "silly group",
+    "maintainer": "stwupid",
+    "processor": "RP2040",
+    "bootloader": "rp2040",
+    "diode_direction": "COL2ROW",
+    "features": {
+        "bootmagic": true,
+        "extrakey": true,
+        "mousekey": true,
+        "oled": true
+    },
+    "usb": {
+        "vid": "0x5347",
+        "pid": "0x3301",
+        "device_version": "1.0.0"
+    },
+    "matrix_pins": {
+        "cols": ["GP0", "GP1", "GP2"],
+        "rows": ["GP3", "GP4", "GP5"]
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0},
+                {"matrix": [0, 1], "x": 1, "y": 0},
+                {"matrix": [0, 2], "x": 2, "y": 0},
+                {"matrix": [1, 0], "x": 0, "y": 1},
+                {"matrix": [1, 1], "x": 1, "y": 1},
+                {"matrix": [1, 2], "x": 2, "y": 1},
+                {"matrix": [2, 0], "x": 0, "y": 2},
+                {"matrix": [2, 1], "x": 1, "y": 2},
+                {"matrix": [2, 2], "x": 2, "y": 2}
+            ]
+        }
+    }
+}

--- a/keyboards/silly_group/meowy_pad/keymaps/default/keymap.c
+++ b/keyboards/silly_group/meowy_pad/keymaps/default/keymap.c
@@ -1,0 +1,27 @@
+// Copyright 2026 silly group (@stwupid)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_Q, KC_W, KC_E,
+        KC_A, KC_S, KC_D,
+        KC_Z, KC_X, KC_C
+    )
+};
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // Display MeowyPad logo/text
+    oled_write_ln_P(PSTR("MeowyPad"), false);
+    oled_write_ln_P(PSTR("by silly group"), false);
+    oled_write_ln_P(PSTR(""), false);
+    
+    // Display current layer
+    oled_write_P(PSTR("Layer: "), false);
+    oled_write_ln_P(PSTR("0"), false);
+    
+    return false;
+}
+#endif

--- a/keyboards/silly_group/meowy_pad/keymaps/default/keymap.c
+++ b/keyboards/silly_group/meowy_pad/keymaps/default/keymap.c
@@ -10,18 +10,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_Z, KC_X, KC_C
     )
 };
-
-#ifdef OLED_ENABLE
-bool oled_task_user(void) {
-    // Display MeowyPad logo/text
-    oled_write_ln_P(PSTR("MeowyPad"), false);
-    oled_write_ln_P(PSTR("by silly group"), false);
-    oled_write_ln_P(PSTR(""), false);
-    
-    // Display current layer
-    oled_write_P(PSTR("Layer: "), false);
-    oled_write_ln_P(PSTR("0"), false);
-    
-    return false;
-}
-#endif

--- a/keyboards/silly_group/meowy_pad/keymaps/via/keymap.c
+++ b/keyboards/silly_group/meowy_pad/keymaps/via/keymap.c
@@ -1,0 +1,43 @@
+// Copyright 2026 silly group (@stwupid)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_Q, KC_W, KC_E,
+        KC_A, KC_S, KC_D,
+        KC_Z, KC_X, KC_C
+    ),
+    [1] = LAYOUT(
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+    [2] = LAYOUT(
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS
+    ),
+    [3] = LAYOUT(
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS,
+        KC_TRNS, KC_TRNS, KC_TRNS
+    )
+};
+
+#ifdef OLED_ENABLE
+bool oled_task_user(void) {
+    // Display MeowyPad logo/text
+    oled_write_ln_P(PSTR("MeowyPad"), false);
+    oled_write_ln_P(PSTR("by silly group"), false);
+    oled_write_ln_P(PSTR(""), false);
+    
+    // Display current layer
+    oled_write_P(PSTR("Layer: "), false);
+    oled_write_char('0' + get_highest_layer(layer_state), false);
+    oled_write_ln_P(PSTR(""), false);
+    
+    return false;
+}
+#endif

--- a/keyboards/silly_group/meowy_pad/keymaps/via/keymap.c
+++ b/keyboards/silly_group/meowy_pad/keymaps/via/keymap.c
@@ -25,19 +25,3 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_TRNS, KC_TRNS, KC_TRNS
     )
 };
-
-#ifdef OLED_ENABLE
-bool oled_task_user(void) {
-    // Display MeowyPad logo/text
-    oled_write_ln_P(PSTR("MeowyPad"), false);
-    oled_write_ln_P(PSTR("by silly group"), false);
-    oled_write_ln_P(PSTR(""), false);
-    
-    // Display current layer
-    oled_write_P(PSTR("Layer: "), false);
-    oled_write_char('0' + get_highest_layer(layer_state), false);
-    oled_write_ln_P(PSTR(""), false);
-    
-    return false;
-}
-#endif

--- a/keyboards/silly_group/meowy_pad/keymaps/via/rules.mk
+++ b/keyboards/silly_group/meowy_pad/keymaps/via/rules.mk
@@ -1,1 +1,0 @@
-VIA_ENABLE = yes

--- a/keyboards/silly_group/meowy_pad/keymaps/via/rules.mk
+++ b/keyboards/silly_group/meowy_pad/keymaps/via/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/silly_group/meowy_pad/mcuconf.h
+++ b/keyboards/silly_group/meowy_pad/mcuconf.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include_next <mcuconf.h>
+
+#undef RP_I2C_USE_I2C1
+#define RP_I2C_USE_I2C1 TRUE

--- a/keyboards/silly_group/meowy_pad/meowy_pad.c
+++ b/keyboards/silly_group/meowy_pad/meowy_pad.c
@@ -1,0 +1,24 @@
+// Copyright 2026 silly group (@stwupid)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+
+#ifdef OLED_ENABLE
+bool oled_task_kb(oled_rotation_t rotation) {
+    if (!oled_task_user(rotation)) {
+        return false;
+    }
+    
+    // Display MeowyPad logo/text
+    oled_write_ln_P(PSTR("MeowyPad"), false);
+    oled_write_ln_P(PSTR("by silly group"), false);
+    oled_write_ln_P(PSTR(""), false);
+    
+    // Display current layer
+    oled_write_P(PSTR("Layer: "), false);
+    oled_write_char('0' + get_highest_layer(layer_state), false);
+    oled_write_ln_P(PSTR(""), false);
+    
+    return false;
+}
+#endif

--- a/keyboards/silly_group/meowy_pad/readme.md
+++ b/keyboards/silly_group/meowy_pad/readme.md
@@ -1,0 +1,26 @@
+# MeowyPad
+
+![MeowyPad](https://i.imgur.com/placeholder.png)
+
+A cute 3x3 macropad with OLED display, powered by Seeed XIAO RP2040.
+
+* Keyboard Maintainer: [silly group](https://github.com/stwupid)
+* Hardware Supported: Seeed XIAO RP2040
+* Hardware Availability: Custom build
+
+Make example for this keyboard (after setting up your build environment):
+
+    qmk compile -kb silly_group/meowy_pad -km default
+
+Flashing example for this keyboard:
+
+    qmk flash -kb silly_group/meowy_pad -km via
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 2 ways:
+
+* **Physical reset button**: Hold the BOOT button on the XIAO RP2040 while plugging in
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (top left key) and plug in the keyboard

--- a/keyboards/silly_group/meowy_pad/readme.md
+++ b/keyboards/silly_group/meowy_pad/readme.md
@@ -1,6 +1,6 @@
 # MeowyPad
 
-![MeowyPad](https://i.imgur.com/placeholder.png)
+![MeowyPad](https://i.imgur.com/meowy_pad.png)
 
 A cute 3x3 macropad with OLED display, powered by Seeed XIAO RP2040.
 

--- a/keyboards/silly_group/meowy_pad/rules.mk
+++ b/keyboards/silly_group/meowy_pad/rules.mk
@@ -1,0 +1,16 @@
+# MCU name
+MCU = RP2040
+BOOTLOADER = rp2040
+
+# Build Options
+BOOTMAGIC_ENABLE = yes      # Enable Bootmagic Lite
+MOUSEKEY_ENABLE = yes       # Mouse keys
+EXTRAKEY_ENABLE = yes       # Audio control and System control
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = yes           # Enable N-Key Rollover
+BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
+RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
+AUDIO_ENABLE = no           # Audio output
+OLED_ENABLE = yes
+OLED_DRIVER = ssd1306

--- a/keyboards/silly_group/meowy_pad/rules.mk
+++ b/keyboards/silly_group/meowy_pad/rules.mk
@@ -12,5 +12,3 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-OLED_ENABLE = yes
-OLED_DRIVER = ssd1306


### PR DESCRIPTION
## Description

Adds support for MeowyPad by silly group - a 3x3 macropad with SSD1306 OLED display (0.96").

**Hardware:**
- Controller: Seeed XIAO RP2040
- Layout: 3x3 matrix (COL2ROW)
- Features: SSD1306 OLED display connected to D6/D7 (GP6/GP7)
- VID: 0x5347 (SG - silly group)
- PID: 0x3301

**Keymaps:**
- `default`: Basic QWERTY layout (Q/W/E, A/S/D, Z/X/C)
- `via`: VIA-enabled with 4 layers for full customization

**OLED Implementation:**
- Displays keyboard name and manufacturer
- Shows current layer number
- Connected via I2C (GP6=SDA, GP7=SCL)

## Types of Changes

- [x] Keyboard (addition or update)

## Issues Fixed or Closed by This PR

* N/A - new keyboard addition

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Additional Notes

VIA support PR: https://github.com/the-via/keyboards/pull/2520