### PR TITLE
Progressive keyboard reports: report mods separately

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -190,6 +190,10 @@ If you define these options you will enable the associated feature, which may in
   * Sets the key repeat interval for [key overrides](features/key_overrides).
 * `#define LEGACY_MAGIC_HANDLING`
   * Enables magic configuration handling for advanced keycodes (such as Mod Tap and Layer Tap)
+* `#define PROGRESSIVE_KEYBOARD_REPORTS`
+  * Splits a single logical report change into ordered sub-reports so that modifier and key ordering is preserved on the host: keys that are no longer held are released first, then the new modifier byte is applied against the surviving keys, then the full report is sent. This guarantees that e.g. `Shift` is registered before the key it modifies (and that keys release before their modifiers), avoiding mis-shifted characters on fast or chorded input. When the define is absent, report emission is unchanged. Has no effect on `PROTOCOL_VUSB` boards, which always send a single report.
+* `#define PROGRESSIVE_REPORT_DELAY 1`
+  * Optional. When `PROGRESSIVE_KEYBOARD_REPORTS` is enabled, sets the delay in milliseconds inserted between each sub-report. If not defined, no delay is added.
 
 
 ## RGB Light Configuration

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -193,7 +193,7 @@ If you define these options you will enable the associated feature, which may in
 * `#define PROGRESSIVE_KEYBOARD_REPORTS`
   * Splits a single logical report change into ordered sub-reports so that modifier and key ordering is preserved on the host: keys that are no longer held are released first, then the new modifier byte is applied against the surviving keys, then the full report is sent. This guarantees that e.g. `Shift` is registered before the key it modifies (and that keys release before their modifiers), avoiding mis-shifted characters on fast or chorded input. When the define is absent, report emission is unchanged. Has no effect on `PROTOCOL_VUSB` boards, which always send a single report.
 * `#define PROGRESSIVE_REPORT_DELAY 1`
-  * Optional. When `PROGRESSIVE_KEYBOARD_REPORTS` is enabled, sets the delay in milliseconds inserted between each sub-report. If not defined, no delay is added.
+  * Optional. When `PROGRESSIVE_KEYBOARD_REPORTS` is enabled, sets the delay in milliseconds inserted between each sub-report. There is no default; if not defined, no delay is added.
 
 
 ## RGB Light Configuration

--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -191,9 +191,10 @@ If you define these options you will enable the associated feature, which may in
 * `#define LEGACY_MAGIC_HANDLING`
   * Enables magic configuration handling for advanced keycodes (such as Mod Tap and Layer Tap)
 * `#define PROGRESSIVE_KEYBOARD_REPORTS`
-  * Splits a single logical report change into ordered sub-reports so that modifier and key ordering is preserved on the host: keys that are no longer held are released first, then the new modifier byte is applied against the surviving keys, then the full report is sent. This guarantees that e.g. `Shift` is registered before the key it modifies (and that keys release before their modifiers), avoiding mis-shifted characters on fast or chorded input. When the define is absent, report emission is unchanged. Has no effect on `PROTOCOL_VUSB` boards, which always send a single report.
+  * Splits a logical report change that alters the modifier byte into ordered sub-reports so that modifier and key ordering is preserved on the host.
+    * Keys that are no longer held are released first, then the new modifier byte is applied against the surviving keys, then the full report is sent. Each of these is only emitted when it differs from the previous report, so a change to the modifier byte alone still goes out as a single report. This guarantees that e.g. `Shift` is registered before the key it modifies (and that keys release before their modifiers), avoiding mis-shifted characters on fast or chorded input. Report changes that leave the modifier byte untouched are sent as a single report, as is everything when the define is absent. Has no effect on `PROTOCOL_VUSB` boards, which always send a single report.
 * `#define PROGRESSIVE_REPORT_DELAY 1`
