### PR TITLE
Add Responsive Hold RGB Matrix effect

### DIFF
--- a/docs/features/rgb_matrix.md
+++ b/docs/features/rgb_matrix.md
@@ -156,6 +156,7 @@ enum rgb_matrix_effects {
     RGB_MATRIX_STARLIGHT_DUAL_HUE,  // LEDs turn on and off at random at varying brightness, modifies user set hue by +- 30
     RGB_MATRIX_STARLIGHT_DUAL_SAT,  // LEDs turn on and off at random at varying brightness, modifies user set saturation by +- 30
     RGB_MATRIX_RIVERFLOW,           // Modification to breathing animation, offset's animation depending on key location to simulate a river flowing
+    RGB_MATRIX_RESPONSIVE_HOLD,     // Lights pressed keys with shimmering hue at full brightness while held, then fades out on release
     RGB_MATRIX_EFFECT_MAX
 };
 ```
@@ -200,6 +201,7 @@ You can enable a single effect by defining `ENABLE_[EFFECT_NAME]` in your `confi
 |`#define ENABLE_RGB_MATRIX_STARLIGHT_DUAL_HUE`        |Enables `RGB_MATRIX_STARLIGHT_DUAL_HUE`       |
 |`#define ENABLE_RGB_MATRIX_STARLIGHT_DUAL_SAT`        |Enables `RGB_MATRIX_STARLIGHT_DUAL_SAT`       |
 |`#define ENABLE_RGB_MATRIX_RIVERFLOW`                 |Enables `RGB_MATRIX_RIVERFLOW`                |
+|`#define ENABLE_RGB_MATRIX_RESPONSIVE_HOLD`           |Enables `RGB_MATRIX_RESPONSIVE_HOLD`          |
 
 |Framebuffer Defines                                   |Description                                   |
 |------------------------------------------------------|----------------------------------------------|

--- a/quantum/rgb_matrix/animations/responsive_hold_anim.h
+++ b/quantum/rgb_matrix/animations/responsive_hold_anim.h
@@ -1,0 +1,56 @@
+// Copyright @filterpaper
+// SPDX-License-Identifier: GPL-2.0+
+
+#ifdef ENABLE_RGB_MATRIX_RESPONSIVE_HOLD
+RGB_MATRIX_EFFECT(RESPONSIVE_HOLD)
+#    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#        include "matrix.h"
+
+bool RESPONSIVE_HOLD(effect_params_t* params) {
+    // Store current brightness per LED
+    static uint8_t  led_brightness[RGB_MATRIX_LED_COUNT] = {0};
+    static uint8_t  decay;
+    static uint32_t timer;
+
+    if (params->iter == 0) {
+        // On the first iteration, calculate brightness decay based on time scale since last update
+        uint16_t ticks = MIN(g_rgb_timer - timer, 0xFFFF);
+        uint8_t  phase = MIN(scale16by8(ticks, qadd8(rgb_matrix_config.speed, 1)), 0xFF);
+        decay          = MAX(1, scale8(phase, rgb_matrix_config.hsv.v));
+        timer          = g_rgb_timer;
+
+        // Scan the key matrix and set maximum LED brightness for currently pressed keys
+        for (uint8_t row = 0; row < MATRIX_ROWS; ++row) {
+            matrix_row_t row_state = matrix_get_row(row);
+            if (!row_state) continue;
+            for (uint8_t col = 0; col < MATRIX_COLS; ++col) {
+                if (!((row_state >> col) & 1)) continue;
+                uint8_t led = g_led_config.matrix_co[row][col];
+                if (led < RGB_MATRIX_LED_COUNT) led_brightness[led] = rgb_matrix_config.hsv.v;
+            }
+        }
+    }
+
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+    for (uint8_t i = led_min; i < led_max; ++i) {
+        RGB_MATRIX_TEST_LED_FLAGS();
+        rgb_t rgb = {0, 0, 0};
+        if (led_brightness[i] > 0) {
+            // Apply a triangle wave hue shift to LEDs with brightness value
+            uint8_t time = scale16by8(g_rgb_timer, qadd8(rgb_matrix_config.speed / 16, 1));
+            uint8_t wave = triwave8(time) / 4;
+            hsv_t   hsv  = rgb_matrix_config.hsv;
+            hsv.h        = hsv.h - wave;
+            hsv.v        = led_brightness[i];
+            rgb          = rgb_matrix_hsv_to_rgb(hsv);
+            // Fade brightness based on time since last update
+            led_brightness[i] = qsub8(led_brightness[i], decay);
+        }
+        rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+    }
+
+    return rgb_matrix_check_finished_leds(led_max);
+}
+
+#    endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif     // ENABLE_RGB_MATRIX_RESPONSIVE_HOLD

--- a/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix/animations/rgb_matrix_effects.inc
@@ -44,3 +44,4 @@
 #include "starlight_dual_sat_anim.h"
 #include "starlight_dual_hue_anim.h"
 #include "riverflow_anim.h"
+#include "responsive_hold_anim.h"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Responsive Hold lights each key at full brightness for the entire duration it is held, and only begins fading once the key is released. This effect does not require RGB_MATRIX_KEYPRESSES or RGB_MATRIX_KEYRELEASES. It polls the live matrix state directly each frame instead of relying on the core key-event tracking feature.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
