### PR TITLE
process_key_lock: clear entire key state in cancel_key_lock()

### DIFF
--- a/quantum/process_keycode/process_key_lock.c
+++ b/quantum/process_keycode/process_key_lock.c
@@ -57,7 +57,12 @@ static inline uint16_t translate_keycode(uint16_t keycode) {
 
 void cancel_key_lock(void) {
     watching = false;
-    UNSET_KEY_STATE(0x0);
+    // Clear the full 256-bit state: UNSET_KEY_STATE(0x0) only cleared bit 0
+    // of the first word, leaving every actually-locked key still latched.
+    key_state[0] = 0;
+    key_state[1] = 0;
+    key_state[2] = 0;
+    key_state[3] = 0;
 }
 
 bool process_key_lock(uint16_t *keycode, keyrecord_t *record) {

--- a/quantum/process_keycode/process_key_lock.c
+++ b/quantum/process_keycode/process_key_lock.c
@@ -57,8 +57,7 @@ static inline uint16_t translate_keycode(uint16_t keycode) {
 
 void cancel_key_lock(void) {
     watching = false;
-    // Clear the full 256-bit state: UNSET_KEY_STATE(0x0) only cleared bit 0
-    // of the first word, leaving every actually-locked key still latched.
+    // Clear the full 256-bit state, otherwise every actually-locked key will still be latched.
     key_state[0] = 0;
     key_state[1] = 0;
     key_state[2] = 0;


### PR DESCRIPTION
## Description

`cancel_key_lock()` called `UNSET_KEY_STATE(0x0)`, which expands to clearing
only bit 0 of `key_state[0]`. The Key Lock state is a 256-bit map spread across
`key_state[0..3]`, so every locked key other than keycode `0x00` (`KC_NO`, which
can never be locked) stayed latched after a cancel — i.e. `cancel_key_lock()`
was effectively a no-op for all real locked keys.

This zeroes all four words so `cancel_key_lock()` releases every locked key, as
its name and its public declaration in `process_key_lock.h` imply.

Verified on hardware (RP2040 split, `KEY_LOCK_ENABLE = yes`): with the bug,
locking a key then calling `cancel_key_lock()` left the key stuck down at the
host; with the fix the key releases immediately.

## Types of Changes

- [x] Core
- [x] Bugfix

## Issues Fixed or Closed by This PR

None — no existing tracking issue.

## Checklist

- [x] My PR targets the `develop` branch.
- [x] My code follows the code style of this project (`qmk format-c` clean).
- [x] I have read the [PR Checklist](https://docs.qmk.fm/#/pr_checklist).
