### PR TITLE
fix `make test:all` failures seen on macOS Tahoe

### DIFF
--- a/builddefs/common_rules.mk
+++ b/builddefs/common_rules.mk
@@ -52,8 +52,12 @@ ifeq ($(strip $(DEBUG_ENABLE)),yes)
 	ASFLAGS  += -ggdb3
 endif
 
-# Always create a map file to see what was compiled and where.
+# Create a map file to see what was compiled and where, unless disabled
+# (e.g. test builds, which use the host linker — Apple's ld does not accept
+# -Map=/--cref).
+ifneq ($(strip $(CREATE_MAP)), no)
 LDFLAGS  += -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref
+endif
 
 #---------------- C Compiler Options ----------------
 

--- a/docs/features/unicode.md
+++ b/docs/features/unicode.md
@@ -25,7 +25,7 @@ Add the following to your `config.h`:
 |`UNICODE_KEY_MAC`       |`KC_LEFT_ALT`     |The key to hold when beginning a Unicode sequence with the macOS input mode     |
 |`UNICODE_KEY_LNX`       |`LCTL(LSFT(KC_U))`|The key to tap when beginning a Unicode sequence with the Linux input mode      |
 |`UNICODE_KEY_WINC`      |`KC_RIGHT_ALT`    |The key to hold when beginning a Unicode sequence with the WinCompose input mode|
-|`UNICODE_SELECTED_MODES`|`-1`              |A comma separated list of input modes for cycling through                       |
+|`UNICODE_SELECTED_MODES`|*n/a*             |A comma separated list of input modes for cycling through                       |
 |`UNICODE_CYCLE_PERSIST` |`true`            |Whether to persist the current Unicode input mode to EEPROM                     |
 |`UNICODE_TYPE_DELAY`    |`10`              |The amount of time to wait, in milliseconds, between Unicode sequence keystrokes|
 

--- a/platforms/chibios/drivers/eeprom/eeprom_legacy_emulated_flash.c
+++ b/platforms/chibios/drivers/eeprom/eeprom_legacy_emulated_flash.c
@@ -204,7 +204,9 @@ void print_eeprom(void) {
             }
             xprintf("%04x", i);
         }
