### PR TITLE
Add KC_DICTATION keycode for macOS Dictation

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.9_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.9_basic.hjson
@@ -1,0 +1,12 @@
+{
+    "keycodes": {
+        "0x00C3": {
+            "group": "media",
+            "key": "KC_DICTATION",
+            "label": "Dictation",
+            "aliases": [
+                "KC_DICT"
+            ]
+        }
+    }
+}

--- a/docs/keycodes.md
+++ b/docs/keycodes.md
@@ -211,6 +211,7 @@ See also: [Basic Keycodes](keycodes_basic)
 |`KC_ASSISTANT`          |`KC_ASST`                      |Launch Context-Aware Assistant         |✔            |             |                 |
 |`KC_MISSION_CONTROL`    |`KC_MCTL`                      |Open Mission Control                   |             |✔            |                 |
 |`KC_LAUNCHPAD`          |`KC_LPAD`                      |Open Launchpad                         |             |✔            |                 |
+|`KC_DICTATION`          |`KC_DICT`                      |Start Dictation                        |             |✔            |                 |
 
 <sup>1. The Linux kernel HID driver recognizes [nearly all keycodes](https://github.com/torvalds/linux/blob/master/drivers/hid/hid-input.c), but the default bindings depend on the DE/WM.</sup><br/>
 <sup>2. Treated as F13-F15.</sup><br/>

--- a/docs/keycodes_basic.md
+++ b/docs/keycodes_basic.md
@@ -227,6 +227,7 @@ Some of these keycodes may behave differently depending on the OS. For example, 
 |`KC_ASSISTANT`         |`KC_ASST`|Launch Assistant    |
 |`KC_MISSION_CONTROL`   |`KC_MCTL`|Open Mission Control|
 |`KC_LAUNCHPAD`         |`KC_LPAD`|Open Launchpad      |
+|`KC_DICTATION`         |`KC_DICT`|Start Dictation     |
 
 ## Number Pad
 

--- a/quantum/keycodes.h
+++ b/quantum/keycodes.h
@@ -297,6 +297,7 @@ enum qk_keycode_defines {
     KC_ASSISTANT = 0x00C0,
     KC_MISSION_CONTROL = 0x00C1,
     KC_LAUNCHPAD = 0x00C2,
+    KC_DICTATION = 0x00C3,
     QK_MOUSE_CURSOR_UP = 0x00CD,
     QK_MOUSE_CURSOR_DOWN = 0x00CE,
     QK_MOUSE_CURSOR_LEFT = 0x00CF,
@@ -1021,6 +1022,7 @@ enum qk_keycode_defines {
     KC_ASST    = KC_ASSISTANT,
     KC_MCTL    = KC_MISSION_CONTROL,
     KC_LPAD    = KC_LAUNCHPAD,
+    KC_DICT    = KC_DICTATION,
     MS_UP      = QK_MOUSE_CURSOR_UP,
     MS_DOWN    = QK_MOUSE_CURSOR_DOWN,
     MS_LEFT    = QK_MOUSE_CURSOR_LEFT,
@@ -1572,7 +1574,7 @@ enum qk_keycode_defines {
 #define IS_INTERNAL_KEYCODE(code) ((code) >= KC_NO && (code) <= KC_TRANSPARENT)
 #define IS_BASIC_KEYCODE(code) ((code) >= KC_A && (code) <= KC_EXSEL)
 #define IS_SYSTEM_KEYCODE(code) ((code) >= KC_SYSTEM_POWER && (code) <= KC_SYSTEM_WAKE)
-#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_LAUNCHPAD)
+#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_DICTATION)
 #define IS_MOUSE_KEYCODE(code) ((code) >= QK_MOUSE_CURSOR_UP && (code) <= QK_MOUSE_ACCELERATION_2)
 #define IS_MODIFIER_KEYCODE(code) ((code) >= KC_LEFT_CTRL && (code) <= KC_RIGHT_GUI)
 #define IS_SWAP_HANDS_KEYCODE(code) ((code) >= QK_SWAP_HANDS_TOGGLE && (code) <= QK_SWAP_HANDS_ONE_SHOT)
@@ -1599,7 +1601,7 @@ enum qk_keycode_defines {
 #define INTERNAL_KEYCODE_RANGE              KC_NO ... KC_TRANSPARENT
 #define BASIC_KEYCODE_RANGE                 KC_A ... KC_EXSEL
 #define SYSTEM_KEYCODE_RANGE                KC_SYSTEM_POWER ... KC_SYSTEM_WAKE
-#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_LAUNCHPAD
+#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_DICTATION
 #define MOUSE_KEYCODE_RANGE                 QK_MOUSE_CURSOR_UP ... QK_MOUSE_ACCELERATION_2
 #define MODIFIER_KEYCODE_RANGE              KC_LEFT_CTRL ... KC_RIGHT_GUI
 #define SWAP_HANDS_KEYCODE_RANGE            QK_SWAP_HANDS_TOGGLE ... QK_SWAP_HANDS_ONE_SHOT

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -82,6 +82,7 @@ enum consumer_usages {
     TRANSPORT_RANDOM_PLAY  = 0x0B9,
     TRANSPORT_STOP_EJECT   = 0x0CC,
     TRANSPORT_PLAY_PAUSE   = 0x0CD,
+    VOICE_COMMAND          = 0x0CF, // triggers Dictation on macOS Sonoma and later
     // 15.9.1 Audio Controls - Volume
     AUDIO_MUTE     = 0x0E2,
     AUDIO_VOL_UP   = 0x0E9,
@@ -345,6 +346,8 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
             return AC_DESKTOP_SHOW_ALL_WINDOWS;
         case KC_LAUNCHPAD:
             return AC_SOFT_KEY_LEFT;
+        case KC_DICTATION:
+            return VOICE_COMMAND;
         default:
             return 0;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds KC_DICTATION mapping to the standard usage 0x0CF. Requires EXTRAKEY_ENABLE
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
