### PR TITLE
Remove deprecated GPIO defines

### DIFF
--- a/platforms/gpio.h
+++ b/platforms/gpio.h
@@ -20,20 +20,3 @@
 #if __has_include_next("gpio.h")
 #    include_next "gpio.h" /* Include the platforms gpio.h */
 #endif
-
-// ======== DEPRECATED DEFINES - DO NOT USE ========
-
-#define setPinInput(pin) gpio_set_pin_input(pin)
-#define setPinInputHigh(pin) gpio_set_pin_input_high(pin)
-#define setPinInputLow(pin) gpio_set_pin_input_low(pin)
-#define setPinOutputPushPull(pin) gpio_set_pin_output_push_pull(pin)
-#define setPinOutputOpenDrain(pin) gpio_set_pin_output_open_drain(pin)
-#define setPinOutput(pin) gpio_set_pin_output_push_pull(pin)
-
-#define writePinHigh(pin) gpio_write_pin_high(pin)
-#define writePinLow(pin) gpio_write_pin_low(pin)
-#define writePin(pin, level) gpio_write_pin(pin, level)
-
-#define readPin(pin) gpio_read_pin(pin)
-
-#define togglePin(pin) gpio_toggle_pin(pin)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
2 years since #23085 introduced updated API. This should be enough time for these to be removed, above and beyond our deprecation policy.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
