### PR TITLE
Fix osm unlock not sending mod release

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -488,14 +488,14 @@ void process_action(keyrecord_t *record, action_t action) {
                         } else {
                             if (tap_count == 0) {
                                 // Release hold: unregister the held mod and its variants
-                                unregister_mods(mods);
                                 del_oneshot_mods(mods);
                                 del_oneshot_locked_mods(mods);
+                                unregister_mods(mods);
 #        if defined(ONESHOT_TAP_TOGGLE) && ONESHOT_TAP_TOGGLE > 1
                             } else if (tap_count == 1 && (mods & get_mods())) {
-                                unregister_mods(mods);
                                 del_oneshot_mods(mods);
                                 del_oneshot_locked_mods(mods);
+                                unregister_mods(mods);
 #        endif
                             }
                         }

--- a/tests/one_shot_keys/oneshot_tap_toggle/config.h
+++ b/tests/one_shot_keys/oneshot_tap_toggle/config.h
@@ -1,0 +1,8 @@
+// Copyright 2026 NapOli1084 (@NapOli1084)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "test_common.h"
+
+#define ONESHOT_TAP_TOGGLE 2

--- a/tests/one_shot_keys/oneshot_tap_toggle/test.mk
+++ b/tests/one_shot_keys/oneshot_tap_toggle/test.mk
@@ -1,0 +1,6 @@
+# Copyright 2026 NapOli1084 (@NapOli1084)
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# --------------------------------------------------------------------------------
+# Keep this file, even if it is empty, as a marker that this folder contains tests
+# --------------------------------------------------------------------------------

--- a/tests/one_shot_keys/oneshot_tap_toggle/test_one_shot_keys.cpp
+++ b/tests/one_shot_keys/oneshot_tap_toggle/test_one_shot_keys.cpp
@@ -1,0 +1,107 @@
+// Copyright 2026 NapOli1084 (@NapOli1084)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "action_util.h"
+#include "keyboard_report_util.hpp"
+#include "test_common.hpp"
+
+using testing::_;
+using testing::InSequence;
+
+class OneShot : public TestFixture {
+   protected:
+    TestDriver driver;
+};
+
+class OneShotParametrizedTestFixture : public ::testing::WithParamInterface<std::pair<KeymapKey, KeymapKey>>, public OneShot {
+   protected:
+    void setup_lock_osm_and_verify(KeymapKey& osm_key, KeymapKey& regular_key) {
+        set_keymap({osm_key, regular_key});
+
+        /* Lock OSM by tapping it ONESHOT_TAP_TOGGLE times */
+        EXPECT_REPORT(driver, (osm_key.report_code)).Times(1);
+        for (int i = 0; i < ONESHOT_TAP_TOGGLE; ++i) {
+            tap_key(osm_key);
+        }
+        VERIFY_AND_CLEAR(driver);
+
+        /* Press regular key */
+        EXPECT_REPORT(driver, (osm_key.report_code, regular_key.report_code)).Times(1);
+        regular_key.press();
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        /* Release regular key */
+        EXPECT_REPORT(driver, (osm_key.report_code)).Times(1);
+        regular_key.release();
+        run_one_scan_loop();
+        VERIFY_AND_CLEAR(driver);
+
+        /* Tap regular key again; mod should still be reported */
+        EXPECT_REPORT(driver, (osm_key.report_code, regular_key.report_code)).Times(1);
+        EXPECT_REPORT(driver, (osm_key.report_code)).Times(1);
+        tap_key(regular_key);
+        VERIFY_AND_CLEAR(driver);
+    }
+
+    void tap_regular_key_no_mod(KeymapKey& regular_key) {
+        /* Tap regular key; confirm no mod */
+        EXPECT_REPORT(driver, (regular_key.report_code)).Times(1);
+        EXPECT_EMPTY_REPORT(driver);
+        tap_key(regular_key);
+        VERIFY_AND_CLEAR(driver);
+    }
+};
+
+TEST_P(OneShotParametrizedTestFixture, OSMLockAndUnlockOnTap) {
+    KeymapKey  osm_key     = GetParam().first;
+    KeymapKey  regular_key = GetParam().second;
+
+    setup_lock_osm_and_verify(osm_key, regular_key);
+
+    /* Unlock OSM by tapping it */
+    EXPECT_EMPTY_REPORT(driver);
+    tap_key(osm_key);
+    VERIFY_AND_CLEAR(driver);
+
+    tap_regular_key_no_mod(regular_key);
+}
+
+TEST_P(OneShotParametrizedTestFixture, OSMLockAndUnlockOnHold) {
+    KeymapKey  osm_key     = GetParam().first;
+    KeymapKey  regular_key = GetParam().second;
+
+    setup_lock_osm_and_verify(osm_key, regular_key);
+
+    /* Unlock OSM by holding it */
+    EXPECT_NO_REPORT(driver);
+    osm_key.press();
+    run_one_scan_loop();
+    idle_for(TAPPING_TERM);
+    VERIFY_AND_CLEAR(driver);
+
+    /* Release OSM */
+    EXPECT_EMPTY_REPORT(driver);
+    osm_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    tap_regular_key_no_mod(regular_key);
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(
+    OneShotModifierTests,
+    OneShotParametrizedTestFixture,
+    ::testing::Values(
+        /* first is osm key, second is regular key. */
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_LSFT), KC_LSFT}, KeymapKey{0, 1, 1, KC_A}),
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_LCTL), KC_LCTL}, KeymapKey{0, 1, 1, KC_A}),
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_LALT), KC_LALT}, KeymapKey{0, 1, 1, KC_A}),
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_LGUI), KC_LGUI}, KeymapKey{0, 1, 1, KC_A}),
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_RCTL), KC_RCTL}, KeymapKey{0, 1, 1, KC_A}),
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_RSFT), KC_RSFT}, KeymapKey{0, 1, 1, KC_A}),
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_RALT), KC_RALT}, KeymapKey{0, 1, 1, KC_A}),
+        std::make_pair(KeymapKey{0, 0, 0, OSM(MOD_RGUI), KC_RGUI}, KeymapKey{0, 1, 1, KC_A})
+        ));
+// clang-format on

