### PR TITLE
Update `emerge-webrsync` to `emaint sync`

### DIFF
--- a/.github/workflows/bootstrap_testing.yml
+++ b/.github/workflows/bootstrap_testing.yml
@@ -99,7 +99,7 @@ jobs:
                   zypper --non-interactive install sudo git shadow findutils tar  # findutils=xargs
                   ;;
                 *gentoo*)
-                  emerge-webrsync
+                  emaint sync
                   emerge --noreplace --ask=n sudo dev-vcs/git shadow findutils  # findutils=xargs
                   ;;
                 *archlinux*|*cachyos*|*manjaro*)

--- a/util/env-bootstrap.sh
+++ b/util/env-bootstrap.sh
@@ -359,7 +359,7 @@ __EOT__
             *gentoo*)
                 echo "It will also install the following system packages using 'emerge':" >&2
                 print_package_manager_deps_and_delay
-                $(nsudo) emerge-webrsync
+                $(nsudo) emaint sync
                 $(nsudo) emerge --noreplace --ask=n $(get_package_manager_deps | tr ' ' '\n') || signal_execution_failure
                 exit_if_execution_failed
                 ;;


### PR DESCRIPTION
Changes `emerge-webrsync` command to `emaint sync` for Gentoo users.
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Gentoo users using git to sync cannot use `emerge-webrsync` command, but it seems like `emaint sync` still works with the webrsync method. Furthermore, running the version with `emerge-webrsync` on my Gentoo computer, which syncs with git, seemed to break syncing until manually fixed (by deleting and reinstalling the gentoo repository)
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
