### PR TITLE
Add matt keymap for idyllic/pizzapad (Pretty Paddy)

### DIFF
--- a/keyboards/idyllic/pizzapad/keymaps/matt/KEYMAP.md
+++ b/keyboards/idyllic/pizzapad/keymaps/matt/KEYMAP.md
@@ -1,0 +1,164 @@
+# Pretty Paddy — Window Management Keymap
+
+**Board:** Idyllic Pizza Pad (sold by MechStock AU as "Pretty Paddy")
+**QMK path:** `keyboards/idyllic/pizzapad`
+**MCU:** Seeed XIAO RP2040
+**Layout:** 3×3 ortho (9 keys)
+
+---
+
+## Concept
+
+All 9 keys map to window management commands in **Raycast** on macOS. Every key has a tap action. Seven of the nine keys also act as chord anchors — hold one, tap another to send a different command.
+
+- **Tap** — sends a keycode directly to Raycast
+- **Chord (hold anchor + tap target)** — holding an anchor key activates a layer; tapping a second key sends the chord output
+
+Chords use `LT()` (Layer-Tap) with `HOLD_ON_OTHER_KEY_PRESS` and `PERMISSIVE_HOLD` so the hold registers the instant a second key is pressed.
+
+---
+
+## Physical Layout
+
+```
+[ K0 ] [ K1 ] [ K2 ]
+[ K3 ] [ K4 ] [ K5 ]
+[ K6 ] [ K7 ] [ K8 ]
+```
+
+---
+
+## Base Layer — Taps
+
+| Key | Output | Raycast target |
+|-----|--------|----------------|
+| K0 | Hyper+1 | Top-Left Sixth |
+| K1 | Hyper+2 | Top-Center Sixth |
+| K2 | Hyper+3 | Top-Right Sixth |
+| K3 | F18 | Left Third |
+| K4 | Hyper+5 | Center Third | (plain key — no hold) |
+| K5 | F19 | Right Third |
+| K6 | Hyper+7 | Bottom-Left Sixth |
+| K7 | Hyper+8 | Bottom-Center Sixth |
+| K8 | Hyper+9 | Bottom-Right Sixth |
+
+---
+
+## Chords — Hold + Tap
+
+### Hold K3 (left anchor)
+
+| Chord | Output | Raycast target |
+|-------|--------|----------------|
+| K3 + K1 | Hyper+0 | Top Half |
+| K3 + K4 | F13 | Left Two-Thirds |
+| K3 + K5 | Hyper+Return | Full Screen |
+| K3 + K7 | F16 | Bottom Half |
+
+### Hold K5 (right anchor)
+
+| Chord | Output | Raycast target |
+|-------|--------|----------------|
+| K5 + K3 | Hyper+Return | Full Screen |
+| K5 + K4 | F20 | Right Two-Thirds |
+
+### Hold K0 or K2 (top-row anchors, shared layer)
+
+| Chord | Output | Raycast target |
+|-------|--------|----------------|
+| K0 + K2 | Hyper+0 | Top Half |
+| K2 + K0 | Hyper+0 | Top Half |
+
+### Hold K6 or K8 (bottom-row anchors, shared layer)
+
+| Chord | Output | Raycast target |
+|-------|--------|----------------|
+| K6 + K8 | F16 | Bottom Half |
+| K8 + K6 | F16 | Bottom Half |
+
+---
+
+## Raycast Setup
+
+Open **Raycast → Extensions → Window Management**, click a shortcut field, and trigger the key or chord on the pad — Raycast detects the keycode automatically.
+
+| Raycast action | Shortcut | Trigger |
+|----------------|----------|---------|
+| Top-Left Sixth | Hyper+1 | Tap K0 |
+| Top-Center Sixth | Hyper+2 | Tap K1 |
+| Top-Right Sixth | Hyper+3 | Tap K2 |
+| Left Third | F18 | Tap K3 |
+| Center Third | Hyper+5 | Tap K4 |
+| Right Third | F19 | Tap K5 |
+| Bottom-Left Sixth | Hyper+7 | Tap K6 |
+| Bottom-Center Sixth | Hyper+8 | Tap K7 |
+| Bottom-Right Sixth | Hyper+9 | Tap K8 |
+| Top Half | Hyper+0 | K3+K1 · K0+K2 · K2+K0 |
+| Bottom Half | F16 | K3+K7 · K6+K8 · K8+K6 |
+| Left Two-Thirds | F13 | K3+K4 |
+| Right Two-Thirds | F20 | K5+K4 |
+| Full Screen | Hyper+Return | K3+K5 · K5+K3 |
+
+> **Hyper** = Ctrl+Shift+Alt+Cmd.
+
+---
+
+## Build & Flash
+
+```bash
+# Compile
+qmk compile -kb idyllic/pizzapad -km matt
+
+# Flash (enter bootloader first)
+qmk flash -kb idyllic/pizzapad -km matt
+```
+
+### Entering bootloader (Seeed XIAO RP2040)
+
+1. **Bootmagic** — hold **K0** while plugging in USB-C → board mounts as `RPI-RP2`
+2. **Physical buttons** — with USB connected, press **BOOT + RESET** simultaneously
+3. **Keycode** — map `QK_BOOT` to a key and press it
+
+### Restore to default
+
+`_backups/idyllic_pizzapad_default_RESTORE.uf2` — enter bootloader and drag onto `RPI-RP2`.
+
+---
+
+## Implementation Notes
+
+### LT() + HYPR() incompatibility
+`LT()` only accepts basic keycodes (≤ 0xFF) as the tap action. `HYPR(KC_x)` is a modifier-stacked keycode and gets silently stripped to a bare keycode. Keys that need to tap `HYPR+something` use an inert placeholder keycode inside `LT()`, overridden in `process_record_user()`.
+
+| Key | Placeholder | Tap output |
+|-----|-------------|------------|
+| K0 | KC_F22 | Hyper+1 |
+| K2 | KC_F23 | Hyper+3 |
+| K6 | KC_F24 | Hyper+7 |
+| K8 | KC_SCRL | Hyper+9 |
+
+K3/K5 tap to plain F-keys (F18/F19) — no workaround needed. K1/K4/K7 are plain keys.
+
+### Shared layers for symmetric pairs
+K0 and K2 share `_TOP_HOLD`; K6 and K8 share `_BOT_HOLD`. Sharing is intentional: with `HOLD_ON_OTHER_KEY_PRESS`, if both keys target the same layer, the second key pressing doesn't activate a *new* layer — it's a no-op since that layer is already active. This prevents the second key from becoming a conflicting anchor. Separate layers caused K2 to also register as held when K0 was held, preventing any keycode from firing.
+
+### Avoided F-keys
+| F-key | Reason avoided |
+|-------|---------------|
+| F14 | Brightness down (macOS) |
+| F15 | Brightness up (macOS) |
+| F17 | Brightness (macOS, some configs) |
+| F21+ | Not recognised by Raycast as recordable hotkeys |
+
+### Layers (5 total)
+| Layer | Name | Trigger |
+|-------|------|---------|
+| 0 | `_BASE` | Always active |
+| 1 | `_LEFT_HOLD` | Hold K3 |
+| 2 | `_RIGHT_HOLD` | Hold K5 |
+| 3 | `_TOP_HOLD` | Hold K0 or K2 |
+| 4 | `_BOT_HOLD` | Hold K6 or K8 |
+
+### config.h
+- `HOLD_ON_OTHER_KEY_PRESS` — registers hold the instant another key is pressed
+- `PERMISSIVE_HOLD` — also registers hold if another key is pressed and released while the LT() key is down

