### PR TITLE
Update satisfaction75 to only use keyboard datablock

### DIFF
--- a/keyboards/cannonkeys/lib/satisfaction75/satisfaction_core.c
+++ b/keyboards/cannonkeys/lib/satisfaction75/satisfaction_core.c
@@ -18,6 +18,10 @@
 #include "eeprom.h"
 #include "version.h" // for QMK_BUILDDATE used in EEPROM magic
 
+#ifdef VIA_ENABLE
+#    include "via.h"
+#endif
+
 /* Artificial delay added to get media keys to work in the encoder*/
 #define MEDIA_KEY_DELAY 10
 
@@ -54,22 +58,16 @@ void board_init(void) {
 }
 
 uint32_t read_custom_config(void *data, uint32_t offset, uint32_t length) {
-#ifdef VIA_ENABLE
-    return via_read_custom_config(data, offset, length);
-#else
     return eeconfig_read_kb_datablock(data, offset, length);
-#endif
 }
 
 uint32_t write_custom_config(const void *data, uint32_t offset, uint32_t length) {
-#ifdef VIA_ENABLE
-    return via_update_custom_config(data, offset, length);
-#else
     return eeconfig_update_kb_datablock(data, offset, length);
-#endif
 }
 
 void keyboard_post_init_kb(void) {
+    custom_config_load();
+
       /*
         This is a workaround to some really weird behavior
         Without this code, the OLED will turn on, but not when you initially plug the keyboard in.
@@ -305,14 +303,8 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
   return true;
 }
 
-void custom_config_reset(void){
-  for(int i = 0; i < VIA_EEPROM_CUSTOM_CONFIG_SIZE; ++i) {
-    uint8_t dummy = 0;
-    write_custom_config(&dummy, i, 1);
-  }
-
-  uint8_t encoder_modes = 0x1F;
-  write_custom_config(&encoder_modes, EEPROM_ENABLED_ENCODER_MODES_OFFSET, 1);
+void custom_config_reset(void) {
+  eeconfig_init_kb_datablock();
 }
 
 void custom_config_load(void){
@@ -322,39 +314,19 @@ void custom_config_load(void){
 #endif
 }
 
-// Called from via_init() if VIA_ENABLE
-// Called from matrix_init_kb() if not VIA_ENABLE
-void satisfaction_core_init(void)
-{
-  // This checks both an EEPROM reset (from bootmagic lite, keycodes)
-  // and also firmware build date (from via_eeprom_is_valid())
-  if (eeconfig_is_enabled()) {
-    custom_config_load();
-  } else	{
-#ifdef DYNAMIC_KEYMAP_ENABLE
-    // Reset the custom stuff
-    custom_config_reset();
-#endif
-    // DO NOT set EEPROM valid here, let caller do this
-  }
+void eeconfig_init_kb_datablock(void) {
+  uint8_t default_data[EECONFIG_KB_DATA_SIZE] = { 0 };
+
+  default_data[EEPROM_ENABLED_ENCODER_MODES_OFFSET] = 0x1F;
+
+  eeconfig_update_kb_datablock(default_data, 0, sizeof(default_data));
 }
 
-void matrix_init_kb(void)
-{
-#ifndef VIA_ENABLE
-  satisfaction_core_init();
-#endif // VIA_ENABLE
-
+void matrix_init_kb(void) {
   rtcGetTime(&RTCD1, &last_timespec);
   matrix_init_user();
   oled_request_wakeup();
 }
-
-#ifdef VIA_ENABLE
-void via_init_kb(void) {
-    satisfaction_core_init();
-}
-#endif // VIA_ENABLE
 
 void housekeeping_task_kb(void) {
   rtcGetTime(&RTCD1, &last_timespec);

--- a/keyboards/cannonkeys/lib/satisfaction75/satisfaction_core.h
+++ b/keyboards/cannonkeys/lib/satisfaction75/satisfaction_core.h
@@ -8,7 +8,6 @@
 
 #include <hal.h>
 
-#include "via.h" // only for EEPROM address
 #include "satisfaction_keycodes.h"
 
 #define EEPROM_ENABLED_ENCODER_MODES_OFFSET 0

--- a/keyboards/cannonkeys/lib/satisfaction75/satisfaction_keycodes.h
+++ b/keyboards/cannonkeys/lib/satisfaction75/satisfaction_keycodes.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "keycodes.h"
+
 enum my_keycodes {
   ENC_PRESS = QK_KB_0,
   CLOCK_SET,

--- a/keyboards/cannonkeys/satisfaction75/config.h
+++ b/keyboards/cannonkeys/satisfaction75/config.h
@@ -34,15 +34,8 @@
 // OLED timeout reimplemented in the keyboard-specific code
 #define CUSTOM_OLED_TIMEOUT 60000
 
-// Custom config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
 // Custom config Usage:
 // 1 for enabled encoder modes (1 byte)
 // 1 for OLED default mode (1 byte)
 // 6 for 3x custom encoder settings, left, right, and press (18 bytes)
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 20
-
-// And if VIA isn't enabled, fall back to using standard QMK for configuration
-#ifndef VIA_ENABLE
-#define EECONFIG_KB_DATA_SIZE VIA_EEPROM_CUSTOM_CONFIG_SIZE
-#endif
+#define EECONFIG_KB_DATA_SIZE 20

--- a/keyboards/cannonkeys/satisfaction75_hs/config.h
+++ b/keyboards/cannonkeys/satisfaction75_hs/config.h
@@ -32,18 +32,11 @@
 // OLED timeout reimplemented in the keyboard-specific code
 #define CUSTOM_OLED_TIMEOUT 60000
 
-// Custom config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
 // Custom config Usage:
 // 1 for enabled encoder modes (1 byte)
 // 1 for OLED default mode (1 byte)
 // 6 for 3x custom encoder settings, left, right, and press (18 bytes)
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 20
-
-// And if VIA isn't enabled, fall back to using standard QMK for configuration
-#ifndef VIA_ENABLE
-#define EECONFIG_KB_DATA_SIZE VIA_EEPROM_CUSTOM_CONFIG_SIZE
-#endif
+#define EECONFIG_KB_DATA_SIZE 20
 
 // VIA lighting is handled by the keyboard-level code
 #define VIA_CUSTOM_LIGHTING_ENABLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Preparing for changes where `via.h` is not always on the path, and the feature is handed over, this PR:

* Removes unconditional use of `via.h`
* Migrates use of `VIA_EEPROM_CUSTOM_CONFIG_SIZE` to always use keyboard datablock
* Updates eeprom init in line with recent changes to develop

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
