### PR TITLE
Mask out active mods when unregistering after retro tapping

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -879,7 +879,9 @@ void process_action(keyrecord_t *record, action_t action) {
                     wait_ms(TAP_CODE_DELAY);
                     tap_code(action.layer_tap.code);
                     wait_ms(TAP_CODE_DELAY);
-                    unregister_mods(retro_tap_curr_mods);
+                    // Only unregister the mods that were active at the time of
+                    // the tap and are not independently held by other keys.
+                    unregister_mods(retro_tap_curr_mods & ~curr_mods);
 #        endif
                 }
                 retro_tap_primed = false;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Do not unregister modifiers still held by other keys

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes #26126

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
