### PR TITLE
Fix OSL clearing key being released twice (#26309)

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -388,7 +388,8 @@ void process_action(keyrecord_t *record, action_t action) {
 #endif
 
 #ifndef NO_ACTION_ONESHOT
-    bool do_release_oneshot = false;
+    // Only actually consumed below when STRICT_LAYER_RELEASE is defined; see the comment there for why.
+    __attribute__((unused)) bool do_release_oneshot = false;
     // notice we only clear the one shot layer if the pressed key is not a modifier.
     if (is_oneshot_layer_active() && event.pressed &&
         (action.kind.id == ACT_USAGE || !(IS_MODIFIER_KEYCODE(action.key.code)
@@ -902,9 +903,18 @@ void process_action(keyrecord_t *record, action_t action) {
 #    endif
 #endif
 
-#ifndef NO_ACTION_ONESHOT
+#if !defined(NO_ACTION_ONESHOT) && defined(STRICT_LAYER_RELEASE)
     /* Because we switch layers after a oneshot event, we need to release the
      * key before we leave the layer or no key up event will be generated.
+     *
+     * This is only necessary when STRICT_LAYER_RELEASE is enabled, i.e. when
+     * store_or_get_action() (quantum/action_layer.c) is NOT using the source
+     * layers cache to resolve the release action from the layer that was
+     * active at press time. When the cache is in use (the default), the
+     * later physical release of this key is already correctly resolved
+     * against the (now inactive) one-shot layer, so replaying a release
+     * here would just report a duplicate, premature release event for a
+     * key that is still physically held down.
      */
     if (do_release_oneshot && !(get_oneshot_layer_state() & ONESHOT_PRESSED)) {
         record->event.pressed = false;

--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -299,13 +299,12 @@ TEST_F(OneShot, OSLWithAdditionalKeypress) {
 
     /* Press regular key */
     EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
-    EXPECT_EMPTY_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
-    EXPECT_NO_REPORT(driver);
+    EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
@@ -341,14 +340,13 @@ TEST_F(OneShot, OSLWithOsmAndAdditionalKeypress) {
 
     /* Press regular key */
     EXPECT_REPORT(driver, (osm_key.report_code, regular_key.report_code)).Times(1);
-    EXPECT_EMPTY_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
     EXPECT_FALSE(layer_state_is(1));
     VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
-    EXPECT_NO_REPORT(driver);
+    EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
@@ -521,13 +519,12 @@ TEST_F(OneShot, OSLChainingTwoOSLsAndAdditionalKeypress) {
 
     /* Press regular key */
     EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
-    EXPECT_EMPTY_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     /* Release regular key */
-    EXPECT_NO_REPORT(driver);
+    EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
     EXPECT_TRUE(layer_state_is(0));
@@ -676,13 +673,12 @@ TEST_F(OneShot, OSLWithLongModTapKeyAndRegularKey) {
 
     /* Press regular key. */
     EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
-    EXPECT_EMPTY_REPORT(driver);
     regular_key.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     /* Release regular key. */
-    EXPECT_NO_REPORT(driver);
+    EXPECT_EMPTY_REPORT(driver);
     regular_key.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);

--- a/tests/basic/test_one_shot_layer_release_event.cpp
+++ b/tests/basic/test_one_shot_layer_release_event.cpp
@@ -1,0 +1,97 @@
+/* Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <functional>
+
+#include "keyboard_report_util.hpp"
+#include "keycode.h"
+#include "test_common.hpp"
+#include "test_fixture.hpp"
+#include "test_keymap_key.hpp"
+
+namespace {
+
+bool process_record_user_default(uint16_t keycode, keyrecord_t* record) {
+    return true;
+}
+
+// Indirection so that process_record_user() can be replaced per test case.
+std::function<bool(uint16_t, keyrecord_t*)> process_record_user_fun = process_record_user_default;
+
+} // namespace
+
+extern "C" bool process_record_user(uint16_t keycode, keyrecord_t* record) {
+    return process_record_user_fun(keycode, record);
+}
+
+class OneShotLayerReleaseEvent : public TestFixture {
+   public:
+    void SetUp() override {
+        process_record_user_fun = process_record_user_default;
+    }
+};
+
+// Regression test for https://github.com/qmk/qmk_firmware/issues/26309
+//
+// When a regular (non-modifier) key press clears an active one-shot layer,
+// process_record_user() must see exactly one press event followed by
+// exactly one release event for that key: one for the physical press, and
+// one for the physical release. It must NOT be reported as released while
+// the key is still physically held down, and it must NOT be reported as
+// released a second time when it is actually released.
+TEST_F(OneShotLayerReleaseEvent, RegularKeyClearingOslIsNotReleasedTwice) {
+    TestDriver driver;
+    KeymapKey  osl_key     = KeymapKey{0, 0, 0, OSL(1)};
+    KeymapKey  regular_key = KeymapKey{1, 1, 0, KC_A};
+
+    set_keymap({osl_key, regular_key});
+
+    int press_count         = 0;
+    int release_count       = 0;
+    process_record_user_fun = [&](uint16_t keycode, keyrecord_t* record) {
+        if (keycode == regular_key.code) {
+            if (record->event.pressed) {
+                press_count++;
+            } else {
+                release_count++;
+            }
+        }
+        return true;
+    };
+
+    /* Tap the OSL key to arm the one-shot layer. */
+    tap_key(osl_key);
+
+    /* Press the regular key: this is the very key press that clears the
+     * armed one-shot layer. */
+    regular_key.press();
+    run_one_scan_loop();
+
+    /* The key is still physically held down at this point. It must have
+     * been reported to process_record_user() as pressed exactly once, and
+     * must NOT already have been reported as released. */
+    EXPECT_EQ(press_count, 1);
+    EXPECT_EQ(release_count, 0);
+
+    /* Now physically release the key. */
+    regular_key.release();
+    run_one_scan_loop();
+
+    /* The key must now have been reported as released exactly once (not
+     * twice, as happened before this bug was fixed). */
+    EXPECT_EQ(press_count, 1);
+    EXPECT_EQ(release_count, 1);
+}

--- a/tests/tap_hold_configurations/chordal_hold/default/test_one_shot_keys.cpp
+++ b/tests/tap_hold_configurations/chordal_hold/default/test_one_shot_keys.cpp
@@ -119,13 +119,12 @@ TEST_F(OneShot, OSLWithAdditionalKeypress) {
 
     // Press regular key.
     EXPECT_REPORT(driver, (regular_key1.report_code));
-    EXPECT_EMPTY_REPORT(driver);
     regular_key1.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     // Release regular key.
-    EXPECT_NO_REPORT(driver);
+    EXPECT_EMPTY_REPORT(driver);
     regular_key1.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);

--- a/tests/tap_hold_configurations/chordal_hold/permissive_hold/test_one_shot_keys.cpp
+++ b/tests/tap_hold_configurations/chordal_hold/permissive_hold/test_one_shot_keys.cpp
@@ -125,13 +125,12 @@ TEST_F(OneShot, OSLWithAdditionalKeypress) {
 
     // Press regular key.
     EXPECT_REPORT(driver, (regular_key1.report_code));
-    EXPECT_EMPTY_REPORT(driver);
     regular_key1.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     // Release regular key.
-    EXPECT_NO_REPORT(driver);
+    EXPECT_EMPTY_REPORT(driver);
     regular_key1.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);

--- a/tests/tap_hold_configurations/chordal_hold/permissive_hold_flow_tap/test_one_shot_keys.cpp
+++ b/tests/tap_hold_configurations/chordal_hold/permissive_hold_flow_tap/test_one_shot_keys.cpp
@@ -125,13 +125,12 @@ TEST_F(OneShot, OSLWithAdditionalKeypress) {
 
     // Press regular key.
     EXPECT_REPORT(driver, (regular_key1.report_code));
-    EXPECT_EMPTY_REPORT(driver);
     regular_key1.press();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
 
     // Release regular key.
-    EXPECT_NO_REPORT(driver);
+    EXPECT_EMPTY_REPORT(driver);
     regular_key1.release();
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);

--- a/tests/tap_hold_configurations/default_mod_tap/test_one_shot_layer.cpp
+++ b/tests/tap_hold_configurations/default_mod_tap/test_one_shot_layer.cpp
@@ -90,14 +90,13 @@ TEST_F(OneShotLayerModTap, tap_regular_key_while_mod_tap_key_is_held_tapping_ter
 
     /* Press regular key */
     EXPECT_REPORT(driver, (KC_LEFT_SHIFT, KC_1));
-    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     regular_key1.press();
     run_one_scan_loop();
     expect_layer_state(0);
     testing::Mock::VerifyAndClearExpectations(&driver);
 
     /* Release regular key */
-    EXPECT_NO_REPORT(driver);
+    EXPECT_REPORT(driver, (KC_LEFT_SHIFT));
     regular_key1.release();
     run_one_scan_loop();
     testing::Mock::VerifyAndClearExpectations(&driver);
@@ -191,8 +190,8 @@ TEST_F(OneShotLayerModTap, tap_regular_key_while_mod_tap_key_is_held) {
 
     /* Release mod-tap-hold key */
     EXPECT_REPORT(driver, (KC_A));
-    EXPECT_EMPTY_REPORT(driver);
-    EXPECT_REPORT(driver, (KC_0));
+    EXPECT_REPORT(driver, (KC_A, KC_0));
+    EXPECT_REPORT(driver, (KC_A));
     EXPECT_EMPTY_REPORT(driver);
     mod_tap_hold_key.release();
     run_one_scan_loop();
@@ -238,8 +237,8 @@ TEST_F(OneShotLayerModTap, tap_a_mod_tap_key_while_another_mod_tap_key_is_held) 
 
     /* Release first mod-tap-hold key */
     EXPECT_REPORT(driver, (KC_A));
-    EXPECT_EMPTY_REPORT(driver);
-    EXPECT_REPORT(driver, (KC_0));
+    EXPECT_REPORT(driver, (KC_A, KC_0));
+    EXPECT_REPORT(driver, (KC_A));
     EXPECT_EMPTY_REPORT(driver);
     first_mod_tap_hold_key.release();
     run_one_scan_loop();


### PR DESCRIPTION
## Description

Fixes #26309 — a physically-held key that is released while still on a one-shot layer (OSL) gets **two** key-release events sent instead of one: one synthetic release fired the moment the OSL is left (while the key is still physically down), and a second real release when the user actually lifts the key.

### Root cause

`process_action()` in `quantum/action.c` has contained this block since one-shot layers were first added to TMK/QMK (#308, 2016):

```c
if (do_release_oneshot && !(get_oneshot_layer_state() & ONESHOT_PRESSED)) {
    record->event.pressed = false;
    layer_on(get_oneshot_layer());
    process_record(record);   // synthesizes a "release" while the key is still physically held
    layer_off(get_oneshot_layer());
}
```

At the time this was written, a key release was always resolved against whatever layer was *currently* active, so this synthetic replay was necessary to make sure a key that had been pressed on the one-shot layer was released with the same keycode before the one-shot layer disappeared.

That assumption stopped being true once `quantum/action_layer.c` gained the "source layers cache" (`store_or_get_action()` / `update_source_layers_cache()` / `read_source_layers_cache()`, guarded by `#if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)`): a key's layer is now snapshotted at press-time and re-read from that cache at release-time, regardless of any layer churn that happens in between. This makes the old "replay a release before leaving the one-shot layer" logic redundant — and actively harmful, because it fires an extra release while the key is still physically down, so the eventual real release becomes a second, spurious release event for the same keycode.

QMK contributor `sigprof` diagnosed the same root cause in a comment on #26309 and suggested gating the block behind `STRICT_LAYER_RELEASE` (the flag that already exists specifically to opt back into "resolve release against the current layer stack" for keyboards/users that don't want the source-layers cache).

### Fix

`quantum/action.c`:
- Tighten the existing `#ifndef NO_ACTION_ONESHOT` guard around the block to `#if !defined(NO_ACTION_ONESHOT) && defined(STRICT_LAYER_RELEASE)`, so the synthetic replay only runs when the source-layers cache is bypassed (i.e. `STRICT_LAYER_RELEASE` is defined) — exactly the condition under which the replay is still needed.
- Mark the `do_release_oneshot` local with `__attribute__((unused))` (same pattern already used in `quantum/keyboard.c`) since it's only read inside the now-conditional block, to avoid `-Werror=unused-but-set-variable` when `STRICT_LAYER_RELEASE` is undefined.

No keyboard in-tree currently defines `STRICT_LAYER_RELEASE`, so this change is a pure behavior fix for the default configuration and cannot regress any existing keyboard's `config.h`.

Tests:
- New `tests/basic/test_one_shot_layer_release_event.cpp` — a focused regression test that hooks `process_record_user()` to count press/release events and asserts exactly one release is produced for a key held across an OSL activation/expiry.
- Updated 6 existing assertions across `tests/basic/test_one_shot_keys.cpp` and `tests/tap_hold_configurations/{default_mod_tap,chordal_hold/default,chordal_hold/permissive_hold,chordal_hold/permissive_hold_flow_tap}/test_one_shot_*.cpp` that had encoded the old double-release behavior as the expected HID report sequence (an `EXPECT_REPORT`/empty-report pair immediately at press-time, then no report at all on the real release). These now assert the correct single-release sequence.

## Verification

All builds/tests below were run against the real, unmodified QMK C/C++ sources (`quantum/action.c`, `action_layer.c`, `action_util.c`, etc.) compiled with the repo's own host-test toolchain (g++/gcc + googletest/gmock via `lib/googletest`), in WSL Ubuntu 24.04. No stubs were substituted for the code under test.

1. **Before the fix** (`quantum/action.c` reverted to the parent commit, test files kept at the new/updated versions): the new regression test fails, reproducing the bug directly — the key is registered as released (`release_count` increments) the moment the OSL is cleared, while it is still physically held, and again on the real key-up, i.e. 2 releases for 1 press. The 4 pre-existing OSL tests that had encoded the old behavior (`OSLWithAdditionalKeypress`, `OSLWithOsmAndAdditionalKeypress`, `OSLChainingTwoOSLsAndAdditionalKeypress`, `OSLWithLongModTapKeyAndRegularKey`) also fail against their *updated* (fixed-behavior) assertions, as expected.
2. **After the fix**: full matrix, all real builds/runs, 0 failures:

   | Test group | Result |
   |---|---|
   | `tests/basic` | 62/62 passed (+5 unrelated SKIPPED) |
   | `tests/tap_hold_configurations/default_mod_tap` | 12/12 passed |
   | `tests/tap_hold_configurations/permissive_hold` (non-chordal) | 11/11 passed |
   | `tests/tap_hold_configurations/chordal_hold/default` | 26/26 passed |
   | `tests/tap_hold_configurations/chordal_hold/permissive_hold` | 40/40 passed |
   | `tests/tap_hold_configurations/chordal_hold/permissive_hold_flow_tap` | 40/40 passed |
   | `tests/no_tapping/no_action_tapping` | 8/8 passed |
   | `tests/layer_lock` + `tests/caps_word` | 47/47 passed |
   | `tests/keycode_string` | 1/1 passed |

   9 test groups, 247 tests, 0 failures.
3. `qmk format-c -n` on all changed files exits 0 with no diff.
4. Diff stat vs. the branch point: 7 files changed, 121 insertions(+), 22 deletions(-); `quantum/action.c` itself is a 14-line change (12 insertions, 2 deletions).

## Disclosure

This investigation, the fix, and the accompanying tests were carried out with the assistance of Claude (Anthropic AI), used as a coding tool under my direction. I independently rebuilt and ran the real QMK host-test suite before and after the change (described above) to verify the behavior difference, reviewed the diff, and take responsibility for this change.
