### PR TITLE
Makes Key Lock accessible from code enabling Locking Modifiers #22206

### DIFF
--- a/docs/features/key_lock.md
+++ b/docs/features/key_lock.md
@@ -14,6 +14,17 @@ First, enable Key Lock by setting `KEY_LOCK_ENABLE = yes` in your `rules.mk`. Th
 |---------|--------------------------------------------------------------|
 |`QK_LOCK`|Hold down the next key pressed, until the key is pressed again|
 
+## User callbacks
+
+In addition to the keycodes, there are a few functions that you can use to interact with Key Lock.
+
+|Function            |Description                                                            |
+|--------------------|-----------------------------------------------------------------------|
+|begin_key_lock()    |Begins the key lock sequence. Mimics pressing QK_LOCK                  |
+|cancel_key_lock()   |Cancels the key lock sequnec if called before a lockable key is pressed|
+|get_key_lock_begun()|Checks whether the key lock sequence has started                       |
+|get_key_lock_state()|Checks whether a specific key is locked                                |
+
 ## Caveats
 
 Key Lock is only able to hold standard action keys and [One Shot modifier](../one_shot_keys) keys (for example, if you have your Shift defined as `OSM(MOD_LSFT)`).
@@ -21,3 +32,19 @@ This does not include any of the QMK special functions (except One Shot modifier
 
 Switching layers will not cancel the Key Lock. The Key Lock can be cancelled by calling the `cancel_key_lock()` function.
 
+QK_LOCK is incompatible with tap_code and tap_code16, to send QK_LOCK from code call the `begin_key_lock()` function.
+
+## Examples
+
+Force certain modifiers, in this case RCTL, RSFT, and RALT to toggle on/off like CAPS LOCK when pressed.
+
+```
+bool pre_process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (keycode == KC_RCTL || keycode == KC_RSFT || keycode == KC_RALT) {
+        if (!get_key_lock_state(keycode) && !get_key_lock_begun()) {
+            begin_key_lock(); // emulates pressing QK_LOCK when needed
+        }
+    }
+    return true;   
+}
+```

--- a/docs/features/key_lock.md
+++ b/docs/features/key_lock.md
@@ -20,10 +20,10 @@ In addition to the keycodes, there are a few functions that you can use to inter
 
 |Function            |Description                                                            |
 |--------------------|-----------------------------------------------------------------------|
-|begin_key_lock()    |Begins the key lock sequence. Mimics pressing QK_LOCK                  |
-|cancel_key_lock()   |Cancels the key lock sequnec if called before a lockable key is pressed|
-|get_key_lock_begun()|Checks whether the key lock sequence has started                       |
-|get_key_lock_state()|Checks whether a specific key is locked                                |
+|key_lock_start()    |Begins the key lock sequence. Mimics pressing QK_LOCK                  |
+|key_lock_cancel()   |Cancels the key lock sequnec if called before a lockable key is pressed|
+|key_lock_active()   |Checks whether the key lock sequence has started                       |
+|key_lock_get_state()|Checks whether a specific key is locked                                |
 
 ## Caveats
 
@@ -37,7 +37,6 @@ Switching layers will not cancel the Key Lock. The Key Lock can be cancelled by 
 ## Examples
 
 Force certain modifiers, in this case `RCTL`, `RSFT`, and `RALT` to toggle on/off like Caps Lock when pressed.
-
         }
     }
     return true;   

--- a/docs/features/key_lock.md
+++ b/docs/features/key_lock.md
@@ -18,12 +18,12 @@ First, enable Key Lock by setting `KEY_LOCK_ENABLE = yes` in your `rules.mk`. Th
 
 In addition to the keycodes, there are a few functions that you can use to interact with Key Lock.
 
-|Function            |Description                                                            |
-|--------------------|-----------------------------------------------------------------------|
-|key_lock_start()    |Begins the key lock sequence. Mimics pressing QK_LOCK                  |
-|key_lock_cancel()   |Cancels the key lock sequnec if called before a lockable key is pressed|
-|key_lock_active()   |Checks whether the key lock sequence has started                       |
-|key_lock_get_state()|Checks whether a specific key is locked                                |
+|Function            |Description                                                             |
+|--------------------|------------------------------------------------------------------------|
+|key_lock_start()    |Begins the key lock sequence. Mimics pressing QK_LOCK                   |
+|key_lock_cancel()   |Cancels the key lock sequnece if called before a lockable key is pressed|
+|key_lock_active()   |Checks whether the key lock sequence has started                        |
+|key_lock_get_state()|Checks whether a specific key is locked                                 |
 
 ## Caveats
 

