### PR TITLE
Fix encoder pins for Portico75 to resolve #25051

### DIFF
--- a/keyboards/tkc/portico75/keyboard.json
+++ b/keyboards/tkc/portico75/keyboard.json
@@ -154,7 +154,7 @@
     "diode_direction": "COL2ROW",
     "encoder": {
         "rotary": [
-            {"pin_a": "B1", "pin_b": "B2", "resolution": 2}
+            {"pin_a": "B2", "pin_b": "B1", "resolution": 2}
         ]
     },
     "processor": "atmega32u4",


### PR DESCRIPTION
## Description

The mapping of CCW=VOLD, CW=VOLU was wrong in the original commit 13821fd, but wasn't noticed because the pin mapping was _also_ wrong. The encoder mapping was fixed in commit a73014f but that resulted in the encoder working backwards. This commit corrects the pin mapping so that the encoder works as expected.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #25051

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
