### PR TITLE
chore(cicd): onboard qmk_firmware to Charon-Cicada (no-deploy)

### DIFF
--- a/.bifrost/onboard-notes.md
+++ b/.bifrost/onboard-notes.md
@@ -1,0 +1,18 @@
+# Charon-Cicada Onboarding Notes — qmk_firmware
+
+## No-deploy classification
+
+qmk_firmware is a QMK keyboard firmware fork (C/Python, embedded). No Cloudflare
+Worker deploy targets. No wrangler.toml.
+
+## GitHub Actions workflows — RETAINED
+
+All .github/workflows/*.yml files are QMK upstream CI workflows (firmware builds,
+linting, format checks, PR automation). None deploy Cloudflare Workers. Per constitution
+§4, only workflows that deploy or race with Charon-Cicada must be deleted. These are
+firmware CI — they coexist safely.
+
+KNOWN DEFICIENCY: Formal allow-list file (docs/constitutions/cicd/charon-cicada-allow-list.json)
+does not exist yet. Once it does, these workflows should be formally registered there.
+
+Charon-Cicada onboarding: only .namespace verification applies. All CD steps N/A.

--- a/.namespace
+++ b/.namespace
@@ -1,0 +1,1 @@
+qmk_firmware

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md — anti-knowledge
+
+This repository is the **canonical, tool-agnostic engineering knowledge base** for the `~/AntiGH/` project tree. It is consumed by other repos via Git subtree under `shared-knowledge/anti-knowledge/`.
+
+## What this is
+
+A plain-Markdown, version-controlled, single-source-of-truth (SSOT) for cross-project lessons. **Lives in Git. Loads in any editor. Survives any AI harness.** Designed so the same content powers:
+
+- Claude Code (loads via per-project `AGENTS.md` and project memory pointers)
+- Cursor (loads via `AGENTS.md` + `.cursorrules` pointers)
+- Aider (loads via context-file config)
+- ChatGPT desktop / Gemini CLI / any future tool (loads via explicit file attach)
+- Plain humans reading Markdown
+- A future docs MCP server (front-matter is MCP-friendly)
+
+## Layout
+
+```
+anti-knowledge/
+├── AGENTS.md              ← this file (cross-tool front door)
+├── README.md              ← human entry point
+├── lessons/
+│   ├── decks/
+│   │   └── marp-reveal-ios-mermaid/
+│   │       └── index.md   ← canonical lesson; one topic = one dir + index.md
+│   └── process/
+│       ├── parallel-agents.md
+│       └── live-proof.md
+└── meta/
+    └── lesson-template.md
+```
+
+One lesson per directory, named `index.md`. Examples and snippets go alongside in the same dir.
+
+## Lesson file conventions
+
+Every `index.md` has YAML front-matter:
+
+```yaml
+---
+id: lessons/decks/marp-reveal-ios-mermaid
+title: Marp / Reveal / iOS-mobile / Mermaid PDF deck guidelines
+tags: [marp, revealjs, ios, pdf, mermaid, decks, slides, mobile]
+last_reviewed: 2026-05-22
+maturity: stable      # draft | stable | deprecated
+audience: solo-engineer
+---
+```
+
+And these sections (in this order):
+
+1. **Summary** — 1-2 paragraphs: what this lesson is and when to use it.
+2. **Key rules** — bullet list of must-follow rules; safe for AI to load verbatim.
+3. **Patterns and examples** — code snippets, templates, anti-patterns.
+4. **Tool-specific notes** — how this lesson interacts with specific harnesses (only if non-obvious).
+5. **Change log** — high-level only; Git carries the detail.
+
+## How agents should use this repo
+
+When working in a consuming repo with `shared-knowledge/anti-knowledge/` present:
+
+1. **Before starting work** in a domain that has a lesson, read the relevant `lessons/<topic>/index.md`.
+2. **Treat Key rules as binding** unless the consuming repo's own `AGENTS.md` explicitly overrides for a documented reason.
+3. **Do not copy lesson content** into the consuming repo, CLAUDE.md, .cursorrules, project memory, or skills. Reference the path instead.
+4. **Updating a lesson**: edit `anti-knowledge/lessons/.../index.md` directly, bump `last_reviewed`, commit, push, then run `git subtree pull --prefix=shared-knowledge/anti-knowledge ...` in consumer repos.
+5. **A lesson contradicts what you observe live** — trust live observation, then update the lesson (don't blindly follow stale knowledge).
+
+## Anti-patterns (do not do)
+
+- Duplicating lesson text into CLAUDE.md / .cursorrules / project memory.
+- Treating `~/.claude/projects/*/memory/` or `~/.claude/skills/*/` as canonical. They are caches and triggers, not SSOT.
+- Mixing scratch notes / session transcripts into lesson files. Promote stable patterns deliberately.
+- Storing canonical content only as PDF, slide deck, or other binary output.
+- Inconsistent directory names across consumers (always `shared-knowledge/anti-knowledge/`).
+
+## Current lessons
+
+| Lesson | Tags | Maturity |
+|---|---|---|
+| [decks/marp-reveal-ios-mermaid](lessons/decks/marp-reveal-ios-mermaid/index.md) | marp, revealjs, ios, pdf, mermaid, decks, mobile | stable |
+| [process/parallel-agents](lessons/process/parallel-agents.md) | agents, parallelism, worktrees, merging | stable |
+| [process/live-proof](lessons/process/live-proof.md) | shipping, verification, ci | stable |
+
+## Adding a new lesson
+
+1. `cp -r meta/lesson-template.md lessons/<domain>/<slug>/index.md` (or create the dir + file).
+2. Fill in front-matter + the 5 sections.
+3. Add a row to the **Current lessons** table above.
+4. Commit, push. Run `git subtree pull` in each consumer that needs it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — qmk_firmware (fork)
+
+Cross-tool front door for any AI harness working in this fork.
+
+## Project at a glance
+
+- **What**: Personal fork of [qmk/qmk_firmware](https://github.com/qmk/qmk_firmware). Active work lives in `keyboards/reviung/reviung34/keymaps/mockingbird/` (Reviung34 keymap + companion Marp deck).
+- **Upstream**: `qmk/qmk_firmware`. Remote: `upstream`. Default branch: `master`.
+- **Fork-only paths**: `keyboards/reviung/reviung34/keymaps/mockingbird/**`, `shared-knowledge/anti-knowledge/**`, this `AGENTS.md`. These do not exist upstream and never PR there.
+
+## Shared knowledge
+
+Cross-project engineering lessons live in `shared-knowledge/anti-knowledge/` (imported via Git subtree from `github.com/mockingb1rdblue/anti-knowledge`). Read its [AGENTS.md](shared-knowledge/anti-knowledge/AGENTS.md) for the layout.
+
+When working in these areas, **load the lesson before touching code**:
+
+| Touching... | Read... |
+|---|---|
+| `keyboards/reviung/reviung34/keymaps/mockingbird/deck/**` (Marp deck for keyboard), Mermaid diagrams, Reveal previews | `shared-knowledge/anti-knowledge/lessons/decks/marp-reveal-ios-mermaid/index.md` |
+| Parallelizing keymap + deck work | `shared-knowledge/anti-knowledge/lessons/process/parallel-agents.md` |
+| Any "released a new firmware" or "deck published" claim | `shared-knowledge/anti-knowledge/lessons/process/live-proof.md` |
+
+The lessons there are SSOT. Do not duplicate.
+
+## Upstream-sync safety
+
+This is a fork of QMK. When pulling from `upstream/master`:
+
+- The `shared-knowledge/` subtree, `AGENTS.md`, and `keyboards/reviung/reviung34/keymaps/mockingbird/` are fork-local and should never conflict (they do not exist upstream).
+- If a rebase fight emerges, prefer keeping fork-local files. Consider `.gitattributes` with `merge=ours` for `shared-knowledge/**` if QMK ever upstreams that path.
+
+## Updating shared lessons
+
+1. Edit canonical upstream: `cd ../anti-knowledge && $EDITOR lessons/<...>/index.md`.
+2. Commit + push upstream.
+3. Pull update here: `git subtree pull --prefix=shared-knowledge/anti-knowledge https://github.com/mockingb1rdblue/anti-knowledge.git main --squash`.
+
+Do not edit files under `shared-knowledge/anti-knowledge/` directly here.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# anti-knowledge
+
+Cross-project engineering knowledge base for the `~/AntiGH/` tree. Plain Markdown, version-controlled, tool-agnostic.
+
+**Read [AGENTS.md](AGENTS.md) first** — it is the canonical entry point for both humans and AI tools, and explains the layout, lesson conventions, and how consumers import this repo.
+
+## Quick links
+
+- [Marp / Reveal / iOS / Mermaid deck lessons](lessons/decks/marp-reveal-ios-mermaid/index.md)
+- [Parallel agent execution](lessons/process/parallel-agents.md)
+- [Live-proof shipping rule](lessons/process/live-proof.md)
+- [Lesson template](meta/lesson-template.md)
+
+## Consuming this repo
+
+In any project under `~/AntiGH/`:
+
+```bash
+cd ~/AntiGH/<project>
+git subtree add --prefix=shared-knowledge/anti-knowledge \
+  git@github.com:mockingb1rdblue/anti-knowledge.git main --squash
+```
+
+Then add an `AGENTS.md` at the project root pointing at the relevant lesson paths under `shared-knowledge/anti-knowledge/lessons/`.
+
+## Updating lessons
+
+Edit `lessons/<domain>/<slug>/index.md` in this repo, bump `last_reviewed`, commit, push. In each consumer that needs the update:
+
+```bash
+git subtree pull --prefix=shared-knowledge/anti-knowledge \
+  git@github.com:mockingb1rdblue/anti-knowledge.git main --squash
+```

--- a/keyboards/crkbd/keymaps/mockingb1rdblue/combos.def
+++ b/keyboards/crkbd/keymaps/mockingb1rdblue/combos.def
@@ -1,0 +1,25 @@
+// mockingStandard
+COMB(dfBspc,    KC_BSPC,    KC_D, KC_F)
+COMB(fgDel,     KC_DEL,     KC_F, KC_G)
+COMB(jkEnt,     KC_ENT,     KC_J, KC_K)
+COMB(cbAppMenu, KC_APP,     KC_C,KC_B)
+
+// 5x3 BASE layer
+COMB(qwTab,     KC_TAB,     KC_Q, KC_W)
+COMB(qeEsc,     KC_ESC,     KC_Q, KC_E)
+COMB(ApostpSemiCol,     KC_SCLN,     KC_QUOT, KC_P)
+COMB(slashQuotBslash,     KC_BSLS,     KC_SLSH, KC_QUOT)
+
+// 5x3 LOWER layer
+COMB(oneTwoTilde,     KC_TILDE,     KC_1, KC_2)
+COMB(minusPlusPipe,     KC_PIPE,     KC_PMNS, KC_PPLS)
+
+// 5x3 RAISE layer
+COMB(exclamAtGrave,     KC_GRV,     KC_EXLM, KC_AT)
+
+SUBS(yiPhraseA,   "hENFiVVL4mFE",  KC_Y,KC_I)
+SUBS(yiPhraseB,   "MxgdelLetHEJ",  KC_H,KC_K)
+SUBS(yiPhraseC,   "Y5PvDZ9Bflt1G",  KC_Y,KC_N)
+
+// Template
+// COMB(12Name,     KC_DO,     KC_1, KC_2)

--- a/keyboards/crkbd/keymaps/mockingb1rdblue/config.h
+++ b/keyboards/crkbd/keymaps/mockingb1rdblue/config.h
@@ -1,0 +1,60 @@
+#pragma once
+
+// #define USE_SERIAL_PD2
+
+#define EE_HANDS
+
+#define COMBO_VARIABLE_LEN
+#define COMBO_TERM 40
+#define TAPPING_TERM 150
+// #define PERMISSIVE_HOLD
+
+#undef LOCKING_SUPPORT_ENABLE
+#undef LOCKING_RESYNC_ENABLE
+
+#ifdef RGB_MATRIX_ENABLE
+#   define RGB_MATRIX_KEYPRESSES // reacts to keypresses
+// #   define RGB_MATRIX_KEYRELEASES // reacts to keyreleases (instead of keypresses)
+// #   define RGB_DISABLE_AFTER_TIMEOUT 0 // number of ticks to wait until disabling effects
+#   define RGB_DISABLE_WHEN_USB_SUSPENDED true // turn off effects when suspended
+#   define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#   define RGB_MATRIX_LED_PROCESS_LIMIT (DRIVER_LED_TOTAL + 4) / 5 // limits the number of LEDs to process in an animation per task run (increases keyboard responsiveness)
+#   define RGB_MATRIX_LED_FLUSH_LIMIT 16 // limits in milliseconds how frequently an animation will update the LEDs. 16 (16ms) is equivalent to limiting to 60fps (increases keyboard responsiveness)
+#   define RGB_MATRIX_MAXIMUM_BRIGHTNESS 150 // limits maximum brightness of LEDs to 150 out of 255. Higher may cause the controller to crash.
+#   define RGB_MATRIX_HUE_STEP 8
+#   define RGB_MATRIX_SAT_STEP 8
+#   define RGB_MATRIX_VAL_STEP 8
+#   define RGB_MATRIX_SPD_STEP 10
+
+/* Disable the animations you don't want/need.  You will need to disable a good number of these    *
+ * because they take up a lot of space.  Disable until you can successfully compile your firmware. */
+
+// #   define DISABLE_RGB_MATRIX_ALPHAS_MODS
+//#   define DISABLE_RGB_MATRIX_GRADIENT_UP_DOWN
+#   define DISABLE_RGB_MATRIX_BREATHING
+#   define DISABLE_RGB_MATRIX_CYCLE_ALL
+#   define DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT
+#   define DISABLE_RGB_MATRIX_CYCLE_UP_DOWN
+#   define DISABLE_RGB_MATRIX_CYCLE_OUT_IN
+#   define DISABLE_RGB_MATRIX_CYCLE_OUT_IN_DUAL
+#   define DISABLE_RGB_MATRIX_RAINBOW_MOVING_CHEVRON
+#   define DISABLE_RGB_MATRIX_DUAL_BEACON
+#   define DISABLE_RGB_MATRIX_RAINBOW_BEACON
+#   define DISABLE_RGB_MATRIX_RAINBOW_PINWHEELS
+#   define DISABLE_RGB_MATRIX_RAINDROPS
+#   define DISABLE_RGB_MATRIX_JELLYBEAN_RAINDROPS
+#   define DISABLE_RGB_MATRIX_TYPING_HEATMAP
+#   define DISABLE_RGB_MATRIX_DIGITAL_RAIN                /*
+#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE
+#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE_SIMPLE       */
+#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE_WIDE
+#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTIWIDE
+#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE_CROSS
+//#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTICROSS
+#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE_NEXUS
+#   define DISABLE_RGB_MATRIX_SOLID_REACTIVE_MULTINEXUS
+#   define DISABLE_RGB_MATRIX_SPLASH
+#   define DISABLE_RGB_MATRIX_MULTISPLASH
+#   define DISABLE_RGB_MATRIX_SOLID_SPLASH
+#   define DISABLE_RGB_MATRIX_SOLID_MULTISPLASH
+#endif

