### PR TITLE
Preserve Azoteq mouse buttons

### DIFF
--- a/drivers/sensors/azoteq_iqs5xx.c
+++ b/drivers/sensors/azoteq_iqs5xx.c
@@ -354,7 +354,7 @@ bool azoteq_iqs5xx_init(void) {
 };
 
 report_mouse_t azoteq_iqs5xx_get_report(report_mouse_t mouse_report) {
-    report_mouse_t temp_report = {0};
+    report_mouse_t temp_report = {.buttons = mouse_report.buttons};
 
     azoteq_iqs5xx_base_data_t base_data       = {0};
     i2c_status_t              status          = azoteq_iqs5xx_get_base_data(&base_data);

--- a/tests/pointing/azoteq_iqs5xx/azoteq_iqs5xx_mock.c
+++ b/tests/pointing/azoteq_iqs5xx/azoteq_iqs5xx_mock.c
@@ -1,0 +1,45 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <string.h>
+
+#include "azoteq_iqs5xx.h"
+
+static azoteq_iqs5xx_base_data_t mock_base_data;
+static i2c_status_t              mock_read_status = I2C_STATUS_SUCCESS;
+
+void azoteq_iqs5xx_mock_reset(void) {
+    memset(&mock_base_data, 0, sizeof(mock_base_data));
+    mock_read_status = I2C_STATUS_SUCCESS;
+}
+
+void azoteq_iqs5xx_mock_set_base_data(azoteq_iqs5xx_base_data_t base_data) {
+    mock_base_data   = base_data;
+    mock_read_status = I2C_STATUS_SUCCESS;
+}
+
+void i2c_init(void) {}
+
+i2c_status_t i2c_ping_address(uint8_t address, uint16_t timeout) {
+    return I2C_STATUS_SUCCESS;
+}
+
+i2c_status_t i2c_read_register16(uint8_t devaddr, uint16_t regaddr, uint8_t *data, uint16_t length, uint16_t timeout) {
+    if (mock_read_status == I2C_STATUS_SUCCESS && data != NULL) {
+        memcpy(data, &mock_base_data, MIN(length, sizeof(mock_base_data)));
+    }
+    return mock_read_status;
+}
+
+i2c_status_t i2c_write_register16(uint8_t devaddr, uint16_t regaddr, const uint8_t *data, uint16_t length, uint16_t timeout) {
+    return I2C_STATUS_SUCCESS;
+}
+
+uint8_t pointing_device_handle_buttons(uint8_t buttons, bool pressed, pointing_device_buttons_t button) {
+    if (pressed) {
+        buttons |= 1 << button;
+    } else {
+        buttons &= ~(1 << button);
+    }
+    return buttons;
+}

--- a/tests/pointing/azoteq_iqs5xx/config.h
+++ b/tests/pointing/azoteq_iqs5xx/config.h
@@ -1,0 +1,8 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define AZOTEQ_IQS5XX_TPS43

--- a/tests/pointing/azoteq_iqs5xx/test.mk
+++ b/tests/pointing/azoteq_iqs5xx/test.mk
@@ -1,0 +1,8 @@
+# Copyright 2026 QMK
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+SRC += drivers/sensors/azoteq_iqs5xx.c
+SRC += tests/pointing/azoteq_iqs5xx/azoteq_iqs5xx_mock.c
+
+VPATH += $(QUANTUM_DIR)/pointing_device
+VPATH += drivers/sensors

--- a/tests/pointing/azoteq_iqs5xx/test_azoteq_iqs5xx.cpp
+++ b/tests/pointing/azoteq_iqs5xx/test_azoteq_iqs5xx.cpp
@@ -1,0 +1,54 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "azoteq_iqs5xx.h"
+
+void azoteq_iqs5xx_mock_reset(void);
+void azoteq_iqs5xx_mock_set_base_data(azoteq_iqs5xx_base_data_t base_data);
+}
+
+class AzoteqIqs5xx : public testing::Test {
+   protected:
+    void SetUp() override {
+        azoteq_iqs5xx_mock_reset();
+    }
+};
+
+TEST_F(AzoteqIqs5xx, PreservesIncomingButtonsWhenReportingMovement) {
+    azoteq_iqs5xx_base_data_t base_data = {0};
+    base_data.number_of_fingers         = 1;
+    base_data.x.l                       = 12;
+    base_data.y.l                       = 34;
+    azoteq_iqs5xx_mock_set_base_data(base_data);
+
+    report_mouse_t input_report = {0};
+    input_report.buttons        = (1 << POINTING_DEVICE_BUTTON1) | (1 << POINTING_DEVICE_BUTTON2);
+
+    report_mouse_t report = azoteq_iqs5xx_get_report(input_report);
+
+    EXPECT_EQ(report.x, 12);
+    EXPECT_EQ(report.y, 34);
+    EXPECT_EQ(report.h, 0);
+    EXPECT_EQ(report.v, 0);
+    EXPECT_EQ(report.buttons, input_report.buttons);
+}
+
+TEST_F(AzoteqIqs5xx, CombinesGestureButtonWithIncomingButtons) {
+    azoteq_iqs5xx_base_data_t base_data = {0};
+    base_data.gesture_events_1.two_finger_tap = true;
+    azoteq_iqs5xx_mock_set_base_data(base_data);
+
+    report_mouse_t input_report = {0};
+    input_report.buttons        = 1 << POINTING_DEVICE_BUTTON1;
+
+    report_mouse_t report = azoteq_iqs5xx_get_report(input_report);
+
+    EXPECT_EQ(report.x, 0);
+    EXPECT_EQ(report.y, 0);
+    EXPECT_EQ(report.h, 0);
+    EXPECT_EQ(report.v, 0);
+    EXPECT_EQ(report.buttons, input_report.buttons | (1 << POINTING_DEVICE_BUTTON2));
+}

--- a/tests/pointing/azoteq_iqs5xx/test_azoteq_iqs5xx.cpp
+++ b/tests/pointing/azoteq_iqs5xx/test_azoteq_iqs5xx.cpp
@@ -37,7 +37,7 @@ TEST_F(AzoteqIqs5xx, PreservesIncomingButtonsWhenReportingMovement) {
 }
 
 TEST_F(AzoteqIqs5xx, CombinesGestureButtonWithIncomingButtons) {
-    azoteq_iqs5xx_base_data_t base_data = {0};
+    azoteq_iqs5xx_base_data_t base_data       = {0};
     base_data.gesture_events_1.two_finger_tap = true;
     azoteq_iqs5xx_mock_set_base_data(base_data);
 


### PR DESCRIPTION
## Summary
- preserve incoming mouse button bits when the Azoteq IQS5xx driver builds its report
- add Azoteq pointing tests for movement with existing buttons and gesture buttons combined with existing buttons

Fixes #26168

## Testing
- `PATH=/tmp/qmk-26168-venv/bin:$PATH make test:pointing/azoteq_iqs5xx`
- `PATH=/tmp/qmk-26168-venv/bin:$PATH make test:pointing`
- `git diff --check`