--- a/keyboards/idyllic/pizzapad/keymaps/matt/config.h
+++ b/keyboards/idyllic/pizzapad/keymaps/matt/config.h
@@ -1,0 +1,13 @@
+// Copyright 2024 Matt (@matt)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// When another key is pressed while an LT() key is held, immediately
+// treat it as a hold (layer activation) rather than waiting for tapping term.
+// This makes all chord layers trigger reliably without delay.
+#define HOLD_ON_OTHER_KEY_PRESS
+
+// Additional hold detection: if another key is pressed AND released while
+// an LT() key is still held, also treat it as a hold. Complements the above.
+#define PERMISSIVE_HOLD

--- a/keyboards/idyllic/pizzapad/keymaps/matt/keymap.c
+++ b/keyboards/idyllic/pizzapad/keymaps/matt/keymap.c
@@ -1,0 +1,134 @@
+// Copyright 2024 Matt (@matt)
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Pizza Pad (Pretty Paddy) — Window Management Keymap
+//
+// Layout:
+//   [K0] [K1] [K2]
+//   [K3] [K4] [K5]
+//   [K6] [K7] [K8]
+//
+// All edge keys are LT() (Layer-Tap): tap fires a window command,
+// hold activates an anchor layer for chording.
+//
+// Corner keys (K0/K2/K6/K8) cannot use HYPR(KC_x) directly inside LT()
+// because HYPR(KC_x) is a modified keycode and LT() only accepts basic
+// keycodes as the tap action. Instead, placeholder F-keys are used and
+// intercepted in process_record_user() to emit the correct HYPR+num.
+//
+//   K0 → placeholder KC_F22 → intercepted → HYPR+1
+//   K2 → placeholder KC_F23 → intercepted → HYPR+3
+//   K6 → placeholder KC_F24 → intercepted → HYPR+7
+//   K8 → placeholder KC_SCRL → intercepted → HYPR+9  (scroll lock; macOS ignores it)
+//
+// Layer 0 (Base):
+//   K0: tap=HYPR+1,   hold=_TOP_HOLD
+//   K1: tap=HYPR+2    (plain, no hold)
+//   K2: tap=HYPR+3,   hold=_TOP_HOLD
+//   K3: tap=F18,      hold=_LEFT_HOLD
+//   K4: tap=HYPR+5    (plain, no hold)
+//   K5: tap=F19,      hold=_RIGHT_HOLD
+//   K6: tap=HYPR+7,   hold=_BOT_HOLD
+//   K7: tap=HYPR+8    (plain, no hold)
+//   K8: tap=HYPR+9,   hold=_BOT_HOLD
+//
+// Layer 1 (_LEFT_HOLD — hold K3):
+//   K3+K1 → HYPR+0       (Top Half)
+//   K3+K4 → F13          (Left Two-Thirds)
+//   K3+K5 → HYPR+Return  (Full Screen)
+//   K3+K7 → F16          (Bottom Half)
+//
+// Layer 2 (_RIGHT_HOLD — hold K5):
+//   K5+K3 → HYPR+Return  (Full Screen)
+//   K5+K4 → F20          (Right Two-Thirds)
+//
+// Layer 3 (_TOP_HOLD — hold K0 or K2, shared layer):
+//   K0+K2 → HYPR+0       (Top Half)
+//   K2+K0 → HYPR+0       (Top Half)
+//
+// Layer 4 (_BOT_HOLD — hold K6 or K8, shared layer):
+//   K6+K8 → F16          (Bottom Half)
+//   K8+K6 → F16          (Bottom Half)
+//
+// Avoided F-keys: F14 (brightness down), F15 (brightness up), F17 (brightness).
+// F21+ not recognised by Raycast as recordable hotkeys.
+
+#include QMK_KEYBOARD_H
+
+enum custom_layers {
+    _BASE = 0,
+    _LEFT_HOLD,
+    _RIGHT_HOLD,
+    _TOP_HOLD,        // shared by K0 and K2 — same pattern as _BOT_HOLD for K6/K8
+    _BOT_HOLD         // shared by K6 and K8
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [_BASE] = LAYOUT_ortho_3x3(
+        LT(_TOP_HOLD,   KC_F22),   HYPR(KC_2),   LT(_TOP_HOLD,   KC_F23),
+        LT(_LEFT_HOLD,      KC_F18),   HYPR(KC_5),                   LT(_RIGHT_HOLD,     KC_F19),
+        LT(_BOT_HOLD,       KC_F24),   HYPR(KC_8),   LT(_BOT_HOLD,       KC_SCRL)
+    ),
+
+    // Hold K3
+    [_LEFT_HOLD] = LAYOUT_ortho_3x3(
+        KC_TRNS,       HYPR(KC_0),        KC_TRNS,
+        KC_TRNS,       KC_F13,        HYPR(KC_ENT),
+        KC_TRNS,       KC_F16,        KC_TRNS
+    ),
+
+    // Hold K5
+    [_RIGHT_HOLD] = LAYOUT_ortho_3x3(
+        KC_TRNS,       KC_TRNS,       KC_TRNS,
+        HYPR(KC_ENT),  KC_F20,        KC_TRNS,
+        KC_TRNS,       KC_TRNS,       KC_TRNS
+    ),
+
+    // Shared by K0 and K2 — same pattern as _BOT_HOLD
+    // Both positions have HYPR(KC_0) so either key can be the anchor
+    [_TOP_HOLD] = LAYOUT_ortho_3x3(
+        HYPR(KC_0),        KC_TRNS,       HYPR(KC_0),
+        KC_TRNS,       KC_TRNS,       KC_TRNS,
+        KC_TRNS,       KC_TRNS,       KC_TRNS
+    ),
+
+    // Hold K6 or K8 — both positions send F16 so either can be the anchor
+    [_BOT_HOLD] = LAYOUT_ortho_3x3(
+        KC_TRNS,          KC_TRNS,       KC_TRNS,
+        KC_TRNS,          KC_TRNS,       KC_TRNS,
+        KC_F16,           KC_TRNS,       KC_F16
+    ),
+
+};
+
+// Intercept placeholder taps on corner keys and send the correct HYPR+num.
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case LT(_TOP_HOLD, KC_F22):             // K0 tap → HYPR+1
+            if (record->tap.count && record->event.pressed) {
+                tap_code16(HYPR(KC_1));
+                return false;
+            }
+            break;
+        case LT(_TOP_HOLD, KC_F23):             // K2 tap → HYPR+3
+            if (record->tap.count && record->event.pressed) {
+                tap_code16(HYPR(KC_3));
+                return false;
+            }
+            break;
+        case LT(_BOT_HOLD, KC_F24):             // K6 tap → HYPR+7
+            if (record->tap.count && record->event.pressed) {
+                tap_code16(HYPR(KC_7));
+                return false;
+            }
+            break;
+        case LT(_BOT_HOLD, KC_SCRL):            // K8 tap → HYPR+9
+            if (record->tap.count && record->event.pressed) {
+                tap_code16(HYPR(KC_9));
+                return false;
+            }
+            break;
+    }
+    return true;
+}

