### PR TITLE
rgb_matrix: add optional split EEPROM sync

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -358,6 +358,9 @@ There are a few different ways to set handedness for split keyboards (listed in 
 * `#define SPLIT_TRANSACTION_IDS_USER .....`
   * Allows for custom data sync with the slave when using the QMK-provided split transport. See [custom data sync between sides](features/split_keyboard#custom-data-sync) for more information.
 
+* `#define RGB_MATRIX_SPLIT_EEPROM_SYNC_ENABLE`
+  * For split keyboards using RGB Matrix, mirrors RGB Matrix EEPROM writes to the slave half.
+
 # The `rules.mk` File
 
 This is a [make](https://www.gnu.org/software/make/manual/make.html) file that is included by the top-level `Makefile`. It is used to set some information about the MCU that we will be compiling for as well as enabling and disabling certain features.

--- a/docs/features/rgb_matrix.md
+++ b/docs/features/rgb_matrix.md
@@ -410,6 +410,7 @@ const char* effect_name = rgb_matrix_get_mode_name(rgb_matrix_get_mode());
 #define RGB_MATRIX_DEFAULT_FLAGS LED_FLAG_ALL // Sets the default LED flags, if none has been set
 #define RGB_MATRIX_SPLIT { X, Y } // (Optional) For split keyboards, the number of LEDs connected on each half. X = left, Y = Right.
                                   // If reactive effects are enabled, you also will want to enable SPLIT_TRANSPORT_MIRROR
+#define RGB_MATRIX_SPLIT_EEPROM_SYNC_ENABLE // (Optional) On split keyboards, mirrors RGB Matrix EEPROM writes to the slave half.
 #define RGB_TRIGGER_ON_KEYDOWN      // Triggers RGB keypress events on key down. This makes RGB control feel more responsive. This may cause RGB to not function properly on some boards
 #define RGB_MATRIX_FLAG_STEPS { LED_FLAG_ALL, LED_FLAG_KEYLIGHT | LED_FLAG_MODIFIER, LED_FLAG_UNDERGLOW, LED_FLAG_NONE } // Sets the flags which can be cycled through.
 ```
@@ -417,6 +418,8 @@ const char* effect_name = rgb_matrix_get_mode_name(rgb_matrix_get_mode());
 ## EEPROM storage {#eeprom-storage}
 
 The EEPROM for it is currently shared with the LED Matrix system (it's generally assumed only one feature would be used at a time).
+
+For split keyboards, `RGB_MATRIX_SPLIT_EEPROM_SYNC_ENABLE` can be used to mirror RGB Matrix EEPROM writes to the slave half. This is disabled by default.
 
 ## Callbacks {#callbacks}
 

--- a/quantum/rgb_matrix/rgb_matrix.h
+++ b/quantum/rgb_matrix/rgb_matrix.h
@@ -176,6 +176,10 @@ void rgb_matrix_reload_from_eeprom(void);
 
 void        rgb_matrix_set_suspend_state(bool state);
 bool        rgb_matrix_get_suspend_state(void);
+#if defined(RGB_MATRIX_SPLIT) && defined(RGB_MATRIX_SPLIT_EEPROM_SYNC_ENABLE)
+bool rgb_matrix_split_should_write_eeprom(void);
+void rgb_matrix_split_clear_write_eeprom(void);
+#endif
 void        rgb_matrix_toggle(void);
 void        rgb_matrix_toggle_noeeprom(void);
 void        rgb_matrix_enable(void);

--- a/quantum/split_common/rgb_matrix_split_eeprom_sync.h
+++ b/quantum/split_common/rgb_matrix_split_eeprom_sync.h
@@ -1,0 +1,16 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <stdbool.h>
+
+static inline void rgb_matrix_split_eeprom_sync_flag_set(bool *pending_write_to_eeprom, bool write_to_eeprom) {
+    *pending_write_to_eeprom |= write_to_eeprom;
+}
+
+static inline bool rgb_matrix_split_eeprom_sync_flag_take(bool *pending_write_to_eeprom) {
+    bool write_to_eeprom = *pending_write_to_eeprom;
+    *pending_write_to_eeprom = false;
+    return write_to_eeprom;
+}

--- a/quantum/split_common/transport.h
+++ b/quantum/split_common/transport.h
@@ -92,6 +92,9 @@ typedef struct _led_matrix_sync_t {
 typedef struct _rgb_matrix_sync_t {
     rgb_config_t rgb_matrix;
     bool         rgb_suspend_state;
+#    if defined(RGB_MATRIX_SPLIT_EEPROM_SYNC_ENABLE)
+    bool         rgb_write_to_eeprom;
+#    endif
 } rgb_matrix_sync_t;
 #endif // defined(RGB_MATRIX_ENABLE) && defined(RGB_MATRIX_SPLIT)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Add in optional RGB setting persistence across halves.
This ensures that the slave also saves RGB settings in the event you switch which half of a split keyboard is the master (eg. if you switch which side is plugged into the computer).

Adds an EEPROM flag that gets synced across so the slave knows which RGB changes are supposed to be saved to EEPROM.

Tested on a hotdox76v2, so I don't know how well this works on non-AVR keyboards.

Switching RGB colors and then immediately swapping which half is plugged into the computer now keeps the settings.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
