### PR TITLE
Remove redundant unsigned comparison in apa102_set_brightness

### DIFF
--- a/drivers/led/apa102.c
+++ b/drivers/led/apa102.c
@@ -145,8 +145,6 @@ void apa102_flush(void) {
 void apa102_set_brightness(uint8_t brightness) {
     if (brightness > APA102_MAX_BRIGHTNESS) {
         apa102_led_brightness = APA102_MAX_BRIGHTNESS;
-    } else if (brightness < 0) {
-        apa102_led_brightness = 0;
     } else {
         apa102_led_brightness = brightness;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Remove the condition that is always false for an unsigned integer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
