### PR TITLE
Consistently handle datablock init

### DIFF
--- a/docs/feature_eeprom.md
+++ b/docs/feature_eeprom.md
@@ -191,7 +191,9 @@ void     eeconfig_init_user_datablock(void);
 
 :::::
 
-### Example
+### Examples
+
+#### Basic
 
 This is an example of how to add settings, and read and write it. We're using the user keymap for the example here.
 
@@ -215,10 +217,6 @@ typedef struct my_config_t {
 static my_config_t config;
 
 void keyboard_post_init_user(void) {
-    if (!eeconfig_is_user_datablock_valid()) {
-        eeconfig_init_user_datablock();
-    }
-
     eeconfig_read_user_datablock(&config, 0, sizeof(my_config_t));
 }
 
@@ -240,3 +238,20 @@ void housekeeping_task_user(void) {
     }
 }
 ```
+
+#### Default Values
+
+Extending the above example, a default value for the datablock can be configured as follows:
+
+```c
+void eeconfig_init_user_datablock(void) {
+    my_config_t default_config = {
+        .data = 42,
+    };
+    eeconfig_update_user_datablock(&default_config, 0, sizeof(my_config_t));
+}
+```
+
+::: tip
+For large datablocks, you might need to manually update in chuncks to avoid memory issues.
+:::

--- a/docs/feature_eeprom.md
+++ b/docs/feature_eeprom.md
@@ -253,5 +253,5 @@ void eeconfig_init_user_datablock(void) {
 ```
 
 ::: tip
-For large datablocks, you might need to manually update in chuncks to avoid memory issues.
+For large datablocks, you might need to manually update in chunks to avoid memory issues.
 :::

--- a/lib/python/qmk/cli/generate/community_modules.py
+++ b/lib/python/qmk/cli/generate/community_modules.py
@@ -213,6 +213,7 @@ def _render_eeconfig_declarations(modules):
 
     lines.append('bool eeconfig_is_modules_datablock_valid(void);')
     lines.append('void eeconfig_init_modules_datablock(void);')
+    lines.append('void eeconfig_prepare_modules_datablocks(void);')
     lines.append('')
 
     return lines
@@ -235,7 +236,7 @@ def _render_eeconfig_implementation(modules):
             f'bool eeconfig_is_{module_slug}_datablock_valid(void) {{ return nvm_eeconfig_is_{module_slug}_datablock_valid(); }}',
             f'uint32_t eeconfig_read_{module_slug}_datablock(void *data, uint32_t offset, uint32_t length) {{ return nvm_eeconfig_read_{module_slug}_datablock(data, offset, length); }}',
             f'uint32_t eeconfig_update_{module_slug}_datablock(const void *data, uint32_t offset, uint32_t length) {{ return nvm_eeconfig_update_{module_slug}_datablock(data, offset, length); }}',
-            f'void eeconfig_init_{module_slug}_datablock(void) {{ nvm_eeconfig_init_{module_slug}_datablock(); }}',
+            f'__attribute__((weak)) void eeconfig_init_{module_slug}_datablock(void) {{ nvm_eeconfig_init_{module_slug}_datablock(); }}',
             '',
             '#    if defined(NVM_DRIVER_EEPROM)',
             f'bool nvm_eeconfig_is_{module_slug}_datablock_valid(void) {{',
@@ -294,6 +295,16 @@ def _render_eeconfig_implementation(modules):
         lines.extend([
             f'#if (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE) > 0',
             f'    eeconfig_init_{module_slug}_datablock();',
+            f'#endif // (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE) > 0',
+        ])
+    lines.append('}')
+    lines.append('')
+
+    lines.append('void eeconfig_prepare_modules_datablocks(void) {'),
+    for module_slug in _module_slugs(modules):
+        lines.extend([
+            f'#if (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE) > 0',
+            f'    if (!eeconfig_is_{module_slug}_datablock_valid()) {{ eeconfig_init_{module_slug}_datablock(); }}',
             f'#endif // (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE) > 0',
         ])
     lines.append('}')

--- a/lib/python/qmk/cli/generate/community_modules.py
+++ b/lib/python/qmk/cli/generate/community_modules.py
@@ -224,10 +224,10 @@ def _render_eeconfig_implementation(modules):
 
     lines.append('')
     lines.append('// nvm eeconfig')
