### PR TITLE
Fix userspace detection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,15 @@ $(info QMK Firmware $(QMK_VERSION))
 endif
 endif
 
-# Try to determine userspace from qmk config, if set.
-ifeq ($(QMK_USERSPACE),)
-    QMK_USERSPACE = $(shell qmk config -ro user.overlay_dir | cut -d= -f2 | sed -e 's@^None$$@@g')
-endif
-
 # Determine which qmk cli to use
 QMK_BIN := qmk
+
+# Try to determine userspace from qmk config, if set. Handle direct query on qmk_cli>=1.1.7
+# falling back to legacy method of only supporting user.overlay_dir config
+export override QMK_USERSPACE := $(shell \
+    $(QMK_BIN) env | grep -q QMK_USERSPACE \
+        && $(QMK_BIN) env QMK_USERSPACE \
+        || $(QMK_BIN) config -ro user.overlay_dir | cut -d= -f2 | sed -e 's@^None$$@@g')
 
 # avoid 'Entering|Leaving directory' messages
 MAKEFLAGS += --no-print-directory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the `qmk_cli` container exposes a `QMK_USERSPACE` [environment variable](https://github.com/qmk/qmk_cli/blob/master/Dockerfile#L34).

As this points to `/qmk_userspace`, which might not be mounted. In this case, compilation will fail when copying build artifact. 

This also fixes previously raised issues on [Discord](https://discord.com/channels/440868230475677696/1146201809224994887/1387240260861300758), and aligns to the configuration behaviour of `qmk_cli`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
