### PR TITLE
feat: implement multi profile bluetooth support

### DIFF
--- a/docs/features/wireless.md
+++ b/docs/features/wireless.md
@@ -48,11 +48,32 @@ This is used when multiple keyboard outputs can be selected. Currently this only
 | `QK_OUTPUT_USB`             | `OU_USB`  | Output to USB only                                                                            |
 | `QK_OUTPUT_2P4GHZ`          | `OU_2P4G` | Output to 2.4GHz only **(not yet implemented)**                                               |
 | `QK_OUTPUT_BLUETOOTH`       | `OU_BT`   | Output to Bluetooth only                                                                      |
-| `QK_BLUETOOTH_PROFILE_NEXT` | `BT_NEXT` | Move to the next Bluetooth profile **(not yet implemented)**                                  |
-| `QK_BLUETOOTH_PROFILE_PREV` | `BT_PREV` | Move to the previous Bluetooth profile **(not yet implemented)**                              |
-| `QK_BLUETOOTH_UNPAIR`       | `BT_UNPR` | Un-pair the current Bluetooth profile **(not yet implemented)**                               |
-| `QK_BLUETOOTH_PROFILE1`     | `BT_PRF1` | Swap to Bluetooth profile #1 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE2`     | `BT_PRF2` | Swap to Bluetooth profile #2 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE3`     | `BT_PRF3` | Swap to Bluetooth profile #3 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE4`     | `BT_PRF4` | Swap to Bluetooth profile #4 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE5`     | `BT_PRF5` | Swap to Bluetooth profile #5 **(not yet implemented)**                                        |
+| `QK_BLUETOOTH_PROFILE_NEXT` | `BT_NEXT` | Move to the next Bluetooth profile                                                            |
+| `QK_BLUETOOTH_PROFILE_PREV` | `BT_PREV` | Move to the previous Bluetooth profile                                                        |
+| `QK_BLUETOOTH_UNPAIR`       | `BT_UNPR` | Un-pair the current Bluetooth profile                                                         |
+| `QK_BLUETOOTH_PROFILE1`     | `BT_PRF1` | Swap to Bluetooth profile #1                                                                  |
+| `QK_BLUETOOTH_PROFILE2`     | `BT_PRF2` | Swap to Bluetooth profile #2                                                                  |
+| `QK_BLUETOOTH_PROFILE3`     | `BT_PRF3` | Swap to Bluetooth profile #3                                                                  |
+| `QK_BLUETOOTH_PROFILE4`     | `BT_PRF4` | Swap to Bluetooth profile #4                                                                  |
+| `QK_BLUETOOTH_PROFILE5`     | `BT_PRF5` | Swap to Bluetooth profile #5                                                                  |
+
+## Bluetooth Profiles
+
+A Bluetooth driver may store multiple profiles. It reports its supported profile count via `bluetooth_get_max_profile()`.
+
+* `BT_PRF1`..`BT_PRF5` swap to Bluetooth and select the matching profile (`BT_PRF1` is profile 0).
+* `BT_NEXT` / `BT_PREV` cycle through the profiles.
+* `BT_UNPR` un-pairs the current profile.
+
+The selected profile persists across reboots.
+
+A driver that does not implement the multi-profile API behaves as single-profile: only `BT_PRF1` is honored; the other profile keycodes and `BT_UNPR` are no-ops. The `rn42` and `bluefruit_le` drivers are currently single-profile.
+
+To add multi-profile support, override these from `drivers/bluetooth/bluetooth.h`:
+
+|Function                                  |Purpose                                                  |
+|------------------------------------------|---------------------------------------------------------|
+|`uint8_t bluetooth_get_max_profile(void)` |Supported profile count (>=1)                            |
+|`bool bluetooth_set_profile(uint8_t)`     |Swap to the given profile; `false` if out of range       |
+|`uint8_t bluetooth_get_profile(void)`     |The current profile                                      |
+|`void bluetooth_unpair(void)`             |Un-pair the current profile                              |

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -303,14 +303,14 @@ See also: [Wireless](features/wireless)
 | `QK_OUTPUT_USB`             | `OU_USB`  | Output to USB only                                                                            |
 | `QK_OUTPUT_2P4GHZ`          | `OU_2P4G` | Output to 2.4GHz only **(not yet implemented)**                                               |
 | `QK_OUTPUT_BLUETOOTH`       | `OU_BT`   | Output to Bluetooth only                                                                      |
