### PR TITLE
Add workaround for undefined reference to weak function under mingw

### DIFF
--- a/platforms/test/platform.mk
+++ b/platforms/test/platform.mk
@@ -11,6 +11,10 @@ HEX =
 EEP =
 BIN =
 
+# workaround for undefined reference to weak function under mingw
+ifneq ($(findstring mingw, ${SYSTEM_TYPE}),)
+LTO_ENABLE := yes
+endif
 
 COMPILEFLAGS += -funsigned-char
 ifeq ($(findstring clang, ${GCC_VERSION}),)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
On MSYS, `make clean test:audio` produces the following errors:

```
 | C:/QMK_MSYS/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: .build/test_obj/audio/quantum/quantum.o:quantum.c:(.text$register_code16+0x1e): undefined reference to `register_weak_mods'
 | C:/QMK_MSYS/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: .build/test_obj/audio/quantum/quantum.o:quantum.c:(.text$register_code16+0x3b): undefined reference to `register_mods'
 | C:/QMK_MSYS/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: .build/test_obj/audio/quantum/quantum.o:quantum.c:(.text$register_code16+0x30): undefined reference to `register_code'
 | C:/QMK_MSYS/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: .build/test_obj/audio/quantum/quantum.o:quantum.c:(.text$register_code16+0x4d): undefined reference to `register_code'
 | C:/QMK_MSYS/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: .build/test_obj/audio/quantum/quantum.o:quantum.c:(.text$unregister_code16+0xb): undefined reference to `unregister_code'
 | C:/QMK_MSYS/ucrt64/bin/../lib/gcc/x86_64-w64-ming
...
```

Enabling LTO seems to work round the problem enough to get the full test suite to run.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
