### PR TITLE
repeat_key.c: add implementation for get_last_record

### DIFF
--- a/quantum/repeat_key.c
+++ b/quantum/repeat_key.c
@@ -45,6 +45,10 @@ uint16_t get_last_keycode(void) {
     return last_record.keycode;
 }
 
+keyrecord_t* get_last_record(void) {
+    return &last_record;
+}
+
 uint8_t get_last_mods(void) {
     return last_mods;
 }

--- a/quantum/repeat_key.c
+++ b/quantum/repeat_key.c
@@ -45,7 +45,7 @@ uint16_t get_last_keycode(void) {
     return last_record.keycode;
 }
 
-keyrecord_t* get_last_record(void) {
+const keyrecord_t* get_last_record(void) {
     return &last_record;
 }
 

--- a/quantum/repeat_key.h
+++ b/quantum/repeat_key.h
@@ -26,7 +26,7 @@ void     set_last_keycode(uint16_t keycode); /**< Sets the last key. */
 void     set_last_mods(uint8_t mods);        /**< Sets the last mods. */
 
 /** @brief Gets the record for the last key. */
-keyrecord_t* get_last_record(void);
+const keyrecord_t* get_last_record(void);
 
 /** @brief Sets keycode and record info for the last key. */
 void set_last_record(uint16_t keycode, keyrecord_t* record);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The `get_last_record` signature was present in repeat_key.h but without any implementation in repeat_key.c which caused compilation errors for any user of `get_last_record`.

I know the function is not documented outside of the header file but I had a use case requiring `get_last_record`:

I have an alt-rep/magic key used to eliminate SFBs (same finger bigrams). To avoid spelling out every case manually, I wrote a function that finds [the closest home keypos](https://github.com/precondition/polilla-keymap/blob/74b9fbabc2d07809e26cc72621c729f524059d59/magic_thumb_keys.c#L21). To do that, I need the information on [the last remembered key position](https://github.com/precondition/polilla-keymap/blob/74b9fbabc2d07809e26cc72621c729f524059d59/keymap.c#L1060).



## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