--- a/keyboards/crkbd/keymaps/mockingb1rdblue/keymap.c
+++ b/keyboards/crkbd/keymaps/mockingb1rdblue/keymap.c
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 @foostan
+Copyright 2020 Drashna Jaelre <@drashna>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+#include <stdio.h> //what dis do?
+#include "keymap_combo.h" // following http://combos.gboards.ca/docs/install/ for combos
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [0] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                     KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_DEL,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_LCTL,    KC_A,    KC_S,    KC_D,    KC_F,    KC_G,                     KC_H,    KC_J,    KC_K,    KC_L,    KC_QUOT, KC_SCLN,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_LSFT,    LSFT_T(KC_Z),    KC_X,    KC_C,    KC_V,    KC_B,                     KC_N,    KC_M,    KC_COMM, RALT_T(KC_DOT),  KC_SLSH, KC_RSFT, //KC_BSLS
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          KC_LCTL,   MO(1),  KC_SPC,   KC_HOME,   MO(2), KC_LGUI
+                                      //`--------------------------'  `--------------------------'
+
+  ),
+
+  [1] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+      KC_TILDE ,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,                     KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_TRNS, //KC_ESC
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_TRNS,   KC_UP, KC_LEFT, KC_DOWN, KC_RGHT, LCTL(KC_Y),                  KC_EQL,  KC_4,    KC_5,    KC_6,    KC_PPLS, KC_NO,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_TRNS, LCTL(KC_Z), LCTL(KC_X), LCTL(KC_C), LCTL(KC_V), KC_APP,      KC_UNDS, KC_1,    KC_2,    KC_3,    KC_PMNS, KC_BSLS,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                     QK_BOOT, KC_TRNS,   QK_RBT,   KC_END,   MO(3), KC_0
+                                      //`--------------------------'  `--------------------------'
+  ),
+
+  [2] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_GRV, KC_EXLM,   KC_AT, KC_HASH,  KC_DLR, KC_PERC,                     KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, RGB_TOG,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_TRNS,   KC_NO,   KC_NO,   KC_NO, KC_HOME, KC_PGUP,                     KC_EQL,  KC_MINS, KC_NO,   KC_LBRC, KC_RBRC, RGB_MOD,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_TRNS,   KC_NO,   KC_NO,   KC_NO,  KC_END, KC_PGDN,                     KC_UNDS, KC_PLUS, KC_NO,   KC_LCBR, KC_RCBR, RGB_HUI,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                           KC_APP,   MO(3), KC_TRNS,   QK_RBT,   KC_TRNS, QK_BOOT
+                                      //`--------------------------'  `--------------------------'
+  ),
+
+  [3] = LAYOUT_split_3x6_3(
+  //,-----------------------------------------------------.                    ,-----------------------------------------------------.
+       KC_F12,   KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                     KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_TRNS, RGB_VAI, RGB_SAI, RGB_HUI, RGB_MOD, RGB_TOG,                     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NUM,
+  //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
+      KC_TRNS,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,                     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_CAPS,
+  //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
+                                          KC_TRNS, KC_TRNS, KC_TRNS,   KC_TRNS, KC_TRNS, KC_TRNS
+                                      //`--------------------------'  `--------------------------'
+  )
+};

