### PR TITLE
Extend core API to enable mouse keymap community modules

### DIFF
--- a/tests/mousekeys/test_mousekeys.cpp
+++ b/tests/mousekeys/test_mousekeys.cpp
@@ -63,6 +63,27 @@ TEST_F(Mousekey, PressAndHoldButtonOneCorrectlyReported) {
     VERIFY_AND_CLEAR(driver);
 }
 
+TEST_F(Mousekey, HostLastMouseButtonsTracksLatestReport) {
+    TestDriver driver;
+    KeymapKey  mouse_key = KeymapKey{0, 0, 0, QK_MOUSE_BUTTON_1};
+
+    set_keymap({mouse_key});
+
+    EXPECT_EQ(host_last_mouse_buttons(), 0);
+
+    EXPECT_MOUSE_REPORT(driver, (0, 0, 0, 0, 1));
+    mouse_key.press();
+    run_one_scan_loop();
+    EXPECT_EQ(host_last_mouse_buttons(), 1);
+
+    EXPECT_MOUSE_REPORT(driver, (0, 0, 0, 0, 0));
+    mouse_key.release();
+    run_one_scan_loop();
+    EXPECT_EQ(host_last_mouse_buttons(), 0);
+
+    VERIFY_AND_CLEAR(driver);
+}
+
 TEST_P(MousekeyParametrized, PressAndReleaseIsCorrectlyReported) {
     TestDriver           driver;
     KeymapKey            mouse_key    = GetParam().first;

--- a/tmk_core/protocol/host.c
+++ b/tmk_core/protocol/host.c
@@ -70,6 +70,7 @@ extern keymap_config_t keymap_config;
 static host_driver_t *driver;
 static uint16_t       last_system_usage   = 0;
 static uint16_t       last_consumer_usage = 0;
+static uint8_t        last_mouse_buttons  = 0;
 
 void host_set_driver(host_driver_t *d) {
     driver = d;
@@ -220,6 +221,7 @@ void host_mouse_send(report_mouse_t *report) {
     report->boot_x = (report->x > 127) ? 127 : ((report->x < -127) ? -127 : report->x);
     report->boot_y = (report->y > 127) ? 127 : ((report->y < -127) ? -127 : report->y);
 #endif
+    last_mouse_buttons = report->buttons;
     (*driver->send_mouse)(report);
 }
 
@@ -357,4 +359,8 @@ uint16_t host_last_system_usage(void) {
 
 uint16_t host_last_consumer_usage(void) {
     return last_consumer_usage;
+}
+
+uint8_t host_last_mouse_buttons(void) {
+    return last_mouse_buttons;
 }

--- a/tmk_core/protocol/host.h
+++ b/tmk_core/protocol/host.h
@@ -48,6 +48,7 @@ void    host_raw_hid_send(uint8_t *data, uint8_t length);
 
 uint16_t host_last_system_usage(void);
 uint16_t host_last_consumer_usage(void);
+uint8_t  host_last_mouse_buttons(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

core: add host_last_mouse_buttons() shadow helper

Track the most recent buttons mask passed to host_mouse_send() and
expose it via host_last_mouse_buttons(). Mirrors host_last_system_usage()
and host_last_consumer_usage() in shape and motivation.

Consumers that synthesize out-of-band mouse activity (Raw HID adapters,
pointing-device button handlers) need the current HID-level button
state to stamp onto reports they generate from non-button signals
(motion, wheel). Without this, a click-and-drag whose press and motion
arrive on separate code paths sees buttons=0 on the motion report and
the drag drops mid-stream.

See https://github.com/schuay/qmk_modules/tree/feat/strict-core/native_mouse for the community module that uses these hooks.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
