### PR TITLE
Add "handwired" TwentyPad macro pad

### DIFF
--- a/keyboards/handwired/twentypad/keyboard.json
+++ b/keyboards/handwired/twentypad/keyboard.json
@@ -1,0 +1,54 @@
+{
+    "manufacturer": "Harry Cutts",
+    "keyboard_name": "TwentyPad",
+    "maintainer": "HarryCutts",
+    "bootloader": "atmel-dfu",
+    "features": {
+        "bootmagic": true,
+        "extrakey": true,
+        "mousekey": true
+    },
+    "matrix_pins": {
+        "direct": [
+            ["B7", "D5", "B5", "F6"],
+            ["B3", "D3", "B4", "F7"],
+            ["B2", "D2", "D7", "C7"],
+            ["B1", "D1", "D6", "C6"],
+            ["B0", "D0", "D4", "B6"]
+        ]
+    },
+    "processor": "atmega32u4",
+    "url": "https://github.com/HarryCutts/twentypad/",
+    "usb": {
+        "device_version": "1.0.0",
+        "pid": "0x209D",
+        "vid": "0xFEED"
+    },
+    "community_layouts": ["ortho_5x4"],
+    "layouts": {
+        "LAYOUT_ortho_5x4": {
+            "layout": [
+                {"label": "B7", "matrix": [0, 0], "x": 0, "y": 0},
+                {"label": "D5", "matrix": [0, 1], "x": 1, "y": 0},
+                {"label": "B5", "matrix": [0, 2], "x": 2, "y": 0},
+                {"label": "F6", "matrix": [0, 3], "x": 3, "y": 0},
+                {"label": "B3", "matrix": [1, 0], "x": 0, "y": 1},
+                {"label": "D3", "matrix": [1, 1], "x": 1, "y": 1},
+                {"label": "B4", "matrix": [1, 2], "x": 2, "y": 1},
+                {"label": "F7", "matrix": [1, 3], "x": 3, "y": 1},
+                {"label": "B2", "matrix": [2, 0], "x": 0, "y": 2},
+                {"label": "D2", "matrix": [2, 1], "x": 1, "y": 2},
+                {"label": "D7", "matrix": [2, 2], "x": 2, "y": 2},
+                {"label": "C7", "matrix": [2, 3], "x": 3, "y": 2},
+                {"label": "B1", "matrix": [3, 0], "x": 0, "y": 3},
+                {"label": "D1", "matrix": [3, 1], "x": 1, "y": 3},
+                {"label": "D6", "matrix": [3, 2], "x": 2, "y": 3},
+                {"label": "C6", "matrix": [3, 3], "x": 3, "y": 3},
+                {"label": "B0", "matrix": [4, 0], "x": 0, "y": 4},
+                {"label": "D0", "matrix": [4, 1], "x": 1, "y": 4},
+                {"label": "D4", "matrix": [4, 2], "x": 2, "y": 4},
+                {"label": "B6", "matrix": [4, 3], "x": 3, "y": 4}
+            ]
+        }
+    }
+}

--- a/keyboards/handwired/twentypad/keymaps/default/keymap.json
+++ b/keyboards/handwired/twentypad/keymaps/default/keymap.json
@@ -1,0 +1,14 @@
+{
+    "keyboard": "handwired/twentypad",
+    "keymap": "default",
+    "layout": "LAYOUT_ortho_5x4",
+    "layers": [
+        [
+            "KC_CALCULATOR", "KC_KP_SLASH", "KC_KP_ASTERISK", "KC_KP_MINUS",
+            "KC_KP_7", "KC_KP_8", "KC_KP_9", "KC_KP_PLUS",
+            "KC_KP_4", "KC_KP_5", "KC_KP_6", "KC_LEFT_PAREN",
+            "KC_KP_1", "KC_KP_2", "KC_KP_3", "KC_RIGHT_PAREN",
+            "KC_KP_0", "KC_KP_DOT", "KC_KP_EQUAL", "KC_KP_ENTER"
+        ]
+    ]
+}

--- a/keyboards/handwired/twentypad/readme.md
+++ b/keyboards/handwired/twentypad/readme.md
@@ -1,0 +1,26 @@
+# TwentyPad
+
+![TwentyPad](https://raw.githubusercontent.com/HarryCutts/twentypad/be5223b70d4581e453849865888f682dbc1b52d2/photo.jpg)
+
+A simple twenty-key macro pad, built to learn PCB design.
+
+* Keyboard Maintainer: [Harry Cutts](https://github.com/HarryCutts)
+* Hardware Supported: ATMEGA32U4 on a [custom PCB](https://github.com/HarryCutts/twentypad/)
+
+Make example for this keyboard (after setting up your build environment):
+
+    qmk compile -kb handwired/twentypad -km default
+
+Flashing example for this keyboard:
+
+    qmk flash -kb handwired/twentypad -km default
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+* **Bootmagic reset**: Hold down the key at (0,0) in the matrix (the top left key) and plug in the keyboard
+* **Physical reset button**: Press the button marked `SWR1` in the top-left of the PCB
+* **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/handwired/twentypad/readme.md
+++ b/keyboards/handwired/twentypad/readme.md
@@ -1,6 +1,6 @@
 # TwentyPad
 
-![TwentyPad](https://raw.githubusercontent.com/HarryCutts/twentypad/be5223b70d4581e453849865888f682dbc1b52d2/photo.jpg)
+![TwentyPad](https://i.imgur.com/e1Bsg1M.jpeg)
 
 A simple twenty-key macro pad, built to learn PCB design.
 


### PR DESCRIPTION
## Description

TwentyPad is 20-key macro pad I created as a hobby project. Its configuration is based on ez_maker/directpins/teensy_2, with the bootloader and layout changed.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
