### PR TITLE
implement battery charger (gpio) support

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -973,6 +973,24 @@ ifeq ($(strip $(BATTERY_DRIVER_REQUIRED)), yes)
     endif
 endif
 
+VALID_BATTERY_CHARGER_DRIVER_TYPES := none gpio custom
+
+BATTERY_CHARGER_DRIVER ?= none
+ifneq ($(strip $(BATTERY_CHARGER_DRIVER)), none)
+    ifeq ($(filter $(BATTERY_CHARGER_DRIVER),$(VALID_BATTERY_CHARGER_DRIVER_TYPES)),)
+        $(call CATASTROPHIC_ERROR,Invalid BATTERY_CHARGER_DRIVER,BATTERY_CHARGER_DRIVER="$(BATTERY_CHARGER_DRIVER)" is not a valid battery charger driver)
+    endif
+
+    BATTERY_ENABLE := yes
+    OPT_DEFS += -DBATTERY_CHARGER_ENABLE
+
+    COMMON_VPATH += $(DRIVER_PATH)/battery
+
+    ifeq ($(strip $(BATTERY_CHARGER_DRIVER)), gpio)
+        SRC += battery_charger.c
+    endif
+endif
+
 VALID_WS2812_DRIVER_TYPES := bitbang custom i2c pwm spi vendor
 
 WS2812_DRIVER ?= bitbang

--- a/data/mappings/info_rules.hjson
+++ b/data/mappings/info_rules.hjson
@@ -14,6 +14,7 @@
     "AUDIO_DRIVER": {"info_key": "audio.driver"},
     "BACKLIGHT_DRIVER": {"info_key": "backlight.driver"},
     "BATTERY_DRIVER": {"info_key": "battery.driver"},
+    "BATTERY_CHARGER_DRIVER": {"info_key": "battery.charger_driver"},
     "BLUETOOTH_DRIVER": {"info_key": "bluetooth.driver"},
     "BOARD": {"info_key": "board"},
     "BOOTLOADER": {"info_key": "bootloader", "warn_duplicate": false},

--- a/data/schemas/keyboard.jsonschema
+++ b/data/schemas/keyboard.jsonschema
@@ -196,6 +196,10 @@
                     "type": "string",
                     "enum": ["adc", "custom", "vendor"]
                 },
