### PR TITLE
Add `_noeeprom` variants of backlight enable/disable.

### DIFF
--- a/keyboards/tzarc/djinn/djinn.c
+++ b/keyboards/tzarc/djinn/djinn.c
@@ -209,9 +209,9 @@ void housekeeping_task_kb(void) {
     // Match the backlight to the LCD state
     if (is_keyboard_master() && is_backlight_enabled() != peripherals_on) {
         if (peripherals_on)
-            backlight_enable();
+            backlight_enable_noeeprom();
         else
-            backlight_disable();
+            backlight_disable_noeeprom();
     }
 
     // Draw the UI

--- a/quantum/backlight/backlight.c
+++ b/quantum/backlight/backlight.c
@@ -107,30 +107,42 @@ void backlight_toggle(void) {
 
 /** \brief Enable backlight
  *
- * FIXME: needs doc
+ *  FIXME: needs doc
  */
-void backlight_enable(void) {
+void backlight_enable_noeeprom(void) {
     if (backlight_config.enable) return; // do nothing if backlight is already on
 
     backlight_config.enable = true;
     if (backlight_config.raw == 1) // enabled but level == 0
         backlight_config.level = 1;
-    eeconfig_update_backlight(&backlight_config);
     dprintf("backlight enable\n");
     backlight_set(backlight_config.level);
 }
 
+void backlight_enable(void) {
+    if (backlight_config.enable) return; // do nothing if backlight is already on
+
+    backlight_enable_noeeprom();
+    eeconfig_update_backlight(&backlight_config);
+}
+
 /** \brief Disable backlight
  *
- * FIXME: needs doc
+ *  FIXME: needs doc
  */
-void backlight_disable(void) {
+void backlight_disable_noeeprom(void) {
     if (!backlight_config.enable) return; // do nothing if backlight is already off
 
     backlight_config.enable = false;
-    eeconfig_update_backlight(&backlight_config);
     dprintf("backlight disable\n");
     backlight_set(0);
+}
+
+void backlight_disable(void) {
+    if (!backlight_config.enable) return; // do nothing if backlight is already off
+
+    backlight_disable_noeeprom();
+    eeconfig_update_backlight(&backlight_config);
 }
 
 /** /brief Get the backlight status

--- a/quantum/backlight/backlight.h
+++ b/quantum/backlight/backlight.h
@@ -51,7 +51,9 @@ STATIC_ASSERT(sizeof(backlight_config_t) == sizeof(uint8_t), "Backlight EECONFIG
 void    backlight_init(void);
 void    backlight_toggle(void);
 void    backlight_enable(void);
+void    backlight_enable_noeeprom(void);
 void    backlight_disable(void);
+void    backlight_disable_noeeprom(void);
 bool    is_backlight_enabled(void);
 void    backlight_step(void);
 void    backlight_increase(void);


### PR DESCRIPTION
## Description

As per title, been a bit of a pet peeve for me for a while now. Whenever Djinn went to sleep and switched displays off, it if lost power at that point then powering back up would result in screens off.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
