### PR TITLE
Update RGB Light documentation to include JSON config

### DIFF
--- a/docs/features/rgblight.md
+++ b/docs/features/rgblight.md
@@ -18,21 +18,30 @@ These LEDs are called "addressable" because instead of using a wire per color, e
 
 On keyboards with onboard RGB LEDs, it is usually enabled by default. If it is not working for you, check that your configuration includes the following:
 
+:::::tabs
+
+==== JSON
 ```json
   "features": {
     "rgblight": true
   }
 ```
-or
+
+==== rules.mk
 ```make
 RGBLIGHT_ENABLE = yes
 ```
+:::::
 
 ::: tip
 There are additional configuration options for ARM controllers that offer increased performance over the default WS2812 bitbang driver. Please see [WS2812 Driver](../drivers/ws2812) for more information.
 :::
 
 For APA102 LEDs, add the following to your config:
+
+:::::tabs
+
+==== JSON
 
 ```json
   "features": {
@@ -43,7 +52,36 @@ For APA102 LEDs, add the following to your config:
   }
 ```
 
+==== rules.mk
+
+```make
+RGBLIGHT_ENABLE = yes
+RGBLIGHT_DRIVER = apa102
+```
+
+:::::
+
 At minimum you must define the data pin your LED strip is connected to, and the number of LEDs in the strip, in your `config.h`. For APA102 LEDs, you must also define the clock pin. If your keyboard has onboard RGB LEDs, and you are simply creating a keymap, you usually won't need to modify these.
+
+:::::tabs
+
+==== JSON
+
+```json
+    "ws2812": {
+        "pin": "B2",
+    },
+    "apa102": {
+        "clock_pin": "B3",
+        "data_pin": "B2"
+    },
+    "rgblight": {
+        "led_count": 10,
+        "split_count": [5, 5]
+    }
+```
+
+==== config.h
 
 | JSON                   | Define (Deprecated)  | Description                                                               |
 |------------------------|----------------------|---------------------------------------------------------------------------|
@@ -52,6 +90,8 @@ At minimum you must define the data pin your LED strip is connected to, and the 
 | `apa102.clock_pin`     | `APA102_CI_PIN`      | The pin connected to the clock pin of the LEDs (APA102)                   |
 | `rgblight.led_count`   | `RGBLIGHT_LED_COUNT` | The number of LEDs connected                                              |
 | `rgblight.split_count` | `RGBLED_SPLIT`       | (Optional) For split keyboards, the number of LEDs connected on each half |
+
+:::::
 
 Then you should be able to use the keycodes below to change the RGB lighting to your liking.
 

--- a/docs/features/rgblight.md
+++ b/docs/features/rgblight.md
@@ -16,8 +16,14 @@ These LEDs are called "addressable" because instead of using a wire per color, e
 
 ## Usage
 
-On keyboards with onboard RGB LEDs, it is usually enabled by default. If it is not working for you, check that your `rules.mk` includes the following:
+On keyboards with onboard RGB LEDs, it is usually enabled by default. If it is not working for you, check that your configuration includes the following:
 
+```json
+  "features": {
+    "rgblight": true
+  }
+```
+or
 ```make
 RGBLIGHT_ENABLE = yes
 ```
@@ -26,22 +32,26 @@ RGBLIGHT_ENABLE = yes
 There are additional configuration options for ARM controllers that offer increased performance over the default WS2812 bitbang driver. Please see [WS2812 Driver](../drivers/ws2812) for more information.
 :::
 
-For APA102 LEDs, add the following to your `rules.mk`:
+For APA102 LEDs, add the following to your config:
 
