### PR TITLE
fix(ws2812-pwm): allow WS2812_PWM_TICK_FREQUENCY override

### DIFF
--- a/platforms/chibios/drivers/ws2812_pwm.c
+++ b/platforms/chibios/drivers/ws2812_pwm.c
@@ -89,7 +89,9 @@
 
 /* --- PRIVATE CONSTANTS ---------------------------------------------------- */
 
-#define WS2812_PWM_TICK_FREQUENCY (CPU_CLOCK / 2)                            /**< Clock frequency of PWM ticks, must be valid with respect to system clock! */
+#ifndef WS2812_PWM_TICK_FREQUENCY
+#    define WS2812_PWM_TICK_FREQUENCY (CPU_CLOCK / 2) /**< Clock frequency of PWM ticks, must be valid with respect to system clock! */
+#endif
 #define WS2812_PWM_PERIOD (WS2812_PWM_TICK_FREQUENCY / WS2812_PWM_FREQUENCY) /**< Clock period in PWM ticks. */
 
 /**


### PR DESCRIPTION
## Description

`WS2812_PWM_TICK_FREQUENCY` is the only knob in
`platforms/chibios/drivers/ws2812_pwm.c` that's a flat `#define` rather than
`#ifndef`-guarded. Every other tick/period/frequency macro in the file already
lets a keyboard override it from `config.h`. This wraps it the same way.

The default `(CPU_CLOCK / 2)` works for boards that run at one fixed SYSCLK.
Boards that change SYSCLK at runtime (meletrix/zoom_tkl drops from 144 MHz on
USB to 16 MHz on battery) need to pick a tick frequency the prescaler can land
at both clock rates; at the default 72 MHz tick, the divisor underflows when
TMRCLK is 16 MHz.

No behavior change unless a keyboard defines the macro itself.

## Types of Changes

- [x] Bugfix

## Checklist

- [x] My code follows the C coding style of this project
- [x] I have read the PR Checklist document
- [x] I have tested the changes (verified on meletrix/zoom_tkl with SYSCLK
  switching between 144 MHz and 16 MHz; the default path is unchanged for
  boards that don't define the macro)