### PR TITLE
split_common: validate RPC info before applying wire-supplied lengths

### DIFF
--- a/quantum/split_common/transactions.c
+++ b/quantum/split_common/transactions.c
@@ -1052,6 +1052,20 @@ void slave_rpc_info_callback(uint8_t initiator2target_buffer_size, const void *i
     // Ignore the args -- the `split_shmem` already has the info, we just need to act upon it.
     // We must keep the `split_transaction_table` non-const, so that it is able to be modified at runtime.
 
+    // The serial link carries no payload CRC, so validate before applying:
+    // a corrupted length byte applied here would make the next PUT_RPC_REQ_DATA
+    // receive up to 255 bytes into the fixed-size rpc buffers inside
+    // split_shmem, corrupting slave memory. The reject is not visible to the
+    // master, so the following data transaction may fail or time out against
+    // a stale size; the transport resynchronizes on subsequent transactions,
+    // which is still strictly better than applying a corrupt length.
+    if (crc8(&split_shmem->rpc_info.payload, sizeof(split_shmem->rpc_info.payload)) != split_shmem->rpc_info.checksum) {
+        return;
+    }
+    if (split_shmem->rpc_info.payload.m2s_length > RPC_M2S_BUFFER_SIZE || split_shmem->rpc_info.payload.s2m_length > RPC_S2M_BUFFER_SIZE) {
+        return;
+    }
+
     split_transaction_table[PUT_RPC_REQ_DATA].initiator2target_buffer_size  = split_shmem->rpc_info.payload.m2s_length;
     split_transaction_table[GET_RPC_RESP_DATA].target2initiator_buffer_size = split_shmem->rpc_info.payload.s2m_length;
 }
@@ -1064,7 +1078,13 @@ void slave_rpc_exec_callback(uint8_t initiator2target_buffer_size, const void *i
         return;
     }
 
-    int8_t transaction_id = split_shmem->rpc_info.payload.transaction_id;
+    if (split_shmem->rpc_info.payload.m2s_length > RPC_M2S_BUFFER_SIZE || split_shmem->rpc_info.payload.s2m_length > RPC_S2M_BUFFER_SIZE) {
+        return;
+    }
+
+    // Unsigned on purpose: a corrupted id with the MSB set would pass a
+    // signed upper-bound check and index the table at a negative offset.
+    uint8_t transaction_id = split_shmem->rpc_info.payload.transaction_id;
     if (transaction_id < NUM_TOTAL_TRANSACTIONS) {
         split_transaction_desc_t *trans = &split_transaction_table[transaction_id];
         if (trans->slave_callback) {


### PR DESCRIPTION
# Description

`slave_rpc_info_callback()` applied the master-supplied `m2s_length` and `s2m_length` directly to the transaction table with no validation. At this point the serial link offers no payload integrity guarantee, so a corrupted length byte would make the following `PUT_RPC_REQ_DATA` transaction receive up to 255 bytes into the fixed-size RPC buffers in `split_shmem`, overrunning slave memory.

This change validates the payload CRC and bounds both lengths against `RPC_M2S_BUFFER_SIZE` / `RPC_S2M_BUFFER_SIZE` before applying them; if either check fails the update is dropped. The reject is not visible to the master, so the next data transaction may fail against a stale size; the transport resynchronizes on subsequent transactions, which is still strictly better than applying a corrupt length.

`slave_rpc_exec_callback()` now applies the same length clamp before dispatching to `trans->slave_callback()`. Its CRC check alone cannot rule out a CRC8 collision (about 1 in 256 corruption events), so the wire-supplied lengths are bounded there as well before any slave callback sees them.

It also makes `transaction_id` in `slave_rpc_exec_callback()` unsigned: a corrupted id with the MSB set would otherwise pass the signed `< NUM_TOTAL_TRANSACTIONS` upper-bound check and index the transaction table at a negative offset.

Note for reviewers: the CRC check appears in both callbacks by design. The length write happens in `info_callback`, which runs before `exec_callback`, so the lengths have to be validated before they are applied to the transaction table; the second check in `exec_callback` independently protects the dispatch path in case the shared payload changed between the two transactions.

## Types of Changes

- [x] Core
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: `qmk format-c` applied, diff is noise-free.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] My change targets the `develop` branch.
- [x] My change is restricted to one logical change (core only, no keyboard/keymap mixed in).
- [x] Compile-verified against `pica40/rev2:default` (defines `SPLIT_TRANSACTION_IDS_KB`, so the changed `slave_rpc_*_callback` paths are actually built) and `crkbd/rev1:default`, after rebasing onto current `develop`.