-```make
-RGBLIGHT_ENABLE = yes
-RGBLIGHT_DRIVER = apa102
+```json
+  "features": {
+    "rgblight": true
+  },
+  "rgblight": {
+    "driver": "apa102"
+  }
 ```
 
 At minimum you must define the data pin your LED strip is connected to, and the number of LEDs in the strip, in your `config.h`. For APA102 LEDs, you must also define the clock pin. If your keyboard has onboard RGB LEDs, and you are simply creating a keymap, you usually won't need to modify these.
 
-|Define              |Description                                                              |
-|--------------------|-------------------------------------------------------------------------|
-|`WS2812_DI_PIN`     |The pin connected to the data pin of the LEDs (WS2812)                   |
-|`APA102_DI_PIN`     |The pin connected to the data pin of the LEDs (APA102)                   |
-|`APA102_CI_PIN`     |The pin connected to the clock pin of the LEDs (APA102)                  |
-|`RGBLIGHT_LED_COUNT`|The number of LEDs connected                                             |
-|`RGBLED_SPLIT`      |(Optional) For split keyboards, the number of LEDs connected on each half|
+| JSON                   | Define (Deprecated)  | Description                                                               |
+|------------------------|----------------------|---------------------------------------------------------------------------|
+| `ws2812.pin`           | `WS2812_DI_PIN`      | The pin connected to the data pin of the LEDs (WS2812)                    |
+| `apa102.data_pin`      | `APA102_DI_PIN`      | The pin connected to the data pin of the LEDs (APA102)                    |
+| `apa102.clock_pin`     | `APA102_CI_PIN`      | The pin connected to the clock pin of the LEDs (APA102)                   |
+| `rgblight.led_count`   | `RGBLIGHT_LED_COUNT` | The number of LEDs connected                                              |
+| `rgblight.split_count` | `RGBLED_SPLIT`       | (Optional) For split keyboards, the number of LEDs connected on each half |
 
 Then you should be able to use the keycodes below to change the RGB lighting to your liking.
 
@@ -57,35 +67,40 @@ Changing the **Value** sets the overall brightness.<br>
 
 ![QMK Color Wheel with HSV Values](/vkYVo66.jpg)
 
+
+::: tip
+QMK uses a modified hue value to ensure that 8 bit math is used, and the range is 0-255 instead of the standard 0-360.
+:::
+
 ## Keycodes
 
 ::: warning
 These keycodes also simultaneously control [RGB Matrix](rgb_matrix), if enabled. This behaviour is in the process of being deprecated, so during this time it is recommended to additionally include the dedicated RGB Matrix keycodes to your keymap, and add `#define RGB_MATRIX_DISABLE_SHARED_KEYCODES` to `config.h`.
 :::
 
