### PR TITLE
serial: bounds-check transaction index in bitbang drivers

### DIFF
--- a/platforms/avr/drivers/serial.c
+++ b/platforms/avr/drivers/serial.c
@@ -402,7 +402,7 @@ ISR(SERIAL_PIN_INTERRUPT) {
     bits = serial_read_chunk(&pecount, 8);
     tid  = bits >> 3;
     bits = (bits & 7) != (nibble_bits_count(tid) & 7);
-    if (bits || pecount > 0 || tid > NUM_TOTAL_TRANSACTIONS) {
+    if (bits || pecount > 0 || tid >= NUM_TOTAL_TRANSACTIONS) {
         return;
     }
     serial_delay_half1();
@@ -438,7 +438,7 @@ ISR(SERIAL_PIN_INTERRUPT) {
 //
 // this code is very time dependent, so we need to disable interrupts
 bool soft_serial_transaction(int sstd_index) {
-    if (sstd_index > NUM_TOTAL_TRANSACTIONS) return false;
+    if (sstd_index >= NUM_TOTAL_TRANSACTIONS) return false;
     split_transaction_desc_t *trans = &split_transaction_table[sstd_index];
 
     cli();

--- a/platforms/chibios/drivers/serial.c
+++ b/platforms/chibios/drivers/serial.c
@@ -167,6 +167,12 @@ void interrupt_handler(void *arg) {
     sstd_index = serial_read_byte();
     sync_send();
 
+    if (sstd_index >= NUM_TOTAL_TRANSACTIONS) {
+        serial_input();
+        chSysUnlockFromISR();
+        return;
+    }
+
     split_transaction_desc_t *trans = &split_transaction_table[sstd_index];
     for (int i = 0; i < trans->initiator2target_buffer_size; ++i) {
         split_trans_initiator2target_buffer(trans)[i] = serial_read_byte();
@@ -209,7 +215,7 @@ void interrupt_handler(void *arg) {
 }
 
 static inline bool initiate_transaction(uint8_t sstd_index) {
-    if (sstd_index > NUM_TOTAL_TRANSACTIONS) return false;
+    if (sstd_index >= NUM_TOTAL_TRANSACTIONS) return false;
 
     split_shared_memory_lock_autounlock();
 


### PR DESCRIPTION
# Description

The bitbang split serial drivers index `split_transaction_table` with values that are either taken straight off the wire or insufficiently bounded:

- In `platforms/chibios/drivers/serial.c`, `interrupt_handler()` (the target-side ISR) read the transaction index from the wire with `serial_read_byte()` and used it to index `split_transaction_table` with no bounds check at all. A corrupted or hostile index results in an out-of-bounds struct read and an arbitrary function-pointer call through `trans->slave_callback`.
- `initiate_transaction()` in the same file checked the index with `>` instead of `>=` against `NUM_TOTAL_TRANSACTIONS`, allowing an index one entry past the end of the table.
- `platforms/avr/drivers/serial.c` had the same `>` vs `>=` off-by-one in both the target ISR and `soft_serial_transaction()`.

The new ISR check bails out before the table is indexed. The early-out releases the serial line back to input and the `chSysLockFromISR()` critical section the same way the normal exit path does (the shared-memory lock is a cleanup-attribute guard and releases itself); `sync_send()` earlier in the handler leaves the pin driven as output, so skipping that release would leave the line stuck driven and prevent the target's falling-edge interrupt from ever firing again. Dropping the transaction on the target side causes the initiator's transaction to fail, the same outcome as any other corrupt transaction.

The vendor UART driver (`platforms/chibios/drivers/serial_protocol.c`) already performs this check correctly with `>=`; this change brings the bitbang drivers to parity with it.

## Types of Changes

- [x] Core
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: `qmk format-c` applied, diff is noise-free.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] My change targets the `develop` branch.
- [x] My change is restricted to one logical change (core only, no keyboard/keymap mixed in).
- [x] Compile-verified against `crkbd/rev1:default` (AVR soft serial, builds `platforms/avr/drivers/serial.c`) and `handwired/splittest/bluepill:bitbang` (ChibiOS with `SERIAL_DRIVER = bitbang`, builds `platforms/chibios/drivers/serial.c`).
