### PR TITLE
Fail when a duplicate module name is detected

### DIFF
--- a/lib/python/qmk/info.py
+++ b/lib/python/qmk/info.py
@@ -1137,4 +1137,17 @@ def get_modules(keyboard, keymap_filename):
         if keymap_json:
             modules.extend(keymap_json.get('modules', []))
 
-    return list(dict.fromkeys(modules))  # remove dupes
+    # remove duplicates while maintaining the current order
+    ret = list(dict.fromkeys(modules))
+
+    # We currently do not support duplicate module names
+    # e.g.: ['foo/hello_world', 'bar/hello_world'] will fail
+    seen = set()
+    for module in ret:
+        module_slug = Path(module).name.lower()
+        if module_slug in seen:
+            duplicates = list(filter(lambda m: module_slug == Path(m).name.lower(), ret))
+            raise Exception(f'Duplicate module name detected: "{module_slug}" - {duplicates}')
+        seen.add(module_slug)
+
+    return ret


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
We currently do not support duplicate module names, where something like `["foo/hello_world", "bar/hello_world"]` will fail. The generated code assumes the `hello_world` part is unique, where it then contains duplicate symbols/defines/etc.

This change at least makes the build fail early, with the following:
```ansi
Making handwired/onekey/promicro with keymap community_module

☒ Duplicate module name detected: "hello_world" - ['qmk/hello_world', 'asdf/hello_world']
Traceback (most recent call last):
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.14/lib/python3.14/site-packages/milc/milc.py", line 609, in __call__
    return self.__call__()
           ~~~~~~~~~~~~~^^
  File "/home/zvecr/zv_firmware_clean/.direnv/python-3.14/lib/python3.14/site-packages/milc/milc.py", line 614, in __call__
    return self._subcommand(self)
           ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/cli/generate/community_modules.py", line 182, in generate_community_modules_rules_mk
    rules_mk_lines.extend(_generate_modules_rules(cli.args.keyboard, cli.args.filename))
                          ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/cli/generate/community_modules.py", line 145, in _generate_modules_rules
    modules = get_modules(keyboard, filename)
  File "/home/zvecr/zv_firmware_clean/lib/python/qmk/info.py", line 1150, in get_modules
    raise Exception(f'Duplicate module name detected: "{module_name}" - {duplicates}')
Exception: Duplicate module name detected: "hello_world" - ['qmk/hello_world', 'asdf/hello_world']
builddefs/build_keyboard.mk:186: <class: No such file or directory
make[1]: *** No rule to make target '<class'.  Stop.
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
