### PR TITLE
Fix `qmk compile -km <keyboard> -km all`

### DIFF
--- a/lib/python/qmk/cli/compile.py
+++ b/lib/python/qmk/cli/compile.py
@@ -41,6 +41,7 @@ def compile(cli):
         cli.args.filter = []
         cli.config.mass_compile.keymap = cli.config.compile.keymap
         cli.config.mass_compile.parallel = cli.config.compile.parallel
+        cli.args.print_failures = False
         cli.args.no_temp = False
         return mass_compile(cli)
 
@@ -51,6 +52,7 @@ def compile(cli):
         cli.args.filter = []
         cli.config.mass_compile.keymap = None
         cli.config.mass_compile.parallel = cli.config.compile.parallel
+        cli.args.print_failures = False
         cli.args.no_temp = False
         return mass_compile(cli)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`qmk compile -kb zvecr/zv48/f401 -km all` currently produces the following error:
```
Ψ Retrieving list of keymaps for keyboard "zvecr/zv48/f401"...
Ψ Preparing target list...
<class 'KeyError'>
☒ 'print_failures'
Traceback (most recent call last):
  File "/home/zvecr/qmk_firmware_merge/.direnv/python-3.14/lib/python3.14/site-packages/milc/milc.py", line 609, in __call__
    return self.__call__()
           ~~~~~~~~~~~~~^^
  File "/home/zvecr/qmk_firmware_merge/.direnv/python-3.14/lib/python3.14/site-packages/milc/milc.py", line 614, in __call__
    return self._subcommand(self)
           ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/zvecr/qmk_firmware_merge/lib/python/qmk/decorators.py", line 43, in wrapper
    return func(*args, **kwargs)
  File "/home/zvecr/qmk_firmware_merge/lib/python/qmk/decorators.py", line 65, in wrapper
    return func(*args, **kwargs)
  File "/home/zvecr/qmk_firmware_merge/lib/python/qmk/cli/compile.py", line 55, in compile
    return mass_compile(cli)
  File "/home/zvecr/qmk_firmware_merge/lib/python/qmk/cli/mass_compile.py", line 151, in mass_compile
    return mass_compile_targets(targets, cli.args.clean, cli.args.dry_run, cli.args.no_temp, cli.config.mass_compile.parallel, cli.args.print_failures, **build_environment(cli.args.env))
                                                                                                                               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zvecr/qmk_firmware_merge/.direnv/python-3.14/lib/python3.14/site-packages/milc/attrdict.py", line 32, in __getattr__
    return self.__getitem__(key)
           ~~~~~~~~~~~~~~~~^^^^^
  File "/home/zvecr/qmk_firmware_merge/.direnv/python-3.14/lib/python3.14/site-packages/milc/attrdict.py", line 37, in __getitem__
    return self._data[key]
           ~~~~~~~~~~^^^^^
KeyError: 'print_failures'
```

Pass required print_failures argument to mass compile commands.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