--- a/keyboards/idyllic/pizzapad/keymaps/matt/rules.mk
+++ b/keyboards/idyllic/pizzapad/keymaps/matt/rules.mk
@@ -1,0 +1,1 @@
+# Combos not needed — corner hold behaviour handled via LT() + process_record_user()


### PR DESCRIPTION
## Summary

- Adds a personal `matt` keymap for the Idyllic Pizza Pad (`keyboards/idyllic/pizzapad`), a 3×3 ortho macropad sold by MechStock AU as the "Pretty Paddy"
- All 9 keys map to window management shortcuts via Raycast on macOS
- 7 of the 9 keys act as chord anchors (hold + tap a second key for a different output), implemented with `LT()`, `HOLD_ON_OTHER_KEY_PRESS`, and `PERMISSIVE_HOLD`

## Keymap overview

**Taps:**

| Key | Output |
|-----|--------|
| K0 | Hyper+1 (Top-Left Sixth) |
| K1 | Hyper+2 (Top-Center Sixth) |
| K2 | Hyper+3 (Top-Right Sixth) |
| K3 | F18 (Left Third) |
| K4 | Hyper+5 (Center Third) |
| K5 | F19 (Right Third) |
| K6 | Hyper+7 (Bottom-Left Sixth) |
| K7 | Hyper+8 (Bottom-Center Sixth) |
| K8 | Hyper+9 (Bottom-Right Sixth) |

