### PR TITLE
Fix JSON type for SELECT_SOFT_SERIAL_SPEED

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -196,7 +196,7 @@
 
     // Split Keyboard
     "SOFT_SERIAL_PIN": {"info_key": "split.serial.pin"},
-    "SELECT_SOFT_SERIAL_SPEED": {"info_key": "split.serial.speed"},
+    "SELECT_SOFT_SERIAL_SPEED": {"info_key": "split.serial.speed", "value_type": "int"},
     "SPLIT_HAND_MATRIX_GRID": {"info_key": "split.handedness.matrix_grid", "value_type": "array", "to_c": false},
     "SPLIT_HAND_PIN": {"info_key": "split.handedness.pin"},
     "SPLIT_USB_DETECT": {"info_key": "split.usb_detect.enabled", "value_type": "flag"},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

For the variable `SELECT_SOFT_SERIAL_SPEED`, the JSON definition in `info_config.hjson` doesn't match `keyboard.jsonschema`.

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

If I define the variable `SELECT_SOFT_SERIAL_SPEED` in my keyboard firmware, the generated JSON is invalid. The validation against `keyboard.jsonschema` will fail. I seems that `info_config.hjson` doesn't match `keyboard.jsonschema` for this case.

```text
☐ Running command: ['make', '-r', '-R', '-f', 'builddefs/build_keyboard.mk', 'KEYBOARD=epomaker/split65', 'KEYMAP=via', 'KEYBOARD_FILESAFE=epomaker_split65', 'TARGET=epomaker_split65_via', 'VERBOSE=true', 'COLOR=true', 'SILENT=false', 'QMK_BIN="qmk"']
☒ Invalid API data: epomaker/split65: split.serial.speed: '1' is not of type 'integer'
☒ Invalid API data: epomaker/split65: split.serial.speed: '1' is not of type 'integer'
```

The compile error only happened after migrating my keyboard firmware from a very old version of qmk_firmware to the most recent one.

https://github.com/qmk/qmk_firmware/blob/b01ed7d34f287995dc24cf142745cda040a42e4d/data/schemas/keyboard.jsonschema#L914-L929

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
