### PR TITLE
Endpoint sizing validation.

### DIFF
--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -495,10 +495,6 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM PloverReport[] = {
         HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
     HID_RI_END_COLLECTION(0),
 };
-
-// The Plover HID report is sent with sizeof(report_plover_hid_t), but the endpoint and descriptor
-// are sized with PLOVER_HID_EPSIZE; they must match or reports get truncated/padded.
-STATIC_ASSERT(sizeof(report_plover_hid_t) == PLOVER_HID_EPSIZE, "report_plover_hid_t size must match PLOVER_HID_EPSIZE");
 #endif
 
 #ifdef CONSOLE_ENABLE
@@ -515,6 +511,72 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM ConsoleReport[] = {
         HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
     HID_RI_END_COLLECTION(0),
 };
+#endif
+
+// Report-to-endpoint routing mirrors tmk_core/protocol/chibios/usb_endpoints.c.
+#define STATIC_EPSIZE_ASSERT(report, epsize) STATIC_ASSERT(sizeof(report) <= (epsize) && (epsize) <= 64, #report " must fit within " #epsize " (max 64 bytes)")
+
+#ifdef KEYBOARD_SHARED_EP
+STATIC_EPSIZE_ASSERT(report_keyboard_t, SHARED_EPSIZE);
+#else
+STATIC_EPSIZE_ASSERT(report_keyboard_t, KEYBOARD_EPSIZE);
+#endif
+
+#ifdef NKRO_ENABLE
+STATIC_EPSIZE_ASSERT(report_nkro_t, SHARED_EPSIZE);
+#endif
+
+#ifdef MOUSE_ENABLE
+#    ifdef MOUSE_SHARED_EP
+STATIC_EPSIZE_ASSERT(report_mouse_t, SHARED_EPSIZE);
+#    else
+STATIC_EPSIZE_ASSERT(report_mouse_t, MOUSE_EPSIZE);
+#    endif
+#endif
+
+#ifdef EXTRAKEY_ENABLE
+STATIC_EPSIZE_ASSERT(report_extra_t, SHARED_EPSIZE);
+#endif
+
+#ifdef PROGRAMMABLE_BUTTON_ENABLE
+STATIC_EPSIZE_ASSERT(report_programmable_button_t, SHARED_EPSIZE);
+#endif
+
+#ifdef JOYSTICK_ENABLE
+#    ifdef JOYSTICK_SHARED_EP
+STATIC_EPSIZE_ASSERT(report_joystick_t, SHARED_EPSIZE);
+#    else
+STATIC_EPSIZE_ASSERT(report_joystick_t, JOYSTICK_EPSIZE);
+#    endif
+#endif
+
+#ifdef DIGITIZER_ENABLE
+#    ifdef DIGITIZER_SHARED_EP
+STATIC_EPSIZE_ASSERT(report_digitizer_t, SHARED_EPSIZE);
+#    else
+STATIC_EPSIZE_ASSERT(report_digitizer_t, DIGITIZER_EPSIZE);
+#    endif
+#endif
+
+#ifdef PLOVER_HID_ENABLE
+STATIC_EPSIZE_ASSERT(report_plover_hid_t, PLOVER_HID_EPSIZE);
+#endif
+
+#ifdef RAW_ENABLE
+STATIC_ASSERT(RAW_EPSIZE <= 64, "RAW_EPSIZE must be <= 64 bytes");
+#endif
+
+#ifdef CONSOLE_ENABLE
+STATIC_ASSERT(CONSOLE_EPSIZE <= 64, "CONSOLE_EPSIZE must be <= 64 bytes");
+#endif
+
+#ifdef MIDI_ENABLE
+STATIC_ASSERT(MIDI_STREAM_EPSIZE <= 64, "MIDI_STREAM_EPSIZE must be <= 64 bytes");
+#endif
+
+#ifdef VIRTSER_ENABLE
+STATIC_ASSERT(CDC_EPSIZE <= 64, "CDC_EPSIZE must be <= 64 bytes");
+STATIC_ASSERT(CDC_NOTIFICATION_EPSIZE <= 64, "CDC_NOTIFICATION_EPSIZE must be <= 64 bytes");
 #endif
 
 /*

--- a/tmk_core/protocol/usb_descriptor.h
+++ b/tmk_core/protocol/usb_descriptor.h
@@ -298,16 +298,21 @@ enum usb_endpoints {
 #    error There are not enough available endpoints to support all functions. Please disable one or more of the following: Mouse Keys, Extra Keys, Console, NKRO, MIDI, Serial, Steno
 #endif
 
-#define KEYBOARD_EPSIZE 8
-#define SHARED_EPSIZE 32
-#define MOUSE_EPSIZE 16
-#define RAW_EPSIZE 32
-#define PLOVER_HID_EPSIZE 9
-#define CONSOLE_EPSIZE 32
-#define MIDI_STREAM_EPSIZE 64
-#define CDC_NOTIFICATION_EPSIZE 8
-#define CDC_EPSIZE 16
-#define JOYSTICK_EPSIZE 8
-#define DIGITIZER_EPSIZE 8
+// Endpoint sizes must be a multiple of 4: the ChibiOS block queue stores a size_t
+// length header per buffer (see BQ_BUFFER_SIZE) that must stay 4-byte aligned.
+// EPSIZE_ALIGN() rounds up so this holds regardless of the value given.
+#define EPSIZE_ALIGN(n) (((n) + 3) & ~3)
+
+#define KEYBOARD_EPSIZE EPSIZE_ALIGN(8)
+#define SHARED_EPSIZE EPSIZE_ALIGN(32)
+#define MOUSE_EPSIZE EPSIZE_ALIGN(16)
+#define RAW_EPSIZE EPSIZE_ALIGN(32)
+#define PLOVER_HID_EPSIZE EPSIZE_ALIGN(9)
+#define CONSOLE_EPSIZE EPSIZE_ALIGN(32)
+#define MIDI_STREAM_EPSIZE EPSIZE_ALIGN(64)
+#define CDC_NOTIFICATION_EPSIZE EPSIZE_ALIGN(8)
+#define CDC_EPSIZE EPSIZE_ALIGN(16)
+#define JOYSTICK_EPSIZE EPSIZE_ALIGN(sizeof(report_joystick_t))
+#define DIGITIZER_EPSIZE EPSIZE_ALIGN(8)
 
 uint16_t get_usb_descriptor(const uint16_t wValue, const uint16_t wIndex, const uint16_t wLength, const void** const DescriptorAddress);


### PR DESCRIPTION
## Description

Endpoint sizes need to be a multiple of 4 -- this PR adds validation to fix the runtime error in sizing (non-bootable board) when using Plover HID on ChibiOS (RP2040 at minimum).

Joystick definition changed to be `sizeof`-based as it changes depending on the number of axes; the original size of 8 was a problem. No preprocessor depends on `JOYSTICK_EPSIZE` so no real issue. Rest of them stay literal.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
