### PR TITLE
ws2812: skip power-of-2 divisor enforcement on wb32

### DIFF
--- a/platforms/chibios/drivers/ws2812_spi.c
+++ b/platforms/chibios/drivers/ws2812_spi.c
@@ -65,6 +65,9 @@
 #    else
 #        error "Configured WS2812_SPI_DIVISOR value is not supported at this time."
 #    endif
+#elif defined(WB32F3G71xx) || defined(WB32FQ95xx)
+/* WB32 SPI BAUDR accepts any even integer 2..65534; the WB32 branch below uses
+ * WS2812_SPI_DIVISOR directly and does not need the STM32 BR-field lookup. */
 #else
 // F072 fpclk = 48MHz
 // 48/16 = 3Mhz


### PR DESCRIPTION
## Description

`platforms/chibios/drivers/ws2812_spi.c` has a preprocessor lookup table that maps `WS2812_SPI_DIVISOR` to STM32's SPI_CR1.BR` register bits (8 power-of-2 values: 2/4/8/16/32/64/128/256).
Any other value triggers `#error "Configured WS2812_SPI_DIVISOR value is not supported at this time."`.

WB32 (WB32F3G71xx, WB32FQ95xx) doesn't need that lookup.
its branch in the SPIConfig literal passes `WS2812_SPI_DIVISOR` directly to the WB32 SPI config
struct, which writes the value raw to the BAUDR register. BAUDR accepts any even integer 2..65534.

But the preprocessor still walks the STM32 table for all non AT32 chips including WB32, so WB32 boards are artificially restricted to power-of-2 divisors that don't apply to their hardware.

This PR adds an `#elif defined(WB32F3G71xx) || defined(WB32FQ95xx)` branch that skips the STM32 lookup on WB32. The existing WB32 SPIConfig branch already does the register write correctly; no other changes needed.

### Why this matters

WS2812 timing needs ~3.2 MHz SPI clock to land T0H/T0L/T1H/T1L inside WS2812B spec when each WS2812 bit encodes as 4 SPI bits. At 72 MHz sysclk:

- divisor 22 -> 3.27 MHz -> all four pulses centered in spec
- divisor 16 -> 4.5 MHz -> T0H = 222 ns, below WS2812B minimum 250 ns
- divisor 32 -> 2.25 MHz -> T1H = 1333 ns, above WS2812B maximum 950 ns

Without this patch, only divisors 16 and 32 are accepted on WB32 at 72 MHz, and both fall outside the WS2812B timing window.

It is tested on a WB32FQ95 keyboard (151-LED chain) at 72 MHz sysclk / divisor 22.
No regression vs the prior 96 MHz / divisor 32 configuration, with ~25% MCU core dynamic current savings from the lower sysclk.

## Types of Changes

- [x] Core
- [X] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