-    lines.append('#if defined(NVM_DRIVER_EEPROM)'),
+    lines.append('#if defined(NVM_DRIVER_EEPROM)')
     lines.append('#    include "nvm_eeprom_eeconfig_internal.h"')
     lines.append('#    include "eeprom.h"')
-    lines.append('#endif // defined(NVM_DRIVER_EEPROM)'),
+    lines.append('#endif // defined(NVM_DRIVER_EEPROM)')
     lines.append('')
 
     for module_slug in _module_slugs(modules):

--- a/lib/python/qmk/cli/generate/community_modules.py
+++ b/lib/python/qmk/cli/generate/community_modules.py
@@ -290,7 +290,7 @@ def _render_eeconfig_implementation(modules):
     lines.append('}')
     lines.append('')
 
-    lines.append('void eeconfig_init_modules_datablock(void) {'),
+    lines.append('void eeconfig_init_modules_datablock(void) {')
     for module_slug in _module_slugs(modules):
         lines.extend([
             f'#if (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE) > 0',
@@ -300,7 +300,7 @@ def _render_eeconfig_implementation(modules):
     lines.append('}')
     lines.append('')
 
-    lines.append('void eeconfig_prepare_modules_datablocks(void) {'),
+    lines.append('void eeconfig_prepare_modules_datablocks(void) {')
     for module_slug in _module_slugs(modules):
         lines.extend([
             f'#if (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE) > 0',

--- a/modules/qmk/nvm_test/nvm_test.c
+++ b/modules/qmk/nvm_test/nvm_test.c
@@ -24,11 +24,14 @@ void eeconfig_update_my_config(my_config_t *value) {
 
 EECONFIG_DEBOUNCE_HELPER(my_config, config);
 
-void keyboard_post_init_nvm_test(void) {
-    if (!eeconfig_is_nvm_test_datablock_valid()) {
-        eeconfig_init_nvm_test_datablock();
-    }
+void eeconfig_init_nvm_test_datablock(void) {
+    my_config_t default_config = {
+        .data = 42,
+    };
+    eeconfig_update_nvm_test_datablock(&default_config, 0, sizeof(my_config_t));
+}
 
+void keyboard_post_init_nvm_test(void) {
     eeconfig_init_my_config();
 }
 

--- a/quantum/eeconfig.c
+++ b/quantum/eeconfig.c
@@ -365,3 +365,21 @@ __attribute__((weak)) void eeconfig_init_user_datablock(void) {
     nvm_eeconfig_init_user_datablock();
 }
 #endif // (EECONFIG_USER_DATA_SIZE) > 0
+
+void eeconfig_prepare_datablocks(void) {
+#if (EECONFIG_KB_DATA_SIZE) > 0
+    if (!eeconfig_is_kb_datablock_valid()) {
+        eeconfig_init_kb_datablock();
+    }
+#endif // (EECONFIG_KB_DATA_SIZE) > 0
+
+#if (EECONFIG_USER_DATA_SIZE) > 0
+    if (!eeconfig_is_user_datablock_valid()) {
+        eeconfig_init_user_datablock();
+    }
+#endif // (EECONFIG_USER_DATA_SIZE) > 0
+
+#ifdef COMMUNITY_MODULES_ENABLE
+    eeconfig_prepare_modules_datablocks();
+#endif // COMMUNITY_MODULES_ENABLE
+}

--- a/quantum/eeconfig.h
+++ b/quantum/eeconfig.h
@@ -63,6 +63,8 @@ void eeconfig_init_user(void);
 void eeconfig_enable(void);
 void eeconfig_disable(void);
 
+void eeconfig_prepare_datablocks(void);
+
 typedef union debug_config_t debug_config_t;
 void                         eeconfig_read_debug(debug_config_t *debug_config) __attribute__((nonnull));
 void                         eeconfig_update_debug(const debug_config_t *debug_config) __attribute__((nonnull));

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -449,6 +449,8 @@ void quantum_init(void) {
 
     /* Also initialize layer state to trigger callback functions for layer_state */
     layer_state_set_kb((layer_state_t)layer_state);
+
+    eeconfig_prepare_datablocks();
 }
 
 /** \brief keyboard_init


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Expecting the following to be correctly implemented somewhere on startup is fragile:
```c
if (!eeconfig_is_<whatever>_datablock_valid()) {
    eeconfig_init_<whatever>_datablock();
}
```

This PR implements this automatically for all datablocks.

This also aligns `eeconfig_init_<module>_datablock` to be weak per the kb/user API.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
