### PR TITLE
Add 'none of the above' to `new-keyboard` dev board prompt

### DIFF
--- a/lib/python/qmk/cli/new/keyboard.py
+++ b/lib/python/qmk/cli/new/keyboard.py
@@ -232,7 +232,7 @@ def new_keyboard(cli):
         if prompt_mcu_type():
             mcu = prompt_dev_board()
         if not mcu or mcu == "none of the above":
-            mcu =  prompt_mcu()
+            mcu = prompt_mcu()
 
     config = {}
     if mcu in dev_boards:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As there seems to be some confusion on what to do when a users dev board isnt in the list, this PR adds a "none of the above" option per other questions. In this case we then just prompt the mcu list for them to pick from.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
