### PR TITLE
Remove `OLED_DISPLAY_128X32` config

### DIFF
--- a/keyboards/1upkeyboards/pi40/config.h
+++ b/keyboards/1upkeyboards/pi40/config.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#define OLED_DISPLAY_128X32
 #define I2C1_SCL_PIN        GP17
 #define I2C1_SDA_PIN        GP16
 #define I2C_DRIVER I2CD0

--- a/keyboards/bluebell/swoop/config.h
+++ b/keyboards/bluebell/swoop/config.h
@@ -19,6 +19,5 @@
 
 // OLED driver
 #ifdef OLED_DRIVER_ENABLE
-  #define OLED_DISPLAY_128X32
   #define OLED_TIMEOUT 30000
 #endif

--- a/keyboards/buzzard/rev1/config.h
+++ b/keyboards/buzzard/rev1/config.h
@@ -3,10 +3,6 @@
 
 #pragma once
 
-#ifdef OLED_ENABLE
-#define OLED_DISPLAY_128X32
-#endif
-
 #ifdef PS2_DRIVER_INTERRUPT
 #define PS2_CLOCK_PIN   E6
 #define PS2_DATA_PIN    D7

--- a/keyboards/fearherbs1/blue_team_pad/config.h
+++ b/keyboards/fearherbs1/blue_team_pad/config.h
@@ -7,6 +7,5 @@
 #define I2C1_SCL_PIN        GP27
 #define I2C1_SDA_PIN        GP26
 #define I2C_DRIVER I2CD1
-#define OLED_DISPLAY_128X32
 #define OLED_BRIGHTNESS 128
 #endif

--- a/keyboards/handwired/onekey/kb2040/config.h
+++ b/keyboards/handwired/onekey/kb2040/config.h
@@ -11,7 +11,6 @@
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500U
 
 // settings for the oled keyboard demo with Adafruit 0.91" OLED display on the Stemma QT port
-#define OLED_DISPLAY_128X32
 #define I2C_DRIVER I2CD0
 #define I2C1_SDA_PIN GP12
 #define I2C1_SCL_PIN GP13

--- a/keyboards/jorne/keymaps/default/config.h
+++ b/keyboards/jorne/keymaps/default/config.h
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #pragma once
 
-#define OLED_DISPLAY_128X32
-
 #ifdef RGBLIGHT_ENABLE
 #define RGBLIGHT_EFFECT_BREATHING
 #define RGBLIGHT_EFFECT_RAINBOW_MOOD

--- a/keyboards/splitkb/aurora/corne/rev1/config.h
+++ b/keyboards/splitkb/aurora/corne/rev1/config.h
@@ -18,6 +18,5 @@
 
 // Not yet available in `info.json`
 #ifdef OLED_ENABLE
-#    define OLED_DISPLAY_128X32
 #    define SPLIT_OLED_ENABLE
 #endif

--- a/keyboards/splitkb/aurora/helix/rev1/config.h
+++ b/keyboards/splitkb/aurora/helix/rev1/config.h
@@ -16,5 +16,4 @@
 
 #pragma once
 
-#define OLED_DISPLAY_128X32
 #define SPLIT_OLED_ENABLE

--- a/keyboards/splitkb/aurora/lily58/rev1/config.h
+++ b/keyboards/splitkb/aurora/lily58/rev1/config.h
@@ -18,6 +18,5 @@
 
 // Not yet available in `info.json`
 #ifdef OLED_ENABLE
-#    define OLED_DISPLAY_128X32
 #    define SPLIT_OLED_ENABLE
 #endif

--- a/keyboards/splitkb/aurora/sofle_v2/rev1/config.h
+++ b/keyboards/splitkb/aurora/sofle_v2/rev1/config.h
@@ -16,5 +16,4 @@
 
 #pragma once
 
-#define OLED_DISPLAY_128X32
 #define SPLIT_OLED_ENABLE

--- a/keyboards/splitkb/aurora/sweep/rev1/config.h
+++ b/keyboards/splitkb/aurora/sweep/rev1/config.h
@@ -18,6 +18,5 @@
 
 // Not yet available in `info.json`
 #ifdef OLED_ENABLE
-#    define OLED_DISPLAY_128X32
 #    define SPLIT_OLED_ENABLE
 #endif

--- a/keyboards/zigotica/z12/keymaps/default/config.h
+++ b/keyboards/zigotica/z12/keymaps/default/config.h
@@ -16,8 +16,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#define OLED_DISPLAY_128X32
-
 // EC11 encoders' resolution.
 // Reduce the value to 2 if you feel missing values:
 #define ENCODER_RESOLUTION 4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`OLED_DISPLAY_128X32` doesnt exist, and if it did would represent the default anyway.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
