### PR TITLE
Fix `qmk flash` handling of paths relative to qmk_firmware

### DIFF
--- a/lib/python/qmk/path.py
+++ b/lib/python/qmk/path.py
@@ -177,5 +177,17 @@ class FileType(argparse.FileType):
         """normalize and check exists
             otherwise magic strings like '-' for stdin resolve to bad paths
         """
+        # TODO: This should not return both Path and TextIOWrapper as consumers
+        # assume that they can call Path.as_posix without checking type
+
+        # Handle absolute paths and relative paths to CWD
         norm = normpath(string)
-        return norm if norm.exists() else super().__call__(string)
+        if norm.exists():
+            return norm
+
+        # Handle relative paths to QMK_HOME
+        relative = Path(string)
+        if relative.exists():
+            return relative
+
+        return super().__call__(string)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Flashing a firmware file that is located within the top of `qmk_firmware`, when the current working directory is somewhere else produces the following error:
```
☒ Invalid JSON encountered attempting to load <_io.TextIOWrapper name='lets_split_rev2_default.hex' mode='r' encoding='UTF-8'>:
	Found ':' but no key name (for an empty key name use quotes): line 1 column 1 (char 0)
```

The issue is with the check within flash.py falling through, and it assuming filename is a keymap.json.

https://github.com/qmk/qmk_firmware/blob/6729379041bced3064348395b0bdfed35d61c541/lib/python/qmk/cli/flash.py#L84-L85

This short term fix makes the flashing consistent by ensuring that `Path` objects are returned outside the case of filename being stdin.

The code base really needs to be refactored so `qmk.path.FileType`  does not return multiple types. However this is more involved and requires wider changes.

### Steps to reproduce

1. `qmk compile -kb lets_split -km default`
2. `cd ~/Desktop`
3. `qmk flash lets_split_rev2_default.hex`
4. Observe above error message

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://discord.com/channels/440868230475677696/867530222407778344/1469602143425269923

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
