### PR TITLE
Add includes for std::setw

### DIFF
--- a/tests/test_common/keyboard_report_util.cpp
+++ b/tests/test_common/keyboard_report_util.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <vector>
 #include <algorithm>
+#include <iomanip>
 
 extern "C" {
 #include "keycode_string.h"

--- a/tests/test_common/mouse_report_util.cpp
+++ b/tests/test_common/mouse_report_util.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <vector>
 #include <algorithm>
+#include <iomanip>
 
 using namespace testing;
 

--- a/tests/test_common/test_driver.cpp
+++ b/tests/test_common/test_driver.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "test_driver.hpp"
+#include <iomanip>
 
 TestDriver* TestDriver::m_this = nullptr;
 

--- a/tests/test_common/test_keymap_key.cpp
+++ b/tests/test_common/test_keymap_key.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "test_keymap_key.hpp"
+#include <iomanip>
 #include <cstdint>
 #include <ios>
 #include "matrix.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
As part of evaluating an upgrade of our version of gtest, it brings in the requirement of c++17.

Updating the standard produces the following class of errors:
```
Making test audio                                                                                              [ERRORS]
tests/test_common/mouse_report_util.cpp: In function ‘std::ostream& operator<<(std::ostream&, const report_mouse_t&)’:
tests/test_common/mouse_report_util.cpp:29:16: error: ‘setw’ is not a member of ‘std’
   29 |     os << std::setw(10) << std::left << "mouse report: ";
      |                ^~~~
tests/test_common/mouse_report_util.cpp:18:1: note: ‘std::setw’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
   17 | #include "mouse_report_util.hpp"
  +++ |+#include <iomanip>
   18 | #include <cstdint>
 | 
```

These fixes can go in separately ahead of time.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