-        if (i % 8 == 0) print(" ");
+        if (i % 8 == 0) {
+            print(" ");
+        }
 
         xprintf(" %02x", DataBuf[i]);
         if ((i + 1) % 16 == 0) {

--- a/platforms/test/drivers/audio_pwm_hardware.c
+++ b/platforms/test/drivers/audio_pwm_hardware.c
@@ -16,5 +16,5 @@
 #include "audio.h"
 
 void audio_driver_initialize_impl(void) {}
-void audio_driver_start_impl() {}
-void audio_driver_stop_impl() {}
+void audio_driver_start_impl(void) {}
+void audio_driver_stop_impl(void) {}

--- a/platforms/timer.c
+++ b/platforms/timer.c
@@ -1,7 +1,11 @@
 // Copyright 2023 Sergey Vlasov (@sigprof)
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "timer.h"
+// Use an angle-bracket include so the header is located via the include
+// search path rather than source-relative lookup. timer.h uses
+// #include_next to chain to the active platform's _timer.h, and that
+// only has well-defined semantics when timer.h itself was found via -I.
+#include <timer.h>
 
 // Generate out-of-line copies for inline functions defined in timer.h.
 extern inline fast_timer_t timer_read_fast(void);

--- a/quantum/encoder/tests/encoder_tests.cpp
+++ b/quantum/encoder/tests/encoder_tests.cpp
@@ -26,8 +26,8 @@ extern "C" {
 }
 
 struct update {
-    int8_t index;
-    bool   clockwise;
+    uint8_t index;
+    bool    clockwise;
 };
 
 uint8_t updates_array_idx = 0;

--- a/quantum/encoder/tests/encoder_tests_split_left_eq_right.cpp
+++ b/quantum/encoder/tests/encoder_tests_split_left_eq_right.cpp
@@ -26,8 +26,8 @@ extern "C" {
 }
 
 struct update {
-    int8_t index;
-    bool   clockwise;
+    uint8_t index;
+    bool    clockwise;
 };
 
 uint8_t updates_array_idx = 0;

--- a/quantum/encoder/tests/encoder_tests_split_left_gt_right.cpp
+++ b/quantum/encoder/tests/encoder_tests_split_left_gt_right.cpp
@@ -26,8 +26,8 @@ extern "C" {
 }
 
 struct update {
-    int8_t index;
-    bool   clockwise;
+    uint8_t index;
+    bool    clockwise;
 };
 
 uint8_t updates_array_idx = 0;

--- a/quantum/encoder/tests/encoder_tests_split_left_lt_right.cpp
+++ b/quantum/encoder/tests/encoder_tests_split_left_lt_right.cpp
@@ -26,8 +26,8 @@ extern "C" {
 }
 
 struct update {
-    int8_t index;
-    bool   clockwise;
+    uint8_t index;
+    bool    clockwise;
 };
 
 uint8_t updates_array_idx = 0;

--- a/quantum/encoder/tests/encoder_tests_split_no_left.cpp
+++ b/quantum/encoder/tests/encoder_tests_split_no_left.cpp
@@ -26,8 +26,8 @@ extern "C" {
 }
 
 struct update {
-    int8_t index;
-    bool   clockwise;
+    uint8_t index;
+    bool    clockwise;
 };
 
 uint8_t updates_array_idx = 0;

--- a/quantum/encoder/tests/encoder_tests_split_no_right.cpp
+++ b/quantum/encoder/tests/encoder_tests_split_no_right.cpp
@@ -26,8 +26,8 @@ extern "C" {
 }
 
 struct update {
-    int8_t index;
-    bool   clockwise;
+    uint8_t index;
+    bool    clockwise;
 };
 
 uint8_t updates_array_idx = 0;

--- a/quantum/process_keycode/process_key_override.c
+++ b/quantum/process_keycode/process_key_override.c
@@ -175,7 +175,7 @@ const key_override_t *clear_active_override(const bool allow_reregister) {
 
     const key_override_t *const old = active_override;
 
-    const uint8_t mod_free_replacement = clear_mods_from(active_override->replacement);
+    const uint16_t mod_free_replacement = clear_mods_from(active_override->replacement);
 
     bool unregister_replacement = mod_free_replacement != KC_NO &&   // KC_NO is never registered
                                   mod_free_replacement < SAFE_RANGE; // Custom keycodes are never registered

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -165,6 +165,6 @@ bool process_space_cadet(uint16_t keycode, keyrecord_t *record) {
     return true;
 }
 
-void reset_space_cadet() {
+void reset_space_cadet(void) {
     sc_last = 0;
 }

--- a/quantum/unicode/unicode.c
+++ b/quantum/unicode/unicode.c
@@ -46,12 +46,6 @@
 #    define UNICODE_KEY_WINC KC_RIGHT_ALT
 #endif
 
-// Comma-delimited, ordered list of input modes selected for use (e.g. in cycle)
-// Example: #define UNICODE_SELECTED_MODES UNICODE_MODE_WINCOMPOSE, UNICODE_MODE_LINUX
-#ifndef UNICODE_SELECTED_MODES
-#    define UNICODE_SELECTED_MODES -1
-#endif
-
 // Whether input mode changes in cycle should be written to EEPROM
 #ifndef UNICODE_CYCLE_PERSIST
 #    define UNICODE_CYCLE_PERSIST true
@@ -66,7 +60,7 @@ unicode_config_t unicode_config;
 uint8_t          unicode_saved_mods;
 led_t            unicode_saved_led_state;
 
-#if UNICODE_SELECTED_MODES != -1
+#ifdef UNICODE_SELECTED_MODES
 static uint8_t selected[]     = {UNICODE_SELECTED_MODES};
 static int8_t  selected_count = ARRAY_SIZE(selected);
 static int8_t  selected_index;
@@ -136,7 +130,7 @@ static void unicode_play_song(uint8_t mode) {
 
 void unicode_input_mode_init(void) {
     eeconfig_read_unicode_mode(&unicode_config);
-#if UNICODE_SELECTED_MODES != -1
+#ifdef UNICODE_SELECTED_MODES
 #    if UNICODE_CYCLE_PERSIST
     // Find input_mode in selected modes
     int8_t i;
@@ -178,7 +172,7 @@ void set_unicode_input_mode(uint8_t mode) {
 }
 
 static void cycle_unicode_input_mode(int8_t offset) {
-#if UNICODE_SELECTED_MODES != -1
+#ifdef UNICODE_SELECTED_MODES
     selected_index = (selected_index + offset) % selected_count;
     if (selected_index < 0) {
         selected_index += selected_count;

--- a/tests/test_common/keyboard_report_util.hpp
+++ b/tests/test_common/keyboard_report_util.hpp
@@ -35,5 +35,5 @@ class KeyboardReportMatcher : public testing::MatcherInterface<report_keyboard_t
 
 template <typename... Ts>
 inline testing::Matcher<report_keyboard_t&> KeyboardReport(Ts... keys) {
-    return testing::MakeMatcher(new KeyboardReportMatcher(std::vector<uint8_t>({keys...})));
+    return testing::MakeMatcher(new KeyboardReportMatcher({static_cast<uint8_t>(keys)...}));
 }

--- a/tmk_core/protocol/usb_device_state.c
+++ b/tmk_core/protocol/usb_device_state.c
@@ -78,7 +78,7 @@ void usb_device_state_set_protocol(usb_hid_protocol_t protocol) {
     notify_usb_device_state_change(usb_device_state);
 }
 
-inline usb_hid_protocol_t usb_device_state_get_protocol() {
+inline usb_hid_protocol_t usb_device_state_get_protocol(void) {
     return usb_device_state.protocol;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`make test:all` fails with a variety of errors on macOS Tahoe, I think mostly relating to it using a newer/stricter clang (21) than CI and, presumably, most contributor's machines. Each commit here fixes one class of failure (and has an example of the prior compiler error in the commit description).

As you can tell I let my AI agent write the changes, but I reviewed them and think they're reasonable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
