### PR TITLE
Fix info.json in subfolder not overriding info.json in top-level folder

### DIFF
--- a/keyboards/handwired/pytest/override/keyboard.json
+++ b/keyboards/handwired/pytest/override/keyboard.json
@@ -1,0 +1,7 @@
+{
+    "keyboard_name": "pytest_override",
+    "manufacturer": "test_override",
+    "usb": {
+        "pid": "0x0000"
+    }
+}

--- a/keyboards/handwired/pytest/override/keymaps/default/keymap.c
+++ b/keyboards/handwired/pytest/override/keymaps/default/keymap.c
@@ -1,0 +1,7 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    LAYOUT_ortho_1x1(KC_A)
+};

--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -1002,7 +1002,7 @@ def merge_info_jsons(keyboard, info_data):
     """
     config_files = find_info_json(keyboard)
 
-    for info_file in config_files:
+    for info_file in reversed(config_files):
         # Load and validate the JSON data
         new_info_data = json_load(info_file)
 

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -221,6 +221,13 @@ def test_info():
     assert 'k0' not in result.stdout
 
 
+def test_info_override():
+    result = check_subcommand('info', '-kb', 'handwired/pytest/override')
+    check_returncode(result)
+    assert 'Keyboard Name: pytest_override' in result.stdout
+    assert 'Processor: atmega32u4' in result.stdout
+
+
 def test_info_keyboard_render():
     result = check_subcommand('info', '-kb', 'handwired/pytest/basic', '-l')
     check_returncode(result)

--- a/lib/python/qmk/tests/test_qmk_info.py
+++ b/lib/python/qmk/tests/test_qmk_info.py
@@ -1,0 +1,57 @@
+from qmk.info import info_json
+from qmk.json_schema import deep_update
+
+
+def test_deep_update_child_overrides_parent():
+    """Test that deep_update gives priority to newdict values.
+    """
+    parent = {'keyboard_name': 'parent', 'usb': {'vid': '0x1234', 'pid': '0x0001'}}
+    child = {'keyboard_name': 'child', 'usb': {'pid': '0x0002'}}
+    result = deep_update(parent, child)
+    assert result['keyboard_name'] == 'child'
+    assert result['usb']['vid'] == '0x1234'
+    assert result['usb']['pid'] == '0x0002'
+
+
+def test_deep_update_preserves_parent_only_keys():
+    """Test that keys only in the parent are preserved after deep_update.
+    """
+    parent = {'a': 1, 'b': 2}
+    child = {'b': 3, 'c': 4}
+    result = deep_update(parent, child)
+    assert result == {'a': 1, 'b': 3, 'c': 4}
+
+
+def test_info_json_child_overrides_parent():
+    """Test that child keyboard.json values override parent info.json values.
+
+    handwired/pytest/override/keyboard.json sets keyboard_name to 'pytest_override'
+    while the parent handwired/pytest/info.json sets keyboard_name to 'pytest'.
+    The child value should win.
+    """
+    info_data = info_json('handwired/pytest/override')
+    assert info_data['keyboard_name'] == 'pytest_override'
+    assert info_data['manufacturer'] == 'test_override'
+
+
+def test_info_json_child_overrides_nested_parent():
+    """Test that child keyboard.json overrides nested parent values while preserving siblings.
+
+    handwired/pytest/override/keyboard.json sets usb.pid to '0x0000'
+    while the parent handwired/pytest/info.json sets usb.vid to '0xFEED' and usb.pid to '0x6465'.
+    The child pid should win and the parent vid should be preserved.
+    """
+    info_data = info_json('handwired/pytest/override')
+    assert info_data['usb']['pid'] == '0x0000'
+    assert info_data['usb']['vid'] == '0xFEED'
+
+
+def test_info_json_parent_values_used_when_child_does_not_override():
+    """Test that parent values are used when the child does not override them.
+
+    handwired/pytest/basic/keyboard.json does not set keyboard_name,
+    so the parent value 'pytest' from handwired/pytest/info.json should be used.
+    """
+    info_data = info_json('handwired/pytest/basic')
+    assert info_data['keyboard_name'] == 'pytest'
+    assert info_data['processor'] == 'atmega32u4'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This fixes an issue where more specific json configuration files could not override settings set at a more general level.
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
The only non-test change I made is reverse the order in which merge_info_json processes files. The issue is that the result from the find_info_json is ordered from most specific (child) to most general (parent).

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes [issue 19256](https://github.com/qmk/qmk_firmware/issues/19256)

##  #Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).