### PR TITLE
Fix Caps Word weak shift release (#26086)

### DIFF
--- a/quantum/process_keycode/process_caps_word.c
+++ b/quantum/process_keycode/process_caps_word.c
@@ -147,11 +147,17 @@ bool process_caps_word(uint16_t keycode, keyrecord_t* record) {
     caps_word_reset_idle_timer();
 #endif // CAPS_WORD_IDLE_TIMEOUT > 0
 
-    // From here on, we only take action on press events.
     if (!record->event.pressed) {
+#if defined(AUTO_SHIFT_ENABLE)
+        if (!get_autoshift_state())
+#endif
+        {
+            del_weak_mods(MOD_BIT(KC_LSFT));
+        }
         return true;
     }
 
+    // From here on, we only take action on press events.
     if (!(mods & ~(MOD_MASK_SHIFT | MOD_BIT(KC_RALT)))) {
         switch (keycode) {
             // Ignore MO, TO, TG, TT, and OSL layer switch keys.

--- a/tests/caps_word/test_caps_word.cpp
+++ b/tests/caps_word/test_caps_word.cpp
@@ -158,7 +158,7 @@ TEST_F(CapsWord, IdleTimeout) {
     tap_key(key_a);
     VERIFY_AND_CLEAR(driver);
 
-    EXPECT_EMPTY_REPORT(driver);
+    EXPECT_NO_REPORT(driver);
     idle_for(CAPS_WORD_IDLE_TIMEOUT);
     run_one_scan_loop();
     VERIFY_AND_CLEAR(driver);
@@ -201,6 +201,30 @@ TEST_F(CapsWord, ShiftsLettersButNotDigits) {
     // Turn on Caps Word and tap "A, 4, A, 4".
     caps_word_on();
     tap_keys(key_a, key_4, key_a, key_4);
+
+    VERIFY_AND_CLEAR(driver);
+}
+
+TEST_F(CapsWord, ClearsWeakShiftOnKeyRelease) {
+    TestDriver driver;
+    KeymapKey  key_a(0, 0, 0, KC_A);
+    set_keymap({key_a});
+
+    {
+        InSequence s;
+        EXPECT_REPORT(driver, (KC_LSFT));
+        EXPECT_REPORT(driver, (KC_LSFT, KC_A));
+        EXPECT_EMPTY_REPORT(driver);
+    }
+
+    caps_word_on();
+    key_a.press();
+    run_one_scan_loop();
+    EXPECT_EQ(get_weak_mods(), MOD_BIT(KC_LSFT));
+
+    key_a.release();
+    run_one_scan_loop();
+    EXPECT_EQ(get_weak_mods(), 0);
 
     VERIFY_AND_CLEAR(driver);
 }


### PR DESCRIPTION
## Description

Clear Caps Word's weak Left Shift when a normal key is released. This prevents mouse clicks between Caps Word keypresses from acting as Shift-click. Runtime-enabled Auto Shift keeps its existing delayed-key handling.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #26086

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the PR Checklist document and made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and do not break anything.

## Testing

- `make test:all`
- 82 tests across all six Caps Word configurations
- `qmk format-c -n` with clang-format 20.1.8
- `git diff --check`

AI-assisted; reviewed and tested by the contributor.