### PR TITLE
Fix incorrect `matrix_scan_custom` implementations

### DIFF
--- a/keyboards/mexsistor/ludmila/matrix.c
+++ b/keyboards/mexsistor/ludmila/matrix.c
@@ -14,28 +14,22 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "wait.h"
-#include "util.h"
 #include "matrix.h"
 
 // Encoder things
 #define ENC_SW F7
-static bool read_encoder_switches(matrix_row_t current_matrix[], uint8_t current_row);
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
-
-/* matrix state(1:on, 0:off) */
-extern matrix_row_t raw_matrix[MATRIX_ROWS];  // raw values
-extern matrix_row_t matrix[MATRIX_ROWS];      // debounced values
-
 
 static void select_row(uint8_t row) {
     gpio_set_pin_output(row_pins[row]);
     gpio_write_pin_low(row_pins[row]);
 }
 
-static void unselect_row(uint8_t row) { gpio_set_pin_input_high(row_pins[row]); }
+static void unselect_row(uint8_t row) {
+    gpio_set_pin_input_high(row_pins[row]);
+}
 
 static void unselect_rows(void) {
     for (uint8_t x = 0; x < MATRIX_ROWS; x++) {
@@ -57,9 +51,9 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     // Clear data in matrix row
     current_matrix[current_row] = 0;
 
-    // Select row and wait for row selecton to stabilize
+    // Select row and wait for row selection to stabilize
     select_row(current_row);
-    wait_us(30);
+    matrix_io_delay();
 
     // For each col...
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
@@ -76,27 +70,6 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     return (last_row_value != current_matrix[current_row]);
 }
 
-
-void matrix_init_custom(void) {
-    // initialize key pins
-    gpio_set_pin_input(ENC_SW);
-    init_pins();
-}
-
-bool matrix_scan_custom(void) {
-    bool changed = false;
-
-    // Set row, read cols
-    for (uint8_t current_row = 0; current_row < MATRIX_ROWS; current_row++) {
-        changed |= read_cols_on_row(raw_matrix, current_row);
-    }
-
-    // Read encoder switches, already debounced
-    changed |= read_encoder_switches(matrix, 2);
-
-    return changed;
-}
-
 static bool read_encoder_switches(matrix_row_t current_matrix[], uint8_t current_row) {
     // Store last value of row prior to reading
     matrix_row_t last_row_value = current_matrix[current_row];
@@ -104,15 +77,28 @@ static bool read_encoder_switches(matrix_row_t current_matrix[], uint8_t current
     // Clear data in matrix row
     current_matrix[current_row] = 0;
 
-    // Debounce the encoder buttons using a shift register
-    static uint8_t btn_1_array;
-    bool           btn_1_pressed = 0;
-    btn_1_array <<= 1;
-    btn_1_array |= gpio_read_pin(ENC_SW);
-    (btn_1_array == 0b11111111) ? (btn_1_pressed = 1) : (btn_1_pressed = 0);
-
     // Populate the matrix row with the state of the encoder
-    current_matrix[current_row] |= btn_1_pressed ? (1 << 0) : 0;
+    current_matrix[current_row] |= gpio_read_pin(ENC_SW) ? (1 << 0) : 0;
 
     return (last_row_value != current_matrix[current_row]);
+}
+
+void matrix_init_custom(void) {
+    // initialize key pins
+    gpio_set_pin_input(ENC_SW);
+    init_pins();
+}
+
+bool matrix_scan_custom(matrix_row_t current_matrix[]) {
+    bool changed = false;
+
+    // Set row, read cols
+    for (uint8_t current_row = 0; current_row < MATRIX_ROWS - 1; current_row++) {
+        changed |= read_cols_on_row(current_matrix, current_row);
+    }
+
+    // Read encoder switches, already debounced
+    changed |= read_encoder_switches(current_matrix, 2);
+
+    return changed;
 }

--- a/keyboards/qvex/lynepad2/matrix.c
+++ b/keyboards/qvex/lynepad2/matrix.c
@@ -15,13 +15,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "matrix.h"
-#include "wait.h"
 
 static const pin_t row_pins[MATRIX_ROWS] = MATRIX_ROW_PINS;
 static const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
-
-extern matrix_row_t raw_matrix[MATRIX_ROWS]; // raw values
-extern matrix_row_t matrix[MATRIX_ROWS];     // debounced values
 
 static void select_row(uint8_t row) {
     gpio_set_pin_output(row_pins[row]);
@@ -59,7 +55,7 @@ static bool read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     current_matrix[current_row] = 0;
 
     select_row(current_row);
-    wait_us(30);
+    matrix_io_delay();
 
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         uint8_t pin_state = gpio_read_pin(col_pins[col_index]);
@@ -101,14 +97,14 @@ void matrix_init_custom(void) {
     init_pins();
 }
 
-bool matrix_scan_custom(void) {
+bool matrix_scan_custom(matrix_row_t current_matrix[]) {
     bool changed = false;
 
     for (uint8_t current_row = 0; current_row < MATRIX_ROWS; current_row++) {
-        changed |= read_cols_on_row(raw_matrix, current_row);
+        changed |= read_cols_on_row(current_matrix, current_row);
     }
 
-    changed |= read_encoder_switches(raw_matrix);
+    changed |= read_encoder_switches(current_matrix);
 
     return changed;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
These boards implement custom matrix lite with the incorrect signature of `bool matrix_scan_custom(void);`.

They also then manipulate the denounced matrix directly, potentially re-implementing debounce themselves.

Keyboards have been updated to correctly implement custom matrix lite, and tidy up some of the surrounding code to better align with current standards.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
