### PR TITLE
Remove `config_h_features` from generated `info.json`

### DIFF
--- a/lib/python/qmk/cli/info.py
+++ b/lib/python/qmk/cli/info.py
@@ -24,7 +24,6 @@ def _strip_api_content(info_json):
     info_json.pop('platform_key', None)
     info_json.pop('processor_type', None)
     info_json.pop('protocol', None)
-    info_json.pop('config_h_features', None)
     info_json.pop('keymaps', None)
     info_json.pop('keyboard_folder', None)
     info_json.pop('parse_errors', None)

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -324,9 +324,6 @@ def _extract_features(info_data, rules):
             if key in ['lto']:
                 continue
 
-            if 'config_h_features' not in info_data:
-                info_data['config_h_features'] = {}
-
             if 'features' not in info_data:
                 info_data['features'] = {}
 
@@ -334,7 +331,6 @@ def _extract_features(info_data, rules):
                 _log_warning(info_data, 'Feature %s is specified in both info.json (%s) and rules.mk (%s). The rules.mk value wins.' % (key, info_data['features'], value))
 
             info_data['features'][key] = value
-            info_data['config_h_features'][key] = value
 
     return info_data
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Unused by qmk_firmware and adjacent infrastructure. Redundant as we have the exact same content in `features`, and also poorly named as it doesnt contain anything from `config.h`.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
