### PR TITLE
qp_lvgl: always signal flush ready even with no display

### DIFF
--- a/quantum/painter/lvgl/qp_lvgl.c
+++ b/quantum/painter/lvgl/qp_lvgl.c
@@ -28,8 +28,11 @@ void qp_lvgl_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color
         qp_viewport(selected_display, area->x1, area->y1, area->x2, area->y2);
         qp_pixdata(selected_display, (void *)color_p, number_pixels);
         qp_flush(selected_display);
-        lv_disp_flush_ready(disp);
     }
+    // Must always be signalled, even when there is no selected display:
+    // skipping it leaves LVGL's flush permanently "in progress" and stalls
+    // all further rendering.
+    lv_disp_flush_ready(disp);
 }
 
 static uint32_t tick_task_callback(uint32_t trigger_time, void *cb_arg) {


### PR DESCRIPTION
## Description

`qp_lvgl_flush()` called `lv_disp_flush_ready()` only inside the
`if (selected_display)` block. When LVGL invokes the flush callback while
`selected_display` is `NULL`, the callback returns without ever signalling
completion, so LVGL keeps the flush marked "in progress" and stalls all
further rendering.

This moves `lv_disp_flush_ready()` out of the conditional so it is always
called, per LVGL's contract that every `flush_cb` must signal ready exactly
once.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: <https://docs.qmk.fm/#/contributing>
- [x] I have read the **[PR Checklist](https://docs.qmk.fm/#/pr_checklist)** document and have made the appropriate changes.
- [ ] My change requires a change to the documentation. *(bugfix only — no documented behavior changes)*
- [x] My code needs no new automated tests.