--- a/docs/features/key_lock.md
+++ b/docs/features/key_lock.md
@@ -32,17 +32,12 @@ This does not include any of the QMK special functions (except One Shot modifier
 
 Switching layers will not cancel the Key Lock. The Key Lock can be cancelled by calling the `cancel_key_lock()` function.
 
-QK_LOCK is incompatible with tap_code and tap_code16, to send QK_LOCK from code call the `begin_key_lock()` function.
+`QK_LOCK` is incompatible with `tap_code` and `tap_code16`, to send `QK_LOCK` from code call the `key_lock_start()` function.
 
 ## Examples
 
-Force certain modifiers, in this case RCTL, RSFT, and RALT to toggle on/off like CAPS LOCK when pressed.
+Force certain modifiers, in this case `RCTL`, `RSFT`, and `RALT` to toggle on/off like Caps Lock when pressed.
 
-```
-bool pre_process_record_user(uint16_t keycode, keyrecord_t *record) {
-    if (keycode == KC_RCTL || keycode == KC_RSFT || keycode == KC_RALT) {
-        if (!get_key_lock_state(keycode) && !get_key_lock_begun()) {
-            begin_key_lock(); // emulates pressing QK_LOCK when needed
         }
     }
     return true;   

--- a/quantum/process_keycode/process_key_lock.c
+++ b/quantum/process_keycode/process_key_lock.c
@@ -55,7 +55,7 @@ static inline uint16_t translate_keycode(uint16_t keycode) {
     }
 }
 
-void cancel_key_lock(void) {
+void key_lock_cancel(void) {
     watching = false;
     UNSET_KEY_STATE(0x0);
 }

--- a/quantum/process_keycode/process_key_lock.c
+++ b/quantum/process_keycode/process_key_lock.c
@@ -147,10 +147,10 @@ bool get_key_lock_begun() {
 }
 
 void begin_key_lock() {
-    uint16_t translated_keycode = QK_LOCK;
+    uint16_t    translated_keycode = QK_LOCK;
     keyrecord_t record;
     record.event.pressed = true;
-    process_key_lock(&translated_keycode,&record);
+    process_key_lock(&translated_keycode, &record);
     record.event.pressed = false;
-    process_key_lock(&translated_keycode,&record);
+    process_key_lock(&translated_keycode, &record);
 }

--- a/quantum/process_keycode/process_key_lock.c
+++ b/quantum/process_keycode/process_key_lock.c
@@ -136,3 +136,21 @@ bool process_key_lock(uint16_t *keycode, keyrecord_t *record) {
         return !(IS_STANDARD_KEYCODE(translated_keycode) && KEY_STATE(translated_keycode));
     }
 }
+
+bool get_key_lock_state(uint16_t keycode) {
+    uint16_t translated_keycode = translate_keycode(keycode);
+    return KEY_STATE(translated_keycode);
+}
+
+bool get_key_lock_begun() {
+    return watching;
+}
+
+void begin_key_lock() {
+    uint16_t translated_keycode = QK_LOCK;
+    keyrecord_t record;
+    record.event.pressed = true;
+    process_key_lock(&translated_keycode,&record);
+    record.event.pressed = false;
+    process_key_lock(&translated_keycode,&record);
+}

--- a/quantum/process_keycode/process_key_lock.c
+++ b/quantum/process_keycode/process_key_lock.c
@@ -137,16 +137,16 @@ bool process_key_lock(uint16_t *keycode, keyrecord_t *record) {
     }
 }
 
-bool get_key_lock_state(uint16_t keycode) {
+bool key_lock_get_state(uint16_t keycode) {
     uint16_t translated_keycode = translate_keycode(keycode);
     return KEY_STATE(translated_keycode);
 }
 
-bool get_key_lock_begun() {
+bool key_lock_active(void) {
     return watching;
 }
 
-void begin_key_lock() {
+void key_lock_start(void) {
     uint16_t    translated_keycode = QK_LOCK;
     keyrecord_t record;
     record.event.pressed = true;

--- a/quantum/process_keycode/process_key_lock.h
+++ b/quantum/process_keycode/process_key_lock.h
@@ -22,3 +22,7 @@
 
 void cancel_key_lock(void);
 bool process_key_lock(uint16_t *keycode, keyrecord_t *record);
+
+bool get_key_lock_state(uint16_t keycode);
+bool get_key_lock_begun(void);
+void begin_key_lock(void);

--- a/quantum/process_keycode/process_key_lock.h
+++ b/quantum/process_keycode/process_key_lock.h
@@ -22,7 +22,6 @@
 
 void cancel_key_lock(void);
 bool process_key_lock(uint16_t *keycode, keyrecord_t *record);
-
-bool get_key_lock_state(uint16_t keycode);
-bool get_key_lock_begun(void);
-void begin_key_lock(void);
+bool key_lock_get_state(uint16_t keycode);
+bool key_lock_active(void);
+void key_lock_start(void);

--- a/quantum/process_keycode/process_key_lock.h
+++ b/quantum/process_keycode/process_key_lock.h
@@ -20,8 +20,11 @@
 #include <stdbool.h>
 #include "action.h"
 
-void cancel_key_lock(void);
+// DEPRECATED
+#define cancel_key_lock key_lock_cancel
+
 bool process_key_lock(uint16_t *keycode, keyrecord_t *record);
 bool key_lock_get_state(uint16_t keycode);
 bool key_lock_active(void);
 void key_lock_start(void);
+void key_lock_cancel(void);


### PR DESCRIPTION
## Description
Adds begin_key_lock() which mimics pressing QK_LOCK since tap_code does not accept QK_LOCK and tap_code16 exhibits strange behavior when QK_LOCK is passed (on my machine it types 11).
Adds get_key_lock_begun() which returns whether Key Lock is watching for a key to be locked.
Adds get_key_lock_state() which can be passed a keycode and returns its current lock state.

These combined allow for keymap code that can interact with Key Lock to, for example, make specific modifiers toggle like CAPS LOCK when pressed. See examples section of doc for specifics.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR
These are all already closed, but would be at least partially addressed by this PR.

* https://github.com/qmk/qmk_firmware/issues/22206
* https://github.com/qmk/qmk_firmware/issues/23001
* https://github.com/qmk/qmk_firmware/issues/25783

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