-| `QK_BLUETOOTH_PROFILE_NEXT` | `BT_NEXT` | Move to the next Bluetooth profile **(not yet implemented)**                                  |
-| `QK_BLUETOOTH_PROFILE_PREV` | `BT_PREV` | Move to the previous Bluetooth profile **(not yet implemented)**                              |
-| `QK_BLUETOOTH_UNPAIR`       | `BT_UNPR` | Un-pair the current Bluetooth profile **(not yet implemented)**                               |
-| `QK_BLUETOOTH_PROFILE1`     | `BT_PRF1` | Swap to Bluetooth profile #1 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE2`     | `BT_PRF2` | Swap to Bluetooth profile #2 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE3`     | `BT_PRF3` | Swap to Bluetooth profile #3 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE4`     | `BT_PRF4` | Swap to Bluetooth profile #4 **(not yet implemented)**                                        |
-| `QK_BLUETOOTH_PROFILE5`     | `BT_PRF5` | Swap to Bluetooth profile #5 **(not yet implemented)**                                        |
+| `QK_BLUETOOTH_PROFILE_NEXT` | `BT_NEXT` | Move to the next Bluetooth profile                                                            |
+| `QK_BLUETOOTH_PROFILE_PREV` | `BT_PREV` | Move to the previous Bluetooth profile                                                        |
+| `QK_BLUETOOTH_UNPAIR`       | `BT_UNPR` | Un-pair the current Bluetooth profile                                                         |
+| `QK_BLUETOOTH_PROFILE1`     | `BT_PRF1` | Swap to Bluetooth profile #1                                                                  |
+| `QK_BLUETOOTH_PROFILE2`     | `BT_PRF2` | Swap to Bluetooth profile #2                                                                  |
+| `QK_BLUETOOTH_PROFILE3`     | `BT_PRF3` | Swap to Bluetooth profile #3                                                                  |
+| `QK_BLUETOOTH_PROFILE4`     | `BT_PRF4` | Swap to Bluetooth profile #4                                                                  |
+| `QK_BLUETOOTH_PROFILE5`     | `BT_PRF5` | Swap to Bluetooth profile #5                                                                  |
 
 ## Caps Word {#caps-word}
 

--- a/drivers/bluetooth/bluetooth.c
+++ b/drivers/bluetooth/bluetooth.c
@@ -30,3 +30,17 @@ __attribute__((weak)) void bluetooth_send_consumer(uint16_t usage) {}
 __attribute__((weak)) void bluetooth_send_system(uint16_t usage) {}
 
 __attribute__((weak)) void bluetooth_send_raw_hid(uint8_t *data, uint8_t length) {}
+
+__attribute__((weak)) uint8_t bluetooth_get_max_profile(void) {
+    return 1;
+}
+
+__attribute__((weak)) bool bluetooth_set_profile(uint8_t profile) {
+    return profile == 0;
+}
+
+__attribute__((weak)) uint8_t bluetooth_get_profile(void) {
+    return 0;
+}
+
+__attribute__((weak)) void bluetooth_unpair(void) {}

--- a/drivers/bluetooth/bluetooth.h
+++ b/drivers/bluetooth/bluetooth.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "report.h"
 
 /**
@@ -89,3 +90,32 @@ void bluetooth_send_system(uint16_t usage);
  * \param length The length of the buffer. Always 32.
  */
 void bluetooth_send_raw_hid(uint8_t *data, uint8_t length);
+
+/**
+ * \brief Maximum number of Bluetooth profiles supported by the active driver.
+ *
+ * Single-host drivers return 1. Profile-aware drivers return the count of stored bond slots.
+ *
+ * \return Profile count (>=1).
+ */
+uint8_t bluetooth_get_max_profile(void);
+
+/**
+ * \brief Activate a Bluetooth profile.
+ *
+ * \param profile Zero-based profile index.
+ * \return `true` on success, `false` if `profile` is out of range.
+ */
+bool bluetooth_set_profile(uint8_t profile);
+
+/**
+ * \brief Currently active Bluetooth profile.
+ *
+ * \return Zero-based profile index.
+ */
+uint8_t bluetooth_get_profile(void);
+
+/**
+ * \brief Drop the bond stored at the active Bluetooth profile.
+ */
+void bluetooth_unpair(void);

--- a/quantum/connection/connection.c
+++ b/quantum/connection/connection.c
@@ -18,7 +18,7 @@
 __attribute__((weak)) void set_output_user(uint8_t output) {}
 // ========
 
-#define CONNECTION_HOST_INVALID 0xFF
+#define CONNECTION_CONFIG_UNINITIALIZED 0xFF
 
 #ifndef CONNECTION_HOST_DEFAULT
 #    define CONNECTION_HOST_DEFAULT CONNECTION_HOST_AUTO
