### PR TITLE
Fix `config.h` bool parsing

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -18,8 +18,8 @@ from qmk.makefile import parse_rules_mk_file
 from qmk.math_ops import compute
 from qmk.util import maybe_exit, truthy
 
-true_values = ['1', 'on', 'yes']
-false_values = ['0', 'off', 'no']
+TRUE_VALUES = ['true', '1', 'on', 'yes']
+FALSE_VALUES = ['false', '0', 'off', 'no']
 
 
 class LedFlags(IntFlag):
@@ -319,7 +319,7 @@ def _extract_features(info_data, rules):
     for key, value in rules.items():
         if key.endswith('_ENABLE'):
             key = '_'.join(key.split('_')[:-1]).lower()
-            value = True if value.lower() in true_values else False if value.lower() in false_values else value
+            value = True if value.lower() in TRUE_VALUES else False if value.lower() in FALSE_VALUES else value
 
             if key in ['lto']:
                 continue
@@ -657,7 +657,7 @@ def _config_to_json(key_type, config_value):
     elif key_type in ['bool', 'flag']:
         if isinstance(config_value, bool):
             return config_value
-        return config_value in true_values
+        return config_value in TRUE_VALUES
 
     elif key_type == 'hex':
         return '0x' + config_value[2:].upper()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
PR #26163 has `#define NKRO_DEFAULT_ON true` within a config.h.

Running `qmk info -f json -kb owlab/link65/hotswap` incorrectly produces:

```json
    "host": {
        "default": {
            "nkro": false
        }
    },
```

https://github.com/qmk/qmk_firmware/blob/ccc6c6ce0b4cd60c2ad668c7df180af3b4064feb/lib/python/qmk/info.py#L660

At the point the conversion is handled, the config_value is a string of value `"true"`. This is not within the currently expected true values so returns false.

Also updated variable name as it is a constant.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
