### PR TITLE
add ipad power and home keycodes

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.9_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.9_basic.hjson
@@ -1,0 +1,20 @@
+{
+    "keycodes": {
+        "0x00C3": {
+            "group": "media",
+            "key": "KC_IPAD_POWER",
+            "label": "Power (HID Consumer Range)",
+            "aliases": [
+                "KC_IPWR"
+            ]
+        },
+        "0x00C4": {
+            "group": "media",
+            "key": "KC_IPAD_HOME",
+            "label": "Menu (HID Consumer range)",
+            "aliases": [
+                "KC_IHOM"
+            ]
+        }
+    }
+}

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -211,6 +211,8 @@ See also: [Basic Keycodes](keycodes_basic)
 |`KC_ASSISTANT`          |`KC_ASST`                      |Launch Context-Aware Assistant         |✔            |             |                 |
 |`KC_MISSION_CONTROL`    |`KC_MCTL`                      |Open Mission Control                   |             |✔            |                 |
 |`KC_LAUNCHPAD`          |`KC_LPAD`                      |Open Launchpad                         |             |✔            |                 |
+|`KC_IPAD_POWER`         |`KC_IPWR`                      |Power button in iPadOS                 |             |             |                 |
+|`KC_IPAD_HOME`          |`KC_IHOM`                      |Home button on iPadOS                  |             |             |                 |
 
 <sup>1. The Linux kernel HID driver recognizes [nearly all keycodes](https://github.com/torvalds/linux/blob/master/drivers/hid/hid-input.c), but the default bindings depend on the DE/WM.</sup><br/>
 <sup>2. Treated as F13-F15.</sup><br/>

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -195,38 +195,40 @@ These keycodes are not part of the Keyboard/Keypad usage page. The `SYSTEM_` key
 Some of these keycodes may behave differently depending on the OS. For example, on macOS, the keycodes `KC_MEDIA_FAST_FORWARD`, `KC_MEDIA_REWIND`, `KC_MEDIA_NEXT_TRACK` and `KC_MEDIA_PREV_TRACK` skip within the current track when held, but skip the entire track when tapped.
 :::
 
-|Key                    |Aliases  |Description         |
-|-----------------------|---------|--------------------|
-|`KC_SYSTEM_POWER`      |`KC_PWR` |System Power Down   |
-|`KC_SYSTEM_SLEEP`      |`KC_SLEP`|System Sleep        |
-|`KC_SYSTEM_WAKE`       |`KC_WAKE`|System Wake         |
-|`KC_AUDIO_MUTE`        |`KC_MUTE`|Mute                |
-|`KC_AUDIO_VOL_UP`      |`KC_VOLU`|Volume Up           |
-|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`|Volume Down         |
-|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track          |
-|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track      |
-|`KC_MEDIA_STOP`        |`KC_MSTP`|Stop Track          |
-|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`|Play/Pause Track    |
-|`KC_MEDIA_SELECT`      |`KC_MSEL`|Launch Media Player |
-|`KC_MEDIA_EJECT`       |`KC_EJCT`|Eject               |
-|`KC_MAIL`              |         |Launch Mail         |
-|`KC_CALCULATOR`        |`KC_CALC`|Launch Calculator   |
-|`KC_MY_COMPUTER`       |`KC_MYCM`|Launch My Computer  |
-|`KC_WWW_SEARCH`        |`KC_WSCH`|Browser Search      |
-|`KC_WWW_HOME`          |`KC_WHOM`|Browser Home        |
-|`KC_WWW_BACK`          |`KC_WBAK`|Browser Back        |
-|`KC_WWW_FORWARD`       |`KC_WFWD`|Browser Forward     |
-|`KC_WWW_STOP`          |`KC_WSTP`|Browser Stop        |
-|`KC_WWW_REFRESH`       |`KC_WREF`|Browser Refresh     |
-|`KC_WWW_FAVORITES`     |`KC_WFAV`|Browser Favorites   |
-|`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`|Fast Forward        |
-|`KC_MEDIA_REWIND`      |`KC_MRWD`|Rewind              |
-|`KC_BRIGHTNESS_UP`     |`KC_BRIU`|Brightness Up       |
-|`KC_BRIGHTNESS_DOWN`   |`KC_BRID`|Brightness Down     |
-|`KC_CONTROL_PANEL`     |`KC_CPNL`|Open Control Panel  |
-|`KC_ASSISTANT`         |`KC_ASST`|Launch Assistant    |
-|`KC_MISSION_CONTROL`   |`KC_MCTL`|Open Mission Control|
-|`KC_LAUNCHPAD`         |`KC_LPAD`|Open Launchpad      |
+|Key                    |Aliases  |Description           |
+|-----------------------|---------|----------------------|
+|`KC_SYSTEM_POWER`      |`KC_PWR` |System Power Down     |
+|`KC_SYSTEM_SLEEP`      |`KC_SLEP`|System Sleep          |
+|`KC_SYSTEM_WAKE`       |`KC_WAKE`|System Wake           |
+|`KC_AUDIO_MUTE`        |`KC_MUTE`|Mute                  |
+|`KC_AUDIO_VOL_UP`      |`KC_VOLU`|Volume Up             |
+|`KC_AUDIO_VOL_DOWN`    |`KC_VOLD`|Volume Down           |
+|`KC_MEDIA_NEXT_TRACK`  |`KC_MNXT`|Next Track            |
+|`KC_MEDIA_PREV_TRACK`  |`KC_MPRV`|Previous Track        |
+|`KC_MEDIA_STOP`        |`KC_MSTP`|Stop Track            |
+|`KC_MEDIA_PLAY_PAUSE`  |`KC_MPLY`|Play/Pause Track      |
+|`KC_MEDIA_SELECT`      |`KC_MSEL`|Launch Media Player   |
+|`KC_MEDIA_EJECT`       |`KC_EJCT`|Eject                 |
+|`KC_MAIL`              |         |Launch Mail           |
+|`KC_CALCULATOR`        |`KC_CALC`|Launch Calculator     |
+|`KC_MY_COMPUTER`       |`KC_MYCM`|Launch My Computer    |
+|`KC_WWW_SEARCH`        |`KC_WSCH`|Browser Search        |
+|`KC_WWW_HOME`          |`KC_WHOM`|Browser Home          |
+|`KC_WWW_BACK`          |`KC_WBAK`|Browser Back          |
+|`KC_WWW_FORWARD`       |`KC_WFWD`|Browser Forward       |
+|`KC_WWW_STOP`          |`KC_WSTP`|Browser Stop          |
+|`KC_WWW_REFRESH`       |`KC_WREF`|Browser Refresh       |
+|`KC_WWW_FAVORITES`     |`KC_WFAV`|Browser Favorites     |
+|`KC_MEDIA_FAST_FORWARD`|`KC_MFFD`|Fast Forward          |
+|`KC_MEDIA_REWIND`      |`KC_MRWD`|Rewind                |
+|`KC_BRIGHTNESS_UP`     |`KC_BRIU`|Brightness Up         |
+|`KC_BRIGHTNESS_DOWN`   |`KC_BRID`|Brightness Down       |
+|`KC_CONTROL_PANEL`     |`KC_CPNL`|Open Control Panel    |
+|`KC_ASSISTANT`         |`KC_ASST`|Launch Assistant      |
+|`KC_MISSION_CONTROL`   |`KC_MCTL`|Open Mission Control  |
+|`KC_LAUNCHPAD`         |`KC_LPAD`|Open Launchpad        |
+|`KC_IPAD_POWER`        |`KC_IPWR`|Power button in iPadOS|
+|`KC_IPAD_HOME`         |`KC_IHOM`|Home button on iPadOS |
 
 ## Number Pad
 

--- a/quantum/keycodes.h
+++ b/quantum/keycodes.h
@@ -26,11 +26,11 @@
 #pragma once
 // clang-format off
 
-#define QMK_KEYCODES_VERSION "0.0.8"
-#define QMK_KEYCODES_VERSION_BCD 0x00000008
+#define QMK_KEYCODES_VERSION "0.0.9"
+#define QMK_KEYCODES_VERSION_BCD 0x00000009
 #define QMK_KEYCODES_VERSION_MAJOR 0
 #define QMK_KEYCODES_VERSION_MINOR 0
-#define QMK_KEYCODES_VERSION_PATCH 8
+#define QMK_KEYCODES_VERSION_PATCH 9
 
 enum qk_keycode_ranges {
 // Ranges
@@ -295,6 +295,8 @@ enum qk_keycode_defines {
     KC_ASSISTANT = 0x00C0,
     KC_MISSION_CONTROL = 0x00C1,
     KC_LAUNCHPAD = 0x00C2,
+    KC_IPAD_POWER = 0x00C3,
+    KC_IPAD_HOME = 0x00C4,
     QK_MOUSE_CURSOR_UP = 0x00CD,
     QK_MOUSE_CURSOR_DOWN = 0x00CE,
     QK_MOUSE_CURSOR_LEFT = 0x00CF,
@@ -955,6 +957,8 @@ enum qk_keycode_defines {
     KC_ASST    = KC_ASSISTANT,
     KC_MCTL    = KC_MISSION_CONTROL,
     KC_LPAD    = KC_LAUNCHPAD,
+    KC_IPWR    = KC_IPAD_POWER,
+    KC_IHOM    = KC_IPAD_HOME,
     MS_UP      = QK_MOUSE_CURSOR_UP,
     MS_DOWN    = QK_MOUSE_CURSOR_DOWN,
     MS_LEFT    = QK_MOUSE_CURSOR_LEFT,
@@ -1505,7 +1509,7 @@ enum qk_keycode_defines {
 #define IS_INTERNAL_KEYCODE(code) ((code) >= KC_NO && (code) <= KC_TRANSPARENT)
 #define IS_BASIC_KEYCODE(code) ((code) >= KC_A && (code) <= KC_EXSEL)
 #define IS_SYSTEM_KEYCODE(code) ((code) >= KC_SYSTEM_POWER && (code) <= KC_SYSTEM_WAKE)
-#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_LAUNCHPAD)
+#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_IPAD_HOME)
 #define IS_MOUSE_KEYCODE(code) ((code) >= QK_MOUSE_CURSOR_UP && (code) <= QK_MOUSE_ACCELERATION_2)
 #define IS_MODIFIER_KEYCODE(code) ((code) >= KC_LEFT_CTRL && (code) <= KC_RIGHT_GUI)
 #define IS_SWAP_HANDS_KEYCODE(code) ((code) >= QK_SWAP_HANDS_TOGGLE && (code) <= QK_SWAP_HANDS_ONE_SHOT)
@@ -1531,7 +1535,7 @@ enum qk_keycode_defines {
 #define INTERNAL_KEYCODE_RANGE              KC_NO ... KC_TRANSPARENT
 #define BASIC_KEYCODE_RANGE                 KC_A ... KC_EXSEL
 #define SYSTEM_KEYCODE_RANGE                KC_SYSTEM_POWER ... KC_SYSTEM_WAKE
-#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_LAUNCHPAD
+#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_IPAD_HOME
 #define MOUSE_KEYCODE_RANGE                 QK_MOUSE_CURSOR_UP ... QK_MOUSE_ACCELERATION_2
 #define MODIFIER_KEYCODE_RANGE              KC_LEFT_CTRL ... KC_RIGHT_GUI
 #define SWAP_HANDS_KEYCODE_RANGE            QK_SWAP_HANDS_TOGGLE ... QK_SWAP_HANDS_ONE_SHOT

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -62,9 +62,11 @@ enum mouse_buttons {
  * See https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf#page=75
  */
 enum consumer_usages {
+    // 15.3 General Controls
+    GENERAL_POWER = 0x030,
+    // 15.4 Menu Controls
+    MENU_MENU = 0x040,
     // 15.5 Display Controls
-    CONSUMER_POWER  = 0x030,
-    CONSUMER_MENU   = 0x040,
     SNAPSHOT        = 0x065,
     BRIGHTNESS_UP   = 0x06F, // https://www.usb.org/sites/default/files/hutrr41_0.pdf
     BRIGHTNESS_DOWN = 0x070,
@@ -338,9 +340,9 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
         case KC_LAUNCHPAD:
             return AC_SOFT_KEY_LEFT;
         case KC_IPAD_POWER:
-            return CONSUMER_POWER;
+            return GENERAL_POWER;
         case KC_IPAD_HOME:
-            return CONSUMER_MENU;
+            return MENU_MENU;
         default:
             return 0;
     }

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // clang-format off
 
 /* HID report IDs */
-enum hid_report_ids { 
+enum hid_report_ids {
     REPORT_ID_ALL = 0,
     REPORT_ID_KEYBOARD = 1,
     REPORT_ID_MOUSE,
@@ -63,6 +63,8 @@ enum mouse_buttons {
  */
 enum consumer_usages {
     // 15.5 Display Controls
+    CONSUMER_POWER  = 0x030,
+    CONSUMER_MENU   = 0x040,
     SNAPSHOT        = 0x065,
     BRIGHTNESS_UP   = 0x06F, // https://www.usb.org/sites/default/files/hutrr41_0.pdf
     BRIGHTNESS_DOWN = 0x070,
@@ -335,6 +337,10 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
             return AC_DESKTOP_SHOW_ALL_WINDOWS;
         case KC_LAUNCHPAD:
             return AC_SOFT_KEY_LEFT;
+        case KC_IPAD_POWER:
+            return CONSUMER_POWER;
+        case KC_IPAD_HOME:
+            return CONSUMER_MENU;
         default:
             return 0;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Based on Apple's [Accessory Design Guidelines](https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf) the iPad uses a couple keycodes from the Consumer range of the [HID spec](https://usb.org/document-library/hid-usage-tables-17). 

Most of these codes are already covered or not useful, but Power and Home are extremely so.

I've added the following keycodes:

|Key                    | Aliases  | Description           | QMK Keycode | Consumer page keycode |
|----|---------|---------|------------|--------------|
| `KC_IPAD_POWER`        | `KC_IPWR` | Power button in iPadOS | 0x00C3      | 0x30                   |
| `KC_IPAD_HOME`         |`KC_IHOM` | Home button on iPadOS | 0x00C4      | 0x40                   |


Based on the precedent of KS_LAUNCHPAD (#19884) I've named them according to their current only-known use. I think a more accurate title like `KC_CONSUMER_POWER` would just be confusing.
If these keys have other uses, nobody has needed them in QMK so far.

This also changes the values of `CONSUMER_KEYCODE_RANGE`, as I've placed my keycodes after the existing Launchpad PR.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