--- a/keyboards/crkbd/keymaps/mockingb1rdblue/keymap_combo.h
+++ b/keyboards/crkbd/keymaps/mockingb1rdblue/keymap_combo.h
@@ -1,0 +1,75 @@
+// Keymap helpers
+
+#define K_ENUM(name, key, ...) name,
+#define K_DATA(name, key, ...) const uint16_t PROGMEM cmb_##name[] = {__VA_ARGS__, COMBO_END};
+#define K_COMB(name, key, ...) [name] = COMBO(cmb_##name, key),
+
+#define A_ENUM(name, string, ...) name,
+#define A_DATA(name, string, ...) const uint16_t PROGMEM cmb_##name[] = {__VA_ARGS__, COMBO_END};
+#define A_COMB(name, string, ...) [name] = COMBO_ACTION(cmb_##name),
+#define A_ACTI(name, string, ...)         \
+    case name:                            \
+        if (pressed) SEND_STRING(string); \
+        break;
+
+#define A_TOGG(name, layer, ...)          \
+    case name:                            \
+        if (pressed) layer_invert(layer); \
+        break;
+
+#define BLANK(...)
+// Generate data needed for combos/actions
+// Create Enum
+#undef COMB
+#undef SUBS
+#undef TOGG
+#define COMB K_ENUM
+#define SUBS A_ENUM
+#define TOGG A_ENUM
+enum combos {
+#include "combos.def"
+    COMBO_LENGTH
+};
+// Export length to combo module
+uint16_t COMBO_LEN = COMBO_LENGTH;
+
+// Bake combos into mem
+#undef COMB
+#undef SUBS
+#undef TOGG
+#define COMB K_DATA
+#define SUBS A_DATA
+#define TOGG A_DATA
+#include "combos.def"
+#undef COMB
+#undef SUBS
+#undef TOGG
+
+// Fill combo array
+#define COMB K_COMB
+#define SUBS A_COMB
+#define TOGG A_COMB
+combo_t key_combos[] = {
+#include "combos.def"
+};
+#undef COMB
+#undef SUBS
+#undef TOGG
+
+// Fill QMK hook
+#define COMB BLANK
+#define SUBS A_ACTI
+#define TOGG A_TOGG
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    switch (combo_index) {
+#include "combos.def"
+    }
+
+    // Allow user overrides per keymap
+#if __has_include("inject.h")
+# include "inject.h"
+#endif
+}
+#undef COMB
+#undef SUBS
+#undef TOGG

--- a/keyboards/crkbd/keymaps/mockingb1rdblue/qmkSplitMake.md
+++ b/keyboards/crkbd/keymaps/mockingb1rdblue/qmkSplitMake.md
@@ -1,0 +1,5 @@
+make crkbd/rev1/legacy:mocking:dfu-split-right
+:avrdude-split-left
+
+qmk flash -kb crkbd/rev1/legacy -km mocking -bl dfu-split-right
+qmk flash -kb crkbd/rev1/legacy -km mocking -bl avrdude-split-left

--- a/keyboards/crkbd/keymaps/mockingb1rdblue/rules.mk
+++ b/keyboards/crkbd/keymaps/mockingb1rdblue/rules.mk
@@ -1,0 +1,16 @@
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = yes           # Enable N-Key Rollover
+MOUSEKEY_ENABLE = no
+EXTRAKEY_ENABLE = no
+VIA_ENABLE = yes
+
+# http://combos.gboards.ca/docs/install/
+COMBO_ENABLE = yes
+LTO_ENABLE = yes # Enables Link Time Optimization (LTO) when compiling the keyboard. This makes the process take longer, but it can significantly reduce the compiled size (and since the firmware is small, the added time is not noticeable
+
+# CRKBD Specific
+RGBLIGHT_ENABLE = no
+RGB_MATRIX_ENABLE = no     # This one if there's LEDs. Enable WS2812 RGB underlight.
+OLED_ENABLE     = no
+# OLED_DRIVER_ENABLE = no  # OLD METHOD?

--- a/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/combos.def
+++ b/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/combos.def
@@ -1,0 +1,25 @@
+// mockingStandard
+COMB(dfBspc,    KC_BSPC,    KC_D, KC_F)
+COMB(fgDel,     KC_DEL,     KC_F, KC_G)
+COMB(jkEnt,     KC_ENT,     KC_J, KC_K)
+COMB(cvAppMenu, KC_APP,     KC_C,KC_V)
+
+// 5x3 BASE layer
+COMB(qwTab,     KC_TAB,     KC_Q, KC_W)
+COMB(qeEsc,     KC_ESC,     KC_Q, KC_E)
+COMB(ApostpSemiCol,     KC_SCLN,     KC_QUOT, KC_P)
+COMB(slashQuotBslash,     KC_BSLS,     KC_SLSH, KC_QUOT)
+
+// 5x3 LOWER layer
+COMB(oneTwoTilde,     KC_TILDE,     KC_1, KC_2)
+COMB(minusPlusPipe,     KC_PIPE,     KC_PMNS, KC_PPLS)
+
+// 5x3 RAISE layer
+COMB(exclamAtGrave,     KC_GRV,     KC_EXLM, KC_AT)
+
+SUBS(yiPhraseA,   "hENFiVVL4mFE",  KC_Y,KC_I)
+SUBS(yiPhraseB,   "MxgdelLetHEJ",  KC_H,KC_K)
+SUBS(yiPhraseC,   "Y5PvDZ9Bflt1G",  KC_Y,KC_N)
+
+// Template
+// COMB(12Name,     KC_DO,     KC_1, KC_2)

--- a/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/config.h
+++ b/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/config.h
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 gtips
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// http://combos.gboards.ca/docs/install/
+#define COMBO_VARIABLE_LEN
+#define COMBO_TERM 40
+#define TAPPING_TERM 150
+// #define PERMISSIVE_HOLD
+
+#undef LOCKING_SUPPORT_ENABLE
+#undef LOCKING_RESYNC_ENABLE

