### PR TITLE
ploopyco: fix bitwise typos in opt_encoder_tiny state definitions

### DIFF
--- a/keyboards/ploopyco/common/opt_encoder_tiny.c
+++ b/keyboards/ploopyco/common/opt_encoder_tiny.c
@@ -78,9 +78,9 @@ typedef enum {
     UP_BEGIN_MID,
     STATE_MASK    = 0xf, /* 0b1111 */
     EMIT_UP       = 0x10,
-    EMIT_UP_MID   = EMIT_UP & START_MID,
+    EMIT_UP_MID   = EMIT_UP | START_MID,
     EMIT_DOWN     = 0x80,
-    EMIT_DOWN_MID = EMIT_DOWN & START_MID,
+    EMIT_DOWN_MID = EMIT_DOWN | START_MID,
     EMIT_MASK     = 0xf0
 } encoder_state_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR fixes a bug in the state machine definitions within `opt_encoder_tiny.c` that caused severely delayed or unresponsive scrolling.

The definitions for `EMIT_UP_MID` and `EMIT_DOWN_MID` were using a bitwise AND (`&`) instead of a bitwise OR (`|`):
* `EMIT_UP_MID   = EMIT_UP & START_MID`
* `EMIT_DOWN_MID = EMIT_DOWN & START_MID`

Because `EMIT_UP`/`EMIT_DOWN` are `0x10`/`0x80` and `START_MID` is `3`, using `&` caused both definitions to evaluate to `0` (`START`). This caused the state machine to prematurely reset on almost every transition, ignoring normal wheel movements.

Replacing the operator with `|` correctly packs both the scroll action and the next state into a single byte, restoring snappy and accurate scroll wheel tracking.

This only applies when `OPT_ENCODER_TYPE = tiny` is set in `rules.mk`, which is not the default value.

@ploopyco 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