--- a/tests/one_shot_keys/oneshot_tap_toggle/test_one_shot_keys.cpp
+++ b/tests/one_shot_keys/oneshot_tap_toggle/test_one_shot_keys.cpp
@@ -54,8 +54,8 @@ class OneShotParametrizedTestFixture : public ::testing::WithParamInterface<std:
 };
 
 TEST_P(OneShotParametrizedTestFixture, OSMLockAndUnlockOnTap) {
-    KeymapKey  osm_key     = GetParam().first;
-    KeymapKey  regular_key = GetParam().second;
+    KeymapKey osm_key     = GetParam().first;
+    KeymapKey regular_key = GetParam().second;
 
     setup_lock_osm_and_verify(osm_key, regular_key);
 
@@ -68,8 +68,8 @@ TEST_P(OneShotParametrizedTestFixture, OSMLockAndUnlockOnTap) {
 }
 
 TEST_P(OneShotParametrizedTestFixture, OSMLockAndUnlockOnHold) {
-    KeymapKey  osm_key     = GetParam().first;
-    KeymapKey  regular_key = GetParam().second;
+    KeymapKey osm_key     = GetParam().first;
+    KeymapKey regular_key = GetParam().second;
 
     setup_lock_osm_and_verify(osm_key, regular_key);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

After locking a one-shot mod (OSM) by tapping it `ONESHOT_TAP_TOGGLE` times (when defined to a value >1), tapping it again afterwards to unlock it did not send the release of the mod. The next pressed key would correctly be sent without the mod, but in the meantime the mod was still seen as pressed by the computer. That's a problem if the next thing you do isn't pressing a key on the keyboard, e.g. when clicking with a mouse, because the mod is still applied.

The problem was due to the sequence when unlocking in `process_action()`:
```c
                                unregister_mods(mods);
                                del_oneshot_mods(mods);
                                del_oneshot_locked_mods(mods);
```
`unregister_mods()` calls `send_keyboard_report()`, which will do so only if there's a change. However, at that point the one-shot mod is still locked, so the mod is still added to the report. No change is detected and no report is sent.

To fix it, `del_oneshot_mods()` and `del_oneshot_locked_mods()` must be called before `unregister_mods()`.

I added unit tests to validate this change. The test fails without the change in `process_action()`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Didn't find an existing issue.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