**Chords (hold + tap):** Top/Bottom Half, Left/Right Two-Thirds, Full Screen — full table in `KEYMAP.md`.

## Implementation notes

- **`LT()` + `HYPR()` incompatibility**: `HYPR(KC_x)` is a modified keycode (> 0xFF) and cannot be used directly as the tap action inside `LT()`. Corner keys (K0/K2/K6/K8) use inert placeholder basic keycodes (`KC_F22`, `KC_F23`, `KC_F24`, `KC_SCRL`) inside `LT()`, with the real `HYPR+num` output sent via `process_record_user()`.
- **Shared layers for symmetric anchor pairs**: K0 and K2 share `_TOP_HOLD`; K6 and K8 share `_BOT_HOLD`. With `HOLD_ON_OTHER_KEY_PRESS`, separate layers caused both keys to simultaneously register as held — sharing one layer makes the second key's hold a no-op (layer already active).
- **Avoided F-keys**: F14/F15/F17 conflict with macOS brightness controls; F21+ are not recognised by Raycast as recordable hotkeys.

## Test plan

- [ ] Compile cleanly with `qmk compile -kb idyllic/pizzapad -km matt`
- [ ] All 9 tap outputs fire correct keycodes
- [ ] All chord combinations (hold anchor + tap target) fire correct keycodes
- [ ] No interference between adjacent chord layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)