### PR TITLE
Hybrid scroll for Ploopy Trackball

### DIFF
--- a/keyboards/ploopyco/ploopyco.c
+++ b/keyboards/ploopyco/ploopyco.c
@@ -57,6 +57,9 @@
 #ifndef ENCODER_BUTTON_COL
 #    define ENCODER_BUTTON_COL 0
 #endif
+#ifndef PLOOPY_DRAGSCROLL_HOLD_THRESHOLD_MS
+#    define PLOOPY_DRAGSCROLL_HOLD_THRESHOLD_MS 200
+#endif
 
 keyboard_config_t keyboard_config;
 uint16_t          dpi_array[] = PLOOPY_DPI_OPTIONS;
@@ -67,6 +70,10 @@ bool  is_scroll_clicked    = false;
 bool  is_drag_scroll       = false;
 float scroll_accumulated_h = 0;
 float scroll_accumulated_v = 0;
+
+#ifdef PLOOPY_DRAGSCROLL_HYBRID
+static uint16_t drag_scroll_hybrid_timer = 0;
+#endif
 
 #ifdef ENCODER_ENABLE
 uint16_t lastScroll        = 0; // Previous confirmed wheel event
@@ -191,6 +198,13 @@ bool process_record_kb(uint16_t keycode, keyrecord_t* record) {
     if (keycode == DRAG_SCROLL) {
 #ifdef PLOOPY_DRAGSCROLL_MOMENTARY
         is_drag_scroll = record->event.pressed;
+#elif defined(PLOOPY_DRAGSCROLL_HYBRID)
+        if (record->event.pressed) {
+            drag_scroll_hybrid_timer = timer_read();
+            toggle_drag_scroll();
+        } else if (timer_elapsed(drag_scroll_hybrid_timer) > PLOOPY_DRAGSCROLL_HOLD_THRESHOLD_MS) {
+            toggle_drag_scroll();
+        }
 #else
         if (record->event.pressed) {
             toggle_drag_scroll();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This allows the scroll button to be both toggle and hold. It works as follows:

The first click immediately toggles dragscroll. Then if the button is released within PLOOPY_DRAGSCROLL_HOLD_THRESHOLD_MS the button-up does nothing, if the button is released after this threshold, the dragscroll is toggled again.

Similarly to the existing PLOOPY_DRAGSCROLL_MOMENTARY, this behavior is enabled when PLOOPY_DRAGSCROLL_HYBRID is enabled.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
