### PR TITLE
Fixup `make format-core`, `make pytest`, `make format-and-pytest`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ endef
 TRY_TO_MATCH_RULE_FROM_LIST = $(eval $(call TRY_TO_MATCH_RULE_FROM_LIST_HELPER,$1))$(RULE_FOUND)
 
 # As TRY_TO_MATCH_RULE_FROM_LIST_HELPER, but with additional
-# resolution of keyboard_aliases.hjson for provided rule 
+# resolution of keyboard_aliases.hjson for provided rule
 define TRY_TO_MATCH_RULE_FROM_LIST_HELPER_KB
     # Split on ":", padding with empty strings to avoid indexing issues
     TOKEN1:=$$(shell python3 -c "import sys; print((sys.argv[1].split(':',1)+[''])[0])" $$(RULE))
@@ -452,16 +452,17 @@ distclean_userspace: clean
 endif
 
 # Extra targets for formatting and/or pytest, running within the qmk/qmk_cli container to match GHA.
-CONTAINER_PREAMBLE := export HOME="/tmp"; export PATH="/tmp/.local/bin:\$$PATH"; python3 -m pip install --upgrade pip; python3 -m pip install -r requirements-dev.txt
-
 .PHONY: format-core
 format-core:
-	RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a"
+	RUNTIME=docker ./util/docker_cmd.sh qmk format-c --core-only -a
+	RUNTIME=docker ./util/docker_cmd.sh qmk format-python -a
 
 .PHONY: pytest
 pytest:
-	RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk pytest"
+	RUNTIME=docker ./util/docker_cmd.sh qmk pytest
 
 .PHONY: format-and-pytest
 format-and-pytest:
-	RUNTIME=docker ./util/docker_cmd.sh bash -lic "$(CONTAINER_PREAMBLE); qmk format-c --core-only -a && qmk format-python -a && qmk pytest"
+	RUNTIME=docker ./util/docker_cmd.sh qmk format-c --core-only -a
+	RUNTIME=docker ./util/docker_cmd.sh qmk format-python -a
+	RUNTIME=docker ./util/docker_cmd.sh qmk pytest


### PR DESCRIPTION
## Description

Fixes the container-based formatting execution targets now that the CLI container is uv-based and includes what's necessary.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