-|Key                           |Aliases   |Description                                                          |
-|------------------------------|----------|---------------------------------------------------------------------|
-|`QK_UNDERGLOW_TOGGLE`         |`UG_TOGG` |Toggle RGB lighting on or off                                        |
-|`QK_UNDERGLOW_MODE_NEXT`      |`UG_NEXT` |Cycle through modes, reverse direction when Shift is held            |
-|`QK_UNDERGLOW_MODE_PREVIOUS`  |`UG_PREV` |Cycle through modes in reverse, forward direction when Shift is held |
-|`QK_UNDERGLOW_HUE_UP`         |`UG_HUEU` |Increase hue, decrease hue when Shift is held                        |
-|`QK_UNDERGLOW_HUE_DOWN`       |`UG_HUED` |Decrease hue, increase hue when Shift is held                        |
-|`QK_UNDERGLOW_SATURATION_UP`  |`UG_SATU` |Increase saturation, decrease saturation when Shift is held          |
-|`QK_UNDERGLOW_SATURATION_DOWN`|`UG_SATD` |Decrease saturation, increase saturation when Shift is held          |
-|`QK_UNDERGLOW_VALUE_UP`       |`UG_VALU` |Increase value (brightness), decrease value when Shift is held       |
-|`QK_UNDERGLOW_VALUE_DOWN`     |`UG_VALD` |Decrease value (brightness), increase value when Shift is held       |
-|`QK_UNDERGLOW_SPEED_UP`       |`UG_SPDU` |Increase effect speed (brightness), decrease speed when Shift is held|
-|`QK_UNDERGLOW_SPEED_DOWN`     |`UG_SPDD` |Decrease effect speed (brightness), increase speed when Shift is held|
-|`RGB_MODE_PLAIN`              |`RGB_M_P `|Static (no animation) mode (deprecated)                              |
-|`RGB_MODE_BREATHE`            |`RGB_M_B` |Breathing animation mode (deprecated)                                |
-|`RGB_MODE_RAINBOW`            |`RGB_M_R` |Rainbow animation mode (deprecated)                                  |
-|`RGB_MODE_SWIRL`              |`RGB_M_SW`|Swirl animation mode (deprecated)                                    |
-|`RGB_MODE_SNAKE`              |`RGB_M_SN`|Snake animation mode (deprecated)                                    |
-|`RGB_MODE_KNIGHT`             |`RGB_M_K` |"Knight Rider" animation mode (deprecated)                           |
-|`RGB_MODE_XMAS`               |`RGB_M_X` |Christmas animation mode (deprecated)                                |
-|`RGB_MODE_GRADIENT`           |`RGB_M_G` |Static gradient animation mode (deprecated)                          |
-|`RGB_MODE_RGBTEST`            |`RGB_M_T` |Red, Green, Blue test animation mode (deprecated)                    |
-|`RGB_MODE_TWINKLE`            |`RGB_M_TW`|Twinkle animation mode (deprecated)                                  |
+| Key                            | Aliases    | Description                                                           |
+|--------------------------------|------------|-----------------------------------------------------------------------|
+| `QK_UNDERGLOW_TOGGLE`          | `UG_TOGG`  | Toggle RGB lighting on or off                                         |
+| `QK_UNDERGLOW_MODE_NEXT`       | `UG_NEXT`  | Cycle through modes, reverse direction when Shift is held             |
+| `QK_UNDERGLOW_MODE_PREVIOUS`   | `UG_PREV`  | Cycle through modes in reverse, forward direction when Shift is held  |
+| `QK_UNDERGLOW_HUE_UP`          | `UG_HUEU`  | Increase hue, decrease hue when Shift is held                         |
+| `QK_UNDERGLOW_HUE_DOWN`        | `UG_HUED`  | Decrease hue, increase hue when Shift is held                         |
+| `QK_UNDERGLOW_SATURATION_UP`   | `UG_SATU`  | Increase saturation, decrease saturation when Shift is held           |
+| `QK_UNDERGLOW_SATURATION_DOWN` | `UG_SATD`  | Decrease saturation, increase saturation when Shift is held           |
+| `QK_UNDERGLOW_VALUE_UP`        | `UG_VALU`  | Increase value (brightness), decrease value when Shift is held        |
+| `QK_UNDERGLOW_VALUE_DOWN`      | `UG_VALD`  | Decrease value (brightness), increase value when Shift is held        |
+| `QK_UNDERGLOW_SPEED_UP`        | `UG_SPDU`  | Increase effect speed (brightness), decrease speed when Shift is held |
+| `QK_UNDERGLOW_SPEED_DOWN`      | `UG_SPDD`  | Decrease effect speed (brightness), increase speed when Shift is held |
+| `RGB_MODE_PLAIN`               | `RGB_M_P ` | Static (no animation) mode (deprecated)                               |
+| `RGB_MODE_BREATHE`             | `RGB_M_B`  | Breathing animation mode (deprecated)                                 |
+| `RGB_MODE_RAINBOW`             | `RGB_M_R`  | Rainbow animation mode (deprecated)                                   |
+| `RGB_MODE_SWIRL`               | `RGB_M_SW` | Swirl animation mode (deprecated)                                     |
+| `RGB_MODE_SNAKE`               | `RGB_M_SN` | Snake animation mode (deprecated)                                     |
+| `RGB_MODE_KNIGHT`              | `RGB_M_K`  | "Knight Rider" animation mode (deprecated)                            |
+| `RGB_MODE_XMAS`                | `RGB_M_X`  | Christmas animation mode (deprecated)                                 |
+| `RGB_MODE_GRADIENT`            | `RGB_M_G`  | Static gradient animation mode (deprecated)                           |
+| `RGB_MODE_RGBTEST`             | `RGB_M_T`  | Red, Green, Blue test animation mode (deprecated)                     |
+| `RGB_MODE_TWINKLE`             | `RGB_M_TW` | Twinkle animation mode (deprecated)                                   |
 
 ::: tip
 These keycodes cannot be used with functions like `tap_code16()` as they are not USB HID keycodes. If you wish to replicate similar behaviour in custom code within your firmware (e.g. inside `encoder_update_user()` or `process_record_user()`), the equivalent [RGB functions](#functions) should be used instead.
@@ -95,39 +110,39 @@ These keycodes cannot be used with functions like `tap_code16()` as they are not
 
 Your RGB lighting can be configured by placing these `#define`s in your `config.h`:
 
-|Define                     |Default                     |Description                                                                                                                |
-|---------------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------|
-|`RGBLIGHT_HUE_STEP`        |`8`                         |The value by which to increment the hue per adjustment action                                                              |
-|`RGBLIGHT_SAT_STEP`        |`17`                        |The value by which to increment the saturation per adjustment action                                                       |
-|`RGBLIGHT_VAL_STEP`        |`17`                        |The value by which to increment the brightness per adjustment action                                                       |
-|`RGBLIGHT_LIMIT_VAL`       |`255`                       |The maximum brightness level                                                                                               |
-|`RGBLIGHT_SLEEP`           |*Not defined*               |If defined, the RGB lighting will be switched off when the host goes to sleep                                              |
-|`RGBLIGHT_SPLIT`           |*Not defined*               |If defined, synchronization functionality for split keyboards is added                                                     |
-|`RGBLIGHT_DEFAULT_MODE`    |`RGBLIGHT_MODE_STATIC_LIGHT`|The default mode to use upon clearing the EEPROM                                                                           |
-|`RGBLIGHT_DEFAULT_HUE`     |`0` (red)                   |The default hue to use upon clearing the EEPROM                                                                            |
-|`RGBLIGHT_DEFAULT_SAT`     |`UINT8_MAX` (255)           |The default saturation to use upon clearing the EEPROM                                                                     |
-|`RGBLIGHT_DEFAULT_VAL`     |`RGBLIGHT_LIMIT_VAL`        |The default value (brightness) to use upon clearing the EEPROM                                                             |
-|`RGBLIGHT_DEFAULT_SPD`     |`0`                         |The default speed to use upon clearing the EEPROM                                                                          |
-|`RGBLIGHT_DEFAULT_ON`      |`true`                      |Enable RGB lighting upon clearing the EEPROM                                                                               |
+| JSON                        | Define (Deprecated)     | Default                      | Description                                                                   |
+|-----------------------------|-------------------------|------------------------------|-------------------------------------------------------------------------------|
+| `rgblight.hue_steps`        | `RGBLIGHT_HUE_STEP`     | `8`                          | The value by which to increment the hue per adjustment action                 |
+| `rgblight.saturation_steps` | `RGBLIGHT_SAT_STEP`     | `17`                         | The value by which to increment the saturation per adjustment action          |
+| `rgblight.value_steps`      | `RGBLIGHT_VAL_STEP`     | `17`                         | The value by which to increment the brightness per adjustment action          |
+| `rgblight.max_brightness`   | `RGBLIGHT_LIMIT_VAL`    | `255`                        | The maximum brightness level                                                  |
+| `rgblight.sleep`            | `RGBLIGHT_SLEEP`        | *Not defined*                | If defined, the RGB lighting will be switched off when the host goes to sleep |
+| `rgblight.split`            | `RGBLIGHT_SPLIT`        | *Not defined*                | If defined, synchronization functionality for split keyboards is added        |
+| `rgblight.default.mode`     | `RGBLIGHT_DEFAULT_MODE` | `RGBLIGHT_MODE_STATIC_LIGHT` | The default mode to use upon clearing the EEPROM                              |
+| `rgblight.default.hue`      | `RGBLIGHT_DEFAULT_HUE`  | `0` (red)                    | The default hue to use upon clearing the EEPROM                               |
+| `rgblight.default.sat`      | `RGBLIGHT_DEFAULT_SAT`  | `UINT8_MAX` (255)            | The default saturation to use upon clearing the EEPROM                        |
+| `rgblight.default.val`      | `RGBLIGHT_DEFAULT_VAL`  | `RGBLIGHT_LIMIT_VAL`         | The default value (brightness) to use upon clearing the EEPROM                |
+| `rgblight.default.speed`    | `RGBLIGHT_DEFAULT_SPD`  | `0`                          | The default speed to use upon clearing the EEPROM                             |
+| `rgblight.default.on`       | `RGBLIGHT_DEFAULT_ON`   | `true`                       | Enable RGB lighting upon clearing the EEPROM                                  |
 
 ## Effects and Animations
 
 Not only can this lighting be whatever color you want,
 if `RGBLIGHT_EFFECT_xxxx` is defined, you also have a number of animation modes at your disposal:
 
-|Mode number symbol           |Additional number  |Description                            |
-|-----------------------------|-------------------|---------------------------------------|
-|`RGBLIGHT_MODE_STATIC_LIGHT` | *None*            |Solid color (this mode is always enabled) |
-|`RGBLIGHT_MODE_BREATHING`    | 0,1,2,3           |Solid color breathing                  |
-|`RGBLIGHT_MODE_RAINBOW_MOOD` | 0,1,2             |Cycling rainbow                        |
-|`RGBLIGHT_MODE_RAINBOW_SWIRL`| 0,1,2,3,4,5       |Swirling rainbow                       |
-|`RGBLIGHT_MODE_SNAKE`        | 0,1,2,3,4,5       |Snake                                  |
-|`RGBLIGHT_MODE_KNIGHT`       | 0,1,2             |Knight                                 |
-|`RGBLIGHT_MODE_CHRISTMAS`    | *None*            |Christmas                              |
-|`RGBLIGHT_MODE_STATIC_GRADIENT`| 0,1,..,9        |Static gradient                        |
-|`RGBLIGHT_MODE_RGB_TEST`     | *None*            |RGB Test                               |
-|`RGBLIGHT_MODE_ALTERNATING`  | *None*            |Alternating                            |
-|`RGBLIGHT_MODE_TWINKLE`      | 0,1,2,3,4,5       |Twinkle                                |
+| Mode number symbol              | Additional number | Description                               |
+|---------------------------------|-------------------|-------------------------------------------|
+| `RGBLIGHT_MODE_STATIC_LIGHT`    | *None*            | Solid color (this mode is always enabled) |
+| `RGBLIGHT_MODE_BREATHING`       | 0,1,2,3           | Solid color breathing                     |
+| `RGBLIGHT_MODE_RAINBOW_MOOD`    | 0,1,2             | Cycling rainbow                           |
+| `RGBLIGHT_MODE_RAINBOW_SWIRL`   | 0,1,2,3,4,5       | Swirling rainbow                          |
+| `RGBLIGHT_MODE_SNAKE`           | 0,1,2,3,4,5       | Snake                                     |
+| `RGBLIGHT_MODE_KNIGHT`          | 0,1,2             | Knight                                    |
+| `RGBLIGHT_MODE_CHRISTMAS`       | *None*            | Christmas                                 |
+| `RGBLIGHT_MODE_STATIC_GRADIENT` | 0,1,..,9          | Static gradient                           |
+| `RGBLIGHT_MODE_RGB_TEST`        | *None*            | RGB Test                                  |
+| `RGBLIGHT_MODE_ALTERNATING`     | *None*            | Alternating                               |
+| `RGBLIGHT_MODE_TWINKLE`         | 0,1,2,3,4,5       | Twinkle                                   |
 
 Check out [this video](https://youtube.com/watch?v=VKrpPAHlisY) for a demonstration.
 
@@ -138,41 +153,47 @@ Note: For versions older than 0.6.117, The mode numbers were written directly. I
 
 Use these defines to add or remove animations from the firmware. When you are running low on flash space, it can be helpful to disable animations you are not using.
 
-|Define                              |Default      |Description                                                              |
-|------------------------------------|-------------|-------------------------------------------------------------------------|
-|`RGBLIGHT_ANIMATIONS`               |*Not defined*|Enable all additional animation modes.  (deprecated)                     |
-|`RGBLIGHT_EFFECT_ALTERNATING`       |*Not defined*|Enable alternating animation mode.                                       |
-|`RGBLIGHT_EFFECT_BREATHING`         |*Not defined*|Enable breathing animation mode.                                         |
-|`RGBLIGHT_EFFECT_CHRISTMAS`         |*Not defined*|Enable christmas animation mode.                                         |
-|`RGBLIGHT_EFFECT_KNIGHT`            |*Not defined*|Enable knight animation mode.                                            |
-|`RGBLIGHT_EFFECT_RAINBOW_MOOD`      |*Not defined*|Enable rainbow mood animation mode.                                      |
-|`RGBLIGHT_EFFECT_RAINBOW_SWIRL`     |*Not defined*|Enable rainbow swirl animation mode.                                     |
-|`RGBLIGHT_EFFECT_RGB_TEST`          |*Not defined*|Enable RGB test animation mode.                                          |
-|`RGBLIGHT_EFFECT_SNAKE`             |*Not defined*|Enable snake animation mode.                                             |
-|`RGBLIGHT_EFFECT_STATIC_GRADIENT`   |*Not defined*|Enable static gradient mode.                                             |
-|`RGBLIGHT_EFFECT_TWINKLE`           |*Not defined*|Enable twinkle animation mode.                                           |
+| JSON                                  | Define (Deprecated)               | Default       | Description                          |
+|---------------------------------------|-----------------------------------|---------------|--------------------------------------|
+| `rgblight.animations.alternating`     | `RGBLIGHT_EFFECT_ALTERNATING`     | *Not defined* | Enable alternating animation mode.   |
+| `rgblight.animations.breathing`       | `RGBLIGHT_EFFECT_BREATHING`       | *Not defined* | Enable breathing animation mode.     |
+| `rgblight.animations.christmas`       | `RGBLIGHT_EFFECT_CHRISTMAS`       | *Not defined* | Enable christmas animation mode.     |
+| `rgblight.animations.knight`          | `RGBLIGHT_EFFECT_KNIGHT`          | *Not defined* | Enable knight animation mode.        |
+| `rgblight.animations.rainbow_mood`    | `RGBLIGHT_EFFECT_RAINBOW_MOOD`    | *Not defined* | Enable rainbow mood animation mode.  |
+| `rgblight.animations.rainbow_swirl`   | `RGBLIGHT_EFFECT_RAINBOW_SWIRL`   | *Not defined* | Enable rainbow swirl animation mode. |
+| `rgblight.animations.rgb_test`        | `RGBLIGHT_EFFECT_RGB_TEST`        | *Not defined* | Enable RGB test animation mode.      |
+| `rgblight.animations.snake`           | `RGBLIGHT_EFFECT_SNAKE`           | *Not defined* | Enable snake animation mode.         |
+| `rgblight.animations.static_gradient` | `RGBLIGHT_EFFECT_STATIC_GRADIENT` | *Not defined* | Enable static gradient mode.         |
+| `rgblight.animations.twinkle`         | `RGBLIGHT_EFFECT_TWINKLE`         | *Not defined* | Enable twinkle animation mode.       |
 
-::: warning
-`RGBLIGHT_ANIMATIONS` is being deprecated and animation modes should be explicitly defined.
-:::
+In your json file, this should look like:
+
+```json
+    "rgblight": {
+        "animations": {
+            "breathing": true,
+            "rainbow_mood": true
+        }
+    }
+```
 
 ### Effect and Animation Settings
 
 The following options are used to tweak the various animations:
 
-|Define                              |Default             |Description                                                                                    |
-|------------------------------------|--------------------|-----------------------------------------------------------------------------------------------|
-|`RGBLIGHT_EFFECT_BREATHE_CENTER`    |*Not defined*       |If defined, used to calculate the curve for the breathing animation. Valid values are 1.0 to 2.7 |
-|`RGBLIGHT_EFFECT_BREATHE_MAX`       |`255`               |The maximum brightness for the breathing mode. Valid values are 1 to 255                       |
-|`RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL`|`40`                |How long (in milliseconds) to wait between animation steps for the "Christmas" animation       |
-|`RGBLIGHT_EFFECT_CHRISTMAS_STEP`    |`2`                 |The number of LEDs to group the red/green colors by for the "Christmas" animation              |
-|`RGBLIGHT_EFFECT_KNIGHT_LED_NUM`    |`RGBLIGHT_LED_COUNT`|The number of LEDs to have the "Knight" animation travel                                       |
-|`RGBLIGHT_EFFECT_KNIGHT_LENGTH`     |`3`                 |The number of LEDs to light up for the "Knight" animation                                      |
-|`RGBLIGHT_EFFECT_KNIGHT_OFFSET`     |`0`                 |The number of LEDs to start the "Knight" animation from the start of the strip by              |
-|`RGBLIGHT_RAINBOW_SWIRL_RANGE`      |`255`               |Range adjustment for the rainbow swirl effect to get different swirls                          |
-|`RGBLIGHT_EFFECT_SNAKE_LENGTH`      |`4`                 |The number of LEDs to light up for the "Snake" animation                                       |
-|`RGBLIGHT_EFFECT_TWINKLE_LIFE`      |`200`               |Adjusts how quickly each LED brightens and dims when twinkling (in animation steps)            |
-|`RGBLIGHT_EFFECT_TWINKLE_PROBABILITY`|`1/127`            |Adjusts how likely each LED is to twinkle (on each animation step)                             |
+| Define                                | Default              | Description                                                                                      |
+|---------------------------------------|----------------------|--------------------------------------------------------------------------------------------------|
+| `RGBLIGHT_EFFECT_BREATHE_CENTER`      | *Not defined*        | If defined, used to calculate the curve for the breathing animation. Valid values are 1.0 to 2.7 |
+| `RGBLIGHT_EFFECT_BREATHE_MAX`         | `255`                | The maximum brightness for the breathing mode. Valid values are 1 to 255                         |
+| `RGBLIGHT_EFFECT_CHRISTMAS_INTERVAL`  | `40`                 | How long (in milliseconds) to wait between animation steps for the "Christmas" animation         |
+| `RGBLIGHT_EFFECT_CHRISTMAS_STEP`      | `2`                  | The number of LEDs to group the red/green colors by for the "Christmas" animation                |
+| `RGBLIGHT_EFFECT_KNIGHT_LED_NUM`      | `RGBLIGHT_LED_COUNT` | The number of LEDs to have the "Knight" animation travel                                         |
+| `RGBLIGHT_EFFECT_KNIGHT_LENGTH`       | `3`                  | The number of LEDs to light up for the "Knight" animation                                        |
+| `RGBLIGHT_EFFECT_KNIGHT_OFFSET`       | `0`                  | The number of LEDs to start the "Knight" animation from the start of the strip by                |
+| `RGBLIGHT_RAINBOW_SWIRL_RANGE`        | `255`                | Range adjustment for the rainbow swirl effect to get different swirls                            |
+| `RGBLIGHT_EFFECT_SNAKE_LENGTH`        | `4`                  | The number of LEDs to light up for the "Snake" animation                                         |
+| `RGBLIGHT_EFFECT_TWINKLE_LIFE`        | `200`                | Adjusts how quickly each LED brightens and dims when twinkling (in animation steps)              |
+| `RGBLIGHT_EFFECT_TWINKLE_PROBABILITY` | `1/127`              | Adjusts how likely each LED is to twinkle (on each animation step)                               |
 
 ### Example Usage to Reduce Memory Footprint
   1. Use `#undef` to selectively disable animations. The following would disable two animations and save about 4KiB:
@@ -221,12 +242,12 @@ const uint8_t RGBLED_GRADIENT_RANGES[] PROGMEM = {255, 170, 127, 85, 64};
 **Note:** Lighting Layers is an RGB Light feature, it will not work for RGB Matrix. See [RGB Matrix Indicators](rgb_matrix#indicators) for details on how to do so.
 :::
 
-By including `#define RGBLIGHT_LAYERS` in your `config.h` file you can enable lighting layers. These make
+By setting `rgblight.layers.enabled` to `true` or by including `#define RGBLIGHT_LAYERS` in your `config.h` file you can enable lighting layers. These make
 it easy to use your underglow LEDs as status indicators to show which keyboard layer is currently active, or the state of caps lock, all without disrupting any animations. [Here's a video](https://youtu.be/uLGE1epbmdY) showing an example of what you can do.
 
 ### Defining Lighting Layers {#defining-lighting-layers}
 
-By default, 8 layers are possible. This can be expanded to as many as 32 by overriding the definition of `RGBLIGHT_MAX_LAYERS` in `config.h` (e.g. `#define RGBLIGHT_MAX_LAYERS 32`). Please note, if you use a split keyboard, you will need to flash both sides of the split after changing this. Also, increasing the maximum will increase the firmware size, and will slow sync on split keyboards.
+By default, 8 layers are possible. This can be expanded to as many as 32 by setting `rgblight.layers.max` up to 32 in your json, or by overriding the definition of `RGBLIGHT_MAX_LAYERS` in `config.h` (e.g. `#define RGBLIGHT_MAX_LAYERS 32`). Please note, if you use a split keyboard, you will need to flash both sides of the split after changing this. Also, increasing the maximum will increase the firmware size, and may slow sync on split keyboards.
 
 To define a layer, we modify `keymap.c` to list the LED ranges and the colors we want to overlay on them using an array of `rgblight_segment_t` using the `RGBLIGHT_LAYER_SEGMENTS` macro. We can define multiple layers and enable/disable them independently:
 
@@ -294,10 +315,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 ### Lighting layer blink {#lighting-layer-blink}
 
-By including `#define RGBLIGHT_LAYER_BLINK` in your `config.h` file you can turn a lighting
-layer on for a specified duration. Once the specified number of milliseconds has elapsed
-the layer will be turned off. This is useful, e.g., if you want to acknowledge some
-action (e.g. toggling some setting):
+By setting `rgblight.layers.blink` to `true`, or by including `#define RGBLIGHT_LAYER_BLINK` in your `config.h` file you can turn a lighting layer on for a specified duration. Once the specified number of milliseconds has elapsed the layer will be turned off. This is useful, e.g., if you want to acknowledge some action (e.g. toggling some setting):
 
 ```c
 const rgblight_segment_t PROGMEM _yes_layer[] = RGBLIGHT_LAYER_SEGMENTS( {9, 6, HSV_GREEN} );
@@ -353,12 +371,12 @@ rgblight_blink_layer(2, 500);
 ```
 
 ::: warning
-Lighting layers on split keyboards will require layer state synced to the slave half (e.g. `#define SPLIT_LAYER_STATE_ENABLE`). See [data sync options](split_keyboard#data-sync-options) for more details.
+Lighting layers on split keyboards will require layer state synced to the slave half (e.g. setting `split.transport.sync.layer_state` to `true` or `#define SPLIT_LAYER_STATE_ENABLE`). See [data sync options](split_keyboard#data-sync-options) for more details.
 :::
 
 ### Overriding RGB Lighting on/off status
 
-Normally lighting layers are not shown when RGB Lighting is disabled (e.g. with `UG_TOGG` keycode). If you would like lighting layers to work even when the RGB Lighting is otherwise off, add `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF` to your `config.h`.
+Normally lighting layers are not shown when RGB Lighting is disabled (e.g. with `UG_TOGG` keycode). If you would like lighting layers to work even when the RGB Lighting is otherwise off, set `rgblight.layers.override_rgb` to `true` or add `#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF` to your `config.h`.
 
 ### Retain brightness
 
@@ -513,8 +531,15 @@ Normally, the contents of the LED buffer are output to the LEDs in the same orde
 
 By defining `RGBLIGHT_LED_MAP` as in the example below, you can specify the LED with addressing in reverse order of the electrical connection order.
 
+```json
+    "rgblight": {
+        "led_count": 4,
+        "led_map": [ 3, 2, 1, 0],
+    },
+```
+
 ```c
-// config.h
+// config.h (deprecated)
 
 #define RGBLIGHT_LED_COUNT 4
 #define RGBLIGHT_LED_MAP { 3, 2, 1, 0 }
@@ -536,8 +561,16 @@ rgblight_set_clipping_range(3, 4);
 
 In addition to setting the Clipping Range, you can use `RGBLIGHT_LED_MAP` together.
 
+
+```json
+    "rgblight": {
+        "led_count": 4,
+        "led_map": [ 7, 6, 5, 4, 3, 2, 1, 0],
+    },
+```
+
 ```c
-// config.h
+// config.h (deprecated)
 #define RGBLIGHT_LED_COUNT 8
 #define RGBLIGHT_LED_MAP { 7, 6, 5, 4, 3, 2, 1, 0 }
 
@@ -555,7 +588,7 @@ If your keyboard lacks onboard underglow LEDs, you may often be able to solder o
 Velocikey is a feature that lets you control the speed of lighting effects (like the Rainbow Swirl effect) with the speed of your typing. The faster you type, the faster the lights will go!
 
 ### Usage
-For Velocikey to take effect, there are two steps. First, when compiling your keyboard, you'll need to set `VELOCIKEY_ENABLE=yes` in `rules.mk`, e.g.:
+For Velocikey to take effect, there are two steps. First, when compiling your keyboard, you'll need to set `features.velocikey` to `true` or `VELOCIKEY_ENABLE=yes` in `rules.mk`, e.g.:
 
 ```
 MOUSEKEY_ENABLE = no

--- a/docs/features/rgblight.md
+++ b/docs/features/rgblight.md
@@ -154,11 +154,11 @@ Your RGB lighting can be configured by placing these `#define`s in your `config.
 |-----------------------------|-------------------------|------------------------------|-------------------------------------------------------------------------------|
 | `rgblight.hue_steps`        | `RGBLIGHT_HUE_STEP`     | `8`                          | The value by which to increment the hue per adjustment action                 |
 | `rgblight.saturation_steps` | `RGBLIGHT_SAT_STEP`     | `17`                         | The value by which to increment the saturation per adjustment action          |
-| `rgblight.value_steps`      | `RGBLIGHT_VAL_STEP`     | `17`                         | The value by which to increment the brightness per adjustment action          |
+| `rgblight.brightness_steps` | `RGBLIGHT_VAL_STEP`     | `17`                         | The value by which to increment the brightness per adjustment action          |
 | `rgblight.max_brightness`   | `RGBLIGHT_LIMIT_VAL`    | `255`                        | The maximum brightness level                                                  |
 | `rgblight.sleep`            | `RGBLIGHT_SLEEP`        | *Not defined*                | If defined, the RGB lighting will be switched off when the host goes to sleep |
 | `rgblight.split`            | `RGBLIGHT_SPLIT`        | *Not defined*                | If defined, synchronization functionality for split keyboards is added        |
-| `rgblight.default.mode`     | `RGBLIGHT_DEFAULT_MODE` | `RGBLIGHT_MODE_STATIC_LIGHT` | The default mode to use upon clearing the EEPROM                              |
+| `rgblight.default.animation`| `RGBLIGHT_DEFAULT_MODE` | `RGBLIGHT_MODE_STATIC_LIGHT` | The default mode to use upon clearing the EEPROM                              |
 | `rgblight.default.hue`      | `RGBLIGHT_DEFAULT_HUE`  | `0` (red)                    | The default hue to use upon clearing the EEPROM                               |
 | `rgblight.default.sat`      | `RGBLIGHT_DEFAULT_SAT`  | `UINT8_MAX` (255)            | The default saturation to use upon clearing the EEPROM                        |
 | `rgblight.default.val`      | `RGBLIGHT_DEFAULT_VAL`  | `RGBLIGHT_LIMIT_VAL`         | The default value (brightness) to use upon clearing the EEPROM                |
@@ -574,7 +574,7 @@ By defining `RGBLIGHT_LED_MAP` as in the example below, you can specify the LED 
 ```json
     "rgblight": {
         "led_count": 4,
-        "led_map": [ 3, 2, 1, 0],
+        "led_map": [ 3, 2, 1, 0]
     },
 ```
 

--- a/docs/features/rgblight.md
+++ b/docs/features/rgblight.md
@@ -69,7 +69,7 @@ At minimum you must define the data pin your LED strip is connected to, and the 
 
 ```json
     "ws2812": {
-        "pin": "B2",
+        "pin": "B2"
     },
     "apa102": {
         "clock_pin": "B3",


### PR DESCRIPTION
## Description

Add json configuration in docs (just rgblight currently).

Also reformat some of the tables to be more uniform

## Types of Changes

- [x] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
