### PR TITLE
Fix ChibiOS virtual serial short packet receive

### DIFF
--- a/keyboards/handwired/onekey/keymaps/virtser/keymap.c
+++ b/keyboards/handwired/onekey/keymaps/virtser/keymap.c
@@ -1,0 +1,40 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include QMK_KEYBOARD_H
+#include "virtser.h"
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    LAYOUT_ortho_1x1(KC_A)
+};
+
+static uint32_t counter = 0;
+
+void virtser_recv(const uint8_t ch) {
+    static const char *lut = "0123456789ABCDEF";
+
+    counter++;
+
+    virtser_send(lut[(ch & 0xF0) >> 4]);
+    virtser_send(lut[ch & 0xF]);
+}
+
+#ifdef CONSOLE_ENABLE
+
+void keyboard_post_init_user(void) {
+    // Customise these values to desired behaviour
+    debug_enable = true;
+    // debug_matrix=true;
+    // debug_keyboard=true;
+    // debug_mouse=true;
+}
+
+void housekeeping_task_user(void) {
+    static uint32_t last = 0;
+    if (timer_elapsed32(last) > 1000) {
+        uprintf("recv: %ld!\n", counter);
+
+        last = timer_read32();
+    }
+}
+
+#endif

--- a/keyboards/handwired/onekey/keymaps/virtser/keymap.json
+++ b/keyboards/handwired/onekey/keymaps/virtser/keymap.json
@@ -1,0 +1,12 @@
+{
+    "config": {
+        "usb": {
+            "shared_endpoint": {
+                "keyboard": true
+            }
+        },
+        "features": {
+            "virtser": true
+        }
+    }
+}

--- a/tmk_core/protocol/chibios/usb_driver.c
+++ b/tmk_core/protocol/chibios/usb_driver.c
@@ -320,13 +320,13 @@ bool usb_endpoint_in_is_inactive(usb_endpoint_in_t *endpoint) {
     return inactive;
 }
 
-bool usb_endpoint_out_receive(usb_endpoint_out_t *endpoint, uint8_t *data, size_t size, sysinterval_t timeout) {
+size_t usb_endpoint_out_receive_bytes(usb_endpoint_out_t *endpoint, uint8_t *data, size_t size, sysinterval_t timeout) {
     osalDbgCheck((endpoint != NULL) && (data != NULL) && (size > 0U));
 
     osalSysLock();
     if (usbGetDriverStateI(endpoint->config.usbp) != USB_ACTIVE) {
         osalSysUnlock();
-        return false;
+        return 0;
     }
 
     if (endpoint->timed_out && timeout != TIME_INFINITE) {
@@ -337,5 +337,9 @@ bool usb_endpoint_out_receive(usb_endpoint_out_t *endpoint, uint8_t *data, size_
     const size_t received = ibqReadTimeout(&endpoint->ibqueue, data, size, timeout);
     endpoint->timed_out   = received == 0;
 
-    return received == size;
+    return received;
+}
+
+bool usb_endpoint_out_receive(usb_endpoint_out_t *endpoint, uint8_t *data, size_t size, sysinterval_t timeout) {
+    return usb_endpoint_out_receive_bytes(endpoint, data, size, timeout) == size;
 }

--- a/tmk_core/protocol/chibios/usb_driver.h
+++ b/tmk_core/protocol/chibios/usb_driver.h
@@ -197,7 +197,8 @@ void usb_endpoint_out_init(usb_endpoint_out_t *endpoint);
 void usb_endpoint_out_start(usb_endpoint_out_t *endpoint);
 void usb_endpoint_out_stop(usb_endpoint_out_t *endpoint);
 
-bool usb_endpoint_out_receive(usb_endpoint_out_t *endpoint, uint8_t *data, size_t size, sysinterval_t timeout);
+bool   usb_endpoint_out_receive(usb_endpoint_out_t *endpoint, uint8_t *data, size_t size, sysinterval_t timeout);
+size_t usb_endpoint_out_receive_bytes(usb_endpoint_out_t *endpoint, uint8_t *data, size_t size, sysinterval_t timeout);
 
 void usb_endpoint_out_suspend_cb(usb_endpoint_out_t *endpoint);
 void usb_endpoint_out_wakeup_cb(usb_endpoint_out_t *endpoint);

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -578,8 +578,9 @@ __attribute__((weak)) void virtser_recv(uint8_t c) {
 
 void virtser_task(void) {
     uint8_t buffer[CDC_EPSIZE];
-    while (receive_report(USB_ENDPOINT_OUT_CDC_DATA, buffer, sizeof(buffer))) {
-        for (int i = 0; i < sizeof(buffer); i++) {
+    size_t  received;
+    while ((received = usb_endpoint_out_receive_bytes(&usb_endpoints_out[USB_ENDPOINT_OUT_CDC_DATA], buffer, sizeof(buffer), TIME_IMMEDIATE)) > 0) {
+        for (size_t i = 0; i < received; i++) {
             virtser_recv(buffer[i]);
         }
     }


### PR DESCRIPTION
## Description

ChibiOS virtual serial currently asks the USB OUT queue for a full `CDC_EPSIZE` buffer. The queue copies short CDC packets into that buffer, but the existing boolean receive helper returns `false` unless the requested size was filled exactly. As a result, normal short host writes are consumed and silently discarded before `virtser_recv()` is called.

This change adds a byte-count receive helper and keeps the existing exact-size boolean wrapper for Raw HID and MIDI. `virtser_task()` now dispatches exactly the bytes that were received, matching the LUFA implementation.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #26326

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Verification

- Formatted the touched files with QMK's repository `.clang-format` configuration.
- `git diff --check` passes.
- Confirmed Raw HID and MIDI retain exact-size receive behavior through the existing wrapper.
- Confirmed the new virtual-serial path processes only the byte count returned by the ChibiOS input queue.

The first-time QMK container image pull stalled locally, so the authoritative ChibiOS compile result is left to upstream CI.
