### PR TITLE
Fix VERBOSE make flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ifndef VERBOSE
+ifneq ($(VERBOSE),true)
 .SILENT:
 endif
 

--- a/builddefs/build_keyboard.mk
+++ b/builddefs/build_keyboard.mk
@@ -4,7 +4,7 @@
 # responsible for determining which folder is being used and doing the
 # corresponding environment setup.
 
-ifndef VERBOSE
+ifneq ($(VERBOSE),true)
 .SILENT:
 endif
 

--- a/builddefs/build_test.mk
+++ b/builddefs/build_test.mk
@@ -1,4 +1,4 @@
-ifndef VERBOSE
+ifneq ($(VERBOSE),true)
 .SILENT:
 endif
 

--- a/lib/python/qmk/build_targets.py
+++ b/lib/python/qmk/build_targets.py
@@ -113,9 +113,6 @@ class BuildTarget:
             'builddefs/build_keyboard.mk',
         ]
 
-        if not cli.config.general.verbose:
-            compile_args.append('-s')
-
         verbose = 'true' if cli.config.general.verbose else 'false'
         color = 'true' if cli.config.general.color else 'false'
 


### PR DESCRIPTION
## Description

The docs say set this to `true` to enable verbose output, but setting it to anything, even "false", would enable verbose mode.

The qmk python build program actually does this, supplying "VERBOSE=false" to make, which turns verbose mode on, not off!  The reason it's not verbose is that the wrapper also adds the "-s" switch that has the same effect as turning verbose mode back off.

After fixing the flag, there's no reason to add the "-s", so remove that code.

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
