### PR TITLE
Fix audio.pins in keyboard.json not being converted to C defines

### DIFF
--- a/data/mappings/info_config.hjson
+++ b/data/mappings/info_config.hjson
@@ -19,6 +19,8 @@
     // Audio
     "AUDIO_DEFAULT_ON": {"info_key": "audio.default.on", "value_type": "bool"},
     "AUDIO_DEFAULT_CLICKY_ON": {"info_key": "audio.default.clicky", "value_type": "bool"},
+    "AUDIO_PIN": {"info_key": "audio.pins.0"},
+    "AUDIO_PIN_ALT": {"info_key": "audio.pins.1"},
     "AUDIO_POWER_CONTROL_PIN": {"info_key": "audio.power_control.pin"},
     "AUDIO_POWER_CONTROL_PIN_ON_STATE": {"info_key": "audio.power_control.on_state", "value_type": "int" },
     "AUDIO_VOICES": {"info_key": "audio.voices", "value_type": "flag"},

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -119,6 +119,17 @@ def generate_config_items(kb_info_json, config_h_lines):
             config_h_lines.append(generate_define(config_key, config_value))
 
 
+def generate_audio_config(audio_json, config_h_lines):
+    """Generate the config.h lines for audio pins."""
+    pins = audio_json.get('pins', [])
+
+    if len(pins) > 0:
+        config_h_lines.append(generate_define('AUDIO_PIN', pins[0]))
+
+    if len(pins) > 1:
+        config_h_lines.append(generate_define('AUDIO_PIN_ALT', pins[1]))
+
+
 def generate_encoder_config(encoder_json, config_h_lines, postfix=''):
     """Generate the config.h lines for encoders."""
     a_pads = []
@@ -198,6 +209,9 @@ def generate_config_h(cli):
 
     if 'matrix_pins' in kb_info_json:
         config_h_lines.append(matrix_pins(kb_info_json['matrix_pins']))
+
+    if 'audio' in kb_info_json:
+        generate_audio_config(kb_info_json['audio'], config_h_lines)
 
     if 'encoder' in kb_info_json:
         generate_encoder_config(kb_info_json['encoder'], config_h_lines)

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -119,17 +119,6 @@ def generate_config_items(kb_info_json, config_h_lines):
             config_h_lines.append(generate_define(config_key, config_value))
 
 
-def generate_audio_config(audio_json, config_h_lines):
-    """Generate the config.h lines for audio pins."""
-    pins = audio_json.get('pins', [])
-
-    if len(pins) > 0:
-        config_h_lines.append(generate_define('AUDIO_PIN', pins[0]))
-
-    if len(pins) > 1:
-        config_h_lines.append(generate_define('AUDIO_PIN_ALT', pins[1]))
-
-
 def generate_encoder_config(encoder_json, config_h_lines, postfix=''):
     """Generate the config.h lines for encoders."""
     a_pads = []
@@ -209,9 +198,6 @@ def generate_config_h(cli):
 
     if 'matrix_pins' in kb_info_json:
         config_h_lines.append(matrix_pins(kb_info_json['matrix_pins']))
-
-    if 'audio' in kb_info_json:
-        generate_audio_config(kb_info_json['audio'], config_h_lines)
 
     if 'encoder' in kb_info_json:
         generate_encoder_config(kb_info_json['encoder'], config_h_lines)

--- a/lib/python/qmk/cli/generate/config_h.py
+++ b/lib/python/qmk/cli/generate/config_h.py
@@ -95,7 +95,7 @@ def generate_config_items(kb_info_json, config_h_lines):
 
         try:
             config_value = kb_info_json[info_key]
-        except KeyError:
+        except KeyError, IndexError:
             continue
 
         if key_type.startswith('array.array'):

--- a/lib/python/qmk/cli/generate/rules_mk.py
+++ b/lib/python/qmk/cli/generate/rules_mk.py
@@ -31,7 +31,7 @@ def process_mapping_rule(kb_info_json, rules_key, info_dict):
 
     try:
         rules_value = kb_info_json[info_key]
-    except KeyError:
+    except KeyError, IndexError:
         return None
 
     if key_type in ['array', 'list']:


### PR DESCRIPTION
## Description

The `audio.pins` property defined in `keyboard.json` is not converted to `AUDIO_PIN` / `AUDIO_PIN_ALT` C defines during the build process.

The reverse direction (config.h → keyboard.json) already works via `_extract_audio()` in `info.py`, but the forward direction was missing.

### Changes

~~**[Outdated — see updated changes below]**~~

- ~~Added `generate_audio_config()` function in `lib/python/qmk/cli/generate/config_h.py`~~
  - ~~`audio.pins[0]` → `#define AUDIO_PIN <pin>`~~
  - ~~`audio.pins[1]` → `#define AUDIO_PIN_ALT <pin>` (if present)~~
- ~~Called the function from `generate_config_h()` when `audio` is present in keyboard info JSON~~

**Updated approach (per review feedback):**

Instead of adding a dedicated generation function, this can be handled purely through the existing mapping system in `data/mappings/info_config.hjson`:

- Added `"AUDIO_PIN": {"info_key": "audio.pins.0"}` to `info_config.hjson`
- Added `"AUDIO_PIN_ALT": {"info_key": "audio.pins.1"}` to `info_config.hjson`
- Removed the previously added `generate_audio_config()` function from `config_h.py`

This also correctly parses the non-deprecated defines.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #26106

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).