### PR TITLE
Release interrupted one-shot layers on key-up

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -686,6 +686,9 @@ void process_action(keyrecord_t *record, action_t action) {
                                 set_oneshot_layer(action.layer_tap.val, ONESHOT_TOGGLED);
                             } else {
                                 clear_oneshot_layer_state(ONESHOT_PRESSED);
+                                if (tap_count == 0 || record->tap.interrupted) {
+                                    clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
+                                }
                             }
                         }
 #        else
@@ -693,7 +696,7 @@ void process_action(keyrecord_t *record, action_t action) {
                             set_oneshot_layer(action.layer_tap.val, ONESHOT_START);
                         } else {
                             clear_oneshot_layer_state(ONESHOT_PRESSED);
-                            if (tap_count > 1) {
+                            if (tap_count != 1 || record->tap.interrupted) {
                                 clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
                             }
                         }

--- a/tests/basic/test_one_shot_keys.cpp
+++ b/tests/basic/test_one_shot_keys.cpp
@@ -311,6 +311,51 @@ TEST_F(OneShot, OSLWithAdditionalKeypress) {
     VERIFY_AND_CLEAR(driver);
 }
 
+TEST_F(OneShot, HeldOSLReleasesLayerWhileModifierRemainsHeld) {
+    TestDriver driver;
+    InSequence s;
+    KeymapKey  osl_key       = KeymapKey{0, 0, 0, OSL(1)};
+    KeymapKey  modifier_base = KeymapKey{0, 1, 0, KC_TRNS};
+    KeymapKey  modifier_key  = KeymapKey{1, 1, 0, KC_LCTL};
+    KeymapKey  base_key      = KeymapKey{0, 1, 1, KC_A};
+    KeymapKey  layer_key     = KeymapKey{1, 1, 1, KC_4};
+
+    set_keymap({osl_key, modifier_base, modifier_key, base_key, layer_key});
+
+    /* Hold OSL and then hold a modifier from its layer. */
+    EXPECT_NO_REPORT(driver);
+    osl_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_NO_REPORT(driver);
+    modifier_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    /* Releasing OSL should restore the base layer like MO would. */
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL));
+    osl_key.release();
+    run_one_scan_loop();
+    EXPECT_FALSE(layer_state_is(1));
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL, KC_A));
+    base_key.press();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_REPORT(driver, (KC_LEFT_CTRL));
+    base_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+
+    EXPECT_EMPTY_REPORT(driver);
+    modifier_key.release();
+    run_one_scan_loop();
+    VERIFY_AND_CLEAR(driver);
+}
+
 TEST_F(OneShot, OSLWithOsmAndAdditionalKeypress) {
     TestDriver driver;
     InSequence s;


### PR DESCRIPTION
## Description

When `OSL(layer)` is held and another key is pressed before the OSL key is released, the tapping engine marks the OSL record as interrupted but can still report a tap count of one. The OSL release path therefore clears only `ONESHOT_PRESSED`, leaving `ONESHOT_OTHER_KEY_PRESSED` active. The layer remains enabled and the next physical key is resolved from the one-shot layer instead of the base layer.

This change also clears the remaining one-shot state when the OSL record was interrupted. A normally tapped OSL still keeps the layer active for the next keypress, while a held/interrupted OSL now turns the layer off on release like `MO(layer)`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #26045

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Verification

- Added `OneShot.HeldOSLReleasesLayerWhileModifierRemainsHeld`, reproducing the reported sequence.
- Before the fix, the test leaves layer 1 active and emits Ctrl+4 instead of Ctrl+A.
- After the fix, the complete `make test:basic` suite passes: 62 passed and 5 pre-existing tests skipped.
- The focused regression also passes when compiled with `EXTRAFLAGS=-DONESHOT_TAP_TOGGLE=2`.
- `git diff --check` passes.
