### PR TITLE
Clear weak mods before processing queued keypresses in tap-hold handling

### DIFF
--- a/quantum/action_tapping.c
+++ b/quantum/action_tapping.c
@@ -180,6 +180,9 @@ void action_tapping_process(keyrecord_t record) {
         ac_dprintf("---- action_exec: process waiting_buffer -----\n");
     }
     for (; waiting_buffer_tail != waiting_buffer_head; waiting_buffer_tail = (waiting_buffer_tail + 1) % WAITING_BUFFER_SIZE) {
+        if (waiting_buffer[waiting_buffer_tail].event.pressed) {
+            clear_weak_mods();
+        }
         if (process_tapping(&waiting_buffer[waiting_buffer_tail])) {
             ac_dprintf("processed: waiting_buffer[%u] =", waiting_buffer_tail);
             debug_record(waiting_buffer[waiting_buffer_tail]);
@@ -328,6 +331,7 @@ bool process_tapping(keyrecord_t *keyp) {
                         if (!record->event.pressed) {
                             break;
                         }
+                        clear_weak_mods();
                         const int16_t next_time = record->event.time;
                         if (!is_tap_record(record)) {
                             process_record(record);
@@ -729,6 +733,9 @@ void waiting_buffer_scan_tap(void) {
             // clang-format on
             tapping_key.tap.count = 1;
             candidate->tap.count  = 1;
+            if (tapping_key.event.pressed) {
+                clear_weak_mods();
+            }
             process_record(&tapping_key);
 
             ac_dprintf("waiting_buffer_scan_tap: found at [%u]\n", i);
@@ -963,9 +970,12 @@ static void waiting_buffer_chordal_hold_taps_until(keypos_t key) {
     while (waiting_buffer_tail != waiting_buffer_head) {
         keyrecord_t *record = &waiting_buffer[waiting_buffer_tail];
         ac_dprintf("waiting_buffer_chordal_hold_taps_until: processing [%u]\n", waiting_buffer_tail);
-        if (record->event.pressed && is_tap_record(record)) {
-            record->tap.count = 1;
-            registered_taps_add(record->event.key);
+        if (record->event.pressed) {
+            if (is_tap_record(record)) {
+                record->tap.count = 1;
+                registered_taps_add(record->event.key);
+            }
+            clear_weak_mods();
         }
         process_record(record);
         waiting_buffer_tail = (waiting_buffer_tail + 1) % WAITING_BUFFER_SIZE;
@@ -982,6 +992,9 @@ static void waiting_buffer_process_regular(void) {
             break; // Stop once a tap-hold key event is reached.
         }
         ac_dprintf("waiting_buffer_process_regular: processing [%u]\n", waiting_buffer_tail);
+        if (waiting_buffer[waiting_buffer_tail].event.pressed) {
+            clear_weak_mods();
+        }
         process_record(&waiting_buffer[waiting_buffer_tail]);
     }
     debug_waiting_buffer();

--- a/tests/tap_hold_configurations/default_mod_tap/test_tap_hold.cpp
+++ b/tests/tap_hold_configurations/default_mod_tap/test_tap_hold.cpp
@@ -224,3 +224,62 @@ TEST_F(DefaultTapHold, tap_and_hold_mod_tap_hold_key) {
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 }
+
+TEST_F(DefaultTapHold, weak_mods_cleared_with_layer_tap) {
+    TestDriver driver;
+    InSequence s;
+    auto       layer_tap_hold_key = KeymapKey(0, 1, 0, LT(1, KC_P));
+    auto       base_key_1         = KeymapKey(0, 2, 0, KC_A);
+    auto       base_key_2         = KeymapKey(0, 3, 0, KC_B);
+    auto       shifted_key        = KeymapKey(1, 2, 0, KC_EXLM);
+    auto       regular_key        = KeymapKey(1, 3, 0, KC_EQL);
+    auto       unmodified_code    = ((action_t){.code = shifted_key.report_code}).key.code;
+
+    set_keymap({layer_tap_hold_key, base_key_1, base_key_2, shifted_key, regular_key});
+
+    /* Press layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press shifted key */
+    EXPECT_NO_REPORT(driver);
+    shifted_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Press regular key */
+    EXPECT_NO_REPORT(driver);
+    regular_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release shifted key */
+    EXPECT_NO_REPORT(driver);
+    shifted_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release regular key */
+    EXPECT_NO_REPORT(driver);
+    regular_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Wait out tapping term */
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, unmodified_code));
+    EXPECT_REPORT(driver, (unmodified_code, regular_key.report_code));
+    EXPECT_REPORT(driver, (regular_key.report_code));
+    EXPECT_EMPTY_REPORT(driver);
+    idle_for(TAPPING_TERM);
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release layer-tap-hold key */
+    EXPECT_NO_REPORT(driver);
+    layer_tap_hold_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

In `action_exec()`, there is a bit of code that clears weak mods left over from previous keypresses, so they do not affect new keypresses. However, tap-hold handling code buffers events so that they can be processed after a tap-hold decision is settled. The processing of these buffered events bypasses `action_exec()`, so weak mods from a keypress in the buffer can affect those processed later in the buffer.  This can manifest when activating a layer with LT, and then rapidly typing a modified keycode followed by a non-modified keycode within the tapping term. Example: trying to type != and getting !+ instead.

Have implemented a fix by clearing weak mods before passing buffered records on for processing.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
