### PR TITLE
Clip mouse report values to the logical range from the USB descriptor.

### DIFF
--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -194,21 +194,21 @@ typedef struct {
 } PACKED report_programmable_button_t;
 
 #ifdef MOUSE_EXTENDED_REPORT
-#    define MOUSE_REPORT_XY_MIN INT16_MIN
+#    define MOUSE_REPORT_XY_MIN (INT16_MIN + 1)
 #    define MOUSE_REPORT_XY_MAX INT16_MAX
 typedef int16_t mouse_xy_report_t;
 #else
-#    define MOUSE_REPORT_XY_MIN INT8_MIN
+#    define MOUSE_REPORT_XY_MIN (INT8_MIN + 1)
 #    define MOUSE_REPORT_XY_MAX INT8_MAX
 typedef int8_t mouse_xy_report_t;
 #endif
 
 #ifdef WHEEL_EXTENDED_REPORT
-#    define MOUSE_REPORT_HV_MIN INT16_MIN
+#    define MOUSE_REPORT_HV_MIN (INT16_MIN + 1)
 #    define MOUSE_REPORT_HV_MAX INT16_MAX
 typedef int16_t mouse_hv_report_t;
 #else
-#    define MOUSE_REPORT_HV_MIN INT8_MIN
+#    define MOUSE_REPORT_HV_MIN (INT8_MIN + 1)
 #    define MOUSE_REPORT_HV_MAX INT8_MAX
 typedef int8_t mouse_hv_report_t;
 #endif

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -153,13 +153,13 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
             HID_RI_USAGE(8, 0x30),         // X
             HID_RI_USAGE(8, 0x31),         // Y
 #    ifndef MOUSE_EXTENDED_REPORT
-            HID_RI_LOGICAL_MINIMUM(8, -127),
-            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_RI_LOGICAL_MINIMUM(8, MOUSE_REPORT_XY_MIN),
+            HID_RI_LOGICAL_MAXIMUM(8, MOUSE_REPORT_XY_MAX),
             HID_RI_REPORT_COUNT(8, 0x02),
             HID_RI_REPORT_SIZE(8, 0x08),
 #    else
-            HID_RI_LOGICAL_MINIMUM(16, -32767),
-            HID_RI_LOGICAL_MAXIMUM(16,  32767),
+            HID_RI_LOGICAL_MINIMUM(16, MOUSE_REPORT_XY_MIN),
+            HID_RI_LOGICAL_MAXIMUM(16, MOUSE_REPORT_XY_MAX),
             HID_RI_REPORT_COUNT(8, 0x02),
             HID_RI_REPORT_SIZE(8, 0x10),
 #    endif
@@ -186,13 +186,13 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
             // Vertical wheel (1 or 2 bytes)
             HID_RI_USAGE(8, 0x38),     // Wheel
 #    ifndef WHEEL_EXTENDED_REPORT
-            HID_RI_LOGICAL_MINIMUM(8, -127),
-            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_RI_LOGICAL_MINIMUM(8, MOUSE_REPORT_HV_MIN),
+            HID_RI_LOGICAL_MAXIMUM(8, MOUSE_REPORT_HV_MAX),
             HID_RI_REPORT_COUNT(8, 0x01),
             HID_RI_REPORT_SIZE(8, 0x08),
 #    else
-            HID_RI_LOGICAL_MINIMUM(16, -32767),
-            HID_RI_LOGICAL_MAXIMUM(16,  32767),
+            HID_RI_LOGICAL_MINIMUM(16, MOUSE_REPORT_HV_MIN),
+            HID_RI_LOGICAL_MAXIMUM(16, MOUSE_REPORT_HV_MAX),
             HID_RI_REPORT_COUNT(8, 0x01),
             HID_RI_REPORT_SIZE(8, 0x10),
 #    endif


### PR DESCRIPTION
The clipping range for mouse reports is incorrect.

## Description

The logical range for mouse reports specified in the USB descriptor is different from the range used to clip mouse report values. So it is possible we report values outside of the logical range (-128 or -32768).

I assume we prefer the mouse report values to be symmetric, so I have adjusted the minimum clipping values rather than the logical range.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
