### PR TITLE
Add X0RA 5x5 keyboard

### DIFF
--- a/keyboards/x0ra/5x5/keyboard.json
+++ b/keyboards/x0ra/5x5/keyboard.json
@@ -1,0 +1,88 @@
+{
+    "keyboard_name": "X0RA 5x5",
+    "manufacturer": "X0RA",
+    "maintainer": "X0RA",
+    "usb": {
+        "vid": "0xAE49",
+        "pid": "0x6E6F",
+        "device_version": "0.0.1"
+    },
+    "processor": "atmega32u4",
+    "bootloader": "atmel-dfu",
+    "matrix_pins": {
+        "rows": ["E6", "F0", "D6", "D2", "B6"],
+        "cols": ["F5", "C7", "B7", "B2", "B4"]
+    },
+    "diode_direction": "COL2ROW",
+    "features": {
+        "bootmagic": true,
+        "mousekey": true,
+        "extrakey": true,
+        "nkro": true,
+        "rgblight": true,
+        "backlight": false,
+        "audio": false
+    },
+    "build": {
+        "lto": true
+    },
+    "ws2812": {
+        "pin": "D5"
+    },
+    "rgblight": {
+        "led_count": 40,
+        "max_brightness": 150,
+        "layers": {
+            "enabled": true,
+            "max": 4,
+            "override_rgb": true
+        },
+        "animations": {
+            "alternating": true,
+            "breathing": true,
+            "christmas": true,
+            "knight": true,
+            "rainbow_mood": true,
+            "rainbow_swirl": true,
+            "rgb_test": true,
+            "snake": true,
+            "static_gradient": true,
+            "twinkle": true
+        }
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {"matrix": [0, 0], "x": 0, "y": 0, "label": "K00 (E6,F5)"},
+                {"matrix": [0, 1], "x": 1, "y": 0, "label": "K01 (E6,C7)"},
+                {"matrix": [0, 2], "x": 2, "y": 0, "label": "K02 (E6,B7)"},
+                {"matrix": [0, 3], "x": 3, "y": 0, "label": "K03 (E6,B2)"},
+                {"matrix": [0, 4], "x": 4, "y": 0, "label": "K04 (E6,B4)"},
+
+                {"matrix": [1, 0], "x": 0, "y": 1, "label": "K10 (F0,F5)"},
+                {"matrix": [1, 1], "x": 1, "y": 1, "label": "K11 (F0,C7)"},
+                {"matrix": [1, 2], "x": 2, "y": 1, "label": "K12 (F0,B7)"},
+                {"matrix": [1, 3], "x": 3, "y": 1, "label": "K13 (F0,B2)"},
+                {"matrix": [1, 4], "x": 4, "y": 1, "label": "K14 (F0,B4)"},
+
+                {"matrix": [2, 0], "x": 0, "y": 2, "label": "K20 (D6,F5)"},
+                {"matrix": [2, 1], "x": 1, "y": 2, "label": "K21 (D6,C7)"},
+                {"matrix": [2, 2], "x": 2, "y": 2, "label": "K22 (D6,B7)"},
+                {"matrix": [2, 3], "x": 3, "y": 2, "label": "K23 (D6,B2)"},
+                {"matrix": [2, 4], "x": 4, "y": 2, "label": "K24 (D6,B4)"},
+
+                {"matrix": [3, 0], "x": 0, "y": 3, "label": "K30 (D2,F5)"},
+                {"matrix": [3, 1], "x": 1, "y": 3, "label": "K31 (D2,C7)"},
+                {"matrix": [3, 2], "x": 2, "y": 3, "label": "K32 (D2,B7)"},
+                {"matrix": [3, 3], "x": 3, "y": 3, "label": "K33 (D2,B2)"},
+                {"matrix": [3, 4], "x": 4, "y": 3, "label": "K34 (D2,B4)"},
+
+                {"matrix": [4, 0], "x": 0, "y": 4, "label": "K40 (B6,F5)"},
+                {"matrix": [4, 1], "x": 1, "y": 4, "label": "K41 (B6,C7)"},
+                {"matrix": [4, 2], "x": 2, "y": 4, "label": "K42 (B6,B7)"},
+                {"matrix": [4, 3], "x": 3, "y": 4, "label": "K43 (B6,B2)"},
+                {"matrix": [4, 4], "x": 4, "y": 4, "label": "K44 (B6,B4)"}
+            ]
+        }
+    }
+}

--- a/keyboards/x0ra/5x5/keymaps/default/keymap.c
+++ b/keyboards/x0ra/5x5/keymaps/default/keymap.c
@@ -1,0 +1,37 @@
+// Copyright 2026 X0RA
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+enum layers { _LAYER_ZERO, _LAYER_ONE, _LAYER_TWO, _LAYER_THREE };
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_LAYER_ZERO] = LAYOUT(
+        TO(1),     KC_PSLS,   KC_PAST,   KC_PMNS,   KC_DEL,
+        KC_PGUP,   KC_P7,     KC_P8,     KC_P9,     KC_MNXT,
+        KC_PGDN,   KC_P4,     KC_P5,     KC_P6,     KC_MPLY,
+        KC_PSCR,   KC_P1,     KC_P2,     KC_P3,     KC_MPRV,
+        KC_HOME,   KC_P0,     KC_ESC,    KC_PDOT,   KC_PENT
+    ),
+    [_LAYER_ONE] = LAYOUT(
+        TO(2),     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO
+    ),
+    [_LAYER_TWO] = LAYOUT(
+        TO(3),     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO
+    ),
+    [_LAYER_THREE] = LAYOUT(
+        TO(0),     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO,
+        KC_NO,     KC_NO,     KC_NO,     KC_NO,     KC_NO
+    )
+};

--- a/keyboards/x0ra/5x5/readme.md
+++ b/keyboards/x0ra/5x5/readme.md
@@ -1,0 +1,15 @@
+# X0RA 5x5
+
+A QMK port of the Winry 25tc, a 5x5 25-key macropad with 40 WS2812 RGB LEDs, based on an atmega32u4.
+
+* Keyboard Maintainer: X0RA
+* Hardware Supported: Winry 25tc
+* Hardware Availability: [AliExpress](https://www.aliexpress.com/item/1005002559266513.html)
+
+Make example for this keyboard: `make x0ra/5x5:default`
+
+Flashing example for this keyboard: `make x0ra/5x5:default:flash`
+
+Put the board into bootloader mode by holding the top-left key while plugging it in, or by pressing the physical reset button.
+
+See the [build environment setup](https://docs.qmk.fm/newbs_getting_started) and the [make instructions](https://docs.qmk.fm/faq_build) for more information.


### PR DESCRIPTION
## Description

Adds QMK support for the X0RA 5x5, a Winry 25tc-compatible 5x5 macropad.

This includes:

- `keyboard.json` for the ATmega32U4 controller, matrix pins, bootloader, RGB configuration, and layout metadata
- A default keymap with numpad/media/navigation keys
- A focused keyboard readme with build/flash examples and hardware availability

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Tested with:

- `qmk lint -kb x0ra/5x5`
- `qmk compile -kb x0ra/5x5 -km default`