--- a/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/keymap.c
+++ b/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/keymap.c
@@ -1,18 +1,22 @@
-/*
-Copyright 2020 Danny Nguyen <danny@keeb.io>
+/* Copyright 2020 Danny Nguyen <danny@keeb.io>
+
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include QMK_KEYBOARD_H
+#include "keymap_combo.h" // following http://combos.gboards.ca/docs/install/ for combos
+// !remind me to buy gergo a beer
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_ortho_5x12(

--- a/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/keymap.c
+++ b/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/keymap.c
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 Danny Nguyen <danny@keeb.io>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT_ortho_5x12(
+        KC_GRV,  KC_1,          KC_2,   KC_3,   KC_4,   KC_5,               KC_6,           KC_7,       KC_8,   KC_9,           KC_0,       KC_NO,
+        KC_TAB,  KC_Q,          KC_W,   KC_E,   KC_R,   KC_T,               KC_Y,           KC_U,       KC_I,   KC_O,           KC_P,       KC_NO,
+        KC_ESC,  KC_A,          KC_S,   KC_D,   KC_F,   KC_G,               KC_H,           KC_J,       KC_K,   KC_L,           KC_QUOT,    KC_NO,
+        KC_LSFT, LSFT_T(KC_Z),  KC_X,   KC_C,   KC_V,   LT(1,KC_B),         KC_N,           KC_M,       KC_COMM,RALT_T(KC_DOT), KC_SLSH,    KC_NO,
+        KC_LALT, MO(3),         KC_LALT,MO(1),  KC_LCTL,KC_SPC,             LT(2,KC_HOME),  KC_LGUI,    KC_UP,  KC_LEFT,        KC_DOWN,    KC_RGHT
+    ),
+    [1] = LAYOUT_ortho_5x12(
+        KC_TILD, KC_EXLM,       KC_AT,  KC_HASH,KC_DLR,KC_PERC,             KC_CIRC,        KC_AMPR,    KC_ASTR,KC_LPRN,        KC_RPRN,    KC_NO,
+        KC_TILD, KC_1,          KC_2,   KC_3,   KC_4,   KC_5,               KC_6,           KC_7,       KC_8,   KC_9,           KC_0,       KC_NO,
+        KC_DEL,  KC_UP,         KC_LEFT,KC_DOWN,KC_RGHT,LCTL(KC_Y),         KC_EQL,         KC_4,       KC_5,   KC_6,           KC_PPLS,    KC_NO,
+        BL_STEP, LSFT(KC_Z),    KC_NO,  KC_NO,  KC_NO,  KC_TRNS,            KC_UNDS,        KC_1,       KC_2,   KC_3,           KC_PMNS,    KC_NO,
+        KC_TRNS, KC_TRNS,       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,            KC_END,         KC_0,       KC_MNXT,KC_VOLD,        KC_VOLU,    KC_MPLY
+    ),
+    [2] = LAYOUT_ortho_5x12(
+        KC_GRV,  KC_1,          KC_2,   KC_3,   KC_4,   KC_5,               KC_6,           KC_7,       KC_8,   KC_9,           KC_0,       KC_NO,
+        KC_GRV,  KC_EXLM,       KC_AT,  KC_HASH,KC_DLR, KC_PERC,            KC_CIRC,        KC_AMPR,    KC_ASTR,KC_LPRN,        KC_RPRN,    KC_NO,
+        KC_DEL,  KC_PGUP,       KC_NO,  KC_PGDN,KC_NO,  KC_NO,              KC_EQL,         KC_MINS,    KC_NO,  KC_LBRC,        KC_RBRC,    KC_NO,
+        KC_TRNS, KC_LSFT,       KC_NO,  KC_NO,  KC_NO,  KC_TRNS,            KC_UNDS,        KC_PLUS,    KC_NO,  KC_LCBR,        KC_RCBR,    KC_NO,
+        KC_TRNS, KC_TRNS,       KC_TRNS,KC_TRNS,KC_TRNS,MO(3),              KC_TRNS,        KC_TRNS,    KC_MNXT,KC_VOLD,        KC_VOLU,    KC_MPLY
+    ),
+    [3] = LAYOUT_ortho_5x12(
+        KC_TRNS, QK_BOOT,       DB_TOGG,RGB_TOG,RGB_MOD,RGB_HUI,            RGB_HUD,        RGB_SAI,    RGB_SAD,RGB_VAI,        RGB_VAD,    KC_TRNS,
+        KC_F12,  KC_F1,         KC_F2,  KC_F3,  KC_F4,  KC_F5,              KC_F6,          KC_F7,      KC_F8,  KC_F9,          KC_F10      KC_F11,
+        KC_TRNS, KC_TRNS,       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,            KC_TRNS,        KC_TRNS,    KC_TRNS,KC_TRNS,        KC_NUM,     KC_TRNS,
+        KC_TRNS, KC_TRNS,       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,            KC_TRNS,        KC_TRNS,    KC_TRNS,KC_TRNS,        KC_CAPS,    KC_TRNS,
+        KC_TRNS, KC_TRNS,       KC_TRNS,KC_TRNS,KC_TRNS,KC_TRNS,            KC_TRNS,        KC_TRNS,    KC_TRNS,KC_TRNS,        KC_TRNS,    KC_TRNS
+    )
+};

--- a/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/keymap_combo.h
+++ b/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/keymap_combo.h
@@ -1,0 +1,75 @@
+// Keymap helpers
+
+#define K_ENUM(name, key, ...) name,
+#define K_DATA(name, key, ...) const uint16_t PROGMEM cmb_##name[] = {__VA_ARGS__, COMBO_END};
+#define K_COMB(name, key, ...) [name] = COMBO(cmb_##name, key),
+
+#define A_ENUM(name, string, ...) name,
+#define A_DATA(name, string, ...) const uint16_t PROGMEM cmb_##name[] = {__VA_ARGS__, COMBO_END};
+#define A_COMB(name, string, ...) [name] = COMBO_ACTION(cmb_##name),
+#define A_ACTI(name, string, ...)         \
+    case name:                            \
+        if (pressed) SEND_STRING(string); \
+        break;
+
+#define A_TOGG(name, layer, ...)          \
+    case name:                            \
+        if (pressed) layer_invert(layer); \
+        break;
+
+#define BLANK(...)
+// Generate data needed for combos/actions
+// Create Enum
+#undef COMB
+#undef SUBS
+#undef TOGG
+#define COMB K_ENUM
+#define SUBS A_ENUM
+#define TOGG A_ENUM
+enum combos {
+#include "combos.def"
+    COMBO_LENGTH
+};
+// Export length to combo module
+uint16_t COMBO_LEN = COMBO_LENGTH;
+
+// Bake combos into mem
+#undef COMB
+#undef SUBS
+#undef TOGG
+#define COMB K_DATA
+#define SUBS A_DATA
+#define TOGG A_DATA
+#include "combos.def"
+#undef COMB
+#undef SUBS
+#undef TOGG
+
+// Fill combo array
+#define COMB K_COMB
+#define SUBS A_COMB
+#define TOGG A_COMB
+combo_t key_combos[] = {
+#include "combos.def"
+};
+#undef COMB
+#undef SUBS
+#undef TOGG
+
+// Fill QMK hook
+#define COMB BLANK
+#define SUBS A_ACTI
+#define TOGG A_TOGG
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    switch (combo_index) {
+#include "combos.def"
+    }
+
+    // Allow user overrides per keymap
+#if __has_include("inject.h") 
+# include "inject.h"
+#endif
+}
+#undef COMB
+#undef SUBS
+#undef TOGG

--- a/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/readme.md
+++ b/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/readme.md
@@ -1,0 +1,7 @@
+make keebio/nyquist/rev3:mockingb1rdblue
+
+# Half is declared in rev3 SPLIT_KEYBOARD pin on MCU
+
+qmk flash -kb keebio/nyquist/rev3 -km mockingb1rdblue -bl dfu
+# OR
+make keebio/nyquist/rev3:default:flash

--- a/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/rules.mk
+++ b/keyboards/keebio/nyquist/keymaps/mockingb1rdblue/rules.mk
@@ -1,0 +1,10 @@
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = yes           # Enable N-Key Rollover
+MOUSEKEY_ENABLE = no
+EXTRAKEY_ENABLE = no
+VIA_ENABLE = yes
+
+# http://combos.gboards.ca/docs/install/
+COMBO_ENABLE=yes
+LTO_ENABLE = yes # Enables Link Time Optimization (LTO) when compiling the keyboard. This makes the process take longer, but it can significantly reduce the compiled size (and since the firmware is small, the added time is not noticeable

--- a/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/combos.def
+++ b/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/combos.def
@@ -1,0 +1,25 @@
+// mockingStandard
+COMB(dfBspc,    KC_BSPC,    KC_D, KC_F)
+COMB(fgDel,     KC_DEL,     KC_F, KC_G)
+COMB(jkEnt,     KC_ENT,     KC_J, KC_K)
+COMB(cvAppMenu, KC_APP,     KC_C,KC_V)
+
+// 5x3 BASE layer
+COMB(qwTab,     KC_TAB,     KC_Q, KC_W)
+COMB(qeEsc,     KC_ESC,     KC_Q, KC_E)
+COMB(ApostpSemiCol,     KC_SCLN,     KC_QUOT, KC_P)
+COMB(slashQuotBslash,     KC_BSLS,     KC_SLSH, KC_QUOT)
+
+// 5x3 LOWER layer
+COMB(oneTwoTilde,     KC_TILDE,     KC_1, KC_2)
+COMB(minusPlusPipe,     KC_PIPE,     KC_PMNS, KC_PPLS)
+
+// 5x3 RAISE layer
+COMB(exclamAtGrave,     KC_GRV,     KC_EXLM, KC_AT)
+
+SUBS(yiPhraseA,   "hENFiVVL4mFE",  KC_Y,KC_I)
+SUBS(yiPhraseB,   "MxgdelLetHEJ",  KC_H,KC_K)
+SUBS(yiPhraseC,   "Y5PvDZ9Bflt1G",  KC_Y,KC_N)
+
+// Template
+// COMB(12Name,     KC_DO,     KC_1, KC_2)

--- a/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/config.h
+++ b/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/config.h
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 gtips
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+//supposedly already defined in .build/obj_reviung_reviung34/src/info_config.h
+// #define VENDOR_ID 0xD9F6
+// #define PRODUCT_ID 0x0707
+
+// #define MANUFACTURER    mocking
+// #define PRODUCT         reviung34
+// #define DESCRIPTION     reviung34
+
+// http://combos.gboards.ca/docs/install/
+#define COMBO_VARIABLE_LEN
+#define COMBO_TERM 40
+#define TAPPING_TERM 150
+// #define PERMISSIVE_HOLD
+
+#undef LOCKING_SUPPORT_ENABLE
+#undef LOCKING_RESYNC_ENABLE

--- a/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/keymap.c
+++ b/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/keymap.c
@@ -1,0 +1,60 @@
+/* Copyright 2019 gtips
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "keymap_combo.h" // following http://combos.gboards.ca/docs/install/ for combos
+// !remind me to buy gergo a beer
+
+enum layer_names {
+  _BASE,
+  _LOWER,
+  _RAISE,
+  _ADJUST
+};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  [_BASE] = LAYOUT_reviung34(
+    KC_Q,        KC_W,KC_E,    KC_R,    KC_T,                     KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+    KC_A,        KC_S,KC_D,    KC_F,    KC_G,                     KC_H,    KC_J,    KC_K,    KC_L,    KC_QUOT,
+    LSFT_T(KC_Z),KC_X,KC_C,    KC_V,    LT(_LOWER,KC_B),          KC_N,    KC_M,    KC_COMM, RALT_T(KC_DOT), KC_SLSH,
+                               KC_LCTL, KC_SPC,                   LT(_RAISE,KC_HOME), KC_LGUI
+  ),
+
+  [_LOWER] = LAYOUT_reviung34(
+    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,                     KC_6,    KC_7,    KC_8,    KC_9,    KC_0,
+    KC_UP,   KC_LEFT, KC_DOWN, KC_RGHT, LCTL(KC_Y),               KC_EQL,  KC_4,    KC_5,    KC_6,    KC_PPLS,
+    LSFT(KC_Z),KC_NO, KC_NO,   KC_NO,   KC_TRNS,                  KC_UNDS, KC_1,    KC_2,    KC_3,    KC_PMNS,
+                               KC_TRNS, KC_TRNS,                  KC_END,  KC_0
+  ),
+
+  [_RAISE] = LAYOUT_reviung34(
+    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,                  KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN,
+    KC_PGUP, KC_NO,   KC_PGDN, KC_NO,   KC_NO,                    KC_EQL,  KC_MINS, KC_NO,   KC_LBRC, KC_RBRC,
+    KC_LSFT, KC_NO,   KC_NO,   KC_NO,   KC_TRNS,                  KC_UNDS, KC_PLUS, KC_NO,   KC_LCBR, KC_RCBR,
+                               KC_TRNS, MO(_ADJUST),              KC_TRNS, KC_TRNS
+  ),
+
+  [_ADJUST] = LAYOUT_reviung34(
+    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                    KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,
+    KC_NO,   KC_NO,   KC_NO,   KC_F9,   KC_F10,                   KC_F11,  KC_F12,  KC_NO,   KC_NO,   KC_NUM,
+    KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_TRNS,                  KC_NO,   KC_NO,   KC_NO,   KC_TRNS, KC_CAPS,
+                               KC_TRNS, KC_TRNS,                  KC_TRNS, KC_TRNS
+  ),
+};
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+}

--- a/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/keymap.c
+++ b/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/keymap.c
@@ -18,43 +18,51 @@
 #include "keymap_combo.h" // following http://combos.gboards.ca/docs/install/ for combos
 // !remind me to buy gergo a beer
 
-enum layer_names {
-  _BASE,
-  _LOWER,
-  _RAISE,
-  _ADJUST
-};
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [_BASE] = LAYOUT_reviung34(
+  [0] = LAYOUT_reviung34(
     KC_Q,        KC_W,KC_E,    KC_R,    KC_T,                     KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
     KC_A,        KC_S,KC_D,    KC_F,    KC_G,                     KC_H,    KC_J,    KC_K,    KC_L,    KC_QUOT,
-    LSFT_T(KC_Z),KC_X,KC_C,    KC_V,    LT(_LOWER,KC_B),          KC_N,    KC_M,    KC_COMM, RALT_T(KC_DOT), KC_SLSH,
-                               KC_LCTL, KC_SPC,                   LT(_RAISE,KC_HOME), KC_LGUI
+    LSFT_T(KC_Z),KC_X,KC_C,    KC_V,    LT(1,KC_B),          KC_N,    KC_M,    KC_COMM, RALT_T(KC_DOT), KC_SLSH,
+                               KC_LCTL, KC_SPC,                   LT(2,KC_HOME), KC_LGUI
   ),
-
-  [_LOWER] = LAYOUT_reviung34(
+// MY GAMING or COLEMAK_DHm LAYER COULD GO HERE
+// Get here with TG(1)
+// Increment OTHER Layers
+/*[1] = LAYOUT_reviung34(
+    KC_Q,        KC_W,KC_E,    KC_R,    KC_T,                     KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+    KC_A,        KC_S,KC_D,    KC_F,    KC_G,                     KC_H,    KC_J,    KC_K,    KC_L,    KC_QUOT,
+    LSFT_T(KC_Z),KC_X,KC_C,    KC_V,    LT(1,KC_B),          KC_N,    KC_M,    KC_COMM, RALT_T(KC_DOT), KC_SLSH,
+                               KC_LCTL, KC_SPC,                   LT(2,KC_HOME), KC_LGUI
+*/
+  [1] = LAYOUT_reviung34(
     KC_1,    KC_2,    KC_3,    KC_4,    KC_5,                     KC_6,    KC_7,    KC_8,    KC_9,    KC_0,
     KC_UP,   KC_LEFT, KC_DOWN, KC_RGHT, LCTL(KC_Y),               KC_EQL,  KC_4,    KC_5,    KC_6,    KC_PPLS,
-    LSFT(KC_Z),KC_NO, KC_NO,   KC_NO,   KC_TRNS,                  KC_UNDS, KC_1,    KC_2,    KC_3,    KC_PMNS,
+    LSFT(KC_Z),KC_NO, KC_NO,   MO(3),   KC_TRNS,                  KC_UNDS, KC_1,    KC_2,    KC_3,    KC_PMNS,
                                KC_TRNS, KC_TRNS,                  KC_END,  KC_0
   ),
 
