### PR TITLE
[Docs][MouseKeys] Document the effect of the acceleration key in default mode.

### DIFF
--- a/docs/features/mouse_keys.md
+++ b/docs/features/mouse_keys.md
@@ -78,6 +78,8 @@ Tips:
 * Setting `MOUSEKEY_TIME_TO_MAX` or `MOUSEKEY_WHEEL_TIME_TO_MAX` to `0` will disable acceleration for the cursor or scrolling respectively. This way you can make one of them constant while keeping the other accelerated, which is not possible in constant speed mode.
 * Setting `MOUSEKEY_WHEEL_INTERVAL` too low will make scrolling too fast. Setting it too high will make scrolling too slow when the wheel key is held down.
 
+`MS_ACL0`, `MS_ACL1` and `MS_ACL2` change the cursor and scroll speed to 1/4, 1/2, and the same as the maximum speed, respectively.
+
 Cursor acceleration uses the same algorithm as the X Window System MouseKeysAccel feature. You can read more about it [on Wikipedia](https://en.wikipedia.org/wiki/Mouse_keys).
 
 ### Kinetic Mode

--- a/docs/features/mouse_keys.md
+++ b/docs/features/mouse_keys.md
@@ -77,8 +77,7 @@ Tips:
 * For smoother cursor movements, lower the value of `MOUSEKEY_INTERVAL`. If the refresh rate of your display is 60Hz, you could set it to `16` (1/60). As this raises the cursor speed significantly, you may want to lower `MOUSEKEY_MAX_SPEED`.
 * Setting `MOUSEKEY_TIME_TO_MAX` or `MOUSEKEY_WHEEL_TIME_TO_MAX` to `0` will disable acceleration for the cursor or scrolling respectively. This way you can make one of them constant while keeping the other accelerated, which is not possible in constant speed mode.
 * Setting `MOUSEKEY_WHEEL_INTERVAL` too low will make scrolling too fast. Setting it too high will make scrolling too slow when the wheel key is held down.
-
-`MS_ACL0`, `MS_ACL1` and `MS_ACL2` change the cursor and scroll speed to 1/4, 1/2, and the same as the maximum speed, respectively.
+* `MS_ACL0`, `MS_ACL1` and `MS_ACL2` change the cursor and scroll speed to 1/4, 1/2, and the maximum speed, respectively.
 
 Cursor acceleration uses the same algorithm as the X Window System MouseKeysAccel feature. You can read more about it [on Wikipedia](https://en.wikipedia.org/wiki/Mouse_keys).
 


### PR DESCRIPTION
Add an explanation on the effect of the acceleration key in default mode of mouse keys.

## Description

While there are explanations for acceleration keys in Constant mode and Combined mode, there are none in the default mode (Accelerated mode). This led to the misunderstanding that it couldn't be used in default mode, so I added an explanation.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
