### PR TITLE
Show how to flip semicolon and colon

### DIFF
--- a/docs/features/key_overrides.md
+++ b/docs/features/key_overrides.md
@@ -50,8 +50,7 @@ const key_override_t *key_overrides[] = {
 This second example inverts or swaps semicolon and colon on ANSI and many other layouts.  That means pressing the key alone sends `shift` + `semicolon` giving `colon` (`S(KP_SCLN)` aka `KC_COLN`), but when pressing the key with shift, the shift modifier is suppressed (see `suppressed_mods` below), sending only `semicolon` (`KC_SCLN`):
 
 ```c
-const key_override_t semicolon_colon_key_override =
-    ko_make_basic(MOD_MASK_SHIFT, KC_COLN, KC_SCLN);
+const key_override_t semicolon_colon_key_override = ko_make_basic(MOD_MASK_SHIFT, KC_COLN, KC_SCLN);
 
 // This globally defines all key overrides to be used
 const key_override_t *key_overrides[] = {


### PR DESCRIPTION
## Description

This adds a simple example swapping or inverting semicolon and colon.

The documentation didn't suggest that `ko_make_basic` was clever enough to handle `suppressed_mods` so I had spent rather a long time trying to define a key-override like this at low level.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* Question raised on Discord

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
