### PR TITLE
Remove use of andstor/file-existence-action

### DIFF
--- a/.github/workflows/ci_build_major_branch.yml
+++ b/.github/workflows/ci_build_major_branch.yml
@@ -123,14 +123,7 @@ jobs:
           SOURCE_DIR: .
           DEST_DIR: ${{ inputs.branch || github.ref_name }}/latest
 
-      - name: Check if failure marker file exists
-        id: check_failure_marker
-        uses: andstor/file-existence-action@v3
-        with:
-          files: ./.failed
-
       - name: Fail build if needed
-        if: steps.check_failure_marker.outputs.files_exists == 'true'
         run: |
           # Exit with failure if the compilation stage failed
-          exit 1
+          [ ! -e .failed ] || exit 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Action currently produces the following warning:

```
[Consolidation](https://github.com/qmk/qmk_firmware/actions/runs/23124501631/job/67166602049#step:21:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: andstor/file-existence-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

This PR updates to use shell functionality, as used elsewhere, instead.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
