### PR TITLE
add weak attribute to send_char

### DIFF
--- a/quantum/send_string/send_string.c
+++ b/quantum/send_string/send_string.c
@@ -209,7 +209,7 @@ void send_string_with_delay(const char *string, uint8_t interval) {
     send_string_with_delay_impl(send_string_get_next_ram, &state, interval);
 }
 
-void send_char(char ascii_code) {
+__attribute__((weak)) void send_char(char ascii_code) {
     send_char_with_delay(ascii_code, TAP_CODE_DELAY);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Adds `__attribute__((weak))` to `send_char()`.
Allows users to override it in order to use a custom delay based on some state of the keyboard.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Resolves #26304

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