@@ -37,17 +37,18 @@ static const connection_host_t host_candidates[] = {
 
 #define HOST_CANDIDATES_COUNT ARRAY_SIZE(host_candidates)
 
-static connection_config_t config = {.desired_host = CONNECTION_HOST_INVALID};
+static connection_config_t config = {.raw = CONNECTION_CONFIG_UNINITIALIZED};
 
 void eeconfig_update_connection_default(void) {
-    config.desired_host = CONNECTION_HOST_DEFAULT;
+    config.desired_host      = CONNECTION_HOST_DEFAULT;
+    config.bluetooth_profile = 0;
 
     eeconfig_update_connection(&config);
 }
 
 void connection_init(void) {
     eeconfig_read_connection(&config);
-    if (config.desired_host == CONNECTION_HOST_INVALID) {
+    if (config.raw == CONNECTION_CONFIG_UNINITIALIZED) {
         eeconfig_update_connection_default();
     }
 }
@@ -55,12 +56,32 @@ void connection_init(void) {
 __attribute__((weak)) void connection_host_changed_user(connection_host_t host) {}
 __attribute__((weak)) void connection_host_changed_kb(connection_host_t host) {}
 
+__attribute__((weak)) void connection_bluetooth_profile_changed_user(uint8_t profile) {}
+__attribute__((weak)) void connection_bluetooth_profile_changed_kb(uint8_t profile) {}
+
 static void handle_host_changed(void) {
+#ifdef BLUETOOTH_ENABLE
+    if (config.desired_host == CONNECTION_HOST_BLUETOOTH) {
+        bluetooth_set_profile(config.bluetooth_profile);
+    }
+#endif
+
     connection_host_changed_user(config.desired_host);
     connection_host_changed_kb(config.desired_host);
 
     // TODO: Remove deprecated callback
     set_output_user(config.desired_host);
+}
+
+static void handle_bluetooth_profile_changed(void) {
+#ifdef BLUETOOTH_ENABLE
+    if (config.desired_host == CONNECTION_HOST_BLUETOOTH) {
+        bluetooth_set_profile(config.bluetooth_profile);
+    }
+#endif
+
+    connection_bluetooth_profile_changed_user(config.bluetooth_profile);
+    connection_bluetooth_profile_changed_kb(config.bluetooth_profile);
 }
 
 void connection_set_host_noeeprom(connection_host_t host) {
@@ -138,4 +159,60 @@ connection_host_t connection_get_host(void) {
         return connection_auto_detect_host();
     }
     return config.desired_host;
+}
+
+void connection_set_bluetooth_profile(uint8_t profile) {
+#ifdef BLUETOOTH_ENABLE
+    if (profile >= bluetooth_get_max_profile()) {
+        return;
+    }
+#else
+    if (profile != 0) {
+        return;
+    }
+#endif
+
+    if (config.bluetooth_profile != profile) {
+        config.bluetooth_profile = profile;
+        handle_bluetooth_profile_changed();
+        eeconfig_update_connection(&config);
+    }
+
+    if (config.desired_host != CONNECTION_HOST_BLUETOOTH) {
+        connection_set_host(CONNECTION_HOST_BLUETOOTH);
+    }
+}
+
+uint8_t connection_get_bluetooth_profile(void) {
+    return config.bluetooth_profile;
+}
+
+void connection_next_bluetooth_profile(void) {
+#ifdef BLUETOOTH_ENABLE
+    uint8_t max_profile = bluetooth_get_max_profile();
+    if (max_profile == 0) {
+        return;
+    }
+    uint8_t next = config.bluetooth_profile + 1;
+    if (next >= max_profile) {
+        next = 0;
+    }
+    connection_set_bluetooth_profile(next);
+#endif
+}
+
+void connection_prev_bluetooth_profile(void) {
+#ifdef BLUETOOTH_ENABLE
+    uint8_t max_profile = bluetooth_get_max_profile();
+    if (max_profile == 0) {
+        return;
+    }
+    uint8_t prev;
+    if (config.bluetooth_profile == 0) {
+        prev = max_profile - 1;
+    } else {
+        prev = config.bluetooth_profile - 1;
+    }
+    connection_set_bluetooth_profile(prev);
+#endif
 }

--- a/quantum/connection/connection.h
+++ b/quantum/connection/connection.h
@@ -27,8 +27,11 @@ typedef enum connection_host_t {
  * Configuration structure for the connection subsystem.
  */
 typedef union connection_config_t {
-    uint8_t           raw;
-    connection_host_t desired_host : 8;
+    uint8_t raw;
+    struct {
+        connection_host_t desired_host : 4;
+        uint8_t           bluetooth_profile : 4;
+    } PACKED;
 } PACKED connection_config_t;
 
 STATIC_ASSERT(sizeof(connection_config_t) == sizeof(uint8_t), "Connection EECONFIG out of spec.");
@@ -110,3 +113,39 @@ void connection_host_changed_user(connection_host_t host);
  *
  */
 void connection_host_changed_kb(connection_host_t host);
+
+/**
+ * \brief Set the active Bluetooth profile (0-indexed).
+ *
+ * Clamped to the active driver's `bluetooth_get_max_profile() - 1`.
+ *
+ * \param profile The profile index to activate.
+ */
+void connection_set_bluetooth_profile(uint8_t profile);
+
+/**
+ * \brief Get the currently configured Bluetooth profile.
+ *
+ * \return Zero-based profile index.
+ */
+uint8_t connection_get_bluetooth_profile(void);
+
+/**
+ * \brief Move to the next Bluetooth profile.
+ */
+void connection_next_bluetooth_profile(void);
+
+/**
+ * \brief Move to the previous Bluetooth profile.
+ */
+void connection_prev_bluetooth_profile(void);
+
+/**
+ * \brief user hook called when changing the Bluetooth profile.
+ */
+void connection_bluetooth_profile_changed_user(uint8_t profile);
+
+/**
+ * \brief keyboard hook called when changing the Bluetooth profile.
+ */
+void connection_bluetooth_profile_changed_kb(uint8_t profile);

--- a/quantum/process_keycode/process_connection.c
+++ b/quantum/process_keycode/process_connection.c
@@ -3,6 +3,10 @@
 #include "connection.h"
 #include "process_connection.h"
 
+#ifdef BLUETOOTH_ENABLE
+#    include "bluetooth.h"
+#endif
+
 bool process_connection(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
         switch (keycode) {
@@ -29,17 +33,32 @@ bool process_connection(uint16_t keycode, keyrecord_t *record) {
                 connection_set_host(CONNECTION_HOST_2P4GHZ);
                 return false;
 
+#ifdef BLUETOOTH_ENABLE
             case QK_BLUETOOTH_PROFILE_NEXT:
-            case QK_BLUETOOTH_PROFILE_PREV:
-            case QK_BLUETOOTH_UNPAIR:
-            case QK_BLUETOOTH_PROFILE1:
-            case QK_BLUETOOTH_PROFILE2:
-            case QK_BLUETOOTH_PROFILE3:
-            case QK_BLUETOOTH_PROFILE4:
-            case QK_BLUETOOTH_PROFILE5:
-                // As-yet unimplemented.
-                // When implementation is done, ensure `docs/keycodes.md`, `docs/features/bluetooth.md` are updated accordingly.
+                connection_next_bluetooth_profile();
                 return false;
+            case QK_BLUETOOTH_PROFILE_PREV:
+                connection_prev_bluetooth_profile();
+                return false;
+            case QK_BLUETOOTH_UNPAIR:
+                bluetooth_unpair();
+                return false;
+            case QK_BLUETOOTH_PROFILE1:
+                connection_set_bluetooth_profile(0);
+                return false;
+            case QK_BLUETOOTH_PROFILE2:
+                connection_set_bluetooth_profile(1);
+                return false;
+            case QK_BLUETOOTH_PROFILE3:
+                connection_set_bluetooth_profile(2);
+                return false;
+            case QK_BLUETOOTH_PROFILE4:
+                connection_set_bluetooth_profile(3);
+                return false;
+            case QK_BLUETOOTH_PROFILE5:
+                connection_set_bluetooth_profile(4);
+                return false;
+#endif
         }
     }
     return true;


### PR DESCRIPTION
## Description

implements the QK_BLUETOOTH_PROFILE_* and QK_BLUETOOTH_UNPAIR
keycodes that have been reserved but unwired. fulfills the TODO
in process_connection.c.

extends `connection_config_t` with a 4-bit `bluetooth_profile`
field sharing the existing 1-byte slot (4-bit `desired_host` +
4-bit profile). no eeprom layout shift; existing values decode
unchanged.

new `bluetooth.h` api: `bluetooth_get_max_profile`,
`bluetooth_set_profile`, `bluetooth_get_profile`,
`bluetooth_unpair`. weak defaults in `bluetooth.c` keep `rn42`
and `bluefruit_le` working as single-profile. drivers gain
multi-profile by overriding the four functions.

new connection-layer api:
- `connection_set_bluetooth_profile`,
- `connection_get_bluetooth_profile`,
- `connection_next/prev_bluetooth_profile`
plus `connection_bluetooth_profile_changed_user/_kb` weak hooks.
`connection_set_bluetooth_profile` ensures host is bluetooth as
a side effect, so pressing `BT_PRF1` from usb switches and
selects in one go.

`docs/keycodes.md` and `docs/features/wireless.md` updated:
"not yet implemented" markers removed from the bluetooth profile
rows, and a new section in `wireless.md` describes the
multi-profile contract.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **PR Checklist** document and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