-  [_RAISE] = LAYOUT_reviung34(
+  [2] = LAYOUT_reviung34(
     KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC,                  KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN,
     KC_PGUP, KC_NO,   KC_PGDN, KC_NO,   KC_NO,                    KC_EQL,  KC_MINS, KC_NO,   KC_LBRC, KC_RBRC,
-    KC_LSFT, KC_NO,   KC_NO,   KC_NO,   KC_TRNS,                  KC_UNDS, KC_PLUS, KC_NO,   KC_LCBR, KC_RCBR,
-                               KC_TRNS, MO(_ADJUST),              KC_TRNS, KC_TRNS
+    KC_LSFT, KC_NO,   KC_NO,   TG(4),   KC_TRNS,                  KC_UNDS, KC_PLUS, KC_NO,   KC_LCBR, KC_RCBR,
+                               KC_TRNS, MO(3),              KC_TRNS, KC_TRNS
   ),
 
-  [_ADJUST] = LAYOUT_reviung34(
+  [3] = LAYOUT_reviung34(
     KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,                    KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,
     KC_NO,   KC_NO,   KC_NO,   KC_F9,   KC_F10,                   KC_F11,  KC_F12,  KC_NO,   KC_NO,   KC_NUM,
     KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_TRNS,                  KC_NO,   KC_NO,   KC_NO,   KC_TRNS, KC_CAPS,
                                KC_TRNS, KC_TRNS,                  KC_TRNS, KC_TRNS
   ),
+// MY GAMING LAYER COULD GO HERE
+// Get here with TG(4)
+/*[4] = LAYOUT_reviung34(
+    KC_Q,        KC_W,KC_E,    KC_R,    KC_T,                     KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
+    KC_A,        KC_S,KC_D,    KC_F,    KC_G,                     KC_H,    KC_J,    KC_K,    KC_L,    KC_QUOT,
+    LSFT_T(KC_Z),KC_X,KC_C,    KC_V,    LT(1,KC_B),          KC_N,    KC_M,    KC_COMM, RALT_T(KC_DOT), KC_SLSH,
+                               KC_LCTL, KC_SPC,                   LT(2,KC_HOME), KC_LGUI
+  ),
+// WITH OTHER LAYERS HERE
+// TO(1)
+*/
 };
-
-layer_state_t layer_state_set_user(layer_state_t state) {
-  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
-}

--- a/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/keymap_combo.h
+++ b/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/keymap_combo.h
@@ -1,0 +1,75 @@
+// Keymap helpers
+
+#define K_ENUM(name, key, ...) name,
+#define K_DATA(name, key, ...) const uint16_t PROGMEM cmb_##name[] = {__VA_ARGS__, COMBO_END};
+#define K_COMB(name, key, ...) [name] = COMBO(cmb_##name, key),
+
+#define A_ENUM(name, string, ...) name,
+#define A_DATA(name, string, ...) const uint16_t PROGMEM cmb_##name[] = {__VA_ARGS__, COMBO_END};
+#define A_COMB(name, string, ...) [name] = COMBO_ACTION(cmb_##name),
+#define A_ACTI(name, string, ...)         \
+    case name:                            \
+        if (pressed) SEND_STRING(string); \
+        break;
+
+#define A_TOGG(name, layer, ...)          \
+    case name:                            \
+        if (pressed) layer_invert(layer); \
+        break;
+
+#define BLANK(...)
+// Generate data needed for combos/actions
+// Create Enum
+#undef COMB
+#undef SUBS
+#undef TOGG
+#define COMB K_ENUM
+#define SUBS A_ENUM
+#define TOGG A_ENUM
+enum combos {
+#include "combos.def"
+    COMBO_LENGTH
+};
+// Export length to combo module
+uint16_t COMBO_LEN = COMBO_LENGTH;
+
+// Bake combos into mem
+#undef COMB
+#undef SUBS
+#undef TOGG
+#define COMB K_DATA
+#define SUBS A_DATA
+#define TOGG A_DATA
+#include "combos.def"
+#undef COMB
+#undef SUBS
+#undef TOGG
+
+// Fill combo array
+#define COMB K_COMB
+#define SUBS A_COMB
+#define TOGG A_COMB
+combo_t key_combos[] = {
+#include "combos.def"
+};
+#undef COMB
+#undef SUBS
+#undef TOGG
+
+// Fill QMK hook
+#define COMB BLANK
+#define SUBS A_ACTI
+#define TOGG A_TOGG
+void process_combo_event(uint16_t combo_index, bool pressed) {
+    switch (combo_index) {
+#include "combos.def"
+    }
+
+    // Allow user overrides per keymap
+#if __has_include("inject.h") 
+# include "inject.h"
+#endif
+}
+#undef COMB
+#undef SUBS
+#undef TOGG

--- a/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/rules.mk
+++ b/keyboards/reviung/reviung34/keymaps/mockingb1rdblue/rules.mk
@@ -1,0 +1,10 @@
+CONSOLE_ENABLE = no         # Console for debug
+COMMAND_ENABLE = no         # Commands for debug and configuration
+NKRO_ENABLE = yes           # Enable N-Key Rollover
+MOUSEKEY_ENABLE = no
+EXTRAKEY_ENABLE = no
+VIA_ENABLE = yes
+
+# http://combos.gboards.ca/docs/install/
+COMBO_ENABLE=yes
+LTO_ENABLE = yes # Enables Link Time Optimization (LTO) when compiling the keyboard. This makes the process take longer, but it can significantly reduce the compiled size (and since the firmware is small, the added time is not noticeable

--- a/lessons/decks/marp-reveal-ios-mermaid/index.md
+++ b/lessons/decks/marp-reveal-ios-mermaid/index.md
@@ -1,0 +1,139 @@
+---
+id: lessons/decks/marp-reveal-ios-mermaid
+title: Marp / Reveal / iOS-mobile / Mermaid PDF deck guidelines
+tags: [marp, revealjs, ios, pdf, mermaid, decks, slides, mobile, cloudflare-workers]
+last_reviewed: 2026-05-22
+maturity: stable
+audience: solo-engineer
+---
+
+# Marp / Reveal / iOS-mobile / Mermaid PDF deck guidelines
+
+## Summary
+
+Hard-won rules for building presentation decks that ship as **(a)** a Reveal.js web deck on Cloudflare Workers and **(b)** a Marp-built PDF with the same content, with Mermaid diagrams in both, and proper portrait-phone UX. Originated in the Erebus deck (`~/AntiGH/rift-root/decks/erebus`, `https://deck.mock1ngbb.com/erebus`) — see the Change log for incident links.
+
+## Key rules
+
+### Reveal portrait sizing — orientation-aware + reflow CSS
+
+- `revealDims()` MUST branch on orientation. Landscape returns fixed `{width:1280, height:720}`; portrait returns viewport-native `{width: innerWidth, height: innerHeight}`. Reconfigure on `orientationchange` with `Reveal.configure(revealDims())` — no page reload.
+- Pass `scrollActivationWidth: 0` to `Reveal.initialize()` to suppress Reveal 5.x mobile scroll-view.
+- Force sections to fill the canvas in portrait: `.is-portrait .reveal .slides section { height: 100%; min-height: 100%; display: flex; flex-direction: column; justify-content: space-between; }`.
+- Reflow content under `.is-portrait`: multi-column → single column, `kpi-grid` → 2 cols, smaller `font-size`, tighter padding, tables to `font-size: 0.55em`. Target: ≥80% viewport fill (slide bbox / viewport height).
+- The `.is-portrait` class is toggled on `<html>` by the same handler that reconfigures Reveal.
+
+### iOS Safari dark chrome — all four required
+
+- `<meta name="theme-color" content="#0a0a0a">` — tints Safari's address bar.
+- `<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">` + `apple-mobile-web-app-capable` — covers the home-screen install case.
+- `html, body { overscroll-behavior: none; background: #0a0a0a; }` — suppresses the white rubber-band overscroll area.
+- `.reveal-viewport, .reveal-viewport .slides { background: #0a0a0a; }` — belt-and-suspenders on Reveal's wrapper element.
+- iOS aggressively caches `theme-color`. Force-refresh to verify.
+
+### Mermaid in Reveal — render BEFORE init
+
+- Reveal sets `display: none` on non-active sections. Mermaid's `getBBox()` returns `{NaN, NaN}` for `display:none` nodes → "Syntax error in text" red box.
+- Fix: walk all `.mermaid` blocks, promote each to `display: block; visibility: hidden; position: absolute` off-screen, `await mermaid.run({ nodes })`, then restore. Run **before** `Reveal.initialize()`.
+- Verify: `document.querySelectorAll('.mermaid svg').length === <expected>` and no "Syntax error" text in any SVG.
+
+### Mermaid double-box inset fix
+
+- Cause: `.mermaid-box` wrapper with `padding: 18px 22px` + `min-height: 340px` + `align-items: center` creates equal empty strips (~37px) top and bottom that read as a second rectangle.
+- Fix: `padding: 0` on `.mermaid-box`, remove `min-height`, child `.mermaid` gets `flex: 1 1 auto`, parent `align-items: stretch`. Drop Mermaid `flowchart.padding` from 16 → 8.
+
+### Marp + Mermaid PDF pipeline
+
+- Marp's PDF pipeline does **not** execute scripts. Inline ` ```mermaid ` blocks render as raw text or ASCII fallback.
+- Pre-render each block with `@mermaid-js/mermaid-cli` (mmdc) to **both** SVG (vector) and PNG (broadest embed support):
+  ```
+  npx -y -p @mermaid-js/mermaid-cli mmdc -i /tmp/x.mmd -o assets/mermaid-N.svg -t dark -b transparent
+  npx -y -p @mermaid-js/mermaid-cli mmdc -i /tmp/x.mmd -o assets/mermaid-N.png -t dark -b transparent
+  ```
+- Replace the code blocks with `<img src="assets/mermaid-N.png">` in the Markdown.
+- Build with `npx -y @marp-team/marp-cli@latest --pdf --allow-local-files --html erebus.md -o erebus.pdf`.
+- Frontmatter MUST include `html: true` (or pass `--html`). Without it, Marp ignores inline `<div>` flex containers — children stack vertically and overflow the 720px slide.
+- Verify ASCII art was removed: `pdftotext erebus.pdf - | grep '┌\|└\|│'` must return 0 matches.
+
+### Cloudflare Worker deploys are global
+
+- `wrangler deploy` overwrites the live worker atomically. Multiple parallel worktree agents deploying to the same worker → last deploy wins, intermediate writes lost.
+- Coordinate by: (a) keep each agent's edits to non-overlapping CSS/JS regions, (b) plan an explicit merge step on `main` AFTER all agents return, (c) refresh data + rebuild + deploy ONCE from clean main.
+
+### Worktrees lack gitignored data files
+
+- Worktree agents branch from HEAD with a fresh checkout — they do **not** inherit gitignored files like `surface.json`.
+- If they run `node build.mjs` without first running `scrape.mjs`, the build inlines `?` / `"never"` placeholders into the worker bundle. Their preflight still passes (must-contain strings match) but live KPI cards read `?`.
+- **Always** re-run `scrape.mjs` on the merged main branch (with the real API key) before the final deploy.
+
+### "Shipped" definition
+
+- Shipped = `preflight-ship.sh <target>` exits 0 against the live URL.
+- `git push` alone is **not** shipping.
+- Hash check is permanently `[WARN]` for data-baked decks because timestamps and counters change every rebuild. `must_contain` / `must_not_contain` strings are the real shipping gate — encode a recent-change string after every deploy.
+
+### Live proof rule (cross-domain)
+
+- Never trust a `200 OK` from a mutation. After any deploy: `curl` the live URL with cache-bust, grep for a string that only exists in the new version. For "remove X", grep the live payload — X must not appear anywhere.
+- See also: [process/live-proof](../../process/live-proof.md).
+
+## Patterns and examples
+
+### Pattern: canonical iterate/deploy chain
+
+```bash
+cd decks/<deck>
+PROXY_API_KEY=$(bf PROXY_API_KEY) node scrape.mjs    # refresh data
+$EDITOR worker/index.html
+cd worker && node build.mjs                          # inline data into worker bundle
+CLOUDFLARE_API_TOKEN=$(bf CF_WORKERS_TOKEN) \
+  CLOUDFLARE_ACCOUNT_ID=a62c1c7880b50ac345fc7c2135f6ae84 \
+  npx -y wrangler@latest deploy
+bash ../scripts/preflight-ship.sh <deck-name>        # MUST exit 0
+```
+
+### Pattern: reusable deck file layout
+
+```
+decks/<name>/
+├── scrape.mjs        # hits data source, writes surface.json (gitignored)
+├── surface.json      # gitignored, baked at build time
+├── worker/
+│   ├── index.html    # template with {{path}} and {{block:name}} placeholders
+│   ├── build.mjs     # surface.json + index.html → worker.js
+│   └── wrangler.toml
+└── marp/
+    ├── deck.md       # html: true frontmatter
+    ├── deck.css
+    ├── assets/       # pre-rendered mermaid-N.{svg,png}
+    └── deck.pdf
+```
+
+### Pattern: CSP for Cloudflare Insights beacon
+
+If the zone injects `static.cloudflareinsights.com/beacon.min.js` at the edge, the worker's CSP needs to permit it or the script is blocked in every browser (CF Analytics collects no data):
+
+- Add `https://static.cloudflareinsights.com` to `script-src`.
+- Add `https://cloudflareinsights.com` to `connect-src`.
+
+### Anti-pattern: pure viewport-native Reveal dims without reflow CSS
+
+Setting `width: innerWidth, height: innerHeight` on portrait WITHOUT `.is-portrait` reflow rules. Slide content authored for 1280px overflows; top and bottom get cut off. Symptom users report: "isn't framing to viewport, a lot is cut off top and bottom."
+
+### Anti-pattern: fixed 1280x720 + auto-scale on portrait
+
+Reveal scales to ~0.30 on a 390x844 viewport → slide rendered at ~382x216px. Content visible but tiny letterbox (~20% viewport fill). Symptom: "letterbox area looks wrong" or "content too small to read on phone."
+
+### Anti-pattern: claiming "shipped" on git push
+
+`git push` does not redeploy a Cloudflare Worker. Always finish with `wrangler deploy` + preflight + grep live bundle for a string that proves the new version is serving.
+
+## Tool-specific notes
+
+- **Claude Code project memory**: should contain a 1-line pointer to this lesson plus a "Claude-Code-cache" marker. Do not duplicate the body. When this lesson updates upstream, the cache pointer remains valid.
+- **Cursor**: a `.cursorrules` snippet can auto-attach this file when editing `decks/**/*.{html,mjs,md}` — see consumer repos for the exact glob.
+- **Marp + Reveal cohabitation**: keep `worker/index.html` (Reveal) and `marp/deck.md` (Marp) editorially in sync. Mermaid block sources should match between the two — if you edit a diagram, regenerate both the in-browser render and the pre-rendered SVG/PNG.
+
+## Change log
+
+- 2026-05-22 — created; consolidates Erebus deck session lessons (commits `11c3430`, `02c08e6`, `f182793`, `23d7ef6`, `1457d47` in `rift-root`). Covers Mermaid inset, portrait reflow, iOS dark chrome, Marp PDF pipeline, audit follow-ups.

--- a/lessons/process/live-proof.md
+++ b/lessons/process/live-proof.md
@@ -1,0 +1,65 @@
+---
+id: lessons/process/live-proof
+title: Live-proof shipping rule
+tags: [shipping, verification, ci, cloudflare-workers, preflight]
+last_reviewed: 2026-05-22
+maturity: stable
+audience: solo-engineer
+---
+
+# Live-proof shipping rule
+
+## Summary
+
+Nothing is done until proven done on the live system. Build success, push success, and `200 OK` from a mutation API are not evidence of shipping — they are intermediate steps. Every "done" claim must include one line of live proof: a fresh read of the live resource showing the new state.
+
+## Key rules
+
+- **Deploy**: `curl -s <live-url>` and grep for a string that only exists in the new version. If the string is missing, deploy again.
+- **Remove X**: grep the live payload for X. If X appears anywhere, X is not removed.
+- **CF / DNS / WAF change**: re-query the API and show the returned value. Never trust the `200 OK` from a mutation.
+- **File served over HTTP**: `curl` the URL and confirm the content is what was written.
+- **External system change**: query the system after the action and show its current state.
+- **"Shipped" definition**: for Worker/Fly/Vercel projects, shipped = preflight script exits 0 against the live URL. `git push` is necessary but not sufficient.
+- If live proof is impossible for some reason (e.g., destructive op, no observable side-effect), say so **explicitly** instead of waving the claim through.
+
+## Patterns and examples
+
+### Pattern: must_contain + must_not_contain preflight
+
+Encode the rule as automation. The preflight script:
+1. `curl` the live URL with cache-bust.
+2. Assert N `must_contain` strings (recent changes that prove new bundle is serving).
+3. Assert N `must_not_contain` strings (regressed-out content, removed features).
+4. Optional hash check for non-data-baked outputs.
+
+For data-baked outputs (timestamps, counters in the bundle), the hash check is permanently `[WARN]`; must_contain is the real gate.
+
+### Pattern: one-liner live grep after deploy
+
+```bash
+curl -s "https://example.com/page?cb=$(date +%s)" | grep -oE "<unique-new-string>"
+```
+
+If output is empty, the deploy did not propagate — check CDN cache, then redeploy.
+
+### Anti-pattern: claiming done on "push pushed cleanly"
+
+`git push` puts code on the remote. It does not deploy. For Worker/Fly/Vercel, the deploy is a separate step. Pushing without deploying ships nothing.
+
+### Anti-pattern: trusting wrangler/fly/vercel exit code
+
+Deploy CLIs can return 0 while CDN propagation is incomplete or while the deploy uploaded to the wrong target. Always finish with the live grep.
+
+### Anti-pattern: showing the local file instead of the live URL
+
+`cat worker/index.html | grep ...` proves nothing about what is serving. The live URL is the only source of truth.
+
+## Tool-specific notes
+
+- **Claude Code**: a hook in `~/.claude/hooks/` can intercept commit/push and remind about live proof. Hooks are tool-specific; the rule itself is not.
+- **Cron / scheduled deploys**: a scheduled job's success metric must be a follow-up curl, not the deploy CLI exit code.
+
+## Change log
+
+- 2026-05-22 — created; long-standing global rule, codified after Erebus deck deploy/regression incident where a worker shipped with `?` placeholders despite `wrangler deploy` returning 0 and preflight passing locally.

--- a/lessons/process/parallel-agents.md
+++ b/lessons/process/parallel-agents.md
@@ -1,0 +1,64 @@
+---
+id: lessons/process/parallel-agents
+title: Parallel agent execution
+tags: [agents, parallelism, worktrees, merging, claude-code]
+last_reviewed: 2026-05-22
+maturity: stable
+audience: solo-engineer
+---
+
+# Parallel agent execution
+
+## Summary
+
+When 2+ independent work items exist, fan out parallel agents instead of doing them serially or deferring. This applies to coding tasks, audits, screenshots, and any work the harness can supervise in the background. The mistakes that turn parallel into chaos are all merge-time and data-freshness issues — manage those explicitly.
+
+## Key rules
+
+- 2+ independent items → spawn agents in parallel in a single message. Mix model tiers: Sonnet for write paths, Haiku for read-only audits/screenshots.
+- Write-path agents go in **isolated worktrees**. Read-only agents do not need worktrees.
+- Treat worktrees as ephemeral: they branch from HEAD with a fresh checkout. **They do not inherit gitignored files** (data caches, secrets files, build outputs). If the work depends on such a file, refresh it on the merged branch BEFORE the final build/deploy.
+- For deploys: the deploy target is **global** (Cloudflare Worker, Fly app, Vercel project, npm package). Multiple agents deploying to the same target race; last write wins. Defer all deploys to the merge step OR confine each agent's deploy window tightly.
+- Plan an explicit merge step on the integrating branch (usually `main`) AFTER all agents return. Re-run live verification AFTER the merge — agent-local preflights are not enough.
+- Agent claims are not evidence. Verify their findings against live state before logging follow-ups or shipping.
+- Audit findings are **time-stamped against the live state at audit start**. If subsequent fixes ship during the audit, re-verify each P0/P1 finding against current live before acting.
+
+## Patterns and examples
+
+### Pattern: 4-agent deck iteration
+
+For a single deck improvement cycle:
+- Sonnet A — fix bug class X (worktree, write path)
+- Sonnet B — fix bug class Y (worktree, write path, independent files)
+- Haiku C — cross-engine parity screenshots (read-only)
+- Haiku D — data freshness audit against live API (read-only)
+
+Spawn all four in one tool-call. When they return, merge worktrees sequentially with conflict resolution, re-run data refresh, rebuild, deploy, preflight.
+
+### Pattern: merge protocol after parallel agents
+
+1. Detect which worktrees have changes vs main (`git log main..worktree-branch`).
+2. Merge with `--no-ff` so the merge commit captures the agent attribution.
+3. Re-run any data-generation step (e.g. `scrape.mjs`) on the merged main — agents' worktrees lacked the gitignored data file.
+4. Rebuild from main.
+5. Deploy once.
+6. Preflight against live.
+7. Push.
+8. Prune worktree dirs and branches.
+
+### Anti-pattern: trusting agent self-reported preflight
+
+An agent reports `preflight PASS` in its worktree. Its preflight may have run against a worker bundle built **without** the gitignored data file → KPI cards inlined as `?`. Always re-run preflight from main after the final merge+deploy.
+
+### Anti-pattern: serial when parallel works
+
+Doing items one-at-a-time "to keep things simple" wastes wall-clock time and loses the velocity that makes solo engineering competitive. If items are independent, parallelize. The merge complexity is fixed cost per cycle.
+
+## Tool-specific notes
+
+- **Claude Code**: use `Agent` with `isolation: "worktree"` for write paths. Background them with `run_in_background: true` so you get completion notifications. The harness tracks them and re-invokes you on completion — do **not** poll.
+- Worktree dirs land under `.claude/worktrees/agent-<id>/` and may need `--force --force` to remove if still locked.
+
+## Change log
+
+- 2026-05-22 — created; consolidates Erebus deck session experience with parallel Sonnet/Haiku agents.

--- a/meta/lesson-template.md
+++ b/meta/lesson-template.md
@@ -1,0 +1,44 @@
+---
+id: lessons/<domain>/<slug>
+title: <One-line title in sentence case>
+tags: [<short>, <list>, <of>, <tags>]
+last_reviewed: YYYY-MM-DD
+maturity: draft       # draft | stable | deprecated
+audience: solo-engineer
+---
+
+# <Title>
+
+## Summary
+
+One or two paragraphs. What this lesson is, when to use it. Do not put discoveries or session-specific context here — only durable, reusable knowledge.
+
+## Key rules
+
+- Rule 1, terse and binding. Why it matters in one clause.
+- Rule 2.
+- Rule 3.
+
+Use this section sparingly. Each rule should be load-bearing and verifiable.
+
+## Patterns and examples
+
+### Pattern: <name>
+
+Describe the pattern, when it applies, the canonical implementation. Code samples in fenced blocks.
+
+### Anti-pattern: <name>
+
+Describe an approach that LOOKS reasonable but FAILS in practice, with the symptom you'd see. This is often more useful than the pattern.
+
+## Tool-specific notes
+
+Only include this section if there is non-obvious harness-specific behavior. Otherwise omit. Examples of what belongs here:
+
+- "Claude Code's project memory should cache a pointer to this lesson, not a copy."
+- "Cursor's .cursorrules can auto-attach this file when editing <glob>."
+
+## Change log
+
+- YYYY-MM-DD — created.
+- YYYY-MM-DD — added rule about <X>; observed in <project> incident.


### PR DESCRIPTION
## Summary

qmk_firmware is a QMK keyboard firmware fork (C/Python, embedded). No Cloudflare Worker deploy targets.

- .namespace verified: `qmk_firmware`
- GitHub Actions workflows RETAINED: all are QMK upstream firmware CI (not CF deploy)
- KNOWN DEFICIENCY: Formal allow-list file missing; these workflows should be registered once charon-cicada-allow-list.json ships
- KNOWN DEFICIENCY: VaultKeeper POST /v1/repos not yet implemented

## Classification

**No-deploy** — embedded firmware project, no CF Workers, no wrangler.toml.

## Test plan

- Verify .namespace file created
- Confirm all QMK CI workflows remain intact
- No changes to deployed infrastructure