+                "charger_driver": {
+                    "type": "string",
+                    "enum": ["custom", "gpio"]
+                },
                 "adc": {
                     "type": "object",
                     "additionalProperties": false,

--- a/docs/drivers/battery.md
+++ b/docs/drivers/battery.md
@@ -50,3 +50,41 @@ uint8_t battery_driver_sample_percent(void) {
     return value;
 }
 ```
+
+## Charger Driver Configuration {#charger-driver-configuration}
+
+Charger detection is orthogonal to battery sampling. Driver selection can be configured in `rules.mk` as `BATTERY_CHARGER_DRIVER`. Valid values are `gpio` or `custom`.
+
+### GPIO Driver {#gpio-charger-driver}
+
+The GPIO driver reads two pins typically driven by a Li-ion charger IC.
+
+```make
+BATTERY_CHARGER_DRIVER = gpio
+```
+
+The following `#define`s apply only to the `gpio` driver. Exactly one polarity must be declared per pin.
+
+|Define                                |Description                                                                       |
+|--------------------------------------|----------------------------------------------------------------------------------|
+|`BATTERY_CHARGER_CABLE_PIN`           |The GPIO pin connected to the cable-detect line (required).                       |
+|`BATTERY_CHARGER_FULL_PIN`            |The GPIO pin connected to the charge-full line (required).                        |
+|`BATTERY_CHARGER_CABLE_ACTIVE_HIGH`   |Define when the cable-detect pin reads high while the cable is connected.         |
+|`BATTERY_CHARGER_CABLE_ACTIVE_LOW`    |Define when the cable-detect pin reads low while the cable is connected.          |
+|`BATTERY_CHARGER_FULL_ACTIVE_HIGH`    |Define when the full-detect pin reads high while the battery is fully charged.    |
+|`BATTERY_CHARGER_FULL_ACTIVE_LOW`     |Define when the full-detect pin reads low while the battery is fully charged.     |
+
+### Custom Charger Driver {#custom-charger-driver}
+
+A custom charger driver is expected to implement the following interface:
+
+```c
+void battery_charger_init(void) {
+    // Perform any initialisation here
+}
+
+battery_charging_state_t battery_charger_get_state(void) {
+    // Read and return current state here
+    return state;
+}
+```

--- a/docs/features/battery.md
+++ b/docs/features/battery.md
@@ -53,3 +53,44 @@ Keyboard hook called when battery level changed.
 
  - `uint8_t level`  
    The battery percentage, in the range 0-100.
+
+## Charging State {#charging-state}
+
+When a charger driver is configured (see [Charger Driver Configuration](../drivers/battery#charger-driver-configuration)), the framework also tracks the charging state and emits change notifications.
+
+### `battery_charging_state_t` {#charging-state-enum}
+
+|Value                       |Description                                                |
+|----------------------------|-----------------------------------------------------------|
+|`BATTERY_CHARGING_UNKNOWN`  |State not yet determined or no charger driver configured.  |
+|`BATTERY_NOT_CHARGING`      |Cable is not connected.                                    |
+|`BATTERY_CHARGING`          |Cable is connected and battery is charging.                |
+|`BATTERY_FULL`              |Cable is connected and battery is fully charged.           |
+
+### `battery_charging_state_t battery_get_charging_state(void)` {#api-battery-get-charging-state}
+
+Read current charging state.
+
+#### Return Value {#api-battery-get-charging-state-return}
+
+The current charging state. Returns `BATTERY_CHARGING_UNKNOWN` when no charger driver is configured.
+
+### `void battery_charging_state_changed_user(battery_charging_state_t state)` {#api-battery-charging-state-changed-user}
+
+User hook called when charging state changed.
+
+#### Arguments {#api-battery-charging-state-changed-user-arguments}
+
+ - `battery_charging_state_t state`  
+   The new charging state.
+
+---
+
+### `void battery_charging_state_changed_kb(battery_charging_state_t state)` {#api-battery-charging-state-changed-kb}
+
+Keyboard hook called when charging state changed.
+
+#### Arguments {#api-battery-charging-state-changed-kb-arguments}
+
+ - `battery_charging_state_t state`  
+   The new charging state.

--- a/drivers/battery/battery_charger.c
+++ b/drivers/battery/battery_charger.c
@@ -1,0 +1,22 @@
+// Copyright 2026 Roman Kuzmitskii (@damex)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "battery_charger.h"
+#include "gpio.h"
+
+void battery_charger_init(void) {
+    gpio_set_pin_input(BATTERY_CHARGER_CABLE_PIN);
+    gpio_set_pin_input_high(BATTERY_CHARGER_FULL_PIN);
+}
+
+battery_charging_state_t battery_charger_get_state(void) {
+    bool cable = gpio_read_pin(BATTERY_CHARGER_CABLE_PIN) == BATTERY_CHARGER_CABLE_ACTIVE_LEVEL;
+    bool full  = gpio_read_pin(BATTERY_CHARGER_FULL_PIN) == BATTERY_CHARGER_FULL_ACTIVE_LEVEL;
+    if (!cable) {
+        return BATTERY_NOT_CHARGING;
+    }
+    if (full) {
+        return BATTERY_FULL;
+    }
+    return BATTERY_CHARGING;
+}

--- a/drivers/battery/battery_charger.h
+++ b/drivers/battery/battery_charger.h
@@ -1,0 +1,32 @@
+// Copyright 2026 Roman Kuzmitskii (@damex)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "battery.h"
+
+#ifndef BATTERY_CHARGER_CABLE_PIN
+#    error "BATTERY_CHARGER_CABLE_PIN must be defined"
+#endif
+#ifndef BATTERY_CHARGER_FULL_PIN
+#    error "BATTERY_CHARGER_FULL_PIN must be defined"
+#endif
+
+#if defined(BATTERY_CHARGER_CABLE_ACTIVE_HIGH) && !defined(BATTERY_CHARGER_CABLE_ACTIVE_LOW)
+#    define BATTERY_CHARGER_CABLE_ACTIVE_LEVEL 1
+#elif defined(BATTERY_CHARGER_CABLE_ACTIVE_LOW) && !defined(BATTERY_CHARGER_CABLE_ACTIVE_HIGH)
+#    define BATTERY_CHARGER_CABLE_ACTIVE_LEVEL 0
+#else
+#    error "Define exactly one of BATTERY_CHARGER_CABLE_ACTIVE_HIGH or BATTERY_CHARGER_CABLE_ACTIVE_LOW"
+#endif
+
+#if defined(BATTERY_CHARGER_FULL_ACTIVE_HIGH) && !defined(BATTERY_CHARGER_FULL_ACTIVE_LOW)
+#    define BATTERY_CHARGER_FULL_ACTIVE_LEVEL 1
+#elif defined(BATTERY_CHARGER_FULL_ACTIVE_LOW) && !defined(BATTERY_CHARGER_FULL_ACTIVE_HIGH)
+#    define BATTERY_CHARGER_FULL_ACTIVE_LEVEL 0
+#else
+#    error "Define exactly one of BATTERY_CHARGER_FULL_ACTIVE_HIGH or BATTERY_CHARGER_FULL_ACTIVE_LOW"
+#endif
+
+void battery_charger_init(void);
+battery_charging_state_t battery_charger_get_state(void);

--- a/quantum/battery/battery.c
+++ b/quantum/battery/battery.c
@@ -5,25 +5,44 @@
 #include "battery.h"
 #include "timer.h"
 
+#ifdef BATTERY_CHARGER_ENABLE
+#    include "battery_charger.h"
+#endif
+
 #ifndef BATTERY_SAMPLE_INTERVAL
 #    define BATTERY_SAMPLE_INTERVAL 30000
 #endif
 
-static uint8_t last_bat_level = 100;
+static uint8_t                  last_bat_level       = 100;
+static battery_charging_state_t last_charging_state  = BATTERY_CHARGING_UNKNOWN;
 
 void battery_init(void) {
     battery_driver_init();
-
     last_bat_level = battery_driver_sample_percent();
+
+#ifdef BATTERY_CHARGER_ENABLE
+    battery_charger_init();
+    last_charging_state = battery_charger_get_state();
+#endif
 }
 
 __attribute__((weak)) void battery_percent_changed_user(uint8_t level) {}
 __attribute__((weak)) void battery_percent_changed_kb(uint8_t level) {}
 
+__attribute__((weak)) void battery_charging_state_changed_user(battery_charging_state_t state) {}
+__attribute__((weak)) void battery_charging_state_changed_kb(battery_charging_state_t state) {}
+
 static void handle_percent_changed(void) {
     battery_percent_changed_user(last_bat_level);
     battery_percent_changed_kb(last_bat_level);
 }
+
+#ifdef BATTERY_CHARGER_ENABLE
+static void handle_charging_state_changed(void) {
+    battery_charging_state_changed_user(last_charging_state);
+    battery_charging_state_changed_kb(last_charging_state);
+}
+#endif
 
 void battery_task(void) {
     static uint32_t bat_timer = 0;
@@ -34,8 +53,20 @@ void battery_task(void) {
 
         bat_timer = timer_read32();
     }
+
+#ifdef BATTERY_CHARGER_ENABLE
+    battery_charging_state_t new_state = battery_charger_get_state();
+    if (new_state != last_charging_state) {
+        last_charging_state = new_state;
+        handle_charging_state_changed();
+    }
+#endif
 }
 
 uint8_t battery_get_percent(void) {
     return last_bat_level;
+}
+
+battery_charging_state_t battery_get_charging_state(void) {
+    return last_charging_state;
 }

--- a/quantum/battery/battery.h
+++ b/quantum/battery/battery.h
@@ -14,6 +14,13 @@
  * \{
  */
 
+typedef enum {
+    BATTERY_CHARGING_UNKNOWN = 0,
+    BATTERY_NOT_CHARGING,
+    BATTERY_CHARGING,
+    BATTERY_FULL,
+} battery_charging_state_t;
+
 /**
  * \brief Initialize the battery driver.
  */
@@ -32,6 +39,15 @@ void battery_task(void);
 uint8_t battery_get_percent(void);
 
 /**
+ * \brief Read current charging state.
+ *
+ * Returns BATTERY_CHARGING_UNKNOWN when no charger driver is configured.
+ *
+ * \return The current charging state.
+ */
+battery_charging_state_t battery_get_charging_state(void);
+
+/**
  * \brief user hook called when battery level changed.
  *
  */
@@ -42,5 +58,17 @@ void battery_percent_changed_user(uint8_t level);
  *
  */
 void battery_percent_changed_kb(uint8_t level);
+
+/**
+ * \brief user hook called when charging state changed.
+ *
+ */
+void battery_charging_state_changed_user(battery_charging_state_t state);
+
+/**
+ * \brief keyboard hook called when charging state changed.
+ *
+ */
+void battery_charging_state_changed_kb(battery_charging_state_t state);
 
 /** \} */

--- a/quantum/battery/tests/battery_charger_tests.cpp
+++ b/quantum/battery/tests/battery_charger_tests.cpp
@@ -1,0 +1,132 @@
+// Copyright 2026 Roman Kuzmitskii (@damex)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+extern "C" {
+#include "quantum/battery/battery.h"
+#include "timer.h"
+
+void advance_time(uint32_t ms);
+}
+
+using testing::_;
+using testing::Return;
+
+class BatteryChargerMock {
+   public:
+    virtual ~BatteryChargerMock() {}
+
+    MOCK_METHOD0(battery_driver_init, void(void));
+    MOCK_METHOD0(battery_driver_sample_percent, uint8_t(void));
+    MOCK_METHOD0(battery_charger_init, void(void));
+    MOCK_METHOD0(battery_charger_get_state, battery_charging_state_t(void));
+    MOCK_METHOD1(battery_charging_state_changed_kb, void(battery_charging_state_t));
+};
+
+class BatteryChargerTest : public ::testing::Test {
+   public:
+    BatteryChargerTest() {
+        _mock.reset(new ::testing::NiceMock<BatteryChargerMock>());
+    }
+    virtual ~BatteryChargerTest() {
+        _mock.reset();
+    }
+
+    static std::unique_ptr<BatteryChargerMock> _mock;
+};
+
+std::unique_ptr<BatteryChargerMock> BatteryChargerTest::_mock;
+
+extern "C" {
+
+void battery_driver_init(void) {
+    if (BatteryChargerTest::_mock) {
+        BatteryChargerTest::_mock->battery_driver_init();
+    }
+}
+
+uint8_t battery_driver_sample_percent(void) {
+    if (BatteryChargerTest::_mock) {
+        return BatteryChargerTest::_mock->battery_driver_sample_percent();
+    }
+    return 100;
+}
+
+void battery_charger_init(void) {
+    if (BatteryChargerTest::_mock) {
+        BatteryChargerTest::_mock->battery_charger_init();
+    }
+}
+
+battery_charging_state_t battery_charger_get_state(void) {
+    if (BatteryChargerTest::_mock) {
+        return BatteryChargerTest::_mock->battery_charger_get_state();
+    }
+    return BATTERY_CHARGING_UNKNOWN;
+}
+
+void battery_charging_state_changed_kb(battery_charging_state_t state) {
+    if (BatteryChargerTest::_mock) {
+        BatteryChargerTest::_mock->battery_charging_state_changed_kb(state);
+    }
+}
+}
+
+TEST_F(BatteryChargerTest, TestInit) {
+    EXPECT_CALL(*_mock, battery_charger_init()).Times(1);
+    EXPECT_CALL(*_mock, battery_charger_get_state()).Times(1).WillOnce(Return(BATTERY_NOT_CHARGING));
+    EXPECT_CALL(*_mock, battery_charging_state_changed_kb(_)).Times(0);
+
+    battery_init();
+}
+
+TEST_F(BatteryChargerTest, TestPollingEveryTask) {
+    EXPECT_CALL(*_mock, battery_charger_get_state()).WillRepeatedly(Return(BATTERY_NOT_CHARGING));
+
+    battery_init();
+    EXPECT_CALL(*_mock, battery_charger_get_state()).Times(3).WillRepeatedly(Return(BATTERY_NOT_CHARGING));
+
+    battery_task();
+    battery_task();
+    battery_task();
+}
+
+TEST_F(BatteryChargerTest, TestStateChangeFiresCallback) {
+    EXPECT_CALL(*_mock, battery_charger_get_state()).WillOnce(Return(BATTERY_NOT_CHARGING));
+    battery_init();
+
+    EXPECT_CALL(*_mock, battery_charger_get_state()).WillOnce(Return(BATTERY_CHARGING));
+    EXPECT_CALL(*_mock, battery_charging_state_changed_kb(BATTERY_CHARGING)).Times(1);
+
+    battery_task();
+}
+
+TEST_F(BatteryChargerTest, TestStateUnchangedSuppressesCallback) {
+    EXPECT_CALL(*_mock, battery_charger_get_state()).WillOnce(Return(BATTERY_CHARGING));
+    battery_init();
+
+    EXPECT_CALL(*_mock, battery_charger_get_state()).Times(2).WillRepeatedly(Return(BATTERY_CHARGING));
+    EXPECT_CALL(*_mock, battery_charging_state_changed_kb(_)).Times(0);
+
+    battery_task();
+    battery_task();
+}
+
+TEST_F(BatteryChargerTest, TestGetReturnsLastPolled) {
+    EXPECT_CALL(*_mock, battery_charger_get_state()).WillOnce(Return(BATTERY_FULL));
+    battery_init();
+
+    EXPECT_EQ(battery_get_charging_state(), BATTERY_FULL);
+}
+
+TEST_F(BatteryChargerTest, TestGetReturnsUpdatedAfterTaskTransition) {
+    EXPECT_CALL(*_mock, battery_charger_get_state()).WillOnce(Return(BATTERY_NOT_CHARGING));
+    battery_init();
+    EXPECT_EQ(battery_get_charging_state(), BATTERY_NOT_CHARGING);
+
+    EXPECT_CALL(*_mock, battery_charger_get_state()).WillOnce(Return(BATTERY_FULL));
+    battery_task();
+    EXPECT_EQ(battery_get_charging_state(), BATTERY_FULL);
+}

--- a/quantum/battery/tests/rules.mk
+++ b/quantum/battery/tests/rules.mk
@@ -1,7 +1,20 @@
 VPATH += $(DRIVER_PATH)/battery
+VPATH += $(QUANTUM_PATH)/battery
 
 battery_SRC := \
     $(PLATFORM_PATH)/timer.c \
     $(PLATFORM_PATH)/$(PLATFORM_KEY)/timer.c \
 	$(QUANTUM_PATH)/battery/battery.c \
 	$(QUANTUM_PATH)/battery/tests/battery_tests.cpp \
+
+battery_charger_SRC := \
+    $(PLATFORM_PATH)/timer.c \
+    $(PLATFORM_PATH)/$(PLATFORM_KEY)/timer.c \
+	$(QUANTUM_PATH)/battery/battery.c \
+	$(QUANTUM_PATH)/battery/tests/battery_charger_tests.cpp \
+
+battery_charger_DEFS := -DBATTERY_CHARGER_ENABLE \
+                        -DBATTERY_CHARGER_CABLE_PIN=0 \
+                        -DBATTERY_CHARGER_CABLE_ACTIVE_HIGH \
+                        -DBATTERY_CHARGER_FULL_PIN=0 \
+                        -DBATTERY_CHARGER_FULL_ACTIVE_HIGH

--- a/quantum/battery/tests/testlist.mk
+++ b/quantum/battery/tests/testlist.mk
@@ -1,2 +1,3 @@
 TEST_LIST += \
 	battery \
+	battery_charger \


### PR DESCRIPTION
## Description

adds charger-ic detection as a new driver type, orthogonal to
battery sampling. tracks charging state via two gpios and emits
transition callbacks.

new `drivers/battery/battery_charger.{c,h}`: gpio impl reads
`BATTERY_CHARGER_CABLE_PIN` and `BATTERY_CHARGER_FULL_PIN`.
polarity is explicit per pin via `_ACTIVE_HIGH` or `_ACTIVE_LOW`,
exactly one of each must be defined.

new `quantum/battery` api:
- `battery_charging_state_t` enum (`UNKNOWN`, `NOT_CHARGING`, `CHARGING`, `FULL`)
- `battery_get_charging_state()`
- `battery_charging_state_changed_user/_kb` weak hooks

charger is polled every `battery_task` tick (independent of the
`BATTERY_SAMPLE_INTERVAL` percentage poll). hooks fire on
transitions only.

new `BATTERY_CHARGER_DRIVER` flag with values `none`, `gpio`,
or `custom`. enabling it implicitly pulls in the battery
framework. default off; existing `battery_adc` and `custom`
sampling drivers unaffected.

`docs/drivers/battery.md` and `docs/features/battery.md` updated
with the charger api. `data/schemas/keyboard.jsonschema` extended
with `battery.charger_driver`. `data/mappings/info_rules.hjson`
maps it to the `BATTERY_CHARGER_DRIVER` rules.mk variable.

unit tests in `quantum/battery/tests/battery_charger_tests.cpp`
cover init, polling, transition firing, transition suppression,
and getter return values.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **PR Checklist** document and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
