### PR TITLE
Make framebuffer effects honour `rgb_matrix_map_row_column_to_led`

### DIFF
--- a/quantum/rgb_matrix/animations/digital_rain_anim.h
+++ b/quantum/rgb_matrix/animations/digital_rain_anim.h
@@ -37,18 +37,22 @@ bool DIGITAL_RAIN(effect_params_t* params) {
                     g_rgb_frame_buffer[row][col]--;
                 }
             }
+
             // set the pixel colour
             uint8_t led[LED_HITS_TO_REMEMBER];
             uint8_t led_count = rgb_matrix_map_row_column_to_led(row, col, led);
 
-            // TODO: multiple leds are supported mapped to the same row/column
             if (led_count > 0) {
                 if (g_rgb_frame_buffer[row][col] > pure_green_intensity) {
                     const uint8_t boost = (uint8_t)((uint16_t)max_brightness_boost * (g_rgb_frame_buffer[row][col] - pure_green_intensity) / (max_intensity - pure_green_intensity));
-                    rgb_matrix_set_color(led[0], boost, max_intensity, boost);
+                    for (uint8_t index = 0; index < led_count; index++) {
+                        rgb_matrix_set_color(led[index], boost, max_intensity, boost);
+                    }
                 } else {
                     const uint8_t green = (uint8_t)((uint16_t)max_intensity * g_rgb_frame_buffer[row][col] / pure_green_intensity);
-                    rgb_matrix_set_color(led[0], 0, green, 0);
+                    for (uint8_t index = 0; index < led_count; index++) {
+                        rgb_matrix_set_color(led[index], 0, green, 0);
+                    }
                 }
             }
         }

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -79,6 +79,8 @@ bool TYPING_HEATMAP(effect_params_t* params) {
         for (uint8_t col = 0; col < MATRIX_COLS && RGB_MATRIX_LED_PROCESS_LIMIT; col++) {
             uint8_t val = g_rgb_frame_buffer[row][col];
 
+            bool processed = false;
+
             uint8_t led[LED_HITS_TO_REMEMBER];
             uint8_t led_count = rgb_matrix_map_row_column_to_led(row, col, led);
             for (uint8_t index = 0; index < led_count; index++) {
@@ -86,7 +88,6 @@ bool TYPING_HEATMAP(effect_params_t* params) {
 
                 if (led_index >= led_min && led_index < led_max) {
                     count++;
-
                     if (!HAS_ANY_FLAGS(g_led_config.flags[led_index], params->flags)) {
                         continue;
                     }
@@ -95,10 +96,11 @@ bool TYPING_HEATMAP(effect_params_t* params) {
                     rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
 
                     rgb_matrix_set_color(led_index, rgb.r, rgb.g, rgb.b);
+                    processed = true;
                 }
             }
 
-            if (led_count > 0 && decrease_heatmap_values) {
+            if (processed && decrease_heatmap_values) {
                 g_rgb_frame_buffer[row][col] = qsub8(val, 1);
             }
         }

--- a/quantum/rgb_matrix/animations/typing_heatmap_anim.h
+++ b/quantum/rgb_matrix/animations/typing_heatmap_anim.h
@@ -77,18 +77,29 @@ bool TYPING_HEATMAP(effect_params_t* params) {
     uint8_t count = 0;
     for (uint8_t row = 0; row < MATRIX_ROWS && count < RGB_MATRIX_LED_PROCESS_LIMIT; row++) {
         for (uint8_t col = 0; col < MATRIX_COLS && RGB_MATRIX_LED_PROCESS_LIMIT; col++) {
-            if (g_led_config.matrix_co[row][col] >= led_min && g_led_config.matrix_co[row][col] < led_max) {
-                count++;
-                uint8_t val = g_rgb_frame_buffer[row][col];
-                if (!HAS_ANY_FLAGS(g_led_config.flags[g_led_config.matrix_co[row][col]], params->flags)) continue;
+            uint8_t val = g_rgb_frame_buffer[row][col];
 
-                hsv_t hsv = {170 - qsub8(val, 85), rgb_matrix_config.hsv.s, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.hsv.v)};
-                rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
-                rgb_matrix_set_color(g_led_config.matrix_co[row][col], rgb.r, rgb.g, rgb.b);
+            uint8_t led[LED_HITS_TO_REMEMBER];
+            uint8_t led_count = rgb_matrix_map_row_column_to_led(row, col, led);
+            for (uint8_t index = 0; index < led_count; index++) {
+                uint8_t led_index = led[index];
 
-                if (decrease_heatmap_values) {
-                    g_rgb_frame_buffer[row][col] = qsub8(val, 1);
+                if (led_index >= led_min && led_index < led_max) {
+                    count++;
+
+                    if (!HAS_ANY_FLAGS(g_led_config.flags[led_index], params->flags)) {
+                        continue;
+                    }
+
+                    hsv_t hsv = {170 - qsub8(val, 85), rgb_matrix_config.hsv.s, scale8((qadd8(170, val) - 170) * 3, rgb_matrix_config.hsv.v)};
+                    rgb_t rgb = rgb_matrix_hsv_to_rgb(hsv);
+
+                    rgb_matrix_set_color(led_index, rgb.r, rgb.g, rgb.b);
                 }
+            }
+
+            if (led_count > 0 && decrease_heatmap_values) {
+                g_rgb_frame_buffer[row][col] = qsub8(val, 1);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`rgb_matrix_map_row_column_to_led` handles the mapping of multiple LEDS to a single matrix position. This was missing from typing heatmap, and only partially implemented in digital rain.

Typing heatmap should also handle NO_LED better as `g_led_config.flags[g_led_config.matrix_co[row][col]]` could index out bounds `g_led_config.flags` when `g_led_config.matrix_co[row][col]` returns `NO_LED` (255).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
