### PR TITLE
Add usage clarifications to docs/features/unicode.md

### DIFF
--- a/docs/features/unicode.md
+++ b/docs/features/unicode.md
@@ -8,9 +8,9 @@ There are some limitations to this feature. Because there is no "standard" metho
 
 ## Usage {#usage}
 
-The core Unicode API can be used purely programmatically. However, there are also additional subsystems which build on top of it and come with keycodes to make things easier. See below for more details.
+The core Unicode API can be used purely programmatically. However, there are also additional subsystems which build on top of it and come with keycodes to make things easier. See [below](#input-subsystems) for more details.
 
-Add the following to your keymap's `rules.mk`:
+To start, add the following to your keymap's `rules.mk`:
 
 ```make
 UNICODE_COMMON = yes
@@ -18,7 +18,7 @@ UNICODE_COMMON = yes
 
 ## Basic Configuration {#basic-configuration}
 
-Add the following to your `config.h`:
+The following options can be set/overriden in your `config.h`:
 
 |Define                  |Default           |Description                                                                     |
 |------------------------|------------------|--------------------------------------------------------------------------------|
@@ -29,11 +29,14 @@ Add the following to your `config.h`:
 |`UNICODE_CYCLE_PERSIST` |`true`            |Whether to persist the current Unicode input mode to EEPROM                     |
 |`UNICODE_TYPE_DELAY`    |`10`              |The amount of time to wait, in milliseconds, between Unicode sequence keystrokes|
 
+The default values work well for most use cases, so users usually only need to define `UNICODE_SELECTED_MODES` to set their desired input modes.
+However, if you plan on switching input modes manually (see [keycodes](#keycodes) below) and don't plan on cycling through them, this definition can be omitted as well.
+
 ### Audio Feedback {#audio-feedback}
 
 If you have the [Audio](audio) feature enabled on your board, you can configure it to play sounds when the input mode is changed.
 
-Add the following to your `config.h`:
+Add one or more of the following definitions to your `config.h`:
 
 |Define             |Default|Description                                                |
 |-------------------|-------|-----------------------------------------------------------|

--- a/docs/features/unicode.md
+++ b/docs/features/unicode.md
@@ -18,7 +18,7 @@ UNICODE_COMMON = yes
 
 ## Basic Configuration {#basic-configuration}
 
-The following options can be set/overriden in your `config.h`:
+The following options can be set or overridden in your `config.h`:
 
 |Define                  |Default           |Description                                                                     |
 |------------------------|------------------|--------------------------------------------------------------------------------|
@@ -30,7 +30,7 @@ The following options can be set/overriden in your `config.h`:
 |`UNICODE_TYPE_DELAY`    |`10`              |The amount of time to wait, in milliseconds, between Unicode sequence keystrokes|
 
 The default values work well for most use cases, so users usually only need to define `UNICODE_SELECTED_MODES` to set their desired input modes.
-However, if you plan on switching input modes manually (see [keycodes](#keycodes) below) and don't plan on cycling through them, this definition can be omitted as well.
+However, if you plan on switching input modes manually (see [keycodes](#keycodes) below) and don't plan on cycling through them, this definition can be omitted.
 
 ### Audio Feedback {#audio-feedback}
 


### PR DESCRIPTION
## Description

The current verbiage of the Unicode guide instructs users to define multiple config constants in their `config.h` files; however, most of these are unnecessary as the default values cover most typical use cases. This PR updates the text to be a bit clearer in this regard.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
