### PR TITLE
Add bootloadHID support to `qmk flash`

### DIFF
--- a/lib/python/qmk/flashers.py
+++ b/lib/python/qmk/flashers.py
@@ -136,6 +136,10 @@ def _find_serial_port(vid, pid):
     return None
 
 
+def _flash_bootloadhid(file):
+    cli.run(['bootloadHID', '-r', file], capture_output=False)
+
+
 def _flash_caterina(details, file):
     port = _find_serial_port(details[0], details[1])
     if port:
@@ -218,6 +222,8 @@ def flasher(mcu, file):
     time.sleep(1)
     if bl == 'atmel-dfu':
         _flash_atmel_dfu(details, file)
+    elif bl == 'bootloadhid':
+        _flash_bootloadhid(file)
     elif bl == 'caterina':
         if _flash_caterina(details, file):
             return (True, "The Caterina bootloader was found but is not writable. Check 'qmk doctor' output for advice.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
```
qmk flash kprepublic_jj4x4_default.hex 
Flashing binary firmware...
Please reset your keyboard into bootloader mode now!
Press Ctrl-C to exit.

☒ Known bootloader found but flashing not currently supported!
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
