### PR TITLE
[RFC] Keyboard editor TUI

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -295,6 +295,24 @@ Check your environment and report problems only:
 qmk doctor -n
 ```
 
+## `qmk edit`
+
+This command opens a terminal UI for editing a keyboard's `info.json` configuration. It provides schema-aware field editing with validation, navigation into nested objects and arrays, and search.
+
+This command is directory aware. It will automatically fill in KEYBOARD if you are in a keyboard directory.
+
+**Usage**:
+
+```
+qmk edit [-kb KEYBOARD] [--no-confirm-delete]
+```
+
+**Example**:
+
+```
+$ qmk edit -kb planck/rev6
+```
+
 ## `qmk format-json`
 
 Formats a JSON file in a (mostly) human-friendly way. Will usually correctly detect the format of the JSON (info.json or keymap.json) but you can override this with `--format` if necessary.

--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -64,6 +64,7 @@ subcommands = [
     'qmk.cli.compile',
     'qmk.cli.docs',
     'qmk.cli.doctor',
+    'qmk.cli.edit',
     'qmk.cli.find',
     'qmk.cli.flash',
     'qmk.cli.format.c',

--- a/lib/python/qmk/cli/edit/README.md
+++ b/lib/python/qmk/cli/edit/README.md
@@ -1,0 +1,211 @@
+# Edit TUI Architecture
+
+```mermaid
+classDiagram
+    direction TB
+
+    %% ── Entry & Orchestration ──────────────────────────
+    class edit {
+        +edit(cli)$
+    }
+    class run_editor {
+        +run_editor(keyboard, config)$
+    }
+    class EditorController {
+        -screen
+        -state
+        -file_manager
+        -registry
+        -keymap
+        -config
+        +create_view() FieldListView
+        +set_scene(scene)
+    }
+    class EditorConfig {
+        +no_confirm_delete : bool
+    }
+
+    edit ..> run_editor
+    run_editor ..> EditorController
+    run_editor ..> SchemaLoader
+    run_editor ..> FileManager
+    run_editor ..> EditorState
+    run_editor ..> EditorConfig
+    EditorController --> FieldListView : creates
+    EditorController --> ErrorDialog : creates
+    EditorController --> ConfirmDialog : creates
+    EditorController --> HelpDialog : creates
+
+    %% ── Data Layer ─────────────────────────────────────
+    class EditorState {
+        +original_data : dict
+        +working_data : dict
+        +navigation_path : tuple
+        +is_modified : bool
+        +get(path) any
+        +set(path, value)
+        +navigate_into(key)
+        +navigate_back()
+        +insert_array_item(index, value)
+        +remove_array_item(index)
+        +move_array_item(from, to)
+        +reset()
+    }
+    class SchemaLoader {
+        +schema : dict
+        +get_properties(path) dict
+        +get_type(schema) str
+        +get_constraints(schema) dict
+        +get_enum_values(schema) list
+        +get_items_schema(path) dict
+    }
+    class FileManager {
+        +keyboard : str
+        +file_path : Path
+        +load() dict
+        +save(data)
+        +validate(data) list
+    }
+    class Keymap {
+        +DEFAULTS : dict
+        +matches(action, key_code) bool
+        +get_display(action) str
+    }
+
+    EditorState --> SchemaLoader
+
+    %% ── Widget System ──────────────────────────────────
+    class FieldWidget {
+        <<abstract>>
+        +name : str
+        +schema : dict
+        +state : EditorState
+        +path : tuple
+        +as_asciimatics_widget()* Widget
+        +get_hint() str
+        +get_display_value() str
+        +value
+    }
+    class TextField
+    class NumericField {
+        +hex_format : bool
+    }
+    class BooleanField
+    class EnumField
+    class ObjectRow {
+        +set_on_navigate(callback)
+    }
+    class ArrayRow {
+        +set_on_navigate(callback)
+    }
+    class ArrayItemRow {
+        +index : int
+        +set_on_navigate(callback)
+    }
+
+    FieldWidget <|-- TextField
+    FieldWidget <|-- NumericField
+    FieldWidget <|-- BooleanField
+    FieldWidget <|-- EnumField
+    FieldWidget <|-- ObjectRow
+    FieldWidget <|-- ArrayRow
+    FieldWidget <|-- ArrayItemRow
+    ArrayItemRow o-- NumericField : delegates
+    ArrayItemRow o-- TextField : delegates
+
+    class WidgetRegistry {
+        +register_type_default(type, factory)
+        +register_path_override(path, factory)
+        +register_pattern_override(pattern, factory)
+        +create_widget(name, schema, state, path) FieldWidget
+    }
+    WidgetRegistry ..> FieldWidget : creates
+
+    %% ── View Layer ─────────────────────────────────────
+    class FieldListView {
+        +process_event(event)
+        +update(frame_no)
+        +show_status(message)
+    }
+    class ErrorDialog
+    class ConfirmDialog
+    class HelpDialog
+    class DeleteConfirmDialog
+
+    %% ── View Collaborators ─────────────────────────────
+    class ViewContext {
+        +state : EditorState
+        +keyboard : str
+        +keymap : Keymap
+        +registry : WidgetRegistry
+        +config : EditorConfig
+    }
+    class ViewCallbacks {
+        +rebuild
+        +show_status
+        +focus : FocusManager
+        +on_quit
+        +on_save
+    }
+    class UIBuilder {
+        +build(frame, on_navigate, on_add, status)
+        +build_breadcrumb() str
+    }
+    class EventRouter {
+        +route(event, view)
+    }
+    class FocusManager {
+        +focused_field_name() str
+        +focused_array_index() int
+        +focus_on_field_by_name(name)
+    }
+    class SearchController {
+        +is_active : bool
+        +search_term : str
+        +activate(field_name)
+        +deactivate()
+        +matches(name) bool
+    }
+    class ArrayController {
+        +add_item(index)
+        +delete_item(index)
+        +move_item_up(index)
+        +move_item_down(index)
+    }
+    class StatusDisplay {
+        +show(message, duration)
+        +get_footer_text() str
+    }
+    class FrameHelper {
+        +clear_layouts()
+        +find_fill_frame_layout() Layout
+    }
+    class ItemScaffolder {
+        +scaffold(schema) any
+        +default_value_for_type(type) any
+    }
+    class ConstraintFormatter {
+        +format_hint(constraints, enums)$ str
+    }
+
+    FieldListView *-- ViewContext
+    FieldListView *-- ViewCallbacks
+    FieldListView *-- UIBuilder
+    FieldListView *-- EventRouter
+    FieldListView *-- FocusManager
+    FieldListView *-- SearchController
+    FieldListView *-- ArrayController
+    FieldListView *-- StatusDisplay
+    FieldListView *-- FrameHelper
+    FieldListView *-- ItemScaffolder
+    FieldListView ..> DeleteConfirmDialog : creates
+
+    EventRouter --> SearchController
+    EventRouter --> ArrayController
+    EventRouter --> FocusManager
+    UIBuilder --> SearchController
+    UIBuilder --> WidgetRegistry
+    ArrayController --> ItemScaffolder
+    StatusDisplay --> FrameHelper
+    FieldWidget ..> ConstraintFormatter
+```

--- a/lib/python/qmk/cli/edit/__init__.py
+++ b/lib/python/qmk/cli/edit/__init__.py
@@ -1,1 +1,22 @@
-"""Keyboard editor TUI — data and schema layer."""
+"""QMK Edit
+
+Edit keyboard info.json files in a TUI.
+"""
+from milc import cli
+
+from qmk.decorators import automagic_keyboard
+from qmk.keyboard import keyboard_folder, keyboard_completer
+from qmk.cli.edit.editor import run_editor
+from qmk.cli.edit.config import EditorConfig
+
+
+@cli.argument('--no-confirm-delete', action='store_true', help='Skip confirmation prompts when deleting array items')
+@cli.argument('-kb', '--keyboard', type=keyboard_folder, completer=keyboard_completer, required=True, help='Keyboard to edit')
+@cli.subcommand('Edit keyboard configuration in a TUI.')
+@automagic_keyboard
+def edit(cli):
+    """Launch the keyboard configuration editor.
+    """
+    keyboard = cli.config.edit.keyboard
+    config = EditorConfig(no_confirm_delete=getattr(cli.config.edit, 'no_confirm_delete', False))
+    return run_editor(keyboard, config)

--- a/lib/python/qmk/cli/edit/__init__.py
+++ b/lib/python/qmk/cli/edit/__init__.py
@@ -1,0 +1,1 @@
+"""Keyboard editor TUI — data and schema layer."""

--- a/lib/python/qmk/cli/edit/config.py
+++ b/lib/python/qmk/cli/edit/config.py
@@ -1,0 +1,25 @@
+"""Runtime configuration from CLI flags.
+
+This module provides the EditorConfig class, which encapsulates
+runtime configuration options derived from CLI flags. It allows
+behavioral configuration of the keyboard editor without using
+global state.
+"""
+
+
+class EditorConfig:
+    """Runtime configuration from CLI flags.
+
+    Holds configuration options that affect editor behavior,
+    such as whether to skip confirmation dialogs. This allows
+    the editor to be configured at runtime based on user preferences
+    passed via command-line flags.
+    """
+    def __init__(self, no_confirm_delete=False):
+        """Initialize with CLI flag values.
+
+        Args:
+            no_confirm_delete
+                If True, skip delete confirmation dialogs.
+        """
+        self.no_confirm_delete = no_confirm_delete

--- a/lib/python/qmk/cli/edit/constraint_formatter.py
+++ b/lib/python/qmk/cli/edit/constraint_formatter.py
@@ -1,0 +1,112 @@
+"""Constraint hint formatting for field validation display.
+
+Pure function module that converts schema constraints and enum
+values into human-readable hint strings. No framework dependencies.
+"""
+
+# Known regex patterns mapped to friendly labels.
+PATTERN_LABELS = {
+    '^0x[0-9A-F]{4}$': 'format: 0xNNNN',
+    '^0x[0-9A-F]{2}$': 'format: 0xNN',
+    '^[A-K]\\d{1,2}$': 'pin: A0-K99',
+    '^GP\\d{1,2}$': 'pin: GP0-GP99',
+    '^LINE_PIN\\d{1,2}$': 'pin: LINE_PIN0-99',
+    '^[0-9]{1,2}\\.[0-9]\\.[0-9]$': 'version: N.N.N',
+    '^[a-z][a-z0-9_]*$': 'snake_case',
+    '^[0-9a-z_]*$': 'lowercase alphanumeric',
+}
+
+# Enum values beyond this count are truncated with a total suffix.
+MAX_ENUM_DISPLAY = 5
+
+
+def format_hint(constraints, enum_values=None):
+    """Return constraint hint string, or None if no constraints.
+
+    Args:
+        constraints
+            Dict with optional keys: minimum, maximum, minLength,
+            maxLength, pattern. From SchemaLoader.get_constraints().
+
+        enum_values
+            List of allowed values, or None. From
+            SchemaLoader.get_enum_values().
+
+    Returns:
+        Hint string like '0-255' or 'one of: a, b, c', or None.
+    """
+    # Enum values take priority -- return immediately if present.
+    if enum_values:
+        return _format_enum(enum_values)
+
+    parts = []
+
+    # Integer range constraints
+    _append_range(parts, constraints, 'minimum', 'maximum', '')
+
+    # String length constraints
+    _append_range(parts, constraints, 'minLength', 'maxLength', ' chars')
+
+    # Pattern constraint
+    pattern = constraints.get('pattern')
+    if pattern is not None:
+        label = PATTERN_LABELS.get(pattern, 'pattern: %s' % pattern)
+        parts.append(label)
+
+    if not parts:
+        return None
+
+    return ', '.join(parts)
+
+
+def _format_enum(values):
+    """Format an enum value list as a hint string.
+
+    Truncates to MAX_ENUM_DISPLAY values, appending a total count
+    suffix when the full list is longer.
+
+    Args:
+        values
+            List of allowed values (may be non-string).
+
+    Returns:
+        Hint string like 'one of: a, b, c'.
+    """
+    str_values = [str(v) for v in values]
+    if len(str_values) <= MAX_ENUM_DISPLAY:
+        return 'one of: %s' % ', '.join(str_values)
+
+    truncated = ', '.join(str_values[:MAX_ENUM_DISPLAY])
+    return 'one of: %s, ... (%d total)' % (truncated, len(str_values))
+
+
+def _append_range(parts, constraints, min_key, max_key, suffix):
+    """Append a range or bound hint to parts if present.
+
+    Handles three cases: both min+max, min only, max only.
+
+    Args:
+        parts
+            List to append hint string to.
+
+        constraints
+            Dict of constraint key/value pairs.
+
+        min_key
+            Key name for the minimum bound (e.g. 'minimum', 'minLength').
+
+        max_key
+            Key name for the maximum bound (e.g. 'maximum', 'maxLength').
+
+        suffix
+            Unit suffix appended after the value (e.g. ' chars', '').
+    """
+    min_val = constraints.get(min_key)
+    max_val = constraints.get(max_key)
+
+    if min_val is not None and max_val is not None:
+        parts.append('%s-%s%s' % (min_val, max_val, suffix))
+    elif min_val is not None:
+        parts.append('>= %s%s' % (min_val, suffix))
+    elif max_val is not None:
+        parts.append('<= %s%s' % (max_val, suffix))

--- a/lib/python/qmk/cli/edit/editor.py
+++ b/lib/python/qmk/cli/edit/editor.py
@@ -1,0 +1,332 @@
+"""Main editor orchestration and TUI.
+"""
+# TODO(unassigned): Write integration tests for editor controller once testing infrastructure supports headless asciimatics testing
+
+import contextlib
+import copy
+import curses
+import json
+import os
+import sys
+import traceback
+
+import hjson
+
+from asciimatics.scene import Scene
+from asciimatics.screen import Screen
+from asciimatics.exceptions import ResizeScreenError, StopApplication
+
+from milc import cli
+
+from qmk.cli.edit.schema_loader import SchemaLoader
+from qmk.cli.edit.file_manager import FileManager
+from qmk.cli.edit.state import EditorState
+from qmk.cli.edit.widgets import create_default_registry
+from qmk.cli.edit.keymap import Keymap
+from qmk.cli.edit.config import EditorConfig
+from jsonschema.exceptions import SchemaError
+
+from qmk.cli.edit.views import FieldListView, ErrorDialog, ConfirmDialog, HelpDialog
+
+
+class EditorController:
+    """Controller managing editor state and view transitions.
+    """
+    def __init__(self, screen, state, keyboard, registry, file_manager, keymap=None, config=None):
+        """Initialize the editor controller.
+
+        Args:
+            screen
+                Asciimatics Screen instance.
+            state
+                EditorState instance.
+            keyboard
+                Keyboard name.
+            registry
+                WidgetRegistry instance.
+            file_manager
+                FileManager instance.
+            keymap
+                Keymap instance, or None for default.
+            config
+                EditorConfig instance, or None for defaults.
+        """
+        self._screen = screen
+        self._state = state
+        self._keyboard = keyboard
+        self._registry = registry
+        self._file_manager = file_manager
+        self._keymap = keymap if keymap is not None else Keymap()
+        self._config = config if config is not None else EditorConfig()
+        self._current_view = None
+        self._scene = None
+
+    def create_view(self):
+        """Create the current view based on editor state.
+
+        Returns:
+            FieldListView instance configured for current state.
+        """
+        view = FieldListView(
+            self._screen,
+            self._state,
+            self._keyboard,
+            self._registry,
+            self._keymap,
+            self._config,
+            on_quit=lambda: self._handle_quit(view),
+            on_save=lambda: self._handle_save(view),
+            on_validate=lambda: self._handle_validate(view),
+            on_help=lambda: self._handle_help(view),
+        )
+        self._current_view = view
+        return view
+
+    def set_scene(self, scene):
+        """Store reference to the running scene for dialog overlays.
+
+        Args:
+            scene
+                The Scene instance containing the main view.
+        """
+        self._scene = scene
+
+    def _perform_save(self, view):
+        """Perform save operation with validation.
+
+        Args:
+            view
+                Current FieldListView instance.
+
+        Returns:
+            True if save succeeded, False otherwise.
+        """
+        errors = self._file_manager.validate(self._state.working_data)
+        if errors:
+            self._show_error_dialog(errors)
+            return False
+
+        try:
+            self._file_manager.save(self._state.working_data)
+            cli.log.info('{fg_green}Saved to:{style_reset_all} %s', self._file_manager.file_path)
+            self._state.original_data = copy.deepcopy(self._state.working_data)
+            view.show_status("Saved successfully")
+            return True
+        except PermissionError:
+            error_msg = 'Permission denied. Check file permissions for: %s' % self._file_manager.file_path
+            self._show_error_dialog([{'path': str(self._file_manager.file_path), 'message': error_msg}])
+            return False
+        except OSError as e:
+            error_msg = 'Failed to save file. %s' % str(e)
+            self._show_error_dialog([{'path': str(self._file_manager.file_path), 'message': error_msg}])
+            return False
+
+    def _handle_save(self, view):
+        """Handle save action with validation.
+
+        Args:
+            view
+                Current FieldListView instance.
+        """
+        self._perform_save(view)
+
+    def _handle_quit(self, view):
+        """Handle quit action with unsaved changes check.
+
+        Args:
+            view
+                Current FieldListView instance.
+        """
+        if not self._state.is_modified:
+            raise StopApplication("User quit")
+
+        self._show_confirm_dialog(view)
+
+    def _handle_validate(self, view):
+        """Validate working data and show results.
+
+        Args:
+            view
+                Current FieldListView instance.
+        """
+        try:
+            errors = self._file_manager.validate(self._state.working_data)
+        except SchemaError as e:
+            self._show_error_dialog([{'path': 'Schema', 'message': str(e)}])
+            return
+
+        if errors:
+            self._show_error_dialog(errors)
+        else:
+            view.show_status("No errors found")
+
+    def _handle_help(self, view):
+        """Show keybinding help dialog.
+
+        Args:
+            view
+                Current FieldListView instance.
+        """
+        dialog = HelpDialog(self._screen, self._keymap)
+        self._scene.add_effect(dialog)
+
+    def _on_confirm_close(self, view, action):
+        """Handle confirm dialog result.
+
+        Args:
+            view
+                Current FieldListView instance.
+            action
+                Action string: 'save', 'discard', or 'cancel'.
+        """
+        if action == 'cancel':
+            return
+
+        if action == 'save':
+            if not self._perform_save(view):
+                return
+
+        raise StopApplication("User quit")
+
+    def _show_error_dialog(self, errors):
+        """Show error dialog as overlay on current scene.
+
+        Args:
+            errors
+                List of error dicts with 'path' and 'message' keys.
+        """
+        dialog = ErrorDialog(self._screen, errors)
+        self._scene.add_effect(dialog)
+
+    def _show_confirm_dialog(self, view):
+        """Show confirm dialog as overlay on current scene.
+
+        Args:
+            view
+                Current FieldListView instance.
+        """
+        def on_close(action):
+            self._on_confirm_close(view, action)
+
+        dialog = ConfirmDialog(self._screen, on_close)
+        self._scene.add_effect(dialog)
+
+
+def _validate_screen_size(screen):
+    """Check if terminal is large enough for the editor.
+
+    Args:
+        screen
+            Asciimatics Screen instance.
+
+    Raises:
+        StopApplication
+            If terminal is smaller than 80x24.
+    """
+    if screen.width < 80 or screen.height < 24:
+        cli.log.error('{fg_red}Terminal too small{style_reset_all}')
+        cli.log.error('The editor requires at least 80x24 characters.')
+        cli.log.error('Current size: %dx%d', screen.width, screen.height)
+        cli.log.error('Please resize your terminal and try again.')
+        raise StopApplication("Terminal too small")
+
+
+def _init_editor_components(keyboard):
+    """Initialize all editor components.
+
+    Args:
+        keyboard
+            Keyboard name like 'handwired/pytest/basic'.
+
+    Returns:
+        Tuple of (schema_loader, file_manager, state, registry, keymap).
+    """
+    schema_loader = SchemaLoader()
+    file_manager = FileManager(keyboard, schema_store=schema_loader.schema_store)
+    data = file_manager.load()
+    state = EditorState(data, schema_loader)
+    registry = create_default_registry()
+    keymap = Keymap()
+    return schema_loader, file_manager, state, registry, keymap
+
+
+def _run_screen_loop(run_screen):
+    """Run the screen loop, handling resize and stop events.
+
+    Args:
+        run_screen
+            Callable(screen, scene) that sets up and plays the screen.
+
+    Returns:
+        0 on success, 1 on terminal-too-small error.
+    """
+    last_scene = None
+    while True:
+        try:
+            Screen.wrapper(run_screen, catch_interrupt=True, arguments=[last_scene])
+            return 0
+        except ResizeScreenError as e:
+            last_scene = e.scene
+        except StopApplication as e:
+            if "Terminal too small" in str(e):
+                return 1
+            return 0
+
+
+@contextlib.contextmanager
+def _bypass_milc_streams():
+    """Temporarily replace sys.stdout/sys.stderr with the raw interpreter streams.
+
+    MILC wraps sys.stdout and sys.stderr with its own logging-aware
+    objects.  The curses-based TUI needs the real file descriptors, so
+    this context manager swaps in sys.__stdout__ / sys.__stderr__ for
+    the duration of the block and restores the MILC wrappers on exit.
+    """
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+    try:
+        yield
+    finally:
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+
+
+def run_editor(keyboard, config=None):
+    """Run the keyboard editor TUI.
+
+    Args:
+        keyboard
+            Keyboard name like 'handwired/pytest/basic'.
+        config
+            EditorConfig instance, or None for defaults.
+
+    Returns:
+        0 on success, 1 on error.
+    """
+    if config is None:
+        config = EditorConfig()
+
+    with _bypass_milc_streams():
+        os.environ.setdefault('ESCDELAY', '25')
+        curses.set_escdelay(25)
+
+        try:
+            _, file_manager, state, registry, keymap = _init_editor_components(keyboard)
+
+            def run_screen(screen, scene):
+                _validate_screen_size(screen)
+                controller = EditorController(screen, state, keyboard, registry, file_manager, keymap, config)
+                view = controller.create_view()
+                main_scene = Scene([view], -1)
+                controller.set_scene(main_scene)
+                screen.play([main_scene], stop_on_resize=True)
+
+            return _run_screen_loop(run_screen)
+
+        except StopApplication:
+            return 0
+        except (OSError, SchemaError, hjson.HjsonDecodeError, json.JSONDecodeError) as e:
+            cli.log.error('Error running editor:\n%s', traceback.format_exc())
+            return 1

--- a/lib/python/qmk/cli/edit/file_manager.py
+++ b/lib/python/qmk/cli/edit/file_manager.py
@@ -1,0 +1,112 @@
+"""File manager for keyboard JSON files.
+"""
+
+import json
+
+import referencing
+import referencing.jsonschema
+from jsonschema import Draft202012Validator
+
+import qmk.path
+from qmk.json_encoders import InfoJSONEncoder
+from qmk.json_schema import compile_schema_store, json_load
+
+
+class FileManager:
+    """Handles loading and saving keyboard JSON files."""
+    def __init__(self, keyboard, schema_store=None):
+        """Initialize with keyboard name/path.
+
+        Args:
+            keyboard
+                Keyboard name like 'handwired/pytest/basic'.
+
+            schema_store
+                Pre-compiled schema store dict (schema_id -> schema_dict).
+                If None, compiles via compile_schema_store() as fallback.
+        """
+        self.keyboard = keyboard
+        self._file_path = None
+
+        if schema_store is None:
+            schema_store = compile_schema_store()
+        self._validator = self._build_validator(schema_store)
+
+    def _build_validator(self, schema_store):
+        """Build a Draft202012Validator from a schema store.
+
+        Args:
+            schema_store
+                Dict mapping schema_id to schema_dict.
+
+        Returns:
+            A Draft202012Validator for the qmk.keyboard.v1 schema.
+        """
+        keyboard_schema = schema_store["qmk.keyboard.v1"]
+        resources = [(schema_id, referencing.Resource.from_contents(
+            schema,
+            default_specification=referencing.jsonschema.DRAFT202012,
+        )) for schema_id, schema in schema_store.items()]
+        registry = referencing.Registry().with_resources(resources)
+        return Draft202012Validator(keyboard_schema, registry=registry)
+
+    @property
+    def file_path(self):
+        """Return Path to the keyboard's keyboard.json or info.json."""
+        if self._file_path:
+            return self._file_path
+
+        keyboard_dir = qmk.path.keyboard(self.keyboard)
+        keyboard_json = keyboard_dir / "keyboard.json"
+        info_json = keyboard_dir / "info.json"
+
+        if keyboard_json.exists():
+            self._file_path = keyboard_json
+        elif info_json.exists():
+            self._file_path = info_json
+        else:
+            self._file_path = keyboard_json
+
+        return self._file_path
+
+    def load(self):
+        """Load and return JSON data using hjson.
+
+        Returns:
+            Dictionary of keyboard data, or empty dict if file doesn't exist.
+        """
+        if not self.file_path.exists():
+            return {}
+
+        return json_load(self.file_path)
+
+    def save(self, data):
+        """Save data using InfoJSONEncoder format.
+
+        Args:
+            data
+                Dictionary of keyboard data to save.
+        """
+        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(self.file_path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data, cls=InfoJSONEncoder, sort_keys=False))
+            f.write("\n")
+
+    def validate(self, data):
+        """Validate data against keyboard schema.
+
+        Args:
+            data
+                Dictionary of keyboard data to validate.
+
+        Returns:
+            List of error dicts: [{'path': '...', 'message': '...'}, ...].
+            Empty list if valid.
+        """
+        errors = []
+        for error in self._validator.iter_errors(data):
+            path = ".".join(str(p) for p in error.absolute_path)
+            errors.append({"path": path if path else "<root>", "message": error.message})
+
+        return errors

--- a/lib/python/qmk/cli/edit/keymap.py
+++ b/lib/python/qmk/cli/edit/keymap.py
@@ -1,0 +1,103 @@
+"""Configurable keybinding mapping for editor navigation."""
+
+from asciimatics.screen import Screen
+
+_CTRL_SLASH = 31  # Ctrl+/ sends 0x1F in most terminals
+
+_KEY_NAMES = {
+    Screen.KEY_UP: "up",
+    Screen.KEY_DOWN: "down",
+    Screen.KEY_DELETE: "Delete",
+    Screen.KEY_ESCAPE: "Esc",
+    ord("\n"): "Enter",
+    ord("\r"): "Enter",
+    ord(" "): "Space",
+    Screen.ctrl(Screen.KEY_UP): "Ctrl+up",
+    Screen.ctrl(Screen.KEY_DOWN): "Ctrl+down",
+    _CTRL_SLASH: "Ctrl+/",
+}
+
+
+class Keymap:
+    """Configurable keybinding mapping for the TUI editor."""
+
+    DEFAULTS = {
+        "navigate_up": [Screen.KEY_UP],
+        "navigate_down": [Screen.KEY_DOWN],
+        "select": [ord("\n"), ord("\r")],
+        "back": [Screen.KEY_ESCAPE],
+        "search": [ord("/")],
+        "save": [Screen.ctrl("s")],
+        "quit": [ord("q")],
+        "help": [_CTRL_SLASH],
+        "validate": [Screen.ctrl("e")],
+        "add_item": [Screen.ctrl("a")],
+        "delete_item": [Screen.ctrl("d"), Screen.KEY_DELETE],
+        "move_up": [Screen.ctrl("p")],
+        "move_down": [Screen.ctrl("n")],
+    }
+
+    def __init__(self, overrides=None):
+        """Initialize with optional overrides.
+
+        Args:
+            overrides
+                Dictionary mapping action names to key code lists.
+        """
+        self._bindings = dict(self.DEFAULTS)
+        if overrides:
+            self._bindings.update(overrides)
+
+    def matches(self, action, key_code):
+        """Return True if key_code matches the action's binding.
+
+        Args:
+            action
+                Action name like 'save' or 'quit'.
+            key_code
+                Integer key code from keyboard event.
+
+        Returns:
+            True if key_code is bound to the action.
+        """
+        if action not in self._bindings:
+            return False
+
+        return key_code in self._bindings[action]
+
+    def get_display(self, action):
+        """Return human-readable string for action's primary key.
+
+        Args:
+            action
+                Action name like 'save' or 'quit'.
+
+        Returns:
+            String representation of the primary key binding.
+        """
+        if action not in self._bindings or not self._bindings[action]:
+            return ""
+
+        primary_key = self._bindings[action][0]
+        return self._format_key(primary_key)
+
+    def _format_key(self, key_code):
+        """Format a key code as human-readable string.
+
+        Args:
+            key_code
+                Integer key code.
+
+        Returns:
+            Human-readable string like 'Ctrl+S' or 'Enter'.
+        """
+        if key_code in _KEY_NAMES:
+            return _KEY_NAMES[key_code]
+
+        if 1 <= key_code <= 26:
+            return "Ctrl+%s" % chr(ord("a") + key_code - 1).upper()
+
+        if 32 <= key_code <= 126:
+            return chr(key_code)
+
+        return "?"

--- a/lib/python/qmk/cli/edit/schema_loader.py
+++ b/lib/python/qmk/cli/edit/schema_loader.py
@@ -1,0 +1,272 @@
+"""Schema loader for keyboard.jsonschema.
+"""
+from qmk.json_schema import load_jsonschema, compile_schema_store
+
+
+class SchemaLoader:
+    """Loads and navigates keyboard.jsonschema with $ref resolution.
+    """
+    def __init__(self):
+        """Load schema from data/schemas/keyboard.jsonschema.
+        """
+        self.schema = load_jsonschema('keyboard')
+        self.schema_store = compile_schema_store()
+
+    def get_properties(self, path=None):
+        """Return dict of property_name -> property_schema at path.
+
+        Args:
+            path
+                Tuple of keys like ('usb',) or None for root.
+
+        Returns:
+            Dictionary of property definitions.
+        """
+        schema_fragment = self._get_schema_fragment(path)
+        schema_fragment = self._resolve_ref(schema_fragment)
+
+        return schema_fragment.get('properties', {})
+
+    def get_property_order(self, path=None):
+        """Return list of property names in schema definition order.
+
+        Args:
+            path
+                Tuple of keys like ('usb',) or None for root.
+
+        Returns:
+            List of property names in order.
+        """
+        properties = self.get_properties(path)
+        return list(properties.keys())
+
+    def get_type(self, property_schema):
+        """Return normalized type for a property schema.
+
+        Args:
+            property_schema
+                Property schema fragment.
+
+        Returns:
+            One of: 'string', 'boolean', 'integer', 'number', 'enum', 'array', 'object'.
+        """
+        property_schema = self._resolve_ref(property_schema)
+
+        if 'enum' in property_schema:
+            return 'enum'
+
+        type_value = property_schema.get('type')
+        if type_value:
+            return type_value
+
+        return 'string'
+
+    def get_enum_values(self, property_schema):
+        """Return list of allowed values for enum types.
+
+        Args:
+            property_schema
+                Property schema fragment.
+
+        Returns:
+            List of enum values, or None if not an enum.
+        """
+        property_schema = self._resolve_ref(property_schema)
+        return property_schema.get('enum')
+
+    def get_constraints(self, property_schema):
+        """Return dict of constraints for a property.
+
+        Args:
+            property_schema
+                Property schema fragment.
+
+        Returns:
+            Dictionary containing constraints like minimum, maximum, pattern, etc.
+        """
+        property_schema = self._resolve_ref(property_schema)
+
+        constraints = {}
+        for key in ['minimum', 'maximum', 'minLength', 'maxLength', 'pattern']:
+            if key in property_schema:
+                constraints[key] = property_schema[key]
+
+        return constraints
+
+    def is_array_at_path(self, path):
+        """Check if the schema at path defines an array type.
+
+        Args:
+            path
+                Tuple of keys like ('backlight', 'pins') or None for root.
+
+        Returns:
+            True if schema at path is an array type, False otherwise.
+        """
+        schema_fragment = self._get_schema_fragment(path)
+        schema_fragment = self._resolve_ref(schema_fragment)
+        return schema_fragment.get('type') == 'array'
+
+    def get_items_schema(self, path=None):
+        """Return schema for items in an array.
+
+        Args:
+            path
+                Tuple of keys like ('matrix_pins', 'cols') or None for root.
+
+        Returns:
+            Items schema with $ref resolved, or None if not an array.
+        """
+        schema_fragment = self._get_schema_fragment(path)
+        schema_fragment = self._resolve_ref(schema_fragment)
+
+        if schema_fragment.get('type') != 'array':
+            return None
+
+        items_schema = schema_fragment.get('items')
+        if items_schema is None:
+            return None
+
+        # Resolve the items schema. If it has a $ref that points to definitions,
+        # we need to resolve it in the context of the base schema it came from
+        resolved_items = self._resolve_ref(items_schema)
+
+        # If resolution failed (empty dict), try resolving in definitions schema
+        if not resolved_items and isinstance(items_schema, dict) and '$ref' in items_schema:
+            ref = items_schema['$ref']
+            if ref.startswith('#/'):
+                defs_schema = load_jsonschema('definitions')
+                resolved_items = self._resolve_json_pointer(defs_schema, ref[1:])
+
+        return resolved_items
+
+    def get_required_fields(self, property_schema):
+        """Return list of required fields from a schema.
+
+        Args:
+            property_schema
+                Property schema fragment.
+
+        Returns:
+            List of required field names, or empty list if none.
+        """
+        if not isinstance(property_schema, dict):
+            return []
+
+        return property_schema.get('required', [])
+
+    def _get_schema_fragment(self, path):
+        """Navigate to a schema fragment at the given path.
+
+        Args:
+            path
+                Tuple of keys or None for root.
+
+        Returns:
+            Schema fragment at the path.
+        """
+        if not path:
+            return self.schema
+
+        fragment = self.schema
+        for key in path:
+            fragment = self._resolve_ref(fragment)
+
+            if isinstance(key, int):
+                if fragment.get('type') == 'array' and 'items' in fragment:
+                    fragment = fragment['items']
+                else:
+                    return {}
+            else:
+                properties = fragment.get('properties', {})
+                if key not in properties:
+                    return {}
+                fragment = properties[key]
+
+        return fragment
+
+    def _resolve_relative_ref(self, ref, seen=None):
+        """Resolve a relative $ref starting with './'.
+
+        Args:
+            ref
+                $ref string starting with './'.
+            seen
+                Set of already-visited $ref strings for cycle detection.
+
+        Returns:
+            Resolved schema fragment.
+        """
+        schema_name = ref.split('#')[0].replace('./', '').replace('.jsonschema', '')
+
+        if '#' not in ref:
+            return load_jsonschema(schema_name)
+
+        json_path = ref.split('#')[1]
+        base_schema = load_jsonschema(schema_name) if schema_name else self.schema
+        return self._resolve_json_pointer(base_schema, json_path, seen=seen)
+
+    def _resolve_ref(self, schema_fragment, seen=None):
+        """Resolve $ref references in a schema fragment.
+
+        Args:
+            schema_fragment
+                Schema fragment that may contain $ref.
+            seen
+                Set of already-visited $ref strings for cycle detection.
+
+        Returns:
+            Resolved schema fragment, or {} if a circular $ref is detected.
+        """
+        if not isinstance(schema_fragment, dict):
+            return schema_fragment
+
+        if '$ref' not in schema_fragment:
+            return schema_fragment
+
+        ref = schema_fragment['$ref']
+
+        if seen is None:
+            seen = set()
+        if ref in seen:
+            return {}
+        seen.add(ref)
+
+        if ref.startswith('./'):
+            return self._resolve_relative_ref(ref, seen=seen)
+
+        if ref.startswith('#/'):
+            return self._resolve_json_pointer(self.schema, ref[1:], seen=seen)
+
+        if ref in self.schema_store:
+            return self.schema_store[ref]
+
+        return schema_fragment
+
+    def _resolve_json_pointer(self, schema, pointer, seen=None):
+        """Resolve a JSON pointer path like /definitions/encoder_config.
+
+        Args:
+            schema
+                Base schema to resolve from.
+            pointer
+                JSON pointer path.
+            seen
+                Set of already-visited $ref strings for cycle detection.
+
+        Returns:
+            Resolved schema fragment.
+        """
+        if not pointer.startswith('/'):
+            return schema
+
+        parts = pointer[1:].split('/')
+        fragment = schema
+
+        for part in parts:
+            if isinstance(fragment, dict) and part in fragment:
+                fragment = fragment[part]
+            else:
+                return {}
+
+        return self._resolve_ref(fragment, seen=seen)

--- a/lib/python/qmk/cli/edit/state.py
+++ b/lib/python/qmk/cli/edit/state.py
@@ -1,0 +1,338 @@
+"""Editor state management.
+"""
+import copy
+
+
+class EditorState:
+    """Manages editor data and navigation state.
+
+    Paths are tuples of string keys and int indices, e.g. ('usb', 'vid')
+    or ('encoder', 'rotary', 0).
+    """
+    def __init__(self, original_data, schema_loader):
+        """Initialize with loaded JSON and parsed schema.
+
+        Args:
+            original_data
+                Original keyboard data dictionary.
+            schema_loader
+                SchemaLoader instance.
+        """
+        self.original_data = copy.deepcopy(original_data)
+        self.working_data = copy.deepcopy(original_data)
+        self.schema_loader = schema_loader
+        self.navigation_path = ()
+
+    @property
+    def is_modified(self):
+        """Return True if working_data differs from original_data.
+        """
+        return self.working_data != self.original_data
+
+    @property
+    def current_path(self):
+        """Return current navigation path as tuple.
+        """
+        return self.navigation_path
+
+    def get(self, path):
+        """Get value at path from working_data.
+
+        Args:
+            path
+                Tuple of keys and int indices, e.g. ('usb', 'vid').
+
+        Returns:
+            Value at path, or None if not found.
+        """
+        if not path:
+            return None
+
+        value = self.working_data
+        for key in path:
+            if isinstance(value, dict) and key in value:
+                value = value[key]
+            elif isinstance(value, list) and isinstance(key, int):
+                if 0 <= key < len(value):
+                    value = value[key]
+                else:
+                    return None
+            else:
+                return None
+
+        return value
+
+    def _traverse_parent(self, path_tuple):
+        """Read-only traversal to the parent of the target key.
+
+        Does not create intermediate dicts. Returns None if any
+        intermediate key is missing or out of range.
+
+        Args:
+            path_tuple
+                Tuple of path segments. The last element is the target key.
+
+        Returns:
+            The parent container, or None if the path is invalid.
+        """
+        target = self.working_data
+        for key in path_tuple[:-1]:
+            if isinstance(target, dict) and key in target:
+                target = target[key]
+            elif isinstance(target, list) and isinstance(key, int):
+                if 0 <= key < len(target):
+                    target = target[key]
+                else:
+                    return None
+            else:
+                return None
+        return target
+
+    def _traverse_or_create_parent(self, path_tuple):
+        """Creating traversal to the parent of the target key.
+
+        Creates intermediate dicts for missing dict keys. Returns None
+        if a list index is out of range.
+
+        Args:
+            path_tuple
+                Tuple of path segments. The last element is the target key.
+
+        Returns:
+            The parent container, or None if the path is invalid.
+        """
+        target = self.working_data
+        for key in path_tuple[:-1]:
+            if isinstance(target, dict):
+                if key not in target:
+                    target[key] = {}
+                target = target[key]
+            elif isinstance(target, list) and isinstance(key, int):
+                if 0 <= key < len(target):
+                    target = target[key]
+                else:
+                    return None
+            else:
+                return None
+        return target
+
+    def _set_at_target(self, target, last_key, value):
+        """Assign value into target container at last_key.
+
+        Args:
+            target
+                Dict or list to assign into.
+            last_key
+                String key for dicts or int index for lists.
+            value
+                Value to assign, or None to delete a dict key.
+
+        Raises:
+            ValueError
+                When attempting to set None for array element.
+        """
+        if isinstance(target, dict):
+            if value is None:
+                if last_key in target:
+                    del target[last_key]
+            else:
+                target[last_key] = value
+        elif isinstance(target, list) and isinstance(last_key, int):
+            if 0 <= last_key < len(target):
+                if value is None:
+                    raise ValueError('Cannot set array element to None. Use remove_array_item instead.')
+                target[last_key] = value
+
+    def set(self, path, value):
+        """Set value at path in working_data.
+
+        Use value=None to unset/remove a field (dict keys only).
+
+        Args:
+            path
+                Tuple of keys and int indices, e.g. ('usb', 'vid').
+            value
+                Value to set, or None to remove dict key.
+
+        Raises:
+            ValueError
+                When attempting to set None for array element. Use remove_array_item instead.
+        """
+        if not path:
+            return
+
+        if value is None and self.get(path) is None:
+            return
+
+        target = self._traverse_or_create_parent(path)
+
+        if target is None:
+            return
+
+        self._set_at_target(target, path[-1], value)
+
+    def navigate_into(self, key):
+        """Push key onto navigation path.
+
+        Args:
+            key
+                String key (for objects) or integer index (for arrays) to navigate into.
+        """
+        self.navigation_path = self.navigation_path + (key,)
+
+    def navigate_back(self):
+        """Pop from navigation path.
+
+        Returns:
+            The popped key (string or int), or None if already at root.
+        """
+        if not self.navigation_path:
+            return None
+
+        popped = self.navigation_path[-1]
+        self.navigation_path = self.navigation_path[:-1]
+        return popped
+
+    def get_current_schema(self):
+        """Return the schema fragment for current navigation level.
+        """
+        return self.schema_loader.get_properties(self.navigation_path)
+
+    def _get_value_at_navigation_path(self):
+        """Navigate to the value at current navigation path.
+
+        Returns:
+            Value at navigation path, or None if path is invalid.
+        """
+        if not self.navigation_path:
+            return self.working_data
+        return self.get(self.navigation_path)
+
+    def get_current_data(self):
+        """Return the working_data fragment for current navigation level.
+        """
+        value = self._get_value_at_navigation_path()
+        if value is None:
+            return {}
+        return value
+
+    def is_current_level_array(self):
+        """Return True if current navigation level is an array.
+
+        Checks both the data and the schema. If the data doesn't exist
+        at the current path, falls back to the schema definition.
+
+        Returns:
+            True if current level is a list, False otherwise.
+        """
+        value = self._get_value_at_navigation_path()
+        if isinstance(value, list):
+            return True
+
+        # If the value doesn't exist or isn't a list, check the schema
+        if value is None and self.navigation_path:
+            return self.schema_loader.is_array_at_path(self.navigation_path)
+
+        return False
+
+    def get_current_array_length(self):
+        """Return number of items if current level is an array.
+
+        Returns:
+            Number of items in array, or None if not an array.
+            Returns 0 if array doesn't exist in data but schema defines it as array.
+        """
+        value = self._get_value_at_navigation_path()
+        if isinstance(value, list):
+            return len(value)
+
+        # If value doesn't exist, check if schema says it's an array
+        if value is None and self.navigation_path:
+            if self.schema_loader.is_array_at_path(self.navigation_path):
+                return 0
+
+        return None
+
+    def insert_array_item(self, index, value):
+        """Insert value at index in current array.
+
+        Creates the array if it doesn't exist but schema defines it as array type.
+
+        Args:
+            index
+                Index to insert at (0-based).
+            value
+                Value to insert.
+        """
+        target = self._get_value_at_navigation_path()
+        if isinstance(target, list):
+            target.insert(index, value)
+        elif target is None and self.navigation_path:
+            # Array doesn't exist in data - create it if schema says it's an array
+            if self.schema_loader.is_array_at_path(self.navigation_path):
+                self._create_array_at_current_path()
+                target = self._get_value_at_navigation_path()
+                if isinstance(target, list):
+                    target.insert(index, value)
+
+    def _create_array_at_current_path(self):
+        """Create an empty array at the current navigation path.
+
+        Traverses the path and creates parent objects as needed.
+        """
+        if not self.navigation_path:
+            return
+
+        # Navigate to parent, creating objects as needed
+        target = self.working_data
+        for key in self.navigation_path[:-1]:
+            if isinstance(target, dict):
+                if key not in target:
+                    target[key] = {}
+                target = target[key]
+            elif isinstance(target, list) and isinstance(key, int):
+                if 0 <= key < len(target):
+                    target = target[key]
+                else:
+                    return
+            else:
+                return
+
+        # Set the final key to an empty array
+        final_key = self.navigation_path[-1]
+        if isinstance(target, dict):
+            target[final_key] = []
+
+    def remove_array_item(self, index):
+        """Remove item at index from current array.
+
+        Args:
+            index
+                Index to remove (0-based).
+        """
+        target = self._get_value_at_navigation_path()
+        if isinstance(target, list) and 0 <= index < len(target):
+            del target[index]
+
+    def move_array_item(self, from_index, to_index):
+        """Move item from one index to another in current array.
+
+        Args:
+            from_index
+                Source index (0-based).
+            to_index
+                Destination index (0-based).
+        """
+        if from_index == to_index:
+            return
+
+        target = self._get_value_at_navigation_path()
+        if isinstance(target, list):
+            if 0 <= from_index < len(target) and 0 <= to_index < len(target):
+                item = target.pop(from_index)
+                target.insert(to_index, item)
+
+    def reset(self):
+        """Discard changes, reset working_data to original.
+        """
+        self.working_data = copy.deepcopy(self.original_data)

--- a/lib/python/qmk/cli/edit/views/__init__.py
+++ b/lib/python/qmk/cli/edit/views/__init__.py
@@ -1,5 +1,10 @@
 """Views package for TUI screens.
 """
+from qmk.cli.edit.views.field_list import FieldListView
+from qmk.cli.edit.views.error_dialog import ErrorDialog
+from qmk.cli.edit.views.help_dialog import HelpDialog
+from qmk.cli.edit.views.confirm_dialog import ConfirmDialog
+from qmk.cli.edit.views.delete_confirm_dialog import DeleteConfirmDialog
 from qmk.cli.edit.views.view_context import ViewContext
 from qmk.cli.edit.views.view_callbacks import ViewCallbacks
 from qmk.cli.edit.views.item_scaffolder import ItemScaffolder
@@ -7,10 +12,16 @@ from qmk.cli.edit.views.search_controller import SearchController
 from qmk.cli.edit.views.status_display import StatusDisplay
 from qmk.cli.edit.views.focus_manager import FocusManager
 from qmk.cli.edit.views.array_controller import ArrayController
+from qmk.cli.edit.views.ui_builder import UIBuilder
 from qmk.cli.edit.views.event_router import EventRouter
 from qmk.cli.edit.views.frame_helper import FrameHelper
 
 __all__ = [
+    'FieldListView',
+    'ErrorDialog',
+    'HelpDialog',
+    'ConfirmDialog',
+    'DeleteConfirmDialog',
     'ViewContext',
     'ViewCallbacks',
     'ItemScaffolder',
@@ -18,6 +29,7 @@ __all__ = [
     'StatusDisplay',
     'FocusManager',
     'ArrayController',
+    'UIBuilder',
     'EventRouter',
     'FrameHelper',
 ]

--- a/lib/python/qmk/cli/edit/views/__init__.py
+++ b/lib/python/qmk/cli/edit/views/__init__.py
@@ -1,0 +1,15 @@
+"""Views package for TUI screens.
+"""
+from qmk.cli.edit.views.view_context import ViewContext
+from qmk.cli.edit.views.view_callbacks import ViewCallbacks
+from qmk.cli.edit.views.item_scaffolder import ItemScaffolder
+from qmk.cli.edit.views.status_display import StatusDisplay
+from qmk.cli.edit.views.frame_helper import FrameHelper
+
+__all__ = [
+    'ViewContext',
+    'ViewCallbacks',
+    'ItemScaffolder',
+    'StatusDisplay',
+    'FrameHelper',
+]

--- a/lib/python/qmk/cli/edit/views/__init__.py
+++ b/lib/python/qmk/cli/edit/views/__init__.py
@@ -3,13 +3,21 @@
 from qmk.cli.edit.views.view_context import ViewContext
 from qmk.cli.edit.views.view_callbacks import ViewCallbacks
 from qmk.cli.edit.views.item_scaffolder import ItemScaffolder
+from qmk.cli.edit.views.search_controller import SearchController
 from qmk.cli.edit.views.status_display import StatusDisplay
+from qmk.cli.edit.views.focus_manager import FocusManager
+from qmk.cli.edit.views.array_controller import ArrayController
+from qmk.cli.edit.views.event_router import EventRouter
 from qmk.cli.edit.views.frame_helper import FrameHelper
 
 __all__ = [
     'ViewContext',
     'ViewCallbacks',
     'ItemScaffolder',
+    'SearchController',
     'StatusDisplay',
+    'FocusManager',
+    'ArrayController',
+    'EventRouter',
     'FrameHelper',
 ]

--- a/lib/python/qmk/cli/edit/views/array_controller.py
+++ b/lib/python/qmk/cli/edit/views/array_controller.py
@@ -1,0 +1,140 @@
+"""Array item manipulation: add, delete, and move operations.
+
+Delegates focus and rebuild calls through ViewCallbacks. Receives
+focused_index as a parameter to every method so it stays decoupled
+from focus management. Delete confirmation is handled via a dialog
+callback provided at construction time.
+"""
+
+
+class ArrayController:
+    """Manages add, delete (with dialog confirmation), and move operations on arrays.
+
+    Args:
+        ctx
+            ViewContext providing state, keymap, and config access.
+
+        callbacks
+            ViewCallbacks for rebuild, show_status, and focus control.
+
+        item_scaffolder
+            ItemScaffolder instance for creating new array items.
+
+        show_delete_dialog_fn
+            Callable accepting (item_index, on_confirm, on_cancel)
+            to display a modal delete confirmation dialog.
+    """
+    def __init__(self, ctx, callbacks, item_scaffolder, show_delete_dialog_fn):
+        self._ctx = ctx
+        self._callbacks = callbacks
+        self._scaffolder = item_scaffolder
+        self._show_delete_dialog_fn = show_delete_dialog_fn
+
+    def add_item(self, focused_index):
+        """Insert a new item after the focused index.
+
+        Retrieves the item schema for the current path, scaffolds a
+        default item, and inserts it. For object items, navigates into
+        the new item. For simple items, focuses on the new item.
+
+        Args:
+            focused_index
+                Currently focused array index, or None to append.
+        """
+        item_schema = self._ctx.state.schema_loader.get_items_schema(
+            self._ctx.state.current_path,
+        )
+        if item_schema is None:
+            return
+
+        current_length = self._ctx.state.get_current_array_length() or 0
+        insert_index = focused_index + 1 if focused_index is not None else current_length
+
+        new_item = self._scaffolder.scaffold(item_schema)
+        self._ctx.state.insert_array_item(insert_index, new_item)
+
+        if item_schema.get('type') == 'object':
+            self._ctx.state.navigate_into(insert_index)
+            self._callbacks.rebuild()
+        else:
+            self._callbacks.rebuild()
+            self._callbacks.focus.focus_on_array_index(insert_index)
+
+    def delete_item(self, focused_index):
+        """Begin deletion of an array item via dialog confirmation.
+
+        If no_confirm_delete config is set, deletes immediately.
+        Otherwise opens a modal confirmation dialog with callbacks
+        for confirm and cancel actions.
+
+        Args:
+            focused_index
+                Currently focused array index, or None (early return).
+        """
+        if focused_index is None:
+            return
+
+        if self._ctx.config and getattr(self._ctx.config, 'no_confirm_delete', False):
+            self._perform_delete(focused_index)
+            return
+
+        def on_confirm():
+            self._perform_delete(focused_index)
+
+        def on_cancel():
+            pass
+
+        self._show_delete_dialog_fn(focused_index, on_confirm, on_cancel)
+
+    def move_item_up(self, focused_index):
+        """Swap the focused item with the one above it.
+
+        Args:
+            focused_index
+                Currently focused array index, or None (early return).
+        """
+        if focused_index is None or focused_index == 0:
+            return
+
+        self._ctx.state.move_array_item(focused_index, focused_index - 1)
+        self._callbacks.rebuild()
+        self._callbacks.focus.focus_on_array_index(focused_index - 1)
+        self._callbacks.show_status("Item moved up")
+
+    def move_item_down(self, focused_index):
+        """Swap the focused item with the one below it.
+
+        Args:
+            focused_index
+                Currently focused array index, or None (early return).
+        """
+        if focused_index is None:
+            return
+
+        array_length = self._ctx.state.get_current_array_length()
+        if array_length is None or focused_index >= array_length - 1:
+            return
+
+        self._ctx.state.move_array_item(focused_index, focused_index + 1)
+        self._callbacks.rebuild()
+        self._callbacks.focus.focus_on_array_index(focused_index + 1)
+        self._callbacks.show_status("Item moved down")
+
+    def _perform_delete(self, index):
+        """Perform the actual deletion of an array item.
+
+        Removes the item, shows status, and adjusts focus to the item
+        that shifted into the deleted position (or the new last item).
+
+        Args:
+            index
+                Index of item to delete.
+        """
+        self._ctx.state.remove_array_item(index)
+        self._callbacks.rebuild()
+        self._callbacks.show_status("Item deleted")
+
+        array_length = self._ctx.state.get_current_array_length() or 0
+        if array_length > 0:
+            focus_index = min(index, array_length - 1)
+            self._callbacks.focus.focus_on_array_index(focus_index)

--- a/lib/python/qmk/cli/edit/views/confirm_dialog.py
+++ b/lib/python/qmk/cli/edit/views/confirm_dialog.py
@@ -1,0 +1,87 @@
+"""Confirm dialog for unsaved changes.
+"""
+# TODO(unassigned): Write integration tests for TUI views once testing infrastructure supports headless asciimatics testing
+
+from asciimatics.widgets import Frame, Layout, Label, Button
+from asciimatics.event import KeyboardEvent
+from asciimatics.screen import Screen
+
+
+class ConfirmDialog(Frame):
+    """Modal dialog for confirming unsaved changes.
+    """
+    def __init__(self, screen, on_close=None):
+        """Initialize the confirm dialog.
+
+        Args:
+            screen
+                Asciimatics Screen instance.
+            on_close
+                Callback receiving action: 'save', 'discard', or 'cancel'.
+        """
+        height = 9
+        width = min(screen.width - 4, 60)
+
+        super().__init__(screen, height, width, has_border=True, title="Unsaved Changes", reduce_cpu=True, is_modal=True)
+
+        self._on_close = on_close
+
+        layout = Layout([100], fill_frame=True)
+        self.add_layout(layout)
+
+        layout.add_widget(Label("You have unsaved changes."))
+        layout.add_widget(Label("What would you like to do?"))
+        layout.add_widget(Label(""))
+
+        button_layout = Layout([1, 1, 1])
+        self.add_layout(button_layout)
+        button_layout.add_widget(Button("Save", self._on_save), 0)
+        button_layout.add_widget(Button("Discard", self._on_discard), 2)
+
+        hint_layout = Layout([100])
+        self.add_layout(hint_layout)
+        hint_layout.add_widget(Label("Press ESC to cancel"))
+
+        self.fix()
+
+    def _on_save(self):
+        """Handle Save button press.
+        """
+        self._dismiss('save')
+
+    def _on_discard(self):
+        """Handle Discard button press.
+        """
+        self._dismiss('discard')
+
+    def _dismiss(self, action):
+        """Remove dialog from scene and invoke callback.
+        """
+        self._scene.remove_effect(self)
+        if self._on_close:
+            self._on_close(action)
+
+    def process_event(self, event):
+        """Process keyboard events for shortcuts.
+
+        Args:
+            event
+                Asciimatics event to process.
+
+        Returns:
+            Event processing result from parent class.
+        """
+        if isinstance(event, KeyboardEvent):
+            key_lower = chr(event.key_code).lower() if 32 <= event.key_code < 127 else ''
+
+            if key_lower == 's':
+                self._on_save()
+                return None
+            if key_lower == 'd':
+                self._on_discard()
+                return None
+            if event.key_code == Screen.KEY_ESCAPE:
+                self._dismiss('cancel')
+                return None
+
+        return super().process_event(event)

--- a/lib/python/qmk/cli/edit/views/delete_confirm_dialog.py
+++ b/lib/python/qmk/cli/edit/views/delete_confirm_dialog.py
@@ -1,0 +1,78 @@
+"""Simple confirmation dialog for array item deletion.
+"""
+from asciimatics.widgets import Frame, Layout, Label, Button
+from asciimatics.event import KeyboardEvent
+from asciimatics.screen import Screen
+
+
+class DeleteConfirmDialog(Frame):
+    """Modal dialog for confirming item deletion.
+    """
+    def __init__(self, screen, item_index, on_confirm, on_cancel):
+        """Initialize the delete confirmation dialog.
+
+        Args:
+            screen
+                Asciimatics Screen instance.
+            item_index
+                Index of item to delete.
+            on_confirm
+                Callback to invoke when user confirms deletion.
+            on_cancel
+                Callback to invoke when user cancels.
+        """
+        super().__init__(screen, 7, 50, has_border=True, title="Confirm Delete", is_modal=True)
+
+        self._on_confirm = on_confirm
+        self._on_cancel = on_cancel
+
+        layout = Layout([100], fill_frame=True)
+        self.add_layout(layout)
+
+        layout.add_widget(Label(""))
+        layout.add_widget(Label("Delete item [%d]?" % item_index, height=2))
+        layout.add_widget(Label(""))
+
+        button_layout = Layout([1, 1, 1])
+        self.add_layout(button_layout)
+        button_layout.add_widget(Button("Yes (y)", self._yes), 0)
+        button_layout.add_widget(Button("No (n)", self._no), 2)
+
+        self.fix()
+
+    def _dismiss(self):
+        """Remove dialog from the scene.
+        """
+        self._scene.remove_effect(self)
+
+    def _yes(self):
+        """Handle Yes button click.
+        """
+        self._dismiss()
+        self._on_confirm()
+
+    def _no(self):
+        """Handle No button click.
+        """
+        self._dismiss()
+        self._on_cancel()
+
+    def process_event(self, event):
+        """Process keyboard events.
+
+        Args:
+            event
+                Event to process.
+
+        Returns:
+            Event processing result.
+        """
+        if isinstance(event, KeyboardEvent):
+            if event.key_code in (ord('y'), ord('Y')):
+                self._yes()
+                return None
+            if event.key_code in (ord('n'), ord('N'), Screen.KEY_ESCAPE):
+                self._no()
+                return None
+
+        return super().process_event(event)

--- a/lib/python/qmk/cli/edit/views/error_dialog.py
+++ b/lib/python/qmk/cli/edit/views/error_dialog.py
@@ -1,0 +1,73 @@
+"""Error dialog for displaying validation errors.
+"""
+# TODO(unassigned): Write integration tests for TUI views once testing infrastructure supports headless asciimatics testing
+
+from asciimatics.widgets import Frame, Layout, Label, TextBox
+from asciimatics.event import KeyboardEvent
+from asciimatics.screen import Screen
+
+
+class ErrorDialog(Frame):
+    """Modal dialog for displaying validation or error messages.
+    """
+    def __init__(self, screen, errors, on_close=None):
+        """Initialize the error dialog.
+
+        Args:
+            screen
+                Asciimatics Screen instance.
+            errors
+                List of error dicts with 'path' and 'message' keys.
+            on_close
+                Optional callback when dialog is dismissed.
+        """
+        height = min(screen.height - 4, len(errors) * 2 + 8)
+        width = min(screen.width - 4, 80)
+
+        super().__init__(screen, height, width, has_border=True, title="Validation Errors", reduce_cpu=True, is_modal=True)
+
+        self._on_close = on_close
+        self._errors = errors
+
+        layout = Layout([100], fill_frame=True)
+        self.add_layout(layout)
+
+        layout.add_widget(Label("The following errors were found:"))
+        layout.add_widget(Label(""))
+
+        error_lines = ["%s: %s" % (error.get('path', '<unknown>'), error.get('message', 'Unknown error')) for error in errors]
+
+        error_text = "\n".join(error_lines)
+        text_box = TextBox(height=height - 6, as_string=True, line_wrap=True, readonly=True)
+        text_box.value = error_text
+        layout.add_widget(text_box)
+
+        hint_layout = Layout([100])
+        self.add_layout(hint_layout)
+        hint_layout.add_widget(Label("Press Enter or Esc to close"))
+
+        self.fix()
+
+    def _on_ok(self):
+        """Dismiss the dialog and invoke the on_close callback.
+        """
+        self._scene.remove_effect(self)
+        if self._on_close:
+            self._on_close()
+
+    def process_event(self, event):
+        """Process keyboard events for shortcuts.
+
+        Args:
+            event
+                Asciimatics event to process.
+
+        Returns:
+            Event processing result from parent class.
+        """
+        if isinstance(event, KeyboardEvent):
+            if event.key_code in (Screen.KEY_ESCAPE, ord('\n'), ord('\r')):
+                self._on_ok()
+                return None
+
+        return super().process_event(event)

--- a/lib/python/qmk/cli/edit/views/event_router.py
+++ b/lib/python/qmk/cli/edit/views/event_router.py
@@ -1,0 +1,184 @@
+"""Event routing for keyboard events in the field list view.
+
+Routes KeyboardEvent objects to the correct handler based on the
+current editor mode (search, array, or normal). Does not import
+from asciimatics; receives events and delegates.
+"""
+
+
+class EventRouter:
+    """Routes keyboard events to the appropriate handler.
+
+    Routing priority:
+    1. Quit key (if on_quit set) -> quit callback
+    2. Save key (if on_save set) -> save callback
+    3. Search mode active -> search event handling
+    4. Validate key (if on_validate set) -> validate callback
+    5. Help key (if on_help set) -> help callback
+    6. Back key -> navigation / search clear
+    7. Search key (non-array) -> activate search
+    8. Array mode -> array-specific handling
+    9. Default -> pass to Frame's process_event
+
+    Args:
+        ctx
+            ViewContext providing state, keymap, and config.
+
+        search_controller
+            SearchController for search mode state.
+
+        array_controller
+            ArrayController for array item operations.
+
+        focus_manager
+            FocusManager for querying focused widget state.
+
+        callbacks
+            ViewCallbacks for rebuild, status, and focus.
+
+        add_item_fn
+            Callable for adding array items, bridging
+            FocusManager and ArrayController through the view.
+    """
+    def __init__(self, ctx, search_controller, array_controller, focus_manager, callbacks, add_item_fn=None):
+        self._ctx = ctx
+        self._search = search_controller
+        self._array = array_controller
+        self._focus = focus_manager
+        self._callbacks = callbacks
+        self._add_item_fn = add_item_fn
+
+    def route(self, event, view):
+        """Route a KeyboardEvent to the correct handler.
+
+        Args:
+            event
+                KeyboardEvent to process.
+
+            view
+                The FieldListView for calling default_process_event.
+
+        Returns:
+            Event result, or None if consumed.
+        """
+        if self._callbacks.on_quit and self._ctx.keymap.matches("quit", event.key_code):
+            self._callbacks.on_quit()
+            return None
+
+        if self._callbacks.on_save and self._ctx.keymap.matches("save", event.key_code):
+            self._callbacks.on_save()
+            return None
+
+        if self._search.is_active:
+            return self._route_search_event(event, view)
+
+        if self._callbacks.on_validate and self._ctx.keymap.matches("validate", event.key_code):
+            self._callbacks.on_validate()
+            return None
+
+        if self._callbacks.on_help and self._ctx.keymap.matches("help", event.key_code):
+            self._callbacks.on_help()
+            return None
+
+        if self._ctx.keymap.matches("back", event.key_code):
+            self._handle_back_navigation()
+            return None
+
+        if (self._ctx.keymap.matches("search", event.key_code) and not self._ctx.state.is_current_level_array()):
+            self._search.activate(self._focus.focused_field_name())
+            return None
+
+        if self._ctx.state.is_current_level_array():
+            return self._route_array_event(event, view)
+
+        return view.default_process_event(event)
+
+    def _route_search_event(self, event, view):
+        """Route events when in search mode.
+
+        Back key exits search discarding term. Select key applies
+        the widget value and exits search keeping the term. All
+        other keys pass through to default processing, then sync
+        the search widget value.
+
+        Args:
+            event
+                KeyboardEvent to process.
+
+            view
+                The FieldListView for default event processing.
+
+        Returns:
+            Event result, or None if consumed.
+        """
+        if self._ctx.keymap.matches("back", event.key_code):
+            self._search.deactivate(keep_term=False)
+            return None
+
+        if self._ctx.keymap.matches("select", event.key_code):
+            self._search.apply_search_widget_value()
+            self._search.deactivate(keep_term=True)
+            return None
+
+        result = view.default_process_event(event)
+        self._search.apply_search_widget_value()
+        return result
+
+    def _route_array_event(self, event, view):
+        """Route events in array mode.
+
+        Handles add, delete, move up, and move down. Unrecognized
+        keys fall through to default processing.
+
+        Args:
+            event
+                KeyboardEvent to process.
+
+            view
+                The FieldListView for default event processing.
+
+        Returns:
+            Event result, or None if consumed.
+        """
+        if self._ctx.keymap.matches("add_item", event.key_code):
+            self._add_item_fn()
+            return None
+
+        if self._ctx.keymap.matches("delete_item", event.key_code):
+            self._array.delete_item(self._focus.focused_array_index())
+            return None
+
+        if self._ctx.keymap.matches("move_up", event.key_code):
+            self._array.move_item_up(self._focus.focused_array_index())
+            return None
+
+        if self._ctx.keymap.matches("move_down", event.key_code):
+            self._array.move_item_down(self._focus.focused_array_index())
+            return None
+
+        return view.default_process_event(event)
+
+    def _handle_back_navigation(self):
+        """Handle the back key: navigate up or clear search term.
+
+        1. Try navigate_back(). If it returns a value, clear search,
+           rebuild, and focus on the popped segment.
+        2. Otherwise, if a search term exists, clear it, rebuild,
+           and restore the pre-search focus.
+        """
+        popped = self._ctx.state.navigate_back()
+        if popped is not None:
+            self._search.clear()
+            self._callbacks.rebuild()
+            if isinstance(popped, int):
+                self._callbacks.focus.focus_on_array_index(popped)
+            else:
+                self._callbacks.focus.focus_on_field_by_name(popped)
+            return
+
+        if self._search.search_term:
+            restore_field = self._search.pre_search_field
+            self._search.clear()
+            self._callbacks.rebuild()
+            if restore_field:
+                self._callbacks.focus.focus_on_field_by_name(restore_field)

--- a/lib/python/qmk/cli/edit/views/field_list.py
+++ b/lib/python/qmk/cli/edit/views/field_list.py
@@ -1,0 +1,143 @@
+"""Field list view with navigation and search.
+"""
+from asciimatics.widgets import Frame
+from asciimatics.event import KeyboardEvent
+
+from qmk.cli.edit.keymap import Keymap
+from qmk.cli.edit.views.view_context import ViewContext
+from qmk.cli.edit.views.view_callbacks import ViewCallbacks
+from qmk.cli.edit.views.item_scaffolder import ItemScaffolder
+from qmk.cli.edit.views.status_display import StatusDisplay
+from qmk.cli.edit.views.focus_manager import FocusManager
+from qmk.cli.edit.views.search_controller import SearchController
+from qmk.cli.edit.views.array_controller import ArrayController
+from qmk.cli.edit.views.delete_confirm_dialog import DeleteConfirmDialog
+from qmk.cli.edit.views.ui_builder import UIBuilder
+from qmk.cli.edit.views.event_router import EventRouter
+from qmk.cli.edit.views.frame_helper import FrameHelper
+
+
+class FieldListView(Frame):
+    """Main field list view. Thin shell delegating to collaborators.
+    """
+    def __init__(self, screen, state, keyboard, registry, keymap=None, config=None, on_quit=None, on_save=None, on_validate=None, on_help=None):
+        super().__init__(screen, screen.height, screen.width, has_border=False, title="QMK Edit")
+        self.set_theme("bright")
+        self._frame_helper = FrameHelper(self)
+        ctx = ViewContext(state, keyboard, keymap or Keymap(), registry, config)
+        self._ctx = ctx
+        self._scaffolder = ItemScaffolder(ctx.state.schema_loader)
+        self._status = StatusDisplay(ctx, self._rebuild_ui, frame_helper=self._frame_helper)
+        self._focus_mgr = FocusManager()
+        callbacks = ViewCallbacks(
+            self._rebuild_ui,
+            self._status.show,
+            self._focus_mgr,
+            on_quit=on_quit,
+            on_save=on_save,
+            on_validate=on_validate,
+            on_help=on_help,
+        )
+        self._search = SearchController(callbacks)
+        self._delete_dialog_active = False
+        self._array = ArrayController(ctx, callbacks, self._scaffolder, self._show_delete_dialog)
+        self._builder = UIBuilder(ctx, self._search)
+        self._router = EventRouter(ctx, self._search, self._array, self._focus_mgr, callbacks, add_item_fn=self._on_add_item)
+        self._last_focused_widget = None
+        self._current_hint = None
+        self._rebuild_ui()
+
+    def _rebuild_ui(self):
+        """Clear layouts and rebuild all UI from collaborators.
+        """
+        self._frame_helper.clear_layouts()
+        self._frame_helper.reset_focus_index()
+        all_fields = self._builder.build(self, self._make_navigate_handler, self._on_add_item, self._status)
+        self._focus_mgr.update(self, all_fields, frame_helper=self._frame_helper)
+        self._last_focused_widget = None
+        self._current_hint = None
+        self._frame_helper.set_has_focus(True)
+        self.fix()
+
+    def _make_navigate_handler(self, key):
+        """Create navigation handler for object/array row click.
+        """
+        def handler():
+            self._ctx.state.navigate_into(key)
+            self._search.clear()
+            self._rebuild_ui()
+
+        return handler
+
+    def _on_add_item(self):
+        """Bridge FocusManager and ArrayController for add item.
+        """
+        self._array.add_item(self._focus_mgr.focused_array_index())
+
+    def _show_delete_dialog(self, item_index, on_confirm, on_cancel):
+        """Show modal delete confirmation dialog.
+
+        Guards against stacking multiple dialogs. Wraps callbacks
+        to clear the active flag before delegating.
+
+        Args:
+            item_index
+                Index of the array item to delete.
+
+            on_confirm
+                Callback to invoke when user confirms deletion.
+
+            on_cancel
+                Callback to invoke when user cancels.
+        """
+        if self._delete_dialog_active:
+            return
+
+        self._delete_dialog_active = True
+
+        def _on_confirm():
+            self._delete_dialog_active = False
+            on_confirm()
+
+        def _on_cancel():
+            self._delete_dialog_active = False
+            on_cancel()
+
+        dialog = DeleteConfirmDialog(self.screen, item_index, _on_confirm, _on_cancel)
+        self._scene.add_effect(dialog)
+
+    def show_status(self, message, duration=2.5):
+        """Show a temporary status message.
+        """
+        self._status.show(message, duration)
+
+    def process_event(self, event):
+        """Route keyboard events through EventRouter.
+        """
+        if not isinstance(event, KeyboardEvent):
+            return super().process_event(event)
+        if hasattr(self, '_handle_desktop_ordering'):
+            self._handle_desktop_ordering(event)
+        return self._router.route(event, self)
+
+    def default_process_event(self, event):
+        """Delegate to Frame's process_event for default handling.
+        """
+        return super().process_event(event)
+
+    def update(self, frame_no):
+        """Update breadcrumb and footer widgets each frame.
+
+        Detects focus changes via identity comparison and recomputes
+        the constraint hint only when the focused widget changes.
+        """
+        self._status.update_breadcrumb_widget(self._frame_helper, self._builder.build_breadcrumb())
+
+        # Recompute hint only when focused widget identity changes
+        focused = self._focus_mgr.get_focused_field_widget()
+        if focused is not self._last_focused_widget:
+            self._last_focused_widget = focused
+            self._current_hint = focused.get_hint() if focused else None
+
+        self._status.update_footer_widget(self._frame_helper, self._current_hint)
+        return super().update(frame_no)

--- a/lib/python/qmk/cli/edit/views/focus_manager.py
+++ b/lib/python/qmk/cli/edit/views/focus_manager.py
@@ -1,0 +1,156 @@
+"""Focus management collaborator for FieldListView.
+
+Encapsulates focus querying (which field is focused, what array index)
+and manipulation (move focus to a specific field or array index). The
+FocusManager is updated after each UI rebuild with the fresh widget list
+and frame reference.
+"""
+from qmk.cli.edit.widgets import ArrayItemRow
+from qmk.cli.edit.views.frame_helper import FrameHelper
+
+
+class FocusManager:
+    """Manages widget focus state for FieldListView.
+
+    This collaborator requires a Frame reference because switch_focus is
+    a Frame method. The frame reference is passed via update() after each
+    rebuild rather than in __init__, keeping the constructor simple for
+    testing.
+    """
+    def __init__(self):
+        """Initialize focus manager with empty state.
+        """
+        self._frame = None
+        self._all_fields = []
+
+    def update(self, frame, all_fields, frame_helper=None):
+        """Called after each rebuild with fresh widget list.
+
+        Stores the frame reference and the all_fields list for
+        subsequent focus queries and manipulations. Accepts an
+        optional FrameHelper; creates one if not provided.
+
+        Args:
+            frame
+                The asciimatics Frame instance.
+
+            all_fields
+                List of FieldWidget instances currently displayed.
+
+            frame_helper
+                Optional FrameHelper instance. If None, creates
+                a new one wrapping the given frame.
+        """
+        self._frame = frame
+        self._all_fields = all_fields
+        self._frame_helper = frame_helper if frame_helper is not None else FrameHelper(frame)
+
+    def focused_field_name(self):
+        """Return name of currently focused field, or None.
+
+        Gets the frame's focussed_widget (British spelling per asciimatics),
+        iterates _all_fields to find the FieldWidget whose asciimatics_widget
+        matches the focused asciimatics widget.
+
+        Returns:
+            String name of focused field, or None if no match found.
+        """
+        widget = self.get_focused_field_widget()
+        return widget.name if widget else None
+
+    def focused_array_index(self):
+        """Return index of focused array item, or None.
+
+        Checks the frame's _has_focus flag first. If the frame does not
+        have focus, returns None. Otherwise finds the focused FieldWidget
+        and returns its index if it is an ArrayItemRow instance.
+
+        Returns:
+            Integer index of focused array item, or None.
+        """
+        # Guard added for standalone usage where _frame may be None.
+        if self._frame is None or not self._frame_helper.has_focus():
+            return None
+
+        widget = self.get_focused_field_widget()
+        if isinstance(widget, ArrayItemRow):
+            return widget.index
+        return None
+
+    def focus_on_array_index(self, index):
+        """Move focus to array item at the given index.
+
+        Guards against out-of-bounds indices and missing widget references
+        before delegating to _find_and_focus_widget.
+
+        Args:
+            index
+                Array index to focus on.
+        """
+        if index < 0 or index >= len(self._all_fields):
+            return
+
+        target_widget = self._all_fields[index]
+        if target_widget.asciimatics_widget is None:
+            return
+
+        self._find_and_focus_widget(target_widget.asciimatics_widget)
+
+    def focus_on_field_by_name(self, name):
+        """Move focus to the field matching the given property name.
+
+        Iterates _all_fields to find a widget with a matching name
+        property. Guards against missing widget references before
+        delegating to _find_and_focus_widget.
+
+        Args:
+            name
+                Property name to focus on.
+        """
+        for widget in self._all_fields:
+            if widget.name != name:
+                continue
+            if widget.asciimatics_widget is None:
+                return
+            self._find_and_focus_widget(widget.asciimatics_widget)
+            return
+
+    def _find_and_focus_widget(self, asciimatics_widget):
+        """Find the fill-frame layout containing the widget and switch focus.
+
+        Uses FrameHelper to find the layout with fill_frame == True,
+        then scans the first column of that layout to find the widget
+        index, and calls switch_focus on the frame.
+
+        Args:
+            asciimatics_widget
+                The asciimatics widget to focus on.
+        """
+        field_layout = self._frame_helper.find_fill_frame_layout()
+
+        if field_layout is None:
+            return
+
+        column = self._frame_helper.get_layout_column_widgets(field_layout, 0)
+        for widget_index, col_widget in enumerate(column):
+            if col_widget is asciimatics_widget:
+                self._frame.switch_focus(field_layout, 0, widget_index)
+                return
+
+    def get_focused_field_widget(self):
+        """Return the FieldWidget matching the currently focused asciimatics widget.
+
+        Returns:
+            FieldWidget instance, or None if no field is focused.
+        """
+        if self._frame is None:
+            return None
+
+        focused_widget = self._frame.focussed_widget
+        if focused_widget is None:
+            return None
+
+        for widget in self._all_fields:
+            if widget.asciimatics_widget is not None and widget.asciimatics_widget is focused_widget:
+                return widget
+        return None

--- a/lib/python/qmk/cli/edit/views/frame_helper.py
+++ b/lib/python/qmk/cli/edit/views/frame_helper.py
@@ -1,0 +1,148 @@
+"""Abstraction layer for asciimatics private attribute access.
+
+Centralizes all access to asciimatics internal/private attributes
+(`_layouts`, `_focus`, `_has_focus`, `_columns`) into a single module.
+This confines the coupling to asciimatics internals so that if the
+library changes its private API, only this file needs to be updated.
+
+Public asciimatics APIs (`Label.text`, `Layout.fill_frame`,
+`Frame.focussed_widget`, `Frame.switch_focus`) are used directly
+by consumers and do not need wrapping here.
+"""
+
+
+class FrameHelper:
+    """Wraps asciimatics Frame private attribute access.
+
+    All methods that touch `frame._layouts`, `frame._focus`,
+    `frame._has_focus`, or `layout._columns` live here. Consumers
+    call these methods instead of reaching into private attributes.
+
+    Args:
+        frame
+            The asciimatics Frame instance to wrap.
+    """
+    def __init__(self, frame):
+        """Store the frame reference.
+        """
+        self._frame = frame
+
+    def clear_layouts(self):
+        """Remove all layouts from the frame.
+
+        Wraps `frame._layouts` (private list). Pops all items
+        in a while loop so asciimatics sees an empty list rather
+        than a replaced reference.
+        """
+        while self._frame._layouts:
+            self._frame._layouts.pop()
+
+    def reset_focus_index(self):
+        """Reset the frame's internal focus counter to zero.
+
+        Wraps `frame._focus` (private int). This must be reset
+        after clearing layouts to avoid stale focus indices.
+        """
+        self._frame._focus = 0
+
+    def has_focus(self):
+        """Return whether the frame currently has focus.
+
+        Wraps `frame._has_focus` (private bool). Used by
+        FocusManager to guard focus queries.
+        """
+        return self._frame._has_focus
+
+    def set_has_focus(self, value):
+        """Set the frame's focus ownership flag.
+
+        Wraps ``frame._has_focus`` (private bool). Called during
+        UI rebuilds to restore focus ownership after a modal dialog
+        has blurred the frame, ensuring ``fix()`` resolves focus to
+        a layout with live widgets.
+        """
+        self._frame._has_focus = value
+
+    def find_fill_frame_layout(self):
+        """Return the layout with fill_frame=True, or None.
+
+        Iterates `frame._layouts` (private list) and checks each
+        layout's `fill_frame` public property. Returns the first
+        match or None if no layout fills the frame.
+        """
+        for layout in self._frame._layouts:
+            if layout.fill_frame:
+                return layout
+        return None
+
+    def get_layout_column_widgets(self, layout, column=0):
+        """Return the widget list for a layout column.
+
+        Wraps `layout._columns` (private list of lists). Returns
+        an empty list if the column index is out of range.
+
+        Args:
+            layout
+                The asciimatics Layout instance.
+
+            column
+                Column index within the layout. Defaults to 0.
+        """
+        if column < 0 or column >= len(layout._columns):
+            return []
+        return layout._columns[column]
+
+    def get_layout_by_index(self, index):
+        """Return a layout by index, or None if out of range.
+
+        Wraps `frame._layouts` (private list) with bounds checking.
+        Supports negative indices (e.g. -1 for last layout).
+
+        Args:
+            index
+                Integer index into the layouts list.
+        """
+        layouts = self._frame._layouts
+        try:
+            return layouts[index]
+        except IndexError:
+            return None
+
+    def get_layout_count(self):
+        """Return the number of layouts in the frame.
+
+        Wraps `len(frame._layouts)` (private list).
+        """
+        return len(self._frame._layouts)
+
+    def update_label_text(self, label_widget, new_text):
+        """Set a label widget's text to a new value.
+
+        Uses the public `Label.text` property (available in
+        asciimatics 1.15.0+). This replaces direct access to
+        the private `_text` attribute.
+
+        Args:
+            label_widget
+                The asciimatics Label widget to update.
+
+            new_text
+                The new text string to display.
+        """
+        label_widget.text = new_text
+
+    def get_label_text(self, label_widget):
+        """Return a label widget's current text.
+
+        Uses the public `Label.text` property (available in
+        asciimatics 1.15.0+). This replaces direct access to
+        the private `_text` attribute.
+
+        Args:
+            label_widget
+                The asciimatics Label widget to read.
+
+        Returns:
+            The label's current text string.
+        """
+        return label_widget.text

--- a/lib/python/qmk/cli/edit/views/help_dialog.py
+++ b/lib/python/qmk/cli/edit/views/help_dialog.py
@@ -1,0 +1,116 @@
+"""Help dialog for displaying keybinding reference.
+"""
+from asciimatics.widgets import Frame, Layout, Label, TextBox
+from asciimatics.event import KeyboardEvent
+from asciimatics.screen import Screen
+
+# Column width for key display strings in the help content
+_KEY_COLUMN_WIDTH = 20
+
+
+def build_help_content(keymap):
+    """Build the keybinding help text from a Keymap instance.
+
+    Produces a multi-line string with all keybindings grouped by
+    section: General, Navigation, Search, and Arrays.
+
+    Args:
+        keymap
+            Keymap instance for resolving display names.
+
+    Returns:
+        Multi-line string with all keybindings grouped by section.
+    """
+    lines = ['Keybindings', '']
+
+    # General section -- save, validate, quit, help
+    lines.append('General')
+    lines.append('  %s%s' % (keymap.get_display('save').ljust(_KEY_COLUMN_WIDTH), 'Save'))
+    lines.append('  %s%s' % (keymap.get_display('validate').ljust(_KEY_COLUMN_WIDTH), 'Validate'))
+    lines.append('  %s%s' % (keymap.get_display('quit').ljust(_KEY_COLUMN_WIDTH), 'Quit'))
+    lines.append('  %s%s' % (keymap.get_display('help').ljust(_KEY_COLUMN_WIDTH), 'Help'))
+    lines.append('')
+
+    # Navigation section -- arrows, enter, back
+    lines.append('Navigation')
+    lines.append('  %s%s' % ('Up/Down'.ljust(_KEY_COLUMN_WIDTH), 'Navigate fields'))
+    lines.append('  %s%s' % ('Enter'.ljust(_KEY_COLUMN_WIDTH), 'Edit / Enter'))
+    lines.append('  %s%s' % (keymap.get_display('back').ljust(_KEY_COLUMN_WIDTH), 'Back'))
+    lines.append('')
+
+    # Search section -- start and exit
+    lines.append('Search')
+    lines.append('  %s%s' % ('/'.ljust(_KEY_COLUMN_WIDTH), 'Start search'))
+    lines.append('  %s%s' % ('Esc'.ljust(_KEY_COLUMN_WIDTH), 'Exit search'))
+    lines.append('')
+
+    # Arrays section -- add, delete, move
+    lines.append('Arrays')
+    lines.append('  %s%s' % (keymap.get_display('add_item').ljust(_KEY_COLUMN_WIDTH), 'Add item'))
+    lines.append('  %s%s' % (keymap.get_display('delete_item').ljust(_KEY_COLUMN_WIDTH), 'Delete item'))
+    lines.append('  %s%s' % (keymap.get_display('move_up').ljust(_KEY_COLUMN_WIDTH), 'Move up'))
+    lines.append('  %s%s' % (keymap.get_display('move_down').ljust(_KEY_COLUMN_WIDTH), 'Move down'))
+
+    return '\n'.join(lines)
+
+
+class HelpDialog(Frame):
+    """Modal dialog displaying keybinding help.
+    """
+    def __init__(self, screen, keymap, on_close=None):
+        """Initialize the help dialog.
+
+        Args:
+            screen
+                Asciimatics Screen instance.
+            keymap
+                Keymap instance for resolving display names.
+            on_close
+                Optional callback when dialog is dismissed.
+        """
+        height = min(screen.height - 4, 26)
+        width = min(screen.width - 4, 60)
+
+        super().__init__(screen, height, width, has_border=True, title="Help", reduce_cpu=True, is_modal=True)
+
+        self._on_close = on_close
+
+        # Main content area with keybinding reference
+        layout = Layout([100], fill_frame=True)
+        self.add_layout(layout)
+
+        content = build_help_content(keymap)
+        text_box = TextBox(height=height - 4, as_string=True, line_wrap=True, readonly=True)
+        text_box.value = content
+        layout.add_widget(text_box)
+
+        # Hint at the bottom
+        hint_layout = Layout([100])
+        self.add_layout(hint_layout)
+        hint_layout.add_widget(Label("Press Enter or Esc to close"))
+
+        self.fix()
+
+    def _on_ok(self):
+        """Dismiss the dialog and invoke the on_close callback.
+        """
+        self._scene.remove_effect(self)
+        if self._on_close:
+            self._on_close()
+
+    def process_event(self, event):
+        """Process keyboard events for shortcuts.
+
+        Args:
+            event
+                Asciimatics event to process.
+
+        Returns:
+            Event processing result from parent class.
+        """
+        if isinstance(event, KeyboardEvent):
+            if event.key_code in (Screen.KEY_ESCAPE, ord('\n'), ord('\r')):
+                self._on_ok()
+                return None
+
+        return super().process_event(event)

--- a/lib/python/qmk/cli/edit/views/item_scaffolder.py
+++ b/lib/python/qmk/cli/edit/views/item_scaffolder.py
@@ -1,0 +1,64 @@
+"""Stateless utility for creating default items from JSON schemas.
+
+Extracted from FieldListView._scaffold_item and
+FieldListView._default_value_for_type to enable independent testing
+and reuse across view collaborators.
+"""
+
+
+class ItemScaffolder:
+    """Create new items with default values based on JSON schema definitions.
+
+    Args:
+        schema_loader
+            A SchemaLoader instance used to inspect schema metadata
+            such as required fields and property types.
+    """
+    def __init__(self, schema_loader):
+        self._schema_loader = schema_loader
+
+    def default_value_for_type(self, field_type):
+        """Return the default value for a schema type string.
+
+        Args:
+            field_type
+                Schema type string like 'string', 'integer', 'boolean'.
+
+        Returns:
+            Default value appropriate for the type.
+        """
+        if field_type in ('integer', 'number'):
+            return 0
+        if field_type == 'boolean':
+            return False
+        return ''
+
+    def scaffold(self, item_schema):
+        """Create a new item with default values based on schema type.
+
+        For non-object types, returns the type's default value directly.
+        For object types, builds a dict populated with default values for
+        each required field found in the schema's properties.
+
+        Args:
+            item_schema
+                Schema dict describing the item to create.
+
+        Returns:
+            A new item with default values matching the schema.
+        """
+        item_type = item_schema.get('type', 'string')
+
+        if item_type != 'object':
+            return self.default_value_for_type(item_type)
+
+        obj = {}
+        required_fields = self._schema_loader.get_required_fields(item_schema)
+        properties = item_schema.get('properties', {})
+
+        for field_name in required_fields:
+            if field_name in properties:
+                field_type = self._schema_loader.get_type(properties[field_name])
+                obj[field_name] = self.default_value_for_type(field_type)
+
+        return obj

--- a/lib/python/qmk/cli/edit/views/search_controller.py
+++ b/lib/python/qmk/cli/edit/views/search_controller.py
@@ -1,0 +1,122 @@
+"""Search state management for the field list view.
+
+Owns the search mode flag, search term, search widget reference,
+and pre-search field name. Delegates UI rebuilds to the parent
+view through the callbacks interface.
+"""
+
+
+class SearchController:
+    """Manages search mode state and field filtering.
+
+    Args:
+        callbacks
+            ViewCallbacks instance providing rebuild and status methods.
+    """
+    def __init__(self, callbacks):
+        self._callbacks = callbacks
+        self._search_mode = False
+        self._search_term = ""
+        self._search_widget = None
+        self._pre_search_field = None
+
+    @property
+    def is_active(self):
+        """Return True if search mode is active.
+        """
+        return self._search_mode
+
+    @property
+    def search_term(self):
+        """Return the current search term string.
+        """
+        return self._search_term
+
+    @search_term.setter
+    def search_term(self, value):
+        """Set the search term.
+        """
+        self._search_term = value
+
+    @property
+    def search_widget(self):
+        """Return the asciimatics search Text widget, or None.
+        """
+        return self._search_widget
+
+    @search_widget.setter
+    def search_widget(self, widget):
+        """Set the search widget (called by UIBuilder after building search bar).
+        """
+        self._search_widget = widget
+
+    @property
+    def pre_search_field(self):
+        """Return the field name that was focused before search was activated.
+        """
+        return self._pre_search_field
+
+    def activate(self, current_field_name):
+        """Enter search mode, remembering current focus for restore.
+
+        Sets search mode to active and stores current_field_name
+        so focus can be restored when search is deactivated.
+        Calls callbacks.rebuild() to show the search bar.
+
+        Args:
+            current_field_name
+                Name of the field that had focus before search.
+        """
+        self._search_mode = True
+        self._pre_search_field = current_field_name
+        self._callbacks.rebuild()
+
+    def deactivate(self, keep_term=False):
+        """Exit search mode.
+
+        Clears the search term unless keep_term is True.
+        Calls callbacks.rebuild() to hide the search bar.
+
+        Args:
+            keep_term
+                If True, preserves the current search term.
+        """
+        self._search_mode = False
+        if not keep_term:
+            self._search_term = ""
+        self._callbacks.rebuild()
+
+    def apply_search_widget_value(self):
+        """Sync search_term from the asciimatics Text widget value.
+
+        If the search widget is set, reads its .value attribute
+        and stores it as the current search term.
+        """
+        if self._search_widget is not None:
+            self._search_term = self._search_widget.value or ""
+
+    def clear(self):
+        """Clear search term and pre_search_field without mode change.
+
+        Does not call rebuild or change search mode. Used when
+        navigating into a field to reset search state silently.
+        """
+        self._search_term = ""
+        self._pre_search_field = None
+
+    def matches(self, field_name):
+        """Return True if field_name passes the current search filter.
+
+        When no search term is set, all fields match. Otherwise
+        performs a case-insensitive substring match.
+
+        Args:
+            field_name
+                The field name to test against the search term.
+
+        Returns:
+            True if the field name matches or no filter is active.
+        """
+        if not self._search_term:
+            return True
+        return self._search_term.lower() in field_name.lower()

--- a/lib/python/qmk/cli/edit/views/status_display.py
+++ b/lib/python/qmk/cli/edit/views/status_display.py
@@ -1,0 +1,169 @@
+"""Status message management and footer text generation.
+
+Owns the status message state and expiry timer, and generates
+footer text with help shortcut and optional constraint hint.
+"""
+import time
+
+# Layout indices for accessing Frame._layouts.
+# These are used because asciimatics Frame doesn't provide a public API
+# for layout access. Tested with asciimatics 1.x.
+_HEADER_LAYOUT_INDEX = 0
+_FOOTER_LAYOUT_INDEX = -1
+_FOOTER_TEXT_WIDGET_INDEX = 1  # Second widget in footer (after blank line)
+
+
+class StatusDisplay:
+    """Manages status messages and footer hint text.
+
+    Args:
+        ctx
+            ViewContext instance providing state and keymap access.
+
+        rebuild_fn
+            No-arg callable that triggers a full UI rebuild.
+    """
+    def __init__(self, ctx, rebuild_fn, frame_helper=None):
+        self._ctx = ctx
+        self._rebuild_fn = rebuild_fn
+        self._frame_helper = frame_helper
+        self._status_message = None
+        self._status_expires = 0
+
+    def show(self, message, duration=2.5):
+        """Show status message by updating footer label in-place.
+
+        Sets the status message and its expiry time, then updates
+        the footer widget directly without triggering a rebuild.
+
+        Args:
+            message
+                Text to display in the footer area.
+
+            duration
+                Seconds to display the message. Defaults to 2.5.
+        """
+        self._status_message = message
+        self._status_expires = time.time() + duration
+
+        if self._frame_helper is None:
+            return
+
+        if self._frame_helper.get_layout_count() < 3:
+            return
+
+        footer_layout = self._frame_helper.get_layout_by_index(_FOOTER_LAYOUT_INDEX)
+        if footer_layout is None:
+            return
+
+        footer_widgets = self._frame_helper.get_layout_column_widgets(footer_layout, 0)
+        if not footer_widgets or len(footer_widgets) <= _FOOTER_TEXT_WIDGET_INDEX:
+            return
+
+        footer_widget = footer_widgets[_FOOTER_TEXT_WIDGET_INDEX]
+        self._frame_helper.update_label_text(footer_widget, message)
+
+    def get_footer_text(self, hint=None):
+        """Return footer string with help shortcut and optional hint.
+
+        If a status message is active and not expired, returns it.
+        Otherwise returns '{help_display} Help' optionally followed
+        by ' | {hint}'.
+
+        Args:
+            hint
+                Optional constraint hint string to append.
+
+        Returns:
+            Footer text string.
+        """
+        if self._status_message and time.time() < self._status_expires:
+            return self._status_message
+
+        base = "%s Help" % self._ctx.keymap.get_display("help")
+        if hint:
+            return base + " | " + hint
+        return base
+
+    def check_expiry(self):
+        """Clear expired message. Returns True if footer needs update.
+
+        Returns:
+            True if the message was expired and cleared, False otherwise.
+        """
+        if not self._status_message:
+            return False
+
+        if time.time() >= self._status_expires:
+            self._status_message = None
+            return True
+
+        return False
+
+    def update_footer_widget(self, frame_helper, hint):
+        """Update footer label in-place with current help + hint text.
+
+        Skips the update when a status message is still active.
+        Otherwise computes the footer text and writes it to the
+        widget, clearing any expired status message first.
+
+        Args:
+            frame_helper
+                FrameHelper instance for accessing layouts and widgets.
+
+            hint
+                Optional constraint hint string, or None.
+        """
+        if self._status_message and time.time() < self._status_expires:
+            return
+
+        self._status_message = None
+
+        new_text = self.get_footer_text(hint)
+
+        if frame_helper.get_layout_count() < 3:
+            return
+
+        footer_layout = frame_helper.get_layout_by_index(_FOOTER_LAYOUT_INDEX)
+        if footer_layout is None:
+            return
+
+        footer_widgets = frame_helper.get_layout_column_widgets(footer_layout, 0)
+        if not footer_widgets:
+            return
+
+        if len(footer_widgets) <= _FOOTER_TEXT_WIDGET_INDEX:
+            return
+
+        footer_widget = footer_widgets[_FOOTER_TEXT_WIDGET_INDEX]
+        if frame_helper.get_label_text(footer_widget) != new_text:
+            frame_helper.update_label_text(footer_widget, new_text)
+
+    def update_breadcrumb_widget(self, frame_helper, breadcrumb_text):
+        """Update breadcrumb label in-place if changed.
+
+        Finds the header layout and checks if the first widget's
+        text differs from breadcrumb_text. If so, updates it.
+
+        Args:
+            frame_helper
+                FrameHelper instance for accessing layouts and widgets.
+
+            breadcrumb_text
+                New breadcrumb string to display.
+        """
+        if frame_helper.get_layout_count() == 0:
+            return
+
+        header_layout = frame_helper.get_layout_by_index(_HEADER_LAYOUT_INDEX)
+        if header_layout is None:
+            return
+
+        widgets = frame_helper.get_layout_column_widgets(header_layout, 0)
+        if not widgets:
+            return
+
+        breadcrumb_widget = widgets[0]
+        current_text = frame_helper.get_label_text(breadcrumb_widget)
+        if current_text != breadcrumb_text:
+            frame_helper.update_label_text(breadcrumb_widget, breadcrumb_text)

--- a/lib/python/qmk/cli/edit/views/ui_builder.py
+++ b/lib/python/qmk/cli/edit/views/ui_builder.py
@@ -1,0 +1,327 @@
+"""UI layout builder for the field list view.
+
+Creates asciimatics Layout, Label, Text, and Button widgets and
+adds them to a Frame. Receives callback factories from the Frame
+so it can attach click handlers without knowing about navigation
+or rebuild logic.
+"""
+from asciimatics.widgets import Layout, Label, Text, Button
+
+from qmk.cli.edit.widgets import ObjectRow, ArrayRow, ArrayItemRow
+
+
+class UIBuilder:
+    """Builds all UI layouts and widgets for FieldListView.
+
+    Args:
+        ctx
+            ViewContext instance providing state, keyboard, and registry.
+
+        search_controller
+            SearchController instance for search state and filtering.
+    """
+    def __init__(self, ctx, search_controller):
+        self._ctx = ctx
+        self._search = search_controller
+
+    def build(self, frame, on_navigate, on_add_click, status_display):
+        """Rebuild all layouts on the frame.
+
+        This is the main entry point. It:
+        1. Creates header layout with breadcrumb (add to frame).
+        2. If search is active, creates search bar layout.
+        3. Adds blank label separator.
+        4. Creates fill-frame field layout.
+        5. Builds field list (object or array mode).
+        6. Creates footer layout with keybinding hints.
+        7. Returns the all_fields list.
+
+        Args:
+            frame
+                The asciimatics Frame to populate with layouts.
+
+            on_navigate
+                Callable(key) -> Callable. Factory that creates click
+                handlers for object/array row navigation.
+
+            on_add_click
+                No-arg callable for the array "Add" button.
+
+            status_display
+                StatusDisplay instance for footer text generation.
+
+        Returns:
+            List of FieldWidget instances that were added.
+        """
+        header_layout = Layout([100], fill_frame=False)
+        frame.add_layout(header_layout)
+        header_layout.add_widget(Label(self.build_breadcrumb()))
+
+        self._build_search_bar(frame)
+
+        header_layout.add_widget(Label(""))
+
+        field_layout = Layout([100], fill_frame=True)
+        frame.add_layout(field_layout)
+
+        all_fields = self._build_field_list(
+            frame,
+            field_layout,
+            on_navigate,
+            on_add_click,
+        )
+
+        self._build_footer_layout(frame, status_display)
+
+        return all_fields
+
+    def build_breadcrumb(self):
+        """Build breadcrumb navigation string.
+
+        Builds "QMK Edit: keyboards/{keyboard}" + path segments
+        joined by " > " + optional " [Modified]" suffix.
+
+        Returns:
+            Breadcrumb string showing current navigation path.
+        """
+        parts = ["QMK Edit: keyboards/%s" % self._ctx.keyboard]
+
+        current_path = self._ctx.state.current_path
+        if current_path:
+            parts.append(" > ")
+            formatted = []
+            for segment in current_path:
+                if isinstance(segment, int):
+                    formatted.append("[%d]" % segment)
+                else:
+                    formatted.append(segment)
+            parts.append(" > ".join(formatted))
+
+        if self._ctx.state.is_modified:
+            parts.append(" [Modified]")
+
+        return "".join(parts)
+
+    def _build_search_bar(self, frame):
+        """Add search bar layout when search is active.
+
+        Creates a Layout with a Text widget labeled "Search: ",
+        sets its value to search_controller.search_term, and sets
+        search_controller.search_widget to the Text widget.
+        """
+        if not self._search.is_active:
+            return
+
+        search_layout = Layout([100], fill_frame=False)
+        frame.add_layout(search_layout)
+        search_widget = Text(label="Search: ", name="search")
+        search_widget.value = self._search.search_term
+        search_layout.add_widget(search_widget)
+        self._search.search_widget = search_widget
+
+    def _build_field_list(self, frame, layout, on_navigate, on_add_click):
+        """Build the field list widgets into the given layout.
+
+        Determines array_mode from ctx.state.is_current_level_array().
+        If array mode, calls _build_array_list.
+        Else, calls _build_object_list.
+        If no fields were added and search term exists, adds
+        "No matching fields" label.
+
+        Returns:
+            List of FieldWidget instances added.
+        """
+        array_mode = self._ctx.state.is_current_level_array()
+
+        if array_mode:
+            all_fields = self._build_array_list(
+                layout,
+                on_navigate,
+                on_add_click,
+            )
+        else:
+            all_fields = self._build_object_list(layout, on_navigate)
+
+        if not all_fields and self._search.search_term:
+            layout.add_widget(Label("No matching fields"))
+
+        return all_fields
+
+    def _build_object_list(self, layout, on_navigate):
+        """Build field list for object mode.
+
+        Gets properties from ctx.state.get_current_schema() and
+        property_order from schema_loader.get_property_order().
+        Iterates properties in order, filtering by search term.
+        Creates widgets via ctx.registry.create_widget().
+        For ObjectRow/ArrayRow widgets, injects on_navigate callback
+        before creating the asciimatics widget.
+
+        Returns:
+            List of FieldWidget instances added.
+        """
+        all_fields = []
+        properties = self._ctx.state.get_current_schema()
+        property_order = self._ctx.state.schema_loader.get_property_order(
+            self._ctx.state.current_path,
+        )
+
+        for prop_name in property_order:
+            if prop_name not in properties:
+                continue
+
+            if not self._search.matches(prop_name):
+                continue
+
+            prop_schema = properties[prop_name]
+            path = self._build_path(prop_name)
+
+            widget = self._ctx.registry.create_widget(
+                prop_name,
+                prop_schema,
+                self._ctx.state,
+                path,
+            )
+            all_fields.append(widget)
+
+            if isinstance(widget, (ObjectRow, ArrayRow)):
+                widget.set_on_navigate(on_navigate(prop_name))
+
+            asciimatics_widget = widget.as_asciimatics_widget()
+            layout.add_widget(asciimatics_widget)
+
+        return all_fields
+
+    def _build_array_list(self, layout, on_navigate, on_add_click):
+        """Build field list for array mode.
+
+        Checks _is_layouts_array() exclusion.
+        Gets array_length and item_schema.
+        For empty arrays, shows "(empty array)" label.
+        Creates ArrayItemRow widgets for each index.
+        Injects navigate callback for object items before widget creation.
+        Calls _add_new_item_row for add button.
+
+        Returns:
+            List of FieldWidget instances added.
+        """
+        all_fields = []
+
+        if self._is_layouts_array():
+            layout.add_widget(Label("Layout editing not yet supported"))
+            return all_fields
+
+        array_length = self._ctx.state.get_current_array_length()
+        if array_length is None:
+            return all_fields
+
+        item_schema = self._ctx.state.schema_loader.get_items_schema(
+            self._ctx.state.current_path,
+        )
+        if item_schema is None:
+            return all_fields
+
+        if array_length == 0:
+            layout.add_widget(Label("(empty array)"))
+        else:
+            for index in range(array_length):
+                path = self._build_path(index)
+                widget = ArrayItemRow(index, item_schema, self._ctx.state, path)
+                all_fields.append(widget)
+
+                if item_schema.get('type') == 'object':
+                    widget.set_on_navigate(on_navigate(index))
+
+                asciimatics_widget = widget.as_asciimatics_widget()
+                layout.add_widget(asciimatics_widget)
+
+        self._add_new_item_row(layout, on_add_click)
+
+        return all_fields
+
+    def _is_layouts_array(self):
+        """Check if current path is a layouts array.
+
+        Returns True if path has >= 3 segments and
+        path[0] == 'layouts' and path[2] == 'layout'.
+
+        Returns:
+            True if this is a layouts array that should not be edited.
+        """
+        path = self._ctx.state.current_path
+        if not path or len(path) < 3:
+            return False
+
+        return path[0] == 'layouts' and path[2] == 'layout'
+
+    def _add_new_item_row(self, layout, on_add_click):
+        """Add the 'Add new item' button row for arrays.
+
+        Checks _is_at_max_items(). If at max, shows label.
+        Otherwise creates Button with on_add_click handler.
+        """
+        if self._is_at_max_items():
+            layout.add_widget(Label("(maximum items reached)"))
+            return
+
+        add_button = Button(
+            text="[+] Add new item",
+            on_click=on_add_click,
+            name="add_item",
+        )
+        layout.add_widget(add_button)
+
+    def _is_at_max_items(self):
+        """Check if array has reached maxItems limit.
+
+        Gets parent schema, finds maxItems constraint,
+        compares to current array length.
+
+        Returns:
+            True if at or above maxItems limit, False otherwise.
+        """
+        current_path = self._ctx.state.current_path
+        if not current_path:
+            return False
+
+        parent_path = current_path[:-1] if len(current_path) > 1 else None
+        parent_schema = self._ctx.state.schema_loader.get_properties(parent_path)
+        array_name = current_path[-1]
+
+        if not parent_schema or array_name not in parent_schema:
+            return False
+
+        max_items = parent_schema[array_name].get('maxItems')
+        if max_items is None:
+            return False
+
+        current_length = self._ctx.state.get_current_array_length()
+        return current_length is not None and current_length >= max_items
+
+    def _build_footer_layout(self, frame, status_display):
+        """Add footer layout with help shortcut and optional hint.
+
+        Creates a Layout, adds blank label, adds footer text from
+        status_display.get_footer_text(). No hint is passed during
+        initial build -- hints are injected later via update_footer_widget.
+        """
+        footer_layout = Layout([100], fill_frame=False)
+        frame.add_layout(footer_layout)
+
+        footer_layout.add_widget(Label(""))
+        footer_text = status_display.get_footer_text()
+        footer_layout.add_widget(Label(footer_text))
+
+    def _build_path(self, prop_name):
+        """Build full tuple path for a property.
+
+        Appends prop_name to current_path tuple.
+
+        Args:
+            prop_name
+                Property name string or integer index.
+
+        Returns:
+            Tuple path, e.g. ('usb', 'vid').
+        """
+        return self._ctx.state.current_path + (prop_name,)

--- a/lib/python/qmk/cli/edit/views/view_callbacks.py
+++ b/lib/python/qmk/cli/edit/views/view_callbacks.py
@@ -1,0 +1,41 @@
+"""Callback interface for view collaborators.
+
+Provides the mechanism collaborators use to communicate back to the
+parent view without holding a direct reference to it.
+"""
+
+
+class ViewCallbacks:
+    """Callback bundle passed to collaborators for view communication.
+
+    Args:
+        rebuild_fn
+            No-arg callable that triggers a full UI rebuild.
+
+        show_status_fn
+            Callable taking (message, duration=2.5) to display a
+            temporary status message.
+
+        focus_manager
+            FocusManager instance for controlling widget focus.
+
+        on_quit
+            Optional no-arg callable for quit action.
+
+        on_save
+            Optional no-arg callable for save action.
+
+        on_validate
+            Optional no-arg callable for validate action.
+
+        on_help
+            Optional no-arg callable for help action.
+    """
+    def __init__(self, rebuild_fn, show_status_fn, focus_manager, on_quit=None, on_save=None, on_validate=None, on_help=None):
+        self.rebuild = rebuild_fn
+        self.show_status = show_status_fn
+        self.focus = focus_manager
+        self.on_quit = on_quit
+        self.on_save = on_save
+        self.on_validate = on_validate
+        self.on_help = on_help

--- a/lib/python/qmk/cli/edit/views/view_context.py
+++ b/lib/python/qmk/cli/edit/views/view_context.py
@@ -1,0 +1,32 @@
+"""Shared data container for view collaborators.
+
+Bundles the references every collaborator needs so they can be passed
+as a single object instead of five separate parameters.
+"""
+
+
+class ViewContext:
+    """Read-only data bag holding shared state for all view collaborators.
+
+    Args:
+        state
+            The EditorState instance that owns working data and navigation.
+
+        keyboard
+            Keyboard identifier string (e.g. 'planck/rev6').
+
+        keymap
+            Keymap name string.
+
+        registry
+            The widget registry used for field type resolution.
+
+        config
+            Optional configuration object (may be None).
+    """
+    def __init__(self, state, keyboard, keymap, registry, config):
+        self.state = state
+        self.keyboard = keyboard
+        self.keymap = keymap
+        self.registry = registry
+        self.config = config

--- a/lib/python/qmk/cli/edit/widget_registry.py
+++ b/lib/python/qmk/cli/edit/widget_registry.py
@@ -1,0 +1,77 @@
+"""Widget registry for mapping schema types to widget factories.
+"""
+from qmk.cli.edit.widgets.text_field import TextField
+
+
+class WidgetRegistry:
+    """Maps schema paths and types to widget factories.
+    """
+    def __init__(self):
+        """Initialize with empty registries.
+        """
+        self._type_defaults = {}
+        self._path_overrides = {}
+        self._pattern_overrides = []
+
+    def register_type_default(self, schema_type, widget_factory):
+        """Register default factory for a schema type.
+
+        Args:
+            schema_type
+                Schema type string like 'string', 'boolean', 'integer'.
+            widget_factory
+                Callable(name, schema, state, path) -> FieldWidget.
+        """
+        self._type_defaults[schema_type] = widget_factory
+
+    def register_path_override(self, path, widget_factory):
+        """Register override for exact path.
+
+        Args:
+            path
+                Tuple path like ('usb', 'vid').
+            widget_factory
+                Callable(name, schema, state, path) -> FieldWidget.
+        """
+        self._path_overrides[path] = widget_factory
+
+    def register_pattern_override(self, pattern, widget_factory):
+        """Register override for paths matching compiled regex pattern.
+
+        Args:
+            pattern
+                Compiled re.Pattern object.
+            widget_factory
+                Callable(name, schema, state, path) -> FieldWidget.
+        """
+        self._pattern_overrides.append((pattern, widget_factory))
+
+    def create_widget(self, name, property_schema, state, path):
+        """Create widget with precedence: path > pattern > type > fallback.
+
+        Args:
+            name
+                Field name (e.g., 'vid').
+            property_schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path, e.g. ('usb', 'vid').
+
+        Returns:
+            FieldWidget instance.
+        """
+        if path in self._path_overrides:
+            return self._path_overrides[path](name, property_schema, state, path)
+
+        dot_path = '.'.join(str(s) for s in path)
+        for pattern, factory in self._pattern_overrides:
+            if pattern.match(dot_path):
+                return factory(name, property_schema, state, path)
+
+        schema_type = state.schema_loader.get_type(property_schema)
+        if schema_type in self._type_defaults:
+            return self._type_defaults[schema_type](name, property_schema, state, path)
+
+        return TextField(name, property_schema, state, path)

--- a/lib/python/qmk/cli/edit/widgets/__init__.py
+++ b/lib/python/qmk/cli/edit/widgets/__init__.py
@@ -1,0 +1,49 @@
+"""Widget package for field editors.
+"""
+from qmk.cli.edit.widgets.base import FieldWidget
+from qmk.cli.edit.widgets.text_field import TextField
+from qmk.cli.edit.widgets.numeric_field import NumericField
+from qmk.cli.edit.widgets.boolean_field import BooleanField
+from qmk.cli.edit.widgets.enum_field import EnumField
+from qmk.cli.edit.widgets.object_row import ObjectRow
+from qmk.cli.edit.widgets.array_row import ArrayRow
+from qmk.cli.edit.widgets.array_item_row import ArrayItemRow
+from qmk.cli.edit.widget_registry import WidgetRegistry
+
+
+def create_default_registry():
+    """Create and configure the default widget registry.
+
+    Returns:
+        WidgetRegistry instance with standard type mappings.
+    """
+    registry = WidgetRegistry()
+
+    registry.register_type_default('string', TextField)
+    registry.register_type_default('boolean', BooleanField)
+    registry.register_type_default('integer', NumericField)
+    registry.register_type_default('number', NumericField)
+    registry.register_type_default('enum', EnumField)
+    registry.register_type_default('object', ObjectRow)
+    registry.register_type_default('array', ArrayRow)
+
+    def create_hex_field(name, schema, state, path):
+        return NumericField(name, schema, state, path, hex_format=True)
+
+    registry.register_path_override(('usb', 'vid'), create_hex_field)
+    registry.register_path_override(('usb', 'pid'), create_hex_field)
+
+    return registry
+
+
+__all__ = [
+    'FieldWidget',
+    'TextField',
+    'NumericField',
+    'BooleanField',
+    'EnumField',
+    'ObjectRow',
+    'ArrayRow',
+    'ArrayItemRow',
+    'create_default_registry',
+]

--- a/lib/python/qmk/cli/edit/widgets/array_item_row.py
+++ b/lib/python/qmk/cli/edit/widgets/array_item_row.py
@@ -1,0 +1,166 @@
+"""Array item row widget for individual array items.
+
+This module provides the ArrayItemRow widget, which displays individual
+items within an array. It shows the item index and value for simple types,
+or the index and required field values for object types. Clicking the widget
+navigates into the item for editing.
+"""
+
+from asciimatics.widgets import Button
+from qmk.cli.edit.widgets.base import FieldWidget
+from qmk.cli.edit.widgets.numeric_field import NumericField
+from qmk.cli.edit.widgets.text_field import TextField
+
+
+class ArrayItemRow(FieldWidget):
+    """Widget representing one item in an array.
+
+    For object types, displays as a navigable button showing required field values.
+    For simple types (strings, numbers), displays as an editable text field.
+    """
+    def __init__(self, index, item_schema, state, path, on_navigate=None):
+        """Initialize the array item row widget.
+
+        Args:
+            index
+                Integer position in array.
+            item_schema
+                Schema for array items.
+            state
+                EditorState instance.
+            path
+                Tuple path including index, e.g. ('encoder', 'rotary', 0).
+            on_navigate
+                Optional callback overriding default navigation for object items.
+        """
+        super().__init__(str(index), item_schema, state, path)
+        self._index = index
+        self._widget = None
+        self._delegate = None
+        self._custom_navigate = on_navigate
+
+    @property
+    def index(self):
+        """Integer position in array."""
+        return self._index
+
+    def as_asciimatics_widget(self):
+        """Return asciimatics widget for navigation/editing.
+
+        For object types, returns a Button for navigation.
+        For simple types, delegates to a typed widget (NumericField
+        or TextField) that handles coercion and validation.
+
+        Returns:
+            Button or Text widget.
+        """
+        if self._schema.get("type") == "object":
+            self._widget = Button(
+                text=self.get_display_value(),
+                on_click=self._on_navigate,
+                name=self._path_string,
+            )
+            return self._widget
+
+        self._delegate = self._create_delegate()
+        self._widget = self._init_delegate_widget()
+        # asciimatics Text.label is a read-only property; _label is the
+        # underlying attribute that stores the display text.
+        self._widget._label = "[%d]" % self._index
+        return self._widget
+
+    def _init_delegate_widget(self):
+        """Initialize the delegate's asciimatics widget safely.
+
+        Suppresses the on_change callback during widget creation to
+        prevent ValueError when EditorState rejects None for array
+        elements. The asciimatics Text widget fires on_change during
+        initial value setting, and for empty values the delegate
+        would try to write None to an array element.
+
+        Note: Accesses delegate._on_change (private) because asciimatics
+        provides no public API to suppress change callbacks during
+        widget initialization.
+
+        Returns:
+            The delegate's asciimatics widget.
+        """
+        saved_on_change = (self._delegate._on_change)  # noqa: private access required by asciimatics
+        self._delegate._on_change = lambda: None
+        try:
+            widget = self._delegate.as_asciimatics_widget()
+        finally:
+            self._delegate._on_change = saved_on_change
+        widget._on_change = saved_on_change
+        return widget
+
+    def _create_delegate(self):
+        """Create a typed widget delegate based on schema type.
+
+        Returns:
+            NumericField or TextField instance.
+        """
+        schema_type = self._state.schema_loader.get_type(self._schema)
+        if schema_type in ("integer", "number"):
+            return NumericField(
+                str(self._index),
+                self._schema,
+                self._state,
+                self._path,
+            )
+        return TextField(
+            str(self._index),
+            self._schema,
+            self._state,
+            self._path,
+        )
+
+    def set_on_navigate(self, callback):
+        """Override the default navigation handler.
+
+        Must be called before as_asciimatics_widget().
+        """
+        self._custom_navigate = callback
+
+    def _on_navigate(self):
+        """Handle navigation into this array item.
+
+        Pushes the array index onto the navigation path.
+        Only called for object type items.
+        """
+        if self._custom_navigate:
+            self._custom_navigate()
+        else:
+            self._state.navigate_into(self._index)
+
+    def get_display_value(self):
+        """Return formatted value for object type items.
+
+        Shows index and required field values in a compact format.
+        Truncates display to 40 characters to fit in UI.
+
+        Returns:
+            Formatted string like '[1] pin_a=GP22, pin_b=GP23'.
+        """
+        val = self._state.get(self._path)
+        prefix = "[%d] " % self._index
+
+        if not isinstance(val, dict):
+            return prefix + "[invalid]"
+
+        display_parts = []
+        required_fields = self._schema.get("required", [])
+        properties = self._schema.get("properties", {})
+
+        for field_name in required_fields:
+            if field_name in properties:
+                field_value = val.get(field_name) if val else None
+                field_str = "" if field_value is None else str(field_value)
+                display_parts.append("%s=%s" % (field_name, field_str))
+
+        display_str = prefix + ", ".join(display_parts)
+
+        if len(display_str) > 40:
+            return display_str[:37] + "..."
+
+        return display_str

--- a/lib/python/qmk/cli/edit/widgets/array_row.py
+++ b/lib/python/qmk/cli/edit/widgets/array_row.py
@@ -1,0 +1,80 @@
+"""Array row widget for navigable array fields.
+
+This module provides the ArrayRow widget, which displays array fields
+in the keyboard configuration editor and allows navigation into arrays
+for viewing and editing array items.
+"""
+
+from asciimatics.widgets import Button
+from qmk.cli.edit.widgets.base import FieldWidget
+
+
+class ArrayRow(FieldWidget):
+    """Widget for navigating into arrays.
+
+    Displays array fields as a navigable button showing the item count.
+    Clicking the button navigates into the array to view and edit items.
+    Supports both simple arrays (strings, numbers) and object arrays.
+    """
+    def __init__(self, name, schema, state, path, on_navigate=None):
+        """Initialize the array row widget.
+
+        Args:
+            name
+                Field name.
+            schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path to this field.
+            on_navigate
+                Optional callback overriding default navigation.
+        """
+        super().__init__(name, schema, state, path)
+        self._widget = None
+        self._custom_navigate = on_navigate
+
+    def as_asciimatics_widget(self):
+        """Return asciimatics Button widget for navigation.
+
+        Returns:
+            Button widget configured with navigation handler.
+        """
+        display_text = "%s: %s" % (self.label, self.get_display_value())
+        self._widget = Button(text=display_text, on_click=self._on_navigate, name=self._path_string)
+        return self._widget
+
+    def set_on_navigate(self, callback):
+        """Override the default navigation handler.
+
+        Must be called before as_asciimatics_widget().
+        """
+        self._custom_navigate = callback
+
+    def _on_navigate(self):
+        """Handle navigation into this array.
+
+        Pushes the array field name onto the navigation path,
+        triggering a view update to show array items.
+        """
+        if self._custom_navigate:
+            self._custom_navigate()
+        else:
+            self._state.navigate_into(self._name)
+
+    def get_display_value(self):
+        """Return item count or empty indicator for display.
+
+        Returns:
+            String showing item count like '[3 items] [->]' or '[empty] [->]'.
+        """
+        val = self.value
+        if val is None or not isinstance(val, list):
+            return "[empty] [->]"
+
+        item_count = len(val)
+        if item_count == 0:
+            return "[empty] [->]"
+
+        return "[%d items] [->]" % item_count

--- a/lib/python/qmk/cli/edit/widgets/base.py
+++ b/lib/python/qmk/cli/edit/widgets/base.py
@@ -1,0 +1,95 @@
+"""Base widget interface for field editors.
+"""
+from abc import ABC, abstractmethod
+
+from qmk.cli.edit.constraint_formatter import format_hint
+
+
+class FieldWidget(ABC):
+    """Base interface for all field editor widgets.
+    """
+    def __init__(self, name, schema, state, path):
+        """Initialize the field widget.
+
+        Args:
+            name
+                Field name (e.g., 'vid').
+            schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path to this field, e.g. ('usb', 'vid').
+        """
+        self._name = name
+        self._schema = schema
+        self._state = state
+        self._path = path
+
+    @property
+    def _path_string(self):
+        """Return path as dot-string for asciimatics widget name.
+        """
+        return '.'.join(str(s) for s in self._path)
+
+    @property
+    def name(self):
+        """Field name (e.g., 'vid').
+        """
+        return self._name
+
+    @property
+    def index(self):
+        """Array index for ArrayItemRow widgets, or None.
+
+        Base implementation returns None. ArrayItemRow overrides
+        to return the integer index.
+        """
+        return None
+
+    @property
+    def asciimatics_widget(self):
+        """The underlying asciimatics widget, or None if not yet created.
+        """
+        return getattr(self, '_widget', None)
+
+    @property
+    def label(self):
+        """Display label for the field.
+        """
+        if 'title' in self._schema:
+            return self._schema['title']
+        return self._name
+
+    @property
+    def value(self):
+        """Current value from state, or None if unset.
+        """
+        return self._state.get(self._path)
+
+    @value.setter
+    def value(self, new_value):
+        """Update value in state.
+        """
+        self._state.set(self._path, new_value)
+
+    @abstractmethod
+    def as_asciimatics_widget(self):
+        """Return asciimatics Widget instance for rendering.
+        """
+        pass
+
+    def get_hint(self):
+        """Return constraint hint string for this field, or None.
+        """
+        constraints = self._state.schema_loader.get_constraints(self._schema)
+        enum_values = self._state.schema_loader.get_enum_values(self._schema)
+        return format_hint(constraints, enum_values)
+
+    def get_display_value(self):
+        """Return string representation for display in field list.
+        """
+        val = self.value
+        if val is None:
+            return '[-]'
+        return '[%s]' % str(val)

--- a/lib/python/qmk/cli/edit/widgets/boolean_field.py
+++ b/lib/python/qmk/cli/edit/widgets/boolean_field.py
@@ -1,0 +1,76 @@
+"""Boolean field widget for tri-state toggle."""
+
+from asciimatics.widgets import Button
+from qmk.cli.edit.widgets.base import FieldWidget
+
+
+class BooleanField(FieldWidget):
+    """Widget for editing boolean values with tri-state support.
+
+    States: unset (None) -> true -> false -> unset
+    """
+    def __init__(self, name, schema, state, path):
+        """Initialize the boolean field widget.
+
+        Args:
+            name
+                Field name.
+            schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path to this field.
+        """
+        super().__init__(name, schema, state, path)
+        self._widget = None
+
+    def as_asciimatics_widget(self):
+        """Return asciimatics Button widget for tri-state toggle."""
+        self._widget = Button(
+            text=self._get_button_text(),
+            on_click=self._on_click,
+            name=self._path_string,
+        )
+        return self._widget
+
+    def _get_button_text(self):
+        """Get button text based on current value.
+
+        Returns:
+            Button text showing label and state indicator.
+        """
+        current = self.value
+        if current is None:
+            state_indicator = "[ ]"
+        elif current:
+            state_indicator = "[x]"
+        else:
+            state_indicator = "[-]"
+        return "%s %s" % (self.label, state_indicator)
+
+    def _on_click(self):
+        """Handle button click through tri-state cycle.
+
+        Cycle: unset (None) -> true -> false -> unset
+        """
+        current = self.value
+
+        if current is None:
+            self.value = True
+        elif current is True:
+            self.value = False
+        else:
+            self.value = None
+
+        if self._widget:
+            self._widget.text = self._get_button_text()
+
+    def get_display_value(self):
+        """Return string representation for display in field list."""
+        val = self.value
+        if val is None:
+            return "[ ]"
+        if val:
+            return "[x]"
+        return "[-]"

--- a/lib/python/qmk/cli/edit/widgets/enum_field.py
+++ b/lib/python/qmk/cli/edit/widgets/enum_field.py
@@ -1,0 +1,51 @@
+"""Enum field widget for dropdown picker."""
+
+from asciimatics.widgets import DropdownList
+from qmk.cli.edit.widgets.base import FieldWidget
+
+
+class EnumField(FieldWidget):
+    """Widget for selecting from enumerated values."""
+    def __init__(self, name, schema, state, path):
+        """Initialize the enum field widget.
+
+        Args:
+            name
+                Field name.
+            schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path to this field.
+        """
+        super().__init__(name, schema, state, path)
+        self._widget = None
+        self._enum_values = state.schema_loader.get_enum_values(schema) or []
+
+    def as_asciimatics_widget(self):
+        """Return asciimatics DropdownList widget."""
+        options = [("(unset)", None)] + [(str(v), v) for v in self._enum_values]
+
+        self._widget = DropdownList(
+            options,
+            label=self.label + ":",
+            name=self._path_string,
+            on_change=self._on_change,
+        )
+
+        current = self.value
+        if current is None:
+            self._widget.value = None
+        else:
+            for _, val in options:
+                if val == current:
+                    self._widget.value = val
+                    break
+
+        return self._widget
+
+    def _on_change(self):
+        """Handle selection change."""
+        if self._widget:
+            self.value = self._widget.value

--- a/lib/python/qmk/cli/edit/widgets/numeric_field.py
+++ b/lib/python/qmk/cli/edit/widgets/numeric_field.py
@@ -1,0 +1,131 @@
+"""Numeric field widget for integer and number input."""
+
+from asciimatics.widgets import Text
+from qmk.cli.edit.widgets.base import FieldWidget
+
+
+class NumericField(FieldWidget):
+    """Widget for editing integer and number values."""
+    def __init__(self, name, schema, state, path, hex_format=False):
+        """Initialize the numeric field widget.
+
+        Args:
+            name
+                Field name.
+            schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path to this field.
+            hex_format
+                If True, display and accept hex format (0x prefix).
+        """
+        super().__init__(name, schema, state, path)
+        self._widget = None
+        self._hex_format = hex_format
+        self._constraints = state.schema_loader.get_constraints(schema)
+        self._is_integer = state.schema_loader.get_type(schema) == "integer"
+        self._updating = False
+
+    def as_asciimatics_widget(self):
+        """Return asciimatics Text widget with numeric validation."""
+        self._widget = Text(label=self.label + ":", name=self._path_string, on_change=self._on_change)
+        self._widget.value = self._format_value(self.value)
+        return self._widget
+
+    def _on_change(self):
+        """Handle value change with validation."""
+        if self._updating:
+            return
+
+        if not self._widget:
+            return
+
+        raw_value = self._widget.value
+        if not raw_value:
+            self.value = None
+            return
+
+        parsed = self._parse_value(raw_value)
+        if parsed is not None and self._validate(parsed):
+            self.value = parsed
+        else:
+            try:
+                self._updating = True
+                self._widget.value = self._format_value(self.value)
+            finally:
+                self._updating = False
+
+    def _parse_value(self, raw_value):
+        """Parse string input to numeric value.
+
+        Args:
+            raw_value
+                String input from user.
+
+        Returns:
+            Parsed numeric value, or None if invalid.
+        """
+        if not raw_value:
+            return None
+
+        try:
+            if self._hex_format:
+                return int(raw_value, 16)
+
+            if self._is_integer:
+                return int(raw_value)
+            return float(raw_value)
+        except ValueError:
+            return None
+
+    def _format_value(self, value):
+        """Format value for display.
+
+        Args:
+            value
+                Numeric value to format.
+
+        Returns:
+            Formatted string.
+        """
+        if value is None:
+            return ""
+
+        if not self._hex_format:
+            return str(value)
+
+        if not isinstance(value, str):
+            return "0x%X" % value
+
+        if value.startswith("0x"):
+            return value
+
+        try:
+            return "0x%X" % int(value, 16)
+        except ValueError:
+            return value
+
+    def _validate(self, value):
+        """Validate numeric value against constraints.
+
+        Args:
+            value
+                Numeric value to validate.
+
+        Returns:
+            True if valid, False otherwise.
+        """
+        if "minimum" in self._constraints and value < self._constraints["minimum"]:
+            return False
+        if "maximum" in self._constraints and value > self._constraints["maximum"]:
+            return False
+        return True
+
+    def get_display_value(self):
+        """Return string representation for display in field list."""
+        val = self.value
+        if val is None:
+            return "[-]"
+        return "[%s]" % self._format_value(val)

--- a/lib/python/qmk/cli/edit/widgets/object_row.py
+++ b/lib/python/qmk/cli/edit/widgets/object_row.py
@@ -1,0 +1,53 @@
+"""Object row widget for navigable nested objects."""
+
+from asciimatics.widgets import Button
+from qmk.cli.edit.widgets.base import FieldWidget
+
+
+class ObjectRow(FieldWidget):
+    """Widget for navigating into nested objects."""
+    def __init__(self, name, schema, state, path, on_navigate=None):
+        """Initialize the object row widget.
+
+        Args:
+            name
+                Field name.
+            schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path to this field.
+            on_navigate
+                Optional callback overriding default navigation.
+        """
+        super().__init__(name, schema, state, path)
+        self._widget = None
+        self._custom_navigate = on_navigate
+
+    def as_asciimatics_widget(self):
+        """Return asciimatics Button widget for navigation."""
+        self._widget = Button(
+            text=self.label + " [->]",
+            on_click=self._on_navigate,
+            name=self._path_string,
+        )
+        return self._widget
+
+    def set_on_navigate(self, callback):
+        """Override the default navigation handler.
+
+        Must be called before as_asciimatics_widget().
+        """
+        self._custom_navigate = callback
+
+    def _on_navigate(self):
+        """Handle navigation into this object."""
+        if self._custom_navigate:
+            self._custom_navigate()
+        else:
+            self._state.navigate_into(self._name)
+
+    def get_display_value(self):
+        """Return navigation indicator for display."""
+        return "[->]"

--- a/lib/python/qmk/cli/edit/widgets/text_field.py
+++ b/lib/python/qmk/cli/edit/widgets/text_field.py
@@ -1,0 +1,35 @@
+"""Text field widget for string input."""
+
+from asciimatics.widgets import Text
+from qmk.cli.edit.widgets.base import FieldWidget
+
+
+class TextField(FieldWidget):
+    """Widget for editing string values."""
+    def __init__(self, name, schema, state, path):
+        """Initialize the text field widget.
+
+        Args:
+            name
+                Field name.
+            schema
+                Property schema fragment.
+            state
+                EditorState instance.
+            path
+                Tuple path to this field.
+        """
+        super().__init__(name, schema, state, path)
+        self._widget = None
+
+    def as_asciimatics_widget(self):
+        """Return asciimatics Text widget."""
+        self._widget = Text(label=self.label + ":", name=self._path_string, on_change=self._on_change)
+        self._widget.value = self.value or ""
+        return self._widget
+
+    def _on_change(self):
+        """Handle value change."""
+        if self._widget:
+            new_value = self._widget.value
+            self.value = new_value if new_value else None

--- a/lib/python/qmk/tests/test_edit.py
+++ b/lib/python/qmk/tests/test_edit.py
@@ -1,0 +1,375 @@
+"""Integration tests for the edit TUI.
+
+Tests use the headless Canvas pattern: MagicMock(spec=Screen) + Canvas
+to exercise FieldListView without a real terminal. All assertions target
+EditorState (working_data, current_path, is_modified), never canvas pixels.
+"""
+import copy
+import json
+import os
+
+# ORIG_CWD must be set before any qmk imports.
+os.environ['ORIG_CWD'] = os.getcwd()
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from asciimatics.event import KeyboardEvent  # noqa: E402
+from asciimatics.scene import Scene  # noqa: E402
+from asciimatics.screen import Screen, Canvas  # noqa: E402
+
+from qmk.cli.edit.config import EditorConfig  # noqa: E402
+from qmk.cli.edit.editor import EditorController  # noqa: E402
+from qmk.cli.edit.file_manager import FileManager  # noqa: E402
+from qmk.cli.edit.schema_loader import SchemaLoader  # noqa: E402
+from qmk.cli.edit.state import EditorState  # noqa: E402
+from qmk.cli.edit.widgets import create_default_registry  # noqa: E402
+from qmk.cli.edit.views.confirm_dialog import ConfirmDialog  # noqa: E402
+from qmk.cli.edit.views.error_dialog import ErrorDialog  # noqa: E402
+from qmk.cli.edit.views.field_list import FieldListView  # noqa: E402
+
+# Load default test data at module level.
+_test_data_path = os.path.join(
+    os.environ['ORIG_CWD'], 'lib', 'python', 'qmk', 'tests', 'minimal_info.json',
+)
+with open(_test_data_path) as _f:
+    _DEFAULT_DATA = json.load(_f)
+
+
+def make_test_view(data=None, schema_path=None):
+    """Create a headless FieldListView for testing.
+
+    Args:
+        data
+            JSON dict for EditorState. Defaults to _DEFAULT_DATA contents
+            (deep copied).
+
+        schema_path
+            Unused, reserved for future override. Schema always loaded
+            via SchemaLoader().
+
+    Returns:
+        Tuple of (view, state, canvas, scene).
+    """
+    if data is None:
+        data = copy.deepcopy(_DEFAULT_DATA)
+
+    screen = MagicMock(spec=Screen)
+    screen.height = 30
+    screen.width = 100
+    screen.colours = 8
+    screen.unicode_aware = False
+    canvas = Canvas(screen, 30, 100, 0, 0)
+
+    schema_loader = SchemaLoader()
+    state = EditorState(data, schema_loader)
+    registry = create_default_registry()
+
+    view = FieldListView(canvas, state, 'handwired/pytest/basic', registry)
+    scene = Scene([view], -1)
+    view.reset()
+
+    return (view, state, canvas, scene)
+
+
+def process_keys(form, keys):
+    """Simulate keyboard input on a form.
+
+    Args:
+        form
+            An asciimatics Frame instance.
+
+        keys
+            List of int key codes or str values (each char typed
+            individually).
+    """
+    for item in keys:
+        if isinstance(item, int):
+            form.process_event(KeyboardEvent(item))
+        elif isinstance(item, str):
+            for ch in item:
+                form.process_event(KeyboardEvent(ord(ch)))
+
+
+def test_load_and_render():
+    """FieldListView loads data and renders without error."""
+    view, state, canvas, scene = make_test_view()
+
+    assert 'keyboard_name' in state.working_data
+    assert 'maintainer' in state.working_data
+    assert 'layouts' in state.working_data
+    assert state.working_data['keyboard_name'] == 'tester'
+    assert state.working_data['maintainer'] == 'qmk'
+
+    view.update(0)
+
+    assert state.current_path == ()
+    assert state.is_modified is False
+
+
+def test_edit_text_field():
+    """Typing into a text field updates state.working_data."""
+    view, state, canvas, scene = make_test_view()
+
+    # Tab focuses keyboard_folder (first focusable widget after header).
+    # Type 'hello' into that field.
+    process_keys(view, [Screen.KEY_TAB, 'hello'])
+
+    assert state.working_data['keyboard_folder'] == 'hello'
+    assert state.is_modified is True
+    assert state.working_data['keyboard_name'] == 'tester'
+
+
+def test_navigation():
+    """Enter navigates into an object, Escape navigates back."""
+    view, state, canvas, scene = make_test_view()
+
+    assert state.current_path == ()
+
+    # Tab 8 times to reach the first object row (apa102).
+    tabs = [Screen.KEY_TAB] * 8
+    process_keys(view, tabs)
+
+    # Enter navigates into the object.
+    process_keys(view, [ord('\n')])
+    assert state.current_path == ('apa102',)
+
+    # Escape navigates back to root.
+    process_keys(view, [Screen.KEY_ESCAPE])
+    assert state.current_path == ()
+
+
+def _make_array_test_view(data, array_path, config=None):
+    """Create a headless view pre-navigated into an array.
+
+    Navigates state into the array before creating the FieldListView,
+    so the view renders in array mode rather than object mode.
+
+    Args:
+        data
+            JSON dict with array data already populated.
+
+        array_path
+            String key of the array to navigate into.
+
+        config
+            Optional EditorConfig for behavioral overrides.
+
+    Returns:
+        Tuple of (view, state, canvas, scene).
+    """
+    screen = MagicMock(spec=Screen)
+    screen.height = 30
+    screen.width = 100
+    screen.colours = 8
+    screen.unicode_aware = False
+    canvas = Canvas(screen, 30, 100, 0, 0)
+
+    schema_loader = SchemaLoader()
+    state = EditorState(data, schema_loader)
+    registry = create_default_registry()
+
+    state.navigate_into(array_path)
+
+    view = FieldListView(
+        canvas, state, 'handwired/pytest/basic', registry, config=config,
+    )
+    scene = Scene([view], -1)
+    view.reset()
+
+    return (view, state, canvas, scene)
+
+
+def test_array_add_item():
+    """Ctrl+N adds a scaffolded item to the current array."""
+    data = copy.deepcopy(_DEFAULT_DATA)
+    data['community_layouts'] = ['ortho_1x1']
+
+    view, state, canvas, scene = _make_array_test_view(data, 'community_layouts')
+
+    assert state.get_current_array_length() == 1
+
+    # Tab to focus an array item, then Ctrl+N to add.
+    process_keys(view, [Screen.KEY_TAB, Screen.ctrl('n')])
+
+    assert state.get_current_array_length() == 2
+    assert len(state.working_data['community_layouts']) == 2
+    assert state.working_data['community_layouts'][0] == 'ortho_1x1'
+    # ItemScaffolder returns '' for string-typed array items.
+    assert state.working_data['community_layouts'][1] == ''
+    assert state.is_modified is True
+
+
+def test_array_delete_item():
+    """Ctrl+D deletes the focused array item when no_confirm_delete is set."""
+    data = copy.deepcopy(_DEFAULT_DATA)
+    data['community_layouts'] = ['ortho_1x1', 'numpad_1x1']
+
+    config = EditorConfig(no_confirm_delete=True)
+    view, state, canvas, scene = _make_array_test_view(
+        data, 'community_layouts', config=config,
+    )
+
+    assert state.get_current_array_length() == 2
+
+    # Tab to focus an array item, then Ctrl+D to delete.
+    process_keys(view, [Screen.KEY_TAB, Screen.ctrl('d')])
+
+    assert state.get_current_array_length() == 1
+    assert state.is_modified is True
+    assert state.working_data['community_layouts'] == ['ortho_1x1']
+
+
+def test_array_move_item():
+    """Move-up and move-down reorder items; boundary moves are no-ops."""
+    data = copy.deepcopy(_DEFAULT_DATA)
+    data['community_layouts'] = ['alpha', 'beta', 'gamma']
+
+    view, state, canvas, scene = _make_array_test_view(data, 'community_layouts')
+
+    # Tab to focus item at index 1 (beta).
+    process_keys(view, [Screen.KEY_TAB])
+
+    # Move down: beta swaps with gamma.
+    process_keys(view, [Screen.ctrl('j')])
+    assert state.working_data['community_layouts'] == ['alpha', 'gamma', 'beta']
+    assert state.is_modified is True
+
+    # Move up: beta swaps back with gamma.
+    process_keys(view, [Screen.ctrl('k')])
+    assert state.working_data['community_layouts'] == ['alpha', 'beta', 'gamma']
+
+    # Move up again: beta is now at index 0 after the swap above,
+    # so move up from index 1 puts it at 0; one more move up is a no-op.
+    process_keys(view, [Screen.ctrl('k')])
+    assert state.working_data['community_layouts'] == ['beta', 'alpha', 'gamma']
+
+    process_keys(view, [Screen.ctrl('k')])
+    assert state.working_data['community_layouts'] == ['beta', 'alpha', 'gamma']
+
+
+def test_edit_numeric_array_item():
+    """Typing a number into an integer array item stores an int in state."""
+    data = copy.deepcopy(_DEFAULT_DATA)
+    data['bootmagic'] = {'matrix': [0, 1]}
+
+    screen = MagicMock(spec=Screen)
+    screen.height = 30
+    screen.width = 100
+    screen.colours = 8
+    screen.unicode_aware = False
+    canvas = Canvas(screen, 30, 100, 0, 0)
+
+    schema_loader = SchemaLoader()
+    state = EditorState(data, schema_loader)
+    registry = create_default_registry()
+
+    state.navigate_into('bootmagic')
+    state.navigate_into('matrix')
+
+    view = FieldListView(canvas, state, 'handwired/pytest/basic', registry)
+    scene = Scene([view], -1)  # noqa: F841
+    view.reset()
+
+    # Select all existing text in first array item and replace with '42'.
+    # Ctrl+A selects all, then typing replaces.
+    process_keys(view, [Screen.ctrl('a'), '42'])
+
+    assert state.working_data['bootmagic']['matrix'][0] == 42
+    assert isinstance(state.working_data['bootmagic']['matrix'][0], int)
+    assert state.is_modified is True
+
+    # Type non-numeric input: value should revert to 42 (not corrupted).
+    process_keys(view, [Screen.ctrl('a'), 'abc'])
+    assert state.working_data['bootmagic']['matrix'][0] == 42
+
+
+def make_controller_view(data=None, validate_errors=None):
+    """Create a headless view with EditorController for save/quit testing.
+
+    Args:
+        data
+            JSON dict for EditorState. Defaults to deep copy of _DEFAULT_DATA.
+
+        validate_errors
+            List of error dicts that FileManager.validate() returns.
+            Defaults to [] (no errors, validation passes).
+
+    Returns:
+        Tuple of (view, state, scene, file_manager_mock).
+    """
+    if data is None:
+        data = copy.deepcopy(_DEFAULT_DATA)
+    if validate_errors is None:
+        validate_errors = []
+
+    screen = MagicMock(spec=Screen)
+    screen.height = 30
+    screen.width = 100
+    screen.colours = 8
+    screen.unicode_aware = False
+    canvas = Canvas(screen, 30, 100, 0, 0)
+
+    schema_loader = SchemaLoader()
+    state = EditorState(data, schema_loader)
+    registry = create_default_registry()
+
+    file_manager = MagicMock(spec=FileManager)
+    file_manager.validate.return_value = validate_errors
+    file_manager.save.return_value = None
+
+    controller = EditorController(
+        canvas, state, 'handwired/pytest/basic', registry, file_manager,
+    )
+    view = controller.create_view()
+    scene = Scene([view], -1)
+    controller.set_scene(scene)
+    view.reset()
+
+    return (view, state, scene, file_manager)
+
+
+def test_save_valid():
+    """Ctrl+S triggers validate then save when data is valid."""
+    view, state, scene, file_manager = make_controller_view()
+
+    # Modify data so save is meaningful.
+    process_keys(view, [Screen.KEY_TAB, 'X'])
+    assert state.is_modified is True
+
+    # Press Ctrl+S to save.
+    process_keys(view, [Screen.ctrl('s')])
+
+    assert file_manager.validate.called is True
+    assert file_manager.save.called is True
+    assert file_manager.save.call_args[0][0] == state.working_data
+    assert not any(isinstance(e, ErrorDialog) for e in scene.effects)
+    assert state.is_modified is False
+
+
+def test_save_validation_error():
+    """Ctrl+S with invalid data shows ErrorDialog, does NOT call save."""
+    view, state, scene, file_manager = make_controller_view(
+        validate_errors=[{'path': 'keyboard_name', 'message': 'Invalid value'}],
+    )
+
+    # Press Ctrl+S to attempt save.
+    process_keys(view, [Screen.ctrl('s')])
+
+    assert file_manager.validate.called is True
+    assert file_manager.save.called is False
+    assert any(isinstance(e, ErrorDialog) for e in scene.effects)
+
+
+def test_quit_unsaved_changes():
+    """Pressing 'q' with unsaved changes shows ConfirmDialog."""
+    view, state, scene, file_manager = make_controller_view()
+
+    # Modify data so changes are unsaved.
+    process_keys(view, [Screen.KEY_TAB, 'Z'])
+    assert state.is_modified is True
+
+    # Press quit key.
+    process_keys(view, [ord('q')])
+
+    assert any(isinstance(e, ConfirmDialog) for e in scene.effects)
+    assert file_manager.save.called is False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Python requirements
 # platformdirs
 argcomplete
+asciimatics==1.15.0
 colorama
 dotty-dict
 hid


### PR DESCRIPTION
RFC for adding `qmk edit` TUI for editing keyboard info.json

Resolves #12446

## Description

As requested in #12446, a schema-driven terminal UI for editing keyboard configuration files (`info.json`/`keyboard.json`), invoked via `qmk edit -kb <keyboard>`. The editor reads `data/schemas/keyboard.jsonschema` at runtime to generate its UI. New schema fields are incorperated without code changes.

### Review
~1700 lines of Python code, broken into 8 commits. 

### Caveats
I only tested this manually on macOS for a handful of keyboards.  No Windows or Linux testing yet. The integration tests I added are pretty basic.

**This is my first (attempted) contribution to QMK** and I'm a bit of a n00b, so feedback is welcome and encouraged on everything e.g. conventions, review process, qmk primitives, whatever I've missed! 

## What it does

- Presents all schema-defined fields in a navigable list, grouped by top-level schema properties
- Supports editing strings, booleans, numbers, enums, arrays, and nested objects
- Validates edits against the JSON schema on save
- Presents validation hints in the status bar (for select simple types)
- Search/filter to find fields quickly
- Keybinding help overlay (`Ctrl+/`)

## Out of scope (v1)

- **Layout editing** — keymap/layout visual editing is not included; this focuses on keyboard hardware configuration only
- **Inherited value viewing or editing** — single file editor ie. values inherited from parent keyboard folders are not considered
- Validation hints for "one of" json schema types
- Creating new keyboards 
- Editing `config.h`, `rules.mk`, or keymap files
- Undo/redo within editor session
- Diff view before save

## Screenshots 
### Main screen
<img width="1239" height="1346" alt="Screenshot 2026-02-28 at 9 59 31 AM" src="https://github.com/user-attachments/assets/67c717b7-7807-46b3-ae96-06034ac3e3d2" />

### Enum menu
<img width="916" height="1346" alt="Screenshot 2026-02-28 at 10 00 18 AM" src="https://github.com/user-attachments/assets/c32d9448-3668-44b6-a1d0-14fe0dd12ecd" />

## Array editing + validation error dialog
<img width="1743" height="1342" alt="Screenshot 2026-02-28 at 10 01 03 AM" src="https://github.com/user-attachments/assets/6cc193d6-80e6-4026-b330-ddfbd9bfd5c6" />

### Save diaglog
<img width="1604" height="1343" alt="Screenshot 2026-02-28 at 10 01 24 AM" src="https://github.com/user-attachments/assets/a710316b-0678-4501-b17c-dd223cf0910c" />


## How to try it

```bash
pip install -r requirements.txt  # new asciimatics dependency
qmk edit -kb keebio/iris/rev8
```

## Framework evaluation

The original issue (#12446) suggested four frameworks. Here's how they compared:

| Framework | Windows support | Widget system | Notes |
|-----------|----------------|---------------|-------|
| **urwid** | Requires WSL/Cygwin | Strong | Palette integration issues with MILC (reported by @2ynn in #12446) |
| **blessed** | Partial | None (low-level) | Would require building all widgets from scratch |
| **py_cui** | Via windows-curses | Basic grid | Limited widget flexibility for nested object editing |
| **asciimatics** | Native | Forms, text inputs, dropdowns | Chosen — native Windows support without workarounds, built-in widget module covers our needs |

asciimatics was chosen primarily for its native Windows support (a hard requirement given QMK's cross-platform user base) and its `widgets` module which provides forms, text inputs, and dropdowns out of the box. The urwid palette issue discovered by @2ynn — where color rendering degrades to monochrome when running inside MILC's command structure — was an additional factor against urwid. While asciimatics leans more toward animation than widget toolkits, its simpler frame-based model is easier to maintain long-term than urwid's reactive approach.



## Architecture

See README.md.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #12446

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