-  * Optional. When `PROGRESSIVE_KEYBOARD_REPORTS` is enabled, sets the delay in milliseconds inserted between each sub-report. There is no default; if not defined, no delay is added.
+  * When `PROGRESSIVE_KEYBOARD_REPORTS` is enabled, sets the delay in milliseconds inserted between a sub-report and the report that follows it. There is no default; if not defined, no delay is added.
 
 
 ## RGB Light Configuration

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -315,10 +315,12 @@ void send_6kro_report(void) {
     last_report.report_id = keyboard_report->report_id;
 #        endif // KEYBOARD_SHARED_EP
 
-    /* Remove existing keys that aren't in the intended report. */
+    /* Release any keys that are no longer held before applying the new mods. This only splits out
+       key releases (a slot cleared to 0); a slot that changes from one key to another in a single
+       scan is not split, as 6KRO reports keys positionally rather than as a bitmap. */
     if (memcmp(keyboard_report->keys, last_report.keys, sizeof(keyboard_report->keys)) != 0) {
         bool changed = false;
-        for (int i = 0; i < 6; ++i) {
+        for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; ++i) {
             if (keyboard_report->keys[i] == 0) {
                 if (last_report.keys[i] != 0) {
                     last_report.keys[i] = 0;
@@ -334,7 +336,7 @@ void send_6kro_report(void) {
         }
     }
 
-    /* Send the new mods with the intersecting set of keys */
+    /* Send the new mods alongside the keys that are still held. */
     if (keyboard_report->mods != last_report.mods) {
         last_report.mods = keyboard_report->mods;
         host_keyboard_send(&last_report);
@@ -364,7 +366,7 @@ void send_nkro_report(void) {
     /* Remove existing keys that aren't in the intended report. */
     if (memcmp(nkro_report->bits, last_report.bits, sizeof(nkro_report->bits)) != 0) {
         bool changed = false;
-        for (int i = 0; i < NKRO_REPORT_BITS; ++i) {
+        for (uint8_t i = 0; i < NKRO_REPORT_BITS; ++i) {
             uint8_t orig = last_report.bits[i];
             last_report.bits[i] &= nkro_report->bits[i];
             if (last_report.bits[i] != orig) {
@@ -382,7 +384,6 @@ void send_nkro_report(void) {
     /* Send the new mods with the intersecting set of keys */
     if (nkro_report->mods != last_report.mods) {
         last_report.mods = nkro_report->mods;
-
         host_nkro_send(&last_report);
 #        ifdef PROGRESSIVE_REPORT_DELAY
         wait_ms(PROGRESSIVE_REPORT_DELAY);

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -24,6 +24,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keycode_config.h"
 #include <string.h>
 
+#if defined(PROGRESSIVE_KEYBOARD_REPORTS) && defined(PROGRESSIVE_REPORT_DELAY)
+#    include "wait.h"
+#endif // defined(PROGRESSIVE_KEYBOARD_REPORTS) && defined(PROGRESSIVE_REPORT_DELAY)
+
 extern keymap_config_t keymap_config;
 
 static uint8_t real_mods = 0;
@@ -306,6 +310,40 @@ void send_6kro_report(void) {
 #else
     static report_keyboard_t last_report;
 
+#    ifdef PROGRESSIVE_KEYBOARD_REPORTS
+#        ifdef KEYBOARD_SHARED_EP
+    last_report.report_id = keyboard_report->report_id;
+#        endif // KEYBOARD_SHARED_EP
+
+    /* Remove existing keys that aren't in the intended report. */
+    if (memcmp(keyboard_report->keys, last_report.keys, sizeof(keyboard_report->keys)) != 0) {
+        bool changed = false;
+        for (int i = 0; i < 6; ++i) {
+            if (keyboard_report->keys[i] == 0) {
+                if (last_report.keys[i] != 0) {
+                    last_report.keys[i] = 0;
+                    changed             = true;
+                }
+            }
+        }
+        if (changed) {
+            host_keyboard_send(&last_report);
+#        ifdef PROGRESSIVE_REPORT_DELAY
+            wait_ms(PROGRESSIVE_REPORT_DELAY);
+#        endif // PROGRESSIVE_REPORT_DELAY
+        }
+    }
+
+    /* Send the new mods with the intersecting set of keys */
+    if (keyboard_report->mods != last_report.mods) {
+        last_report.mods = keyboard_report->mods;
+        host_keyboard_send(&last_report);
+#        ifdef PROGRESSIVE_REPORT_DELAY
+        wait_ms(PROGRESSIVE_REPORT_DELAY);
+#        endif // PROGRESSIVE_REPORT_DELAY
+    }
+#    endif     // PROGRESSIVE_KEYBOARD_REPORTS
+
     /* Only send the report if there are changes to propagate to the host. */
     if (memcmp(keyboard_report, &last_report, sizeof(report_keyboard_t)) != 0) {
         memcpy(&last_report, keyboard_report, sizeof(report_keyboard_t));
@@ -319,6 +357,38 @@ void send_nkro_report(void) {
     nkro_report->mods = get_mods_for_report();
 
     static report_nkro_t last_report;
+
+#    ifdef PROGRESSIVE_KEYBOARD_REPORTS
+    last_report.report_id = nkro_report->report_id;
+
+    /* Remove existing keys that aren't in the intended report. */
+    if (memcmp(nkro_report->bits, last_report.bits, sizeof(nkro_report->bits)) != 0) {
+        bool changed = false;
+        for (int i = 0; i < NKRO_REPORT_BITS; ++i) {
+            uint8_t orig = last_report.bits[i];
+            last_report.bits[i] &= nkro_report->bits[i];
+            if (last_report.bits[i] != orig) {
+                changed = true;
+            }
+        }
+        if (changed) {
+            host_nkro_send(&last_report);
+#        ifdef PROGRESSIVE_REPORT_DELAY
+            wait_ms(PROGRESSIVE_REPORT_DELAY);
+#        endif // PROGRESSIVE_REPORT_DELAY
+        }
+    }
+
+    /* Send the new mods with the intersecting set of keys */
+    if (nkro_report->mods != last_report.mods) {
+        last_report.mods = nkro_report->mods;
+
+        host_nkro_send(&last_report);
+#        ifdef PROGRESSIVE_REPORT_DELAY
+        wait_ms(PROGRESSIVE_REPORT_DELAY);
+#        endif // PROGRESSIVE_REPORT_DELAY
+    }
+#    endif // PROGRESSIVE_KEYBOARD_REPORTS
 
     /* Only send the report if there are changes to propagate to the host. */
     if (memcmp(nkro_report, &last_report, sizeof(report_nkro_t)) != 0) {

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -360,11 +360,11 @@ void send_nkro_report(void) {
 
     static report_nkro_t last_report;
 
-#    ifdef PROGRESSIVE_KEYBOARD_REPORTS
+#    if defined(PROGRESSIVE_KEYBOARD_REPORTS) && !defined(PROTOCOL_VUSB)
     last_report.report_id = nkro_report->report_id;
 
     /* Remove existing keys that aren't in the intended report. */
-    if (memcmp(nkro_report->bits, last_report.bits, sizeof(nkro_report->bits)) != 0) {
+    if (nkro_report->mods != last_report.mods && memcmp(nkro_report->bits, last_report.bits, sizeof(nkro_report->bits)) != 0) {
         bool changed = false;
         for (uint8_t i = 0; i < NKRO_REPORT_BITS; ++i) {
             uint8_t orig = last_report.bits[i];
@@ -389,7 +389,7 @@ void send_nkro_report(void) {
         wait_ms(PROGRESSIVE_REPORT_DELAY);
 #        endif // PROGRESSIVE_REPORT_DELAY
     }
-#    endif // PROGRESSIVE_KEYBOARD_REPORTS
+#    endif // defined(PROGRESSIVE_KEYBOARD_REPORTS) && !defined(PROTOCOL_VUSB)
 
     /* Only send the report if there are changes to propagate to the host. */
     if (memcmp(nkro_report, &last_report, sizeof(report_nkro_t)) != 0) {

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -22,9 +22,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_tapping.h"
 #include "timer.h"
 #include "keycode_config.h"
+#include "wait.h"
 #include <string.h>
 
-#include "wait.h"
+#if defined(PROGRESSIVE_REPORT_DELAY) && !defined(PROGRESSIVE_KEYBOARD_REPORTS)
+#    error "PROGRESSIVE_REPORT_DELAY requires PROGRESSIVE_KEYBOARD_REPORTS"
+#endif
 
 #ifdef PROGRESSIVE_REPORT_DELAY
 #    define progressive_report_delay() wait_ms(PROGRESSIVE_REPORT_DELAY)
@@ -319,26 +322,39 @@ void send_6kro_report(void) {
     last_report.report_id = keyboard_report->report_id;
 #        endif // KEYBOARD_SHARED_EP
 
-    /* Release any keys that are no longer held before applying the new mods. This only splits out
-       key releases (a slot cleared to 0); a slot that changes from one key to another in a single
-       scan is not split, as 6KRO reports keys positionally rather than as a bitmap. */
-    bool changed = false;
-    for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; ++i) {
-        if (keyboard_report->keys[i] == 0 && last_report.keys[i] != 0) {
-            last_report.keys[i] = 0;
-            changed             = true;
-        }
-    }
-    if (changed) {
-        host_keyboard_send(&last_report);
-        progressive_report_delay();
-    }
-
-    /* Send the new mods alongside the keys that are still held. */
+    /* When the mods change, stage the transition so the host applies each modifier state to the
+       correct keys: release the keys that are no longer held, apply the new mods against the
+       surviving keys, then send the full report below. A change that leaves the mods untouched
+       goes out as a single report. */
     if (keyboard_report->mods != last_report.mods) {
-        last_report.mods = keyboard_report->mods;
-        host_keyboard_send(&last_report);
-        progressive_report_delay();
+        /* Release any keys that are no longer held before applying the new mods. A held key never
+           moves slots (see add_key_byte()), so a slot whose keycode changed also means the
+           previous occupant was released and the slot reused; it is cleared here too, so the old
+           key is never seen with the new mods. */
+        bool changed = false;
+        for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; ++i) {
+            if (last_report.keys[i] != 0 && last_report.keys[i] != keyboard_report->keys[i]) {
+                last_report.keys[i] = 0;
+                changed             = true;
+            }
+        }
+        if (changed) {
+            /* host_keyboard_send() stamps report_id into the struct it is handed on a shared
+               endpoint; send sub-reports from a copy so last_report stays comparable with the
+               not-yet-stamped keyboard_report. */
+            report_keyboard_t sub_report = last_report;
+            host_keyboard_send(&sub_report);
+            progressive_report_delay();
+        }
+
+        /* Send the new mods alongside the keys that are still held. Only delay afterwards if the
+           final report below still has changes to send. */
+        last_report.mods             = keyboard_report->mods;
+        report_keyboard_t sub_report = last_report;
+        host_keyboard_send(&sub_report);
+        if (memcmp(keyboard_report, &last_report, sizeof(report_keyboard_t)) != 0) {
+            progressive_report_delay();
+        }
     }
 #    endif     // PROGRESSIVE_KEYBOARD_REPORTS
 
@@ -359,8 +375,9 @@ void send_nkro_report(void) {
 #    if defined(PROGRESSIVE_KEYBOARD_REPORTS) && !defined(PROTOCOL_VUSB)
     last_report.report_id = nkro_report->report_id;
 
-    /* Remove existing keys that aren't in the intended report. */
+    /* Stage the transition exactly as in send_6kro_report() above. */
     if (nkro_report->mods != last_report.mods) {
+        /* Release any keys that are no longer held before applying the new mods. */
         bool changed = false;
         for (uint8_t i = 0; i < NKRO_REPORT_BITS; ++i) {
             uint8_t orig = last_report.bits[i];
@@ -370,16 +387,21 @@ void send_nkro_report(void) {
             }
         }
         if (changed) {
-            host_nkro_send(&last_report);
+            /* host_nkro_send() stamps report_id into the struct it is handed; send sub-reports
+               from a copy so last_report stays comparable with the not-yet-stamped nkro_report. */
+            report_nkro_t sub_report = last_report;
+            host_nkro_send(&sub_report);
             progressive_report_delay();
         }
-    }
 
-    /* Send the new mods with the intersecting set of keys */
-    if (nkro_report->mods != last_report.mods) {
-        last_report.mods = nkro_report->mods;
-        host_nkro_send(&last_report);
-        progressive_report_delay();
+        /* Send the new mods alongside the keys that are still held. Only delay afterwards if the
+           final report below still has changes to send. */
+        last_report.mods         = nkro_report->mods;
+        report_nkro_t sub_report = last_report;
+        host_nkro_send(&sub_report);
+        if (memcmp(nkro_report, &last_report, sizeof(report_nkro_t)) != 0) {
+            progressive_report_delay();
+        }
     }
 #    endif // defined(PROGRESSIVE_KEYBOARD_REPORTS) && !defined(PROTOCOL_VUSB)
 

--- a/quantum/action_util.c
+++ b/quantum/action_util.c
@@ -24,9 +24,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keycode_config.h"
 #include <string.h>
 
-#if defined(PROGRESSIVE_KEYBOARD_REPORTS) && defined(PROGRESSIVE_REPORT_DELAY)
-#    include "wait.h"
-#endif // defined(PROGRESSIVE_KEYBOARD_REPORTS) && defined(PROGRESSIVE_REPORT_DELAY)
+#include "wait.h"
+
+#ifdef PROGRESSIVE_REPORT_DELAY
+#    define progressive_report_delay() wait_ms(PROGRESSIVE_REPORT_DELAY)
+#else
+#    define progressive_report_delay()
+#endif // PROGRESSIVE_REPORT_DELAY
 
 extern keymap_config_t keymap_config;
 
@@ -318,31 +322,23 @@ void send_6kro_report(void) {
     /* Release any keys that are no longer held before applying the new mods. This only splits out
        key releases (a slot cleared to 0); a slot that changes from one key to another in a single
        scan is not split, as 6KRO reports keys positionally rather than as a bitmap. */
-    if (memcmp(keyboard_report->keys, last_report.keys, sizeof(keyboard_report->keys)) != 0) {
-        bool changed = false;
-        for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; ++i) {
-            if (keyboard_report->keys[i] == 0) {
-                if (last_report.keys[i] != 0) {
-                    last_report.keys[i] = 0;
-                    changed             = true;
-                }
-            }
+    bool changed = false;
+    for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS; ++i) {
+        if (keyboard_report->keys[i] == 0 && last_report.keys[i] != 0) {
+            last_report.keys[i] = 0;
+            changed             = true;
         }
-        if (changed) {
-            host_keyboard_send(&last_report);
-#        ifdef PROGRESSIVE_REPORT_DELAY
-            wait_ms(PROGRESSIVE_REPORT_DELAY);
-#        endif // PROGRESSIVE_REPORT_DELAY
-        }
+    }
+    if (changed) {
+        host_keyboard_send(&last_report);
+        progressive_report_delay();
     }
 
     /* Send the new mods alongside the keys that are still held. */
     if (keyboard_report->mods != last_report.mods) {
         last_report.mods = keyboard_report->mods;
         host_keyboard_send(&last_report);
-#        ifdef PROGRESSIVE_REPORT_DELAY
-        wait_ms(PROGRESSIVE_REPORT_DELAY);
-#        endif // PROGRESSIVE_REPORT_DELAY
+        progressive_report_delay();
     }
 #    endif     // PROGRESSIVE_KEYBOARD_REPORTS
 
@@ -364,7 +360,7 @@ void send_nkro_report(void) {
     last_report.report_id = nkro_report->report_id;
 
     /* Remove existing keys that aren't in the intended report. */
-    if (nkro_report->mods != last_report.mods && memcmp(nkro_report->bits, last_report.bits, sizeof(nkro_report->bits)) != 0) {
+    if (nkro_report->mods != last_report.mods) {
         bool changed = false;
         for (uint8_t i = 0; i < NKRO_REPORT_BITS; ++i) {
             uint8_t orig = last_report.bits[i];
@@ -375,9 +371,7 @@ void send_nkro_report(void) {
         }
         if (changed) {
             host_nkro_send(&last_report);
-#        ifdef PROGRESSIVE_REPORT_DELAY
-            wait_ms(PROGRESSIVE_REPORT_DELAY);
-#        endif // PROGRESSIVE_REPORT_DELAY
+            progressive_report_delay();
         }
     }
 
@@ -385,9 +379,7 @@ void send_nkro_report(void) {
     if (nkro_report->mods != last_report.mods) {
         last_report.mods = nkro_report->mods;
         host_nkro_send(&last_report);
-#        ifdef PROGRESSIVE_REPORT_DELAY
-        wait_ms(PROGRESSIVE_REPORT_DELAY);
-#        endif // PROGRESSIVE_REPORT_DELAY
+        progressive_report_delay();
     }
 #    endif // defined(PROGRESSIVE_KEYBOARD_REPORTS) && !defined(PROTOCOL_VUSB)
 

--- a/tests/progressive_keyboard_reports/config.h
+++ b/tests/progressive_keyboard_reports/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "test_common.h"
+
+#define PROGRESSIVE_KEYBOARD_REPORTS

--- a/tests/progressive_keyboard_reports/test.mk
+++ b/tests/progressive_keyboard_reports/test.mk
@@ -1,0 +1,18 @@
+# Copyright 2026 QMK
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# --------------------------------------------------------------------------------
+# Keep this file, even if it is empty, as a marker that this folder contains tests
+# --------------------------------------------------------------------------------

--- a/tests/progressive_keyboard_reports/test_progressive_keyboard_reports.cpp
+++ b/tests/progressive_keyboard_reports/test_progressive_keyboard_reports.cpp
@@ -1,0 +1,77 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "action_util.h"
+#include "keyboard_report_util.hpp"
+#include "test_common.hpp"
+
+using testing::_;
+using testing::AnyNumber;
+using testing::InSequence;
+
+class ProgressiveKeyboardReports : public TestFixture {};
+
+// On press, a single logical change that adds both a modifier and a key must be
+// split so the modifier reaches the host first, guaranteeing the key is shifted.
+TEST_F(ProgressiveKeyboardReports, ModifierIsReportedBeforeKeyOnPress) {
+    TestDriver driver;
+    InSequence s;
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_A));
+
+    add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_key(KC_A);
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
+// On release, the same change in reverse must clear the key while the modifier
+// is still held, then clear the modifier, so the key never registers unshifted.
+TEST_F(ProgressiveKeyboardReports, KeyIsReleasedBeforeModifierOnRelease) {
+    TestDriver driver;
+
+    /* Establish the held state: Shift + A. */
+    EXPECT_ANY_REPORT(driver).Times(AnyNumber());
+    add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_key(KC_A);
+    send_keyboard_report();
+    VERIFY_AND_CLEAR(driver);
+
+    InSequence s;
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_EMPTY_REPORT(driver);
+
+    del_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::del_key(KC_A);
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
+// With no modifier change, a plain key press still collapses to a single report.
+TEST_F(ProgressiveKeyboardReports, PlainKeyPressSendsSingleReport) {
+    TestDriver driver;
+
+    EXPECT_REPORT(driver, (KC_A)).Times(1);
+
+    ::add_key(KC_A);
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/progressive_keyboard_reports/test_progressive_keyboard_reports.cpp
+++ b/tests/progressive_keyboard_reports/test_progressive_keyboard_reports.cpp
@@ -22,6 +22,13 @@ using testing::_;
 using testing::AnyNumber;
 using testing::InSequence;
 
+// These tests drive the QMK core report builders directly (add_mods/add_key/... then a single
+// send_keyboard_report()) so that a modifier and a key change land in one report transition,
+// which is what exercises the progressive reporting. The calls are qualified with `::` because the
+// test body is a TestFixture member, and TestFixture::add_key(KeymapKey) would otherwise shadow
+// the global core function ::add_key(uint8_t). The mod helpers have no such collision, but are
+// qualified too for symmetry and to make clear these are core functions, not fixture helpers.
+
 class ProgressiveKeyboardReports : public TestFixture {};
 
 // On press, a single logical change that adds both a modifier and a key must be
@@ -33,7 +40,7 @@ TEST_F(ProgressiveKeyboardReports, ModifierIsReportedBeforeKeyOnPress) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_A));
 
-    add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
     ::add_key(KC_A);
     send_keyboard_report();
 
@@ -47,7 +54,7 @@ TEST_F(ProgressiveKeyboardReports, KeyIsReleasedBeforeModifierOnRelease) {
 
     /* Establish the held state: Shift + A. */
     EXPECT_ANY_REPORT(driver).Times(AnyNumber());
-    add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
     ::add_key(KC_A);
     send_keyboard_report();
     VERIFY_AND_CLEAR(driver);
@@ -57,7 +64,7 @@ TEST_F(ProgressiveKeyboardReports, KeyIsReleasedBeforeModifierOnRelease) {
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     EXPECT_EMPTY_REPORT(driver);
 
-    del_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::del_mods(MOD_BIT(KC_LEFT_SHIFT));
     ::del_key(KC_A);
     send_keyboard_report();
 

--- a/tests/progressive_keyboard_reports/test_progressive_keyboard_reports.cpp
+++ b/tests/progressive_keyboard_reports/test_progressive_keyboard_reports.cpp
@@ -84,8 +84,8 @@ TEST_F(ProgressiveKeyboardReports, PlainKeyPressSendsSingleReport) {
 }
 
 // A key that swaps for another within a single scan, with the modifiers unchanged,
-// is not split into a release sub-report: the swapped key reuses the same slot, so
-// the swap arrives as one report.
+// is not split into a release sub-report: splitting only happens when the modifier
+// byte changes, so the swap arrives as one report.
 TEST_F(ProgressiveKeyboardReports, KeySwapSendsSingleReport) {
     TestDriver driver;
 
@@ -99,6 +99,45 @@ TEST_F(ProgressiveKeyboardReports, KeySwapSendsSingleReport) {
 
     ::del_key(KC_A);
     ::add_key(KC_B);
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
+// A change that only alters the modifier byte collapses to a single report: the
+// mods sub-report already is the final state, so nothing further is sent.
+TEST_F(ProgressiveKeyboardReports, ModsOnlyChangeSendsSingleReport) {
+    TestDriver driver;
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT)).Times(1);
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
+// When a slot is reused within a single scan (release A, press B) while the mods
+// also change, the old key must be released before the new mods are applied: the
+// host must never see the stale key together with the new modifier byte.
+TEST_F(ProgressiveKeyboardReports, ReusedSlotKeyIsReleasedBeforeModsApply) {
+    TestDriver driver;
+
+    /* Establish the held state: A. */
+    EXPECT_ANY_REPORT(driver).Times(AnyNumber());
+    ::add_key(KC_A);
+    send_keyboard_report();
+    VERIFY_AND_CLEAR(driver);
+
+    InSequence s;
+
+    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_B));
+
+    ::del_key(KC_A);
+    ::add_key(KC_B);
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
     send_keyboard_report();
 
     VERIFY_AND_CLEAR(driver);

--- a/tests/progressive_keyboard_reports_delay/config.h
+++ b/tests/progressive_keyboard_reports_delay/config.h
@@ -1,0 +1,22 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "test_common.h"
+
+#define PROGRESSIVE_KEYBOARD_REPORTS
+#define PROGRESSIVE_REPORT_DELAY 5

--- a/tests/progressive_keyboard_reports_delay/test.mk
+++ b/tests/progressive_keyboard_reports_delay/test.mk
@@ -1,0 +1,18 @@
+# Copyright 2026 QMK
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# --------------------------------------------------------------------------------
+# Keep this file, even if it is empty, as a marker that this folder contains tests
+# --------------------------------------------------------------------------------

--- a/tests/progressive_keyboard_reports_delay/test_progressive_keyboard_reports_delay.cpp
+++ b/tests/progressive_keyboard_reports_delay/test_progressive_keyboard_reports_delay.cpp
@@ -1,0 +1,93 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "action_util.h"
+#include "keyboard_report_util.hpp"
+#include "test_common.hpp"
+#include "timer.h"
+
+using testing::_;
+using testing::AnyNumber;
+using testing::InSequence;
+using testing::InvokeWithoutArgs;
+
+// Delay counterpart of tests/progressive_keyboard_reports. The test platform's
+// wait_ms() advances the emulated timer deterministically, so the delay between
+// sub-reports is observable as an exact timestamp difference at the driver mock.
+
+class ProgressiveKeyboardReportsDelay : public TestFixture {};
+
+// A split press must still emit modifier-then-key, with PROGRESSIVE_REPORT_DELAY
+// milliseconds elapsing between the sub-report and the final report.
+TEST_F(ProgressiveKeyboardReportsDelay, DelayIsInsertedBetweenSubReports) {
+    TestDriver driver;
+    InSequence s;
+
+    uint32_t first_time  = 0;
+    uint32_t second_time = 0;
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT)).WillOnce(InvokeWithoutArgs([&]() { first_time = timer_read32(); }));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_A)).WillOnce(InvokeWithoutArgs([&]() { second_time = timer_read32(); }));
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_key(KC_A);
+    send_keyboard_report();
+
+    EXPECT_EQ(second_time - first_time, PROGRESSIVE_REPORT_DELAY);
+    VERIFY_AND_CLEAR(driver);
+}
+
+// A split release must likewise separate the key-release sub-report from the
+// modifier release by PROGRESSIVE_REPORT_DELAY milliseconds.
+TEST_F(ProgressiveKeyboardReportsDelay, DelayIsInsertedBetweenReleaseSubReports) {
+    TestDriver driver;
+
+    /* Establish the held state: Shift + A. */
+    EXPECT_ANY_REPORT(driver).Times(AnyNumber());
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_key(KC_A);
+    send_keyboard_report();
+    VERIFY_AND_CLEAR(driver);
+
+    InSequence s;
+
+    uint32_t first_time  = 0;
+    uint32_t second_time = 0;
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT)).WillOnce(InvokeWithoutArgs([&]() { first_time = timer_read32(); }));
+    EXPECT_EMPTY_REPORT(driver).WillOnce(InvokeWithoutArgs([&]() { second_time = timer_read32(); }));
+
+    ::del_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::del_key(KC_A);
+    send_keyboard_report();
+
+    EXPECT_EQ(second_time - first_time, PROGRESSIVE_REPORT_DELAY);
+    VERIFY_AND_CLEAR(driver);
+}
+
+// An unsplit change — a plain key press with no modifier change — must not
+// insert any delay before its single report.
+TEST_F(ProgressiveKeyboardReportsDelay, UnsplitReportInsertsNoDelay) {
+    TestDriver driver;
+
+    uint32_t start       = timer_read32();
+    uint32_t report_time = 0;
+    EXPECT_REPORT(driver, (KC_A)).Times(1).WillOnce(InvokeWithoutArgs([&]() { report_time = timer_read32(); }));
+
+    ::add_key(KC_A);
+    send_keyboard_report();
+
+    EXPECT_EQ(report_time - start, 0u);
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/progressive_keyboard_reports_delay/test_progressive_keyboard_reports_delay.cpp
+++ b/tests/progressive_keyboard_reports_delay/test_progressive_keyboard_reports_delay.cpp
@@ -73,6 +73,24 @@ TEST_F(ProgressiveKeyboardReportsDelay, DelayIsInsertedBetweenReleaseSubReports)
     send_keyboard_report();
 
     EXPECT_EQ(second_time - first_time, PROGRESSIVE_REPORT_DELAY);
+    /* The mods sub-report is the last report of this change; nothing follows it, so no trailing
+       delay may stall the caller after it is sent. */
+    EXPECT_EQ(timer_read32(), second_time);
+    VERIFY_AND_CLEAR(driver);
+}
+
+// A mods-only change goes out as a single report with no sub-report before or
+// after it, so the whole send must complete without any delay stalling the caller.
+TEST_F(ProgressiveKeyboardReportsDelay, ModsOnlyChangeInsertsNoDelay) {
+    TestDriver driver;
+
+    uint32_t start = timer_read32();
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT)).Times(1);
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    send_keyboard_report();
+
+    EXPECT_EQ(timer_read32() - start, 0u);
     VERIFY_AND_CLEAR(driver);
 }
 
@@ -81,13 +99,12 @@ TEST_F(ProgressiveKeyboardReportsDelay, DelayIsInsertedBetweenReleaseSubReports)
 TEST_F(ProgressiveKeyboardReportsDelay, UnsplitReportInsertsNoDelay) {
     TestDriver driver;
 
-    uint32_t start       = timer_read32();
-    uint32_t report_time = 0;
-    EXPECT_REPORT(driver, (KC_A)).Times(1).WillOnce(InvokeWithoutArgs([&]() { report_time = timer_read32(); }));
+    uint32_t start = timer_read32();
+    EXPECT_REPORT(driver, (KC_A)).Times(1);
 
     ::add_key(KC_A);
     send_keyboard_report();
 
-    EXPECT_EQ(report_time - start, 0u);
+    EXPECT_EQ(timer_read32() - start, 0u);
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/progressive_keyboard_reports_nkro/config.h
+++ b/tests/progressive_keyboard_reports_nkro/config.h
@@ -1,0 +1,23 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "test_common.h"
+
+#define PROGRESSIVE_KEYBOARD_REPORTS
+#define PROGRESSIVE_REPORT_DELAY 5
+#define NKRO_DEFAULT_ON true

--- a/tests/progressive_keyboard_reports_nkro/test.mk
+++ b/tests/progressive_keyboard_reports_nkro/test.mk
@@ -1,0 +1,16 @@
+# Copyright 2026 QMK
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+NKRO_ENABLE = yes

--- a/tests/progressive_keyboard_reports_nkro/test_progressive_keyboard_reports_nkro.cpp
+++ b/tests/progressive_keyboard_reports_nkro/test_progressive_keyboard_reports_nkro.cpp
@@ -17,28 +17,30 @@
 #include "action_util.h"
 #include "keyboard_report_util.hpp"
 #include "test_common.hpp"
+#include "timer.h"
 
 using testing::_;
 using testing::AnyNumber;
 using testing::InSequence;
+using testing::InvokeWithoutArgs;
 
-// These tests drive the QMK core report builders directly (add_mods/add_key/... then a single
-// send_keyboard_report()) so that a modifier and a key change land in one report transition,
-// which is what exercises the progressive reporting. The calls are qualified with `::` because the
-// test body is a TestFixture member, and TestFixture::add_key(KeymapKey) would otherwise shadow
-// the global core function ::add_key(uint8_t). The mod helpers have no such collision, but are
-// qualified too for symmetry and to make clear these are core functions, not fixture helpers.
+// NKRO counterpart of tests/progressive_keyboard_reports: NKRO_DEFAULT_ON routes
+// send_keyboard_report() through send_nkro_report(), exercising the bitmap
+// intersection logic (last_report.bits[i] &= nkro_report->bits[i]) instead of the
+// positional 6KRO key slots. PROGRESSIVE_REPORT_DELAY is also defined here so the
+// delay insertion is covered on the NKRO path. See that suite for why the core
+// calls are `::`-qualified.
 
-class ProgressiveKeyboardReports : public TestFixture {};
+class ProgressiveKeyboardReportsNkro : public TestFixture {};
 
 // On press, a single logical change that adds both a modifier and a key must be
 // split so the modifier reaches the host first, guaranteeing the key is shifted.
-TEST_F(ProgressiveKeyboardReports, ModifierIsReportedBeforeKeyOnPress) {
+TEST_F(ProgressiveKeyboardReportsNkro, ModifierIsReportedBeforeKeyOnPress) {
     TestDriver driver;
     InSequence s;
 
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_A));
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT, KC_A));
 
     ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
     ::add_key(KC_A);
@@ -49,11 +51,11 @@ TEST_F(ProgressiveKeyboardReports, ModifierIsReportedBeforeKeyOnPress) {
 
 // On release, the same change in reverse must clear the key while the modifier
 // is still held, then clear the modifier, so the key never registers unshifted.
-TEST_F(ProgressiveKeyboardReports, KeyIsReleasedBeforeModifierOnRelease) {
+TEST_F(ProgressiveKeyboardReportsNkro, KeyIsReleasedBeforeModifierOnRelease) {
     TestDriver driver;
 
     /* Establish the held state: Shift + A. */
-    EXPECT_ANY_REPORT(driver).Times(AnyNumber());
+    EXPECT_ANY_NKRO_REPORT(driver).Times(AnyNumber());
     ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
     ::add_key(KC_A);
     send_keyboard_report();
@@ -61,8 +63,8 @@ TEST_F(ProgressiveKeyboardReports, KeyIsReleasedBeforeModifierOnRelease) {
 
     InSequence s;
 
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
-    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_EMPTY_NKRO_REPORT(driver);
 
     ::del_mods(MOD_BIT(KC_LEFT_SHIFT));
     ::del_key(KC_A);
@@ -72,10 +74,10 @@ TEST_F(ProgressiveKeyboardReports, KeyIsReleasedBeforeModifierOnRelease) {
 }
 
 // With no modifier change, a plain key press still collapses to a single report.
-TEST_F(ProgressiveKeyboardReports, PlainKeyPressSendsSingleReport) {
+TEST_F(ProgressiveKeyboardReportsNkro, PlainKeyPressSendsSingleReport) {
     TestDriver driver;
 
-    EXPECT_REPORT(driver, (KC_A)).Times(1);
+    EXPECT_NKRO_REPORT(driver, (KC_A)).Times(1);
 
     ::add_key(KC_A);
     send_keyboard_report();
@@ -84,22 +86,40 @@ TEST_F(ProgressiveKeyboardReports, PlainKeyPressSendsSingleReport) {
 }
 
 // A key that swaps for another within a single scan, with the modifiers unchanged,
-// is not split into a release sub-report: the swapped key reuses the same slot, so
-// the swap arrives as one report.
-TEST_F(ProgressiveKeyboardReports, KeySwapSendsSingleReport) {
+// must not be split into a release sub-report — matching 6KRO's behaviour.
+TEST_F(ProgressiveKeyboardReportsNkro, KeySwapSendsSingleReport) {
     TestDriver driver;
 
     /* Establish the held state: A. */
-    EXPECT_ANY_REPORT(driver).Times(AnyNumber());
+    EXPECT_ANY_NKRO_REPORT(driver).Times(AnyNumber());
     ::add_key(KC_A);
     send_keyboard_report();
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_REPORT(driver, (KC_B)).Times(1);
+    EXPECT_NKRO_REPORT(driver, (KC_B)).Times(1);
 
     ::del_key(KC_A);
     ::add_key(KC_B);
     send_keyboard_report();
 
+    VERIFY_AND_CLEAR(driver);
+}
+
+// A split press must still emit modifier-then-key, with PROGRESSIVE_REPORT_DELAY
+// milliseconds elapsing between the sub-report and the final report.
+TEST_F(ProgressiveKeyboardReportsNkro, DelayIsInsertedBetweenSubReports) {
+    TestDriver driver;
+    InSequence s;
+
+    uint32_t first_time  = 0;
+    uint32_t second_time = 0;
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT)).WillOnce(InvokeWithoutArgs([&]() { first_time = timer_read32(); }));
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT, KC_A)).WillOnce(InvokeWithoutArgs([&]() { second_time = timer_read32(); }));
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_key(KC_A);
+    send_keyboard_report();
+
+    EXPECT_EQ(second_time - first_time, PROGRESSIVE_REPORT_DELAY);
     VERIFY_AND_CLEAR(driver);
 }

--- a/tests/progressive_keyboard_reports_nkro/test_progressive_keyboard_reports_nkro.cpp
+++ b/tests/progressive_keyboard_reports_nkro/test_progressive_keyboard_reports_nkro.cpp
@@ -23,6 +23,7 @@ using testing::_;
 using testing::AnyNumber;
 using testing::InSequence;
 using testing::InvokeWithoutArgs;
+using testing::SaveArg;
 
 // NKRO counterpart of tests/progressive_keyboard_reports: NKRO_DEFAULT_ON routes
 // send_keyboard_report() through send_nkro_report(), exercising the bitmap
@@ -85,6 +86,45 @@ TEST_F(ProgressiveKeyboardReportsNkro, PlainKeyPressSendsSingleReport) {
     VERIFY_AND_CLEAR(driver);
 }
 
+// A change that only alters the modifier byte collapses to a single report: the
+// mods sub-report already is the final state, so nothing further is sent.
+TEST_F(ProgressiveKeyboardReportsNkro, ModsOnlyChangeSendsSingleReport) {
+    TestDriver driver;
+
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT)).Times(1);
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
+// When a key swaps for another in the same scan as a mods change, the old key must
+// be released before the new mods are applied: the host must never see the stale
+// key together with the new modifier byte.
+TEST_F(ProgressiveKeyboardReportsNkro, SwappedKeyIsReleasedBeforeModsApply) {
+    TestDriver driver;
+
+    /* Establish the held state: A. */
+    EXPECT_ANY_NKRO_REPORT(driver).Times(AnyNumber());
+    ::add_key(KC_A);
+    send_keyboard_report();
+    VERIFY_AND_CLEAR(driver);
+
+    InSequence s;
+
+    EXPECT_EMPTY_NKRO_REPORT(driver);
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT, KC_B));
+
+    ::del_key(KC_A);
+    ::add_key(KC_B);
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
 // A key that swaps for another within a single scan, with the modifiers unchanged,
 // must not be split into a release sub-report — matching 6KRO's behaviour.
 TEST_F(ProgressiveKeyboardReportsNkro, KeySwapSendsSingleReport) {
@@ -102,6 +142,27 @@ TEST_F(ProgressiveKeyboardReportsNkro, KeySwapSendsSingleReport) {
     ::add_key(KC_B);
     send_keyboard_report();
 
+    VERIFY_AND_CLEAR(driver);
+}
+
+// Sub-reports are sent from a copy of the internal comparison cache; the host layer
+// must still stamp every transmitted report with the NKRO report ID. The NkroReport
+// matcher deliberately ignores report_id, so this is asserted explicitly here.
+TEST_F(ProgressiveKeyboardReportsNkro, SubReportsCarryNkroReportId) {
+    TestDriver driver;
+    InSequence s;
+
+    report_nkro_t sub_report{};
+    report_nkro_t final_report{};
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT)).WillOnce(SaveArg<0>(&sub_report));
+    EXPECT_NKRO_REPORT(driver, (KC_LEFT_SHIFT, KC_A)).WillOnce(SaveArg<0>(&final_report));
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_key(KC_A);
+    send_keyboard_report();
+
+    EXPECT_EQ(sub_report.report_id, REPORT_ID_NKRO);
+    EXPECT_EQ(final_report.report_id, REPORT_ID_NKRO);
     VERIFY_AND_CLEAR(driver);
 }
 

--- a/tests/progressive_keyboard_reports_shared_ep/config.h
+++ b/tests/progressive_keyboard_reports_shared_ep/config.h
@@ -1,0 +1,22 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "test_common.h"
+
+#define PROGRESSIVE_KEYBOARD_REPORTS
+#define KEYBOARD_SHARED_EP

--- a/tests/progressive_keyboard_reports_shared_ep/test.mk
+++ b/tests/progressive_keyboard_reports_shared_ep/test.mk
@@ -1,0 +1,18 @@
+# Copyright 2026 QMK
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# --------------------------------------------------------------------------------
+# Keep this file, even if it is empty, as a marker that this folder contains tests
+# --------------------------------------------------------------------------------

--- a/tests/progressive_keyboard_reports_shared_ep/test_progressive_keyboard_reports_shared_ep.cpp
+++ b/tests/progressive_keyboard_reports_shared_ep/test_progressive_keyboard_reports_shared_ep.cpp
@@ -1,0 +1,60 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "action_util.h"
+#include "keyboard_report_util.hpp"
+#include "test_common.hpp"
+
+using testing::InSequence;
+
+// KEYBOARD_SHARED_EP counterpart of tests/progressive_keyboard_reports: with a
+// shared endpoint, report_keyboard_t carries a report_id which host_keyboard_send()
+// stamps into the struct it is handed. These tests pin the 6KRO progressive path
+// against that interaction — the internal comparison cache must never absorb the
+// stamp, or a mods-only change double-sends on the first report after boot. Both
+// tests must hold in --gtest_filter isolation, where no earlier case has stamped
+// the report globals.
+
+class ProgressiveKeyboardReportsSharedEp : public TestFixture {};
+
+// A change that only alters the modifier byte collapses to a single report, even
+// as the very first report emitted after boot.
+TEST_F(ProgressiveKeyboardReportsSharedEp, ModsOnlyChangeSendsSingleReport) {
+    TestDriver driver;
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT)).Times(1);
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}
+
+// On press, a single logical change that adds both a modifier and a key must be
+// split so the modifier reaches the host first.
+TEST_F(ProgressiveKeyboardReportsSharedEp, ModifierIsReportedBeforeKeyOnPress) {
+    TestDriver driver;
+    InSequence s;
+
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_A));
+
+    ::add_mods(MOD_BIT(KC_LEFT_SHIFT));
+    ::add_key(KC_A);
+    send_keyboard_report();
+
+    VERIFY_AND_CLEAR(driver);
+}

--- a/tests/test_common/keyboard_report_util.cpp
+++ b/tests/test_common/keyboard_report_util.cpp
@@ -16,6 +16,7 @@
 
 #include "keyboard_report_util.hpp"
 #include <cstdint>
+#include <cstring>
 #include <vector>
 #include <algorithm>
 #include <iomanip>
@@ -32,23 +33,32 @@ namespace {
 
 std::vector<uint8_t> get_keys(const report_keyboard_t& report) {
     std::vector<uint8_t> result;
-#if defined(NKRO_ENABLE)
-#    error NKRO support not implemented yet
-#else
     for (size_t i = 0; i < KEYBOARD_REPORT_KEYS; i++) {
         if (report.keys[i]) {
             result.emplace_back(report.keys[i]);
         }
     }
-#endif
     std::sort(result.begin(), result.end());
     return result;
 }
 
-std::vector<uint8_t> get_mods(const report_keyboard_t& report) {
+std::vector<uint8_t> get_keys(const report_nkro_t& report) {
+    std::vector<uint8_t> result;
+    for (size_t i = 0; i < NKRO_REPORT_BITS; i++) {
+        for (size_t j = 0; j < 8; j++) {
+            if (report.bits[i] & (1 << j)) {
+                result.emplace_back(i * 8 + j);
+            }
+        }
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+std::vector<uint8_t> get_mods(uint8_t mods) {
     std::vector<uint8_t> result;
     for (size_t i = 0; i < 8; i++) {
-        if (report.mods & (1 << i)) {
+        if (mods & (1 << i)) {
             uint8_t code = KC_LEFT_CTRL + i;
             result.emplace_back(code);
         }
@@ -65,10 +75,7 @@ bool operator==(const report_keyboard_t& lhs, const report_keyboard_t& rhs) {
     return lhs.mods == rhs.mods && lhskeys == rhskeys;
 }
 
-std::ostream& operator<<(std::ostream& os, const report_keyboard_t& report) {
-    auto keys = get_keys(report);
-    auto mods = get_mods(report);
-
+static std::ostream& print_report(std::ostream& os, const std::vector<uint8_t>& keys, const std::vector<uint8_t>& mods) {
     os << std::setw(10) << std::left << "report: ";
 
     if (!keys.size() && !mods.size()) {
@@ -97,6 +104,19 @@ std::ostream& operator<<(std::ostream& os, const report_keyboard_t& report) {
     return os << "]" << std::endl;
 }
 
+std::ostream& operator<<(std::ostream& os, const report_keyboard_t& report) {
+    return print_report(os, get_keys(report), get_mods(report.mods));
+}
+
+bool operator==(const report_nkro_t& lhs, const report_nkro_t& rhs) {
+    /* report_id is a transport detail and deliberately not compared. */
+    return lhs.mods == rhs.mods && memcmp(lhs.bits, rhs.bits, sizeof(lhs.bits)) == 0;
+}
+
+std::ostream& operator<<(std::ostream& os, const report_nkro_t& report) {
+    return print_report(os, get_keys(report), get_mods(report.mods));
+}
+
 KeyboardReportMatcher::KeyboardReportMatcher(const std::vector<uint8_t>& keys) {
     memset(&m_report, 0, sizeof(report_keyboard_t));
     for (auto k : keys) {
@@ -117,5 +137,29 @@ void KeyboardReportMatcher::DescribeTo(::std::ostream* os) const {
 }
 
 void KeyboardReportMatcher::DescribeNegationTo(::std::ostream* os) const {
+    *os << "is not equal to " << m_report;
+}
+
+NkroReportMatcher::NkroReportMatcher(const std::vector<uint8_t>& keys) {
+    memset(&m_report, 0, sizeof(report_nkro_t));
+    for (auto k : keys) {
+        if (IS_MODIFIER_KEYCODE(k)) {
+            m_report.mods |= MOD_BIT(k);
+        } else {
+            /* add_key_bit() is NKRO_ENABLE-gated, but this matcher must compile for every suite. */
+            m_report.bits[k >> 3] |= 1 << (k & 7);
+        }
+    }
+}
+
+bool NkroReportMatcher::MatchAndExplain(report_nkro_t& report, MatchResultListener* listener) const {
+    return m_report == report;
+}
+
+void NkroReportMatcher::DescribeTo(::std::ostream* os) const {
+    *os << "is equal to " << m_report;
+}
+
+void NkroReportMatcher::DescribeNegationTo(::std::ostream* os) const {
     *os << "is not equal to " << m_report;
 }

--- a/tests/test_common/keyboard_report_util.cpp
+++ b/tests/test_common/keyboard_report_util.cpp
@@ -31,6 +31,9 @@ extern std::map<uint16_t, std::string> KEYCODE_ID_TABLE;
 
 namespace {
 
+/* Note for NKRO-enabled suites: once `host_can_send_nkro() && keymap_config.nkro` holds, reports
+   go through send_nkro() and EXPECT_REPORT/EXPECT_EMPTY_REPORT (which match send_keyboard_mock)
+   never fire — use EXPECT_NKRO_REPORT and friends instead. */
 std::vector<uint8_t> get_keys(const report_keyboard_t& report) {
     std::vector<uint8_t> result;
     for (size_t i = 0; i < KEYBOARD_REPORT_KEYS; i++) {
@@ -145,8 +148,9 @@ NkroReportMatcher::NkroReportMatcher(const std::vector<uint8_t>& keys) {
     for (auto k : keys) {
         if (IS_MODIFIER_KEYCODE(k)) {
             m_report.mods |= MOD_BIT(k);
-        } else {
-            /* add_key_bit() is NKRO_ENABLE-gated, but this matcher must compile for every suite. */
+        } else if ((k >> 3) < NKRO_REPORT_BITS) {
+            /* add_key_bit() is NKRO_ENABLE-gated, but this matcher must compile for every suite;
+               the bounds guard mirrors it. */
             m_report.bits[k >> 3] |= 1 << (k & 7);
         }
     }

--- a/tests/test_common/keyboard_report_util.hpp
+++ b/tests/test_common/keyboard_report_util.hpp
@@ -56,10 +56,6 @@ class NkroReportMatcher : public testing::MatcherInterface<report_nkro_t&> {
     report_nkro_t m_report;
 };
 
-inline testing::Matcher<report_nkro_t&> NkroReport(const std::vector<uint8_t>& keys) {
-    return testing::MakeMatcher(new NkroReportMatcher(keys));
-}
-
 template <typename... Ts>
 inline testing::Matcher<report_nkro_t&> NkroReport(Ts... keys) {
     return testing::MakeMatcher(new NkroReportMatcher({static_cast<uint8_t>(keys)...}));

--- a/tests/test_common/keyboard_report_util.hpp
+++ b/tests/test_common/keyboard_report_util.hpp
@@ -41,3 +41,26 @@ template <typename... Ts>
 inline testing::Matcher<report_keyboard_t&> KeyboardReport(Ts... keys) {
     return testing::MakeMatcher(new KeyboardReportMatcher({static_cast<uint8_t>(keys)...}));
 }
+
+bool          operator==(const report_nkro_t& lhs, const report_nkro_t& rhs);
+std::ostream& operator<<(std::ostream& stream, const report_nkro_t& value);
+
+class NkroReportMatcher : public testing::MatcherInterface<report_nkro_t&> {
+   public:
+    NkroReportMatcher(const std::vector<uint8_t>& keys);
+    virtual bool MatchAndExplain(report_nkro_t& report, testing::MatchResultListener* listener) const override;
+    virtual void DescribeTo(::std::ostream* os) const override;
+    virtual void DescribeNegationTo(::std::ostream* os) const override;
+
+   private:
+    report_nkro_t m_report;
+};
+
+inline testing::Matcher<report_nkro_t&> NkroReport(const std::vector<uint8_t>& keys) {
+    return testing::MakeMatcher(new NkroReportMatcher(keys));
+}
+
+template <typename... Ts>
+inline testing::Matcher<report_nkro_t&> NkroReport(Ts... keys) {
+    return testing::MakeMatcher(new NkroReportMatcher({static_cast<uint8_t>(keys)...}));
+}

--- a/tests/test_common/keyboard_report_util.hpp
+++ b/tests/test_common/keyboard_report_util.hpp
@@ -56,6 +56,10 @@ class NkroReportMatcher : public testing::MatcherInterface<report_nkro_t&> {
     report_nkro_t m_report;
 };
 
+inline testing::Matcher<report_nkro_t&> NkroReport(const std::vector<uint8_t>& keys) {
+    return testing::MakeMatcher(new NkroReportMatcher(keys));
+}
+
 template <typename... Ts>
 inline testing::Matcher<report_nkro_t&> NkroReport(Ts... keys) {
     return testing::MakeMatcher(new NkroReportMatcher({static_cast<uint8_t>(keys)...}));

--- a/tests/test_common/test_driver.cpp
+++ b/tests/test_common/test_driver.cpp
@@ -51,6 +51,7 @@ void TestDriver::send_keyboard(report_keyboard_t* report) {
 }
 
 void TestDriver::send_nkro(report_nkro_t* report) {
+    test_logger.trace() << *report;
     m_this->send_nkro_mock(*report);
 }
 

--- a/tests/test_common/test_driver.hpp
+++ b/tests/test_common/test_driver.hpp
@@ -69,6 +69,25 @@ class TestDriver {
 #define EXPECT_REPORT(driver, report) EXPECT_CALL((driver), send_keyboard_mock(KeyboardReport report))
 
 /**
+ * @brief Sets gmock expectation that an NKRO report of `report` keys will be sent.
+ * For this macro to parse correctly, the `report` arg must be surrounded by
+ * parentheses ( ). For instance,
+ *
+ *   // Expect that an NKRO report of "KC_LSFT + KC_A" is sent to the host.
+ *   EXPECT_NKRO_REPORT(driver, (KC_LSFT, KC_A));
+ *
+ * is shorthand for
+ *
+ *   EXPECT_CALL(driver, send_nkro_mock(NkroReport(KC_LSFT, KC_A)));
+ *
+ * It is possible to use .Times() and other gmock APIs with EXPECT_NKRO_REPORT, for instance,
+ * allow only a single report to be sent:
+ *
+ *   EXPECT_NKRO_REPORT(driver, (KC_LSFT, KC_A)).Times(1);
+ */
+#define EXPECT_NKRO_REPORT(driver, report) EXPECT_CALL((driver), send_nkro_mock(NkroReport report))
+
+/**
  * @brief Sets gmock expectation that a mouse report of `report` will be sent.
  * For this macro to parse correctly, the `report` arg must be surrounded by
  * parentheses ( ). For instance,
@@ -109,6 +128,15 @@ class TestDriver {
 #define EXPECT_EMPTY_REPORT(driver) EXPECT_REPORT(driver, ())
 
 /**
+ * @brief Sets gmock expectation that an empty NKRO report will be sent.
+ * It is possible to use .Times() and other gmock APIs with EXPECT_EMPTY_NKRO_REPORT, for instance,
+ * allow any number of empty reports with:
+ *
+ *   EXPECT_EMPTY_NKRO_REPORT(driver).Times(AnyNumber());
+ */
+#define EXPECT_EMPTY_NKRO_REPORT(driver) EXPECT_NKRO_REPORT(driver, ())
+
+/**
  * @brief Sets gmock expectation that a empty keyboard report will be sent.
  * It is possible to use .Times() and other gmock APIS with EXPECT_EMPTY_MOUSE_REPORT, for instance,
  * allow any number of empty reports with:
@@ -125,6 +153,15 @@ class TestDriver {
  *   EXPECT_ANY_REPORT(driver).Times(1);
  */
 #define EXPECT_ANY_REPORT(driver) EXPECT_CALL((driver), send_keyboard_mock(_))
+
+/**
+ * @brief Sets gmock expectation that an NKRO report will be sent, without matching its content.
+ * It is possible to use .Times() and other gmock APIs with EXPECT_ANY_NKRO_REPORT, for instance,
+ * allow a single arbitrary report with:
+ *
+ *   EXPECT_ANY_NKRO_REPORT(driver).Times(1);
+ */
+#define EXPECT_ANY_NKRO_REPORT(driver) EXPECT_CALL((driver), send_nkro_mock(_))
 
 /**
  * @brief Sets gmock expectation that a mouse report will be sent, without matching its content.


### PR DESCRIPTION
## Description

A branch I'd had sitting for a while, figured I should PR it.

Adds progressive reporting for 6KRO/NKRO such that if a key and a mod are added simultaneously, then the first report contains the mod and the second contains the modded key. Reverse when a modded key are released.

Was a fix for the whole Remote Desktop not reporting mods correctly scenario; been a long time since I used Windows so I'm not sure if it's still an issue... but it was working back then.

Timing is optional and configurable.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
