### PR TITLE
Handle ASCII in send_unicode_string with keycodes

### DIFF
--- a/quantum/send_string/send_string.c
+++ b/quantum/send_string/send_string.c
@@ -213,6 +213,10 @@ void send_char(char ascii_code) {
     send_char_with_delay(ascii_code, TAP_CODE_DELAY);
 }
 
+bool is_valid_send_char(char ascii_code) {
+    return pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]) != KC_NO;
+}
+
 void send_char_with_delay(char ascii_code, uint8_t interval) {
 #if defined(AUDIO_ENABLE) && defined(SENDSTRING_BELL)
     if (ascii_code == '\a') { // BEL

--- a/quantum/send_string/send_string.h
+++ b/quantum/send_string/send_string.h
@@ -24,6 +24,7 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "progmem.h"
 #include "send_string_keycodes.h"
@@ -81,6 +82,13 @@ void send_char(char ascii_code);
  * \param interval The amount of time, in milliseconds, to wait in between key presses. Note this can be set to 0 to ensure no delay, regardless of what TAP_CODE_DELAY is set to.
  */
 void send_char_with_delay(char ascii_code, uint8_t interval);
+
+/**
+ * \brief Check whether an ASCII character has a send-string keycode mapping.
+ *
+ * \param ascii_code The character to check.
+ */
+bool is_valid_send_char(char ascii_code);
 
 /**
  * \brief Type out an eight digit (unsigned 32-bit) hexadecimal value.

--- a/quantum/unicode/unicode.c
+++ b/quantum/unicode/unicode.c
@@ -378,7 +378,7 @@ void send_unicode_string(const char *str) {
         int32_t code_point = 0;
         str                = decode_utf8(str, &code_point);
 
-        if (code_point > 0 && code_point < 0x80 && pgm_read_byte(&ascii_to_keycode_lut[code_point]) != XXXXXXX) {
+        if (code_point > 0 && code_point < 0x80 && is_valid_send_char(code_point)) {
             send_char(code_point);
         } else if (code_point >= 0) {
             register_unicode(code_point);

--- a/quantum/unicode/unicode.c
+++ b/quantum/unicode/unicode.c
@@ -378,7 +378,9 @@ void send_unicode_string(const char *str) {
         int32_t code_point = 0;
         str                = decode_utf8(str, &code_point);
 
-        if (code_point >= 0) {
+        if (code_point > 0 && code_point < 0x80 && pgm_read_byte(&ascii_to_keycode_lut[code_point]) != XXXXXXX) {
+            send_char(code_point);
+        } else if (code_point >= 0) {
             register_unicode(code_point);
         }
     }

--- a/tests/unicode/test_unicode.cpp
+++ b/tests/unicode/test_unicode.cpp
@@ -84,3 +84,27 @@ TEST_F(Unicode, sends_unicode_string) {
 
     VERIFY_AND_CLEAR(driver);
 }
+
+TEST_F(Unicode, sends_unicode_string_ascii_with_keycodes) {
+    TestDriver driver;
+
+    set_unicode_input_mode(UNICODE_MODE_LINUX);
+
+    {
+        testing::InSequence s;
+
+        EXPECT_REPORT(driver, (KC_A));
+        EXPECT_EMPTY_REPORT(driver);
+        EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+        EXPECT_REPORT(driver, (KC_A, KC_LEFT_SHIFT));
+        EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+        EXPECT_EMPTY_REPORT(driver);
+        EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+        EXPECT_REPORT(driver, (KC_1, KC_LEFT_SHIFT));
+        EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+    send_unicode_string("aA!");
+
+    VERIFY_AND_CLEAR(driver);
+}


### PR DESCRIPTION
## Description

Updates `send_unicode_string()` to emit ASCII characters through QMK's existing send-string keycode path when the decoded character has a keycode mapping. Non-ASCII characters continue to use the configured Unicode input mode.

Fixes #25382

## Types of Changes

- [x] Core
- [x] Bugfix
- N/A: New feature
- [x] Enhancement/optimization
- N/A: Keyboard (addition or update)
- N/A: Keymap/layout (addition or update)
- N/A: Documentation

## Issues Fixed or Closed by This PR

* Fixes #25382

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- N/A: My change requires a change to the documentation.
- N/A: I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
