### PR TITLE
Migrate remaining `VIA_EEPROM_CUSTOM_CONFIG_SIZE` to `EECONFIG_KB_DATA_SIZE`

### DIFF
--- a/keyboards/hs60/v2/ansi/config.h
+++ b/keyboards/hs60/v2/ansi/config.h
@@ -72,6 +72,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 32
+#define EECONFIG_KB_DATA_SIZE 32

--- a/keyboards/hs60/v2/hhkb/config.h
+++ b/keyboards/hs60/v2/hhkb/config.h
@@ -72,6 +72,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 32
+#define EECONFIG_KB_DATA_SIZE 32

--- a/keyboards/hs60/v2/iso/config.h
+++ b/keyboards/hs60/v2/iso/config.h
@@ -69,6 +69,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 32
+#define EECONFIG_KB_DATA_SIZE 32

--- a/keyboards/keebwerk/mega/ansi/config.h
+++ b/keyboards/keebwerk/mega/ansi/config.h
@@ -70,6 +70,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 32
+#define EECONFIG_KB_DATA_SIZE 32

--- a/keyboards/novelkeys/nk87/config.h
+++ b/keyboards/novelkeys/nk87/config.h
@@ -71,6 +71,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 32
+#define EECONFIG_KB_DATA_SIZE 32

--- a/keyboards/spaceholdings/nebula12/config.h
+++ b/keyboards/spaceholdings/nebula12/config.h
@@ -92,6 +92,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 32
+#define EECONFIG_KB_DATA_SIZE 32

--- a/keyboards/spaceholdings/nebula68/config.h
+++ b/keyboards/spaceholdings/nebula68/config.h
@@ -76,6 +76,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 32
+#define EECONFIG_KB_DATA_SIZE 32

--- a/keyboards/tkc/portico/config.h
+++ b/keyboards/tkc/portico/config.h
@@ -70,8 +70,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGB_BACKLIGHT_ALPHAS_MODS_ROW_3 0b0111000000000001
 #define RGB_BACKLIGHT_ALPHAS_MODS_ROW_4 0b1111111111111111
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31
 
 #endif

--- a/keyboards/tkc/portico75/config.h
+++ b/keyboards/tkc/portico75/config.h
@@ -75,7 +75,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define RGB_BACKLIGHT_ALPHAS_MODS_ROW_3 0b0111100000000001
 #    define RGB_BACKLIGHT_ALPHAS_MODS_ROW_4 0b1111111111111111
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#    define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#    define EECONFIG_KB_DATA_SIZE 31
 #endif

--- a/keyboards/wilba_tech/rama_works_kara/config.h
+++ b/keyboards/wilba_tech/rama_works_kara/config.h
@@ -85,6 +85,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/rama_works_koyu/config.h
+++ b/keyboards/wilba_tech/rama_works_koyu/config.h
@@ -85,6 +85,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/rama_works_m10_c/config.h
+++ b/keyboards/wilba_tech/rama_works_m10_c/config.h
@@ -68,6 +68,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 51
+#define EECONFIG_KB_DATA_SIZE 51

--- a/keyboards/wilba_tech/rama_works_m50_a/config.h
+++ b/keyboards/wilba_tech/rama_works_m50_a/config.h
@@ -69,6 +69,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/rama_works_m60_a/config.h
+++ b/keyboards/wilba_tech/rama_works_m60_a/config.h
@@ -85,6 +85,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/rama_works_m65_b/config.h
+++ b/keyboards/wilba_tech/rama_works_m65_b/config.h
@@ -69,6 +69,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/rama_works_m65_bx/config.h
+++ b/keyboards/wilba_tech/rama_works_m65_bx/config.h
@@ -69,6 +69,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/rama_works_m6_a/config.h
+++ b/keyboards/wilba_tech/rama_works_m6_a/config.h
@@ -20,6 +20,4 @@
 // NOTE: M6-A doesn't use RGB backlight, but we keep this
 // consistent with M6-B which does.
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 43
+#define EECONFIG_KB_DATA_SIZE 43

--- a/keyboards/wilba_tech/rama_works_m6_b/config.h
+++ b/keyboards/wilba_tech/rama_works_m6_b/config.h
@@ -65,6 +65,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 43
+#define EECONFIG_KB_DATA_SIZE 43

--- a/keyboards/wilba_tech/rama_works_u80_a/config.h
+++ b/keyboards/wilba_tech/rama_works_u80_a/config.h
@@ -87,6 +87,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/wt60_a/config.h
+++ b/keyboards/wilba_tech/wt60_a/config.h
@@ -53,9 +53,7 @@
 // the default effect speed (0-3)
 #define MONO_BACKLIGHT_EFFECT_SPEED 0
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
+#define EECONFIG_KB_DATA_SIZE 7
 
 #define IS31FL3736_I2C_ADDRESS_1 IS31FL3736_I2C_ADDRESS_GND_GND
 #define IS31FL3736_LED_COUNT 96

--- a/keyboards/wilba_tech/wt60_b/config.h
+++ b/keyboards/wilba_tech/wt60_b/config.h
@@ -70,6 +70,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/wt60_bx/config.h
+++ b/keyboards/wilba_tech/wt60_bx/config.h
@@ -70,6 +70,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/wt60_c/config.h
+++ b/keyboards/wilba_tech/wt60_c/config.h
@@ -71,6 +71,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/wt65_a/config.h
+++ b/keyboards/wilba_tech/wt65_a/config.h
@@ -53,9 +53,7 @@
 // the default effect speed (0-3)
 #define MONO_BACKLIGHT_EFFECT_SPEED 0
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
+#define EECONFIG_KB_DATA_SIZE 7
 
 #define IS31FL3736_I2C_ADDRESS_1 IS31FL3736_I2C_ADDRESS_GND_GND
 #define IS31FL3736_LED_COUNT 96

--- a/keyboards/wilba_tech/wt65_b/config.h
+++ b/keyboards/wilba_tech/wt65_b/config.h
@@ -53,9 +53,7 @@
 // the default effect speed (0-3)
 #define MONO_BACKLIGHT_EFFECT_SPEED 0
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
+#define EECONFIG_KB_DATA_SIZE 7
 
 #define IS31FL3736_I2C_ADDRESS_1 IS31FL3736_I2C_ADDRESS_GND_GND
 #define IS31FL3736_LED_COUNT 96

--- a/keyboards/wilba_tech/wt75_a/config.h
+++ b/keyboards/wilba_tech/wt75_a/config.h
@@ -53,9 +53,7 @@
 // the default effect speed (0-3)
 #define MONO_BACKLIGHT_EFFECT_SPEED 0
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
+#define EECONFIG_KB_DATA_SIZE 7
 
 #define IS31FL3736_I2C_ADDRESS_1 IS31FL3736_I2C_ADDRESS_GND_GND
 #define IS31FL3736_LED_COUNT 96

--- a/keyboards/wilba_tech/wt75_b/config.h
+++ b/keyboards/wilba_tech/wt75_b/config.h
@@ -53,9 +53,7 @@
 // the default effect speed (0-3)
 #define MONO_BACKLIGHT_EFFECT_SPEED 0
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
+#define EECONFIG_KB_DATA_SIZE 7
 
 #define IS31FL3736_I2C_ADDRESS_1 IS31FL3736_I2C_ADDRESS_GND_GND
 #define IS31FL3736_LED_COUNT 96

--- a/keyboards/wilba_tech/wt75_c/config.h
+++ b/keyboards/wilba_tech/wt75_c/config.h
@@ -53,9 +53,7 @@
 // the default effect speed (0-3)
 #define MONO_BACKLIGHT_EFFECT_SPEED 000
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
+#define EECONFIG_KB_DATA_SIZE 7
 
 #define IS31FL3736_I2C_ADDRESS_1 IS31FL3736_I2C_ADDRESS_GND_GND
 #define IS31FL3736_LED_COUNT 96

--- a/keyboards/wilba_tech/wt80_a/config.h
+++ b/keyboards/wilba_tech/wt80_a/config.h
@@ -53,9 +53,7 @@
 // the default effect speed (0-3)
 #define MONO_BACKLIGHT_EFFECT_SPEED 0
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 7
+#define EECONFIG_KB_DATA_SIZE 7
 
 #define IS31FL3736_I2C_ADDRESS_1 IS31FL3736_I2C_ADDRESS_GND_GND
 #define IS31FL3736_LED_COUNT 96

--- a/keyboards/wilba_tech/wt_main.c
+++ b/keyboards/wilba_tech/wt_main.c
@@ -24,51 +24,19 @@
 #include "keyboards/wilba_tech/wt_mono_backlight.h"
 #endif // MONO_BACKLIGHT_ENABLED
 
-#ifndef VIA_ENABLE
-#include "via.h"
-#include "eeprom.h"
-#include "version.h" // for QMK_BUILDDATE used in EEPROM magic
-#endif
-
-// Called from via_init() if VIA_ENABLE
-// Called from matrix_init_kb() if not VIA_ENABLE
-void wt_main_init(void)
-{
-    // This checks both an EEPROM reset (from bootmagic lite, keycodes)
-    // and also firmware build date (from via_eeprom_is_valid())
-    if (eeconfig_is_enabled()) {
+void keyboard_post_init_kb(void) {
 #if RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
-        backlight_config_load();
-#endif // RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
-    } else	{
-#if RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
-        // If the EEPROM has not been saved before, or is out of date,
-        // save the default values to the EEPROM. Default values
-        // come from construction of the backlight_config instance.
-        backlight_config_save();
-#endif // RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
+    // Must be called after quantum_init
+    backlight_config_load();
 
-        // DO NOT set EEPROM valid here, let caller do this
-    }
-
-#if RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
     // Initialize LED drivers for backlight.
     backlight_init_drivers();
 
     backlight_timer_init();
     backlight_timer_enable();
 #endif // RGB_BACKLIGHT_ENABLED || MONO_BACKLIGHT_ENABLED
-}
 
-void matrix_init_kb(void)
-{
-    // If VIA is disabled, we still need to load backlight settings.
-    // Call via_init_kb() the same way as via_init_kb() does.
-#ifndef VIA_ENABLE
-    wt_main_init();
-#endif // VIA_ENABLE
-
-    matrix_init_user();
+    keyboard_post_init_user();
 }
 
 void matrix_scan_kb(void)
@@ -106,9 +74,7 @@ void suspend_wakeup_init_kb(void)
 // Moving this to the bottom of this source file is a workaround
 // for an intermittent compiler error for Atmel compiler.
 #ifdef VIA_ENABLE
-void via_init_kb(void) {
-    wt_main_init();
-}
+#    include "via.h"
 
 void via_custom_value_command_kb(uint8_t *data, uint8_t length) {
     uint8_t *command_id        = &(data[0]);

--- a/keyboards/wilba_tech/wt_mono_backlight.c
+++ b/keyboards/wilba_tech/wt_mono_backlight.c
@@ -23,15 +23,10 @@
 #include "i2c_master.h"
 #include "host.h"
 #include "progmem.h"
-#include "eeprom.h"
+#include "eeconfig.h"
 
-#include "nvm_eeprom_eeconfig_internal.h" // expose EEPROM addresses, no appetite to move legacy/deprecated code to nvm
-#include "nvm_eeprom_via_internal.h" // expose EEPROM addresses, no appetite to move legacy/deprecated code to nvm
-#include "via.h" // uses EEPROM address, lighting value IDs
-#define MONO_BACKLIGHT_CONFIG_EEPROM_ADDR (VIA_EEPROM_CUSTOM_CONFIG_ADDR)
-
-#if VIA_EEPROM_CUSTOM_CONFIG_SIZE == 0
-#error VIA_EEPROM_CUSTOM_CONFIG_SIZE was not defined to store backlight_config struct
+#if EECONFIG_KB_DATA_SIZE == 0
+#error EECONFIG_KB_DATA_SIZE was not defined to store backlight_config struct
 #endif
 
 #include "drivers/led/issi/is31fl3736-mono.h"
@@ -341,14 +336,16 @@ void backlight_config_get_value( uint8_t *data )
     }
 }
 
-void backlight_config_load(void)
-{
-    eeprom_read_block( &g_config, ((void*)MONO_BACKLIGHT_CONFIG_EEPROM_ADDR), sizeof(backlight_config) );
+void eeconfig_init_kb_datablock(void) {
+    backlight_config_save();
 }
 
-void backlight_config_save(void)
-{
-    eeprom_update_block( &g_config, ((void*)MONO_BACKLIGHT_CONFIG_EEPROM_ADDR), sizeof(backlight_config) );
+void backlight_config_load(void) {
+    eeconfig_read_kb_datablock( &g_config, 0, sizeof(backlight_config) );
+}
+
+void backlight_config_save(void) {
+    eeconfig_update_kb_datablock( &g_config, 0, sizeof(backlight_config) );
 }
 
 void backlight_update_pwm_buffers(void)

--- a/keyboards/wilba_tech/wt_mono_backlight.c
+++ b/keyboards/wilba_tech/wt_mono_backlight.c
@@ -24,10 +24,7 @@
 #include "host.h"
 #include "progmem.h"
 #include "eeconfig.h"
-
-#if EECONFIG_KB_DATA_SIZE == 0
-#error EECONFIG_KB_DATA_SIZE was not defined to store backlight_config struct
-#endif
+#include "compiler_support.h"
 
 #include "drivers/led/issi/is31fl3736-mono.h"
 
@@ -45,6 +42,8 @@ backlight_config g_config = {
     .effect_speed = MONO_BACKLIGHT_EFFECT_SPEED,
     .color_1 = MONO_BACKLIGHT_COLOR_1,
 };
+
+STATIC_ASSERT(sizeof(backlight_config) == EECONFIG_KB_DATA_SIZE, "Mismatch in keyboard EECONFIG stored data");
 
 bool g_suspend_state = false;
 

--- a/keyboards/wilba_tech/wt_rgb_backlight.c
+++ b/keyboards/wilba_tech/wt_rgb_backlight.c
@@ -64,15 +64,10 @@
 
 #include "progmem.h"
 #include "quantum/color.h"
-#include "eeprom.h"
+#include "eeconfig.h"
 
-#include "nvm_eeprom_eeconfig_internal.h" // expose EEPROM addresses, no appetite to move legacy/deprecated code to nvm
-#include "nvm_eeprom_via_internal.h" // expose EEPROM addresses, no appetite to move legacy/deprecated code to nvm
-#include "via.h" // uses EEPROM address, lighting value IDs
-#define RGB_BACKLIGHT_CONFIG_EEPROM_ADDR (VIA_EEPROM_CUSTOM_CONFIG_ADDR)
-
-#if VIA_EEPROM_CUSTOM_CONFIG_SIZE == 0
-#error VIA_EEPROM_CUSTOM_CONFIG_SIZE was not defined to store backlight_config struct
+#if EECONFIG_KB_DATA_SIZE == 0
+#error EECONFIG_KB_DATA_SIZE was not defined to store backlight_config struct
 #endif
 
 #if defined(RGB_BACKLIGHT_M6_B)
@@ -2097,14 +2092,16 @@ void backlight_config_set_alphas_mods( uint16_t *alphas_mods )
     backlight_config_save();
 }
 
-void backlight_config_load(void)
-{
-    eeprom_read_block( &g_config, ((void*)RGB_BACKLIGHT_CONFIG_EEPROM_ADDR), sizeof(backlight_config) );
+void eeconfig_init_kb_datablock(void) {
+    backlight_config_save();
 }
 
-void backlight_config_save(void)
-{
-    eeprom_update_block( &g_config, ((void*)RGB_BACKLIGHT_CONFIG_EEPROM_ADDR), sizeof(backlight_config) );
+void backlight_config_load(void) {
+    eeconfig_read_kb_datablock( &g_config, 0, sizeof(backlight_config) );
+}
+
+void backlight_config_save(void) {
+    eeconfig_update_kb_datablock( &g_config, 0, sizeof(backlight_config) );
 }
 
 void backlight_init_drivers(void)

--- a/keyboards/wilba_tech/wt_rgb_backlight.c
+++ b/keyboards/wilba_tech/wt_rgb_backlight.c
@@ -65,10 +65,7 @@
 #include "progmem.h"
 #include "quantum/color.h"
 #include "eeconfig.h"
-
-#if EECONFIG_KB_DATA_SIZE == 0
-#error EECONFIG_KB_DATA_SIZE was not defined to store backlight_config struct
-#endif
+#include "compiler_support.h"
 
 #if defined(RGB_BACKLIGHT_M6_B)
 #include "drivers/led/issi/is31fl3218.h"
@@ -134,6 +131,8 @@ backlight_config g_config = {
     .custom_color = { { 0, 255 }, { 43, 255 }, { 85, 255 }, { 128, 255 }, { 171, 255 }, { 213, 255 }, { 0, 255 }, { 43, 255 }, { 85, 255 }, { 128, 255 } }
 #endif
 };
+
+STATIC_ASSERT(sizeof(backlight_config) == EECONFIG_KB_DATA_SIZE, "Mismatch in keyboard EECONFIG stored data");
 
 bool g_suspend_state = false;
 

--- a/keyboards/wilba_tech/zeal60/config.h
+++ b/keyboards/wilba_tech/zeal60/config.h
@@ -84,6 +84,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/wilba_tech/zeal65/config.h
+++ b/keyboards/wilba_tech/zeal65/config.h
@@ -84,6 +84,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31

--- a/keyboards/xelus/dawn60/rev1/config.h
+++ b/keyboards/xelus/dawn60/rev1/config.h
@@ -100,6 +100,4 @@
 #define RGB_BACKLIGHT_LAYER_2_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 #define RGB_BACKLIGHT_LAYER_3_INDICATOR { .color = { .h = 0, .s = 0 }, .index = 255 }
 
-// Backlight config starts after VIA's EEPROM usage,
-// dynamic keymaps start after this.
-#define VIA_EEPROM_CUSTOM_CONFIG_SIZE 31
+#define EECONFIG_KB_DATA_SIZE 31


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Preparing for changes where `via.h` is not always on the path, and the feature is handed over, this PR:

* Removes unconditional use of `via.h`
* Migrates use of `VIA_EEPROM_CUSTOM_CONFIG_SIZE` to always use keyboard datablock
* Updates eeprom init in line with recent changes to develop

These boards are also incorrectly writing to used areas when VIA is not enabled, but something like dynamic keymap is.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
