### PR TITLE
[OS Detection] Don't classify MacOS sequences as Windows when cnt_02 >= 2

### DIFF
--- a/quantum/os_detection.c
+++ b/quantum/os_detection.c
@@ -147,7 +147,7 @@ void process_wlength(const uint16_t w_length) {
     // now try to make a guess
     os_variant_t guessed = OS_UNSURE;
     if (setups_data.count >= 3) {
-        if (setups_data.cnt_ff >= 2 && setups_data.cnt_04 >= 1) {
+        if (setups_data.cnt_ff >= 2 && setups_data.cnt_04 >= 1 && setups_data.cnt_02 < 2) {
             guessed = OS_WINDOWS;
         } else if (setups_data.count == setups_data.cnt_ff) {
             // Linux has 3 packets with 0xFF.

--- a/quantum/os_detection/tests/os_detection.cpp
+++ b/quantum/os_detection/tests/os_detection.cpp
@@ -71,6 +71,7 @@ macOS 12.5: [2, 24, 2, 28, FF]
 macOS 15.1.x: [ 2, 4E, 2, 1C, 2, 1A, FF, FF]
 macOS 15.x (another host): [ 2, 0E, 2, 1E, 2, 42, FF]
 macOS 15.x (periodic weirdness): [ 2, 42, 2, 1C, 2, 1A, FF, 2, 42, 2, 1C, 2, 1A, FF ]
+macOS 26.x: [02, 22, 02, 0E, 02, 42, FF, FF, 4, FF]
 iOS/iPadOS 15.6: [2, 24, 2, 28]
 Linux (including Android, Raspberry Pi and WebOS TV): [FF, FF, FF]
 Linux (another host): [FF, FF, FF, FF, FF, FF]
@@ -159,6 +160,12 @@ TEST_F(OsDetectionTest, TestChibiosMacSequoia2) {
 
 TEST_F(OsDetectionTest, TestChibiosMacSequoia3) {
     EXPECT_EQ(check_sequence({0x02, 0x0E, 0x02, 0x1E, 0x02, 0x42, 0xFF}), OS_MACOS);
+    os_detection_task();
+    assert_not_reported();
+}
+
+TEST_F(OsDetectionTest, TestChibiosMacosWithLate04Packet) {
+    EXPECT_EQ(check_sequence({0x02, 0x22, 0x02, 0x0E, 0x02, 0x42, 0xFF, 0xFF, 0x04, 0xFF}), OS_MACOS);
     os_detection_task();
     assert_not_reported();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Fixes macOS 26.x being misidentified as Windows on ChibiOS keyboards

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
On macOS 26.x with ChibiOS-based keyboards, the USB enumeration sends a late wLength=0x04 packet after the two 0xFF packets that already correctly established OS_MACOS. The existing Windows detection condition (cnt_ff >= 2 && cnt_04 >= 1) fires on this combination and permanently overwrites the correct result, causing the keyboard to report OS_WINDOWS on macOS for the remainder of the session.

Observed sequence (ChibiOS, macOS 15.x):
[0x02, 0x22, 0x02, 0x0E, 0x02, 0x42, 0xFF, 0xFF, 0x04, 0xFF]

After packet #6 (0xFF), detected_os is correctly set to OS_MACOS (cnt_02=3, cnt_ff=1). At packet #8 (0x04), cnt_ff=2 and cnt_04=1 satisfy the Windows condition, overwriting OS_MACOS with OS_WINDOWS. The final 0xFF at packet #9 re-evaluates to OS_WINDOWS again. The debounced callback delivers the incorrect result.

Fix: Add setups_data.cnt_02 < 2 as a conjunct to the Windows detection condition. This is sufficient because:
- Every documented real-world Windows sequence starts with 0xFF packets and has cnt_02 = 0 at the point the Windows condition first triggers.
- Every macOS sequence begins with at least two wLength=0x02 packets (cnt_02 >= 2).

These populations do not overlap. All existing Windows sequences in the test suite pass the new condition unchanged (cnt_02 = 0 in all cases).

A test case for the affected sequence has been added to `quantum/os_detection/tests/os_detection.cpp`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
