### PR TITLE
Use picolibc on arm devices

### DIFF
--- a/lib/python/qmk/cli/doctor/check.py
+++ b/lib/python/qmk/cli/doctor/check.py
@@ -88,16 +88,21 @@ def _check_arm_gcc_installation():
         temp_in = Path(temp_dir) / 'test.c'
         temp_out = Path(temp_dir) / 'test.elf'
 
-        temp_in.write_text('#include <newlib.h>\nint main() { return __NEWLIB__ * __NEWLIB_MINOR__ * __NEWLIB_PATCHLEVEL__; }', encoding='utf-8')
+        temp_in.write_text('#include <stdlib.h>\nint main(void) { return EXIT_SUCCESS; }', encoding='utf-8')
 
         args = ['arm-none-eabi-gcc', '-mcpu=cortex-m0', '-mthumb', '-mno-thumb-interwork', '--specs=nosys.specs', '--specs=nano.specs', '-x', 'c', '-o', str(temp_out), str(temp_in)]
         result = cli.run(args, stdout=None, stderr=None)
         if result.returncode == 0:
-            cli.log.info('Successfully compiled using arm-none-eabi-gcc')
+            cli.log.info('Successfully compiled using arm-none-eabi-gcc with newlib')
         else:
-            cli.log.error(f'Failed to compile a simple program with arm-none-eabi-gcc, return code {result.returncode}')
-            cli.log.error(f'Command: {" ".join(args)}')
-            return CheckStatus.ERROR
+            args = ['arm-none-eabi-gcc', '-x', 'c', '-o', str(temp_out), str(temp_in)]
+            result = cli.run(args, stdout=None, stderr=None)
+            if result.returncode == 0:
+                cli.log.info('Successfully compiled using arm-none-eabi-gcc with picolibc')
+            else:
+                cli.log.error(f'Failed to compile a simple program with arm-none-eabi-gcc, return code {result.returncode}')
+                cli.log.error(f'Command: {" ".join(args)}')
+                return CheckStatus.ERROR
 
         args = ['arm-none-eabi-size', str(temp_out)]
         result = cli.run(args, stdout=None, stderr=None)

--- a/platforms/chibios/syscall-fallbacks.c
+++ b/platforms/chibios/syscall-fallbacks.c
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifndef __PICOLIBC__
 /* To compile the ChibiOS syscall stubs with picolibc
  * the _reent struct has to be defined. */
 #if defined(USE_PICOLIBC)
@@ -113,3 +114,4 @@ __attribute__((weak, used)) void __cxa_pure_virtual(void) {
 }
 
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION

## Description

Check for picolibc support in the toolchain, if available use that.
Pull in a version of chibios with some small picolibc compatibility fixes.
Disable a range of syscall stubs required for newlib but not necesary with picolibc.

## Types of Changes

- [ ] Core
- [X] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation
