### PR TITLE
Fix SEQUENCER_ENABLE so the sequencer feature builds again

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -80,7 +80,11 @@ ifeq ($(strip $(AUDIO_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(SEQUENCER_ENABLE)), yes)
+    OPT_DEFS += -DSEQUENCER_ENABLE
     MUSIC_ENABLE = yes
+    COMMON_VPATH += $(QUANTUM_PATH)/sequencer
+    SRC += $(QUANTUM_DIR)/sequencer/sequencer.c
+    SRC += $(QUANTUM_DIR)/process_keycode/process_sequencer.c
 endif
 
 ifeq ($(strip $(MIDI_ENABLE)), yes)

--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -80,11 +80,7 @@ ifeq ($(strip $(AUDIO_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(SEQUENCER_ENABLE)), yes)
-    OPT_DEFS += -DSEQUENCER_ENABLE
     MUSIC_ENABLE = yes
-    COMMON_VPATH += $(QUANTUM_PATH)/sequencer
-    SRC += $(QUANTUM_DIR)/sequencer/sequencer.c
-    SRC += $(QUANTUM_DIR)/process_keycode/process_sequencer.c
 endif
 
 ifeq ($(strip $(MIDI_ENABLE)), yes)

--- a/quantum/keyboard.c
+++ b/quantum/keyboard.c
@@ -150,6 +150,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef CONNECTION_ENABLE
 #    include "connection.h"
 #endif
+#ifdef SEQUENCER_ENABLE
+#    include "sequencer.h"
+#endif
 
 static uint32_t last_input_modification_time = 0;
 uint32_t        last_input_activity_time(void) {

--- a/quantum/process_keycode/process_sequencer.c
+++ b/quantum/process_keycode/process_sequencer.c
@@ -15,6 +15,8 @@
  */
 
 #include "process_sequencer.h"
+#include "quantum_keycodes.h"
+#include "sequencer.h"
 
 bool process_sequencer(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {


### PR DESCRIPTION
## Description

The MIDI step sequencer (`quantum/sequencer/`) is still in-tree but no longer builds. Its `SEQUENCER_ENABLE` block in `common_features.mk` only sets `MUSIC_ENABLE`, so:

- `-DSEQUENCER_ENABLE` is never defined, which means the runtime hooks (`sequencer_task()` in `keyboard.c`, `process_sequencer()` in `quantum.c`) are compiled out; and
- neither `sequencer.c` nor `process_sequencer.c` are added to `SRC`, so enabling the feature fails to link.

`process_sequencer.c` had also lost the includes it depends on, so it no longer compiles on its own.

This wires `SEQUENCER_ENABLE` up the same way the neighbouring feature blocks do (define the macro, add the sources + VPATH) and adds the two includes `process_sequencer.c` needs. After this, a board can set `SEQUENCER_ENABLE = yes` and use the sequencer again.

Verified by building and flashing a keymap that drives the sequencer as a live MIDI drum machine into a DAW.

If the plan is to remove the sequencer feature rather than keep it, feel free to close this — but while it's in the tree, it seemed worth making it build.

## Types of Changes

- [x] Bug fix

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the [CONTRIBUTING document](https://docs.qmk.fm/#/contributing).
- [x] I have tested the change (built and flashed a keymap with `SEQUENCER_ENABLE = yes`).
