### PR TITLE
Add `UNICODE_TAP_DELAY` to allow a different tap delay for Unicode

### DIFF
--- a/quantum/send_string/send_string.c
+++ b/quantum/send_string/send_string.c
@@ -271,12 +271,16 @@ void send_byte(uint8_t number) {
 }
 
 void send_nibble(uint8_t number) {
+    send_nibble_with_delay(number, TAP_CODE_DELAY);
+}
+
+void send_nibble_with_delay(uint8_t number, uint8_t interval) {
     switch (number & 0xF) {
         case 0 ... 9:
-            send_char(number + '0');
+            send_char_with_delay(number + '0', interval);
             break;
         case 10 ... 15:
-            send_char(number - 10 + 'a');
+            send_char_with_delay(number - 10 + 'a', interval);
             break;
     }
 }

--- a/quantum/send_string/send_string.h
+++ b/quantum/send_string/send_string.h
@@ -119,6 +119,16 @@ void send_byte(uint8_t number);
 void send_nibble(uint8_t number);
 
 /**
+ * \brief Type out a single hexadecimal digit.
+ *
+ * The format is `[0-9a-f]{1}`, eg. `0` through `f`.
+ *
+ * \param number The value to type, from 0 to 15.
+ * \param interval The amount of time, in milliseconds, to wait in between key presses. Note this can be set to 0 to ensure no delay, regardless of what TAP_CODE_DELAY is set to.
+ */
+void send_nibble_with_delay(uint8_t number, uint8_t interval);
+
+/**
  * \brief Type a pseudorandom character from the set `A-Z`, `a-z`, `0-9`, `+` and `/`.
  */
 void tap_random_base64(void);

--- a/quantum/unicode/unicode.c
+++ b/quantum/unicode/unicode.c
@@ -56,6 +56,11 @@
 #    define UNICODE_TYPE_DELAY 10
 #endif
 
+// Delay between `register_code` and `unregister_code` for Unicode "keystrokes"
+#ifndef UNICODE_TAP_DELAY
+#    define UNICODE_TAP_DELAY TAP_CODE_DELAY
+#endif
+
 unicode_config_t unicode_config;
 uint8_t          unicode_saved_mods;
 led_t            unicode_saved_led_state;
@@ -209,7 +214,7 @@ __attribute__((weak)) void unicode_input_start(void) {
     // UNICODE_KEY_LNX (which is usually Ctrl-Shift-U) might not work
     // correctly in the shifted case.
     if (unicode_config.input_mode == UNICODE_MODE_LINUX && unicode_saved_led_state.caps_lock) {
-        tap_code(KC_CAPS_LOCK);
+        tap_code(KC_CAPS_LOCK); // Note: uses TAP_HOLD_CAPS_DELAY
     }
 
     unicode_saved_mods = get_mods(); // Save current mods
@@ -221,26 +226,26 @@ __attribute__((weak)) void unicode_input_start(void) {
             register_code(UNICODE_KEY_MAC);
             break;
         case UNICODE_MODE_LINUX:
-            tap_code16(UNICODE_KEY_LNX);
+            tap_code16_delay(UNICODE_KEY_LNX, UNICODE_TAP_DELAY);
             break;
         case UNICODE_MODE_WINDOWS:
             // For increased reliability, use numpad keys for inputting digits
             if (!unicode_saved_led_state.num_lock) {
-                tap_code(KC_NUM_LOCK);
+                tap_code_delay(KC_NUM_LOCK, UNICODE_TAP_DELAY);
             }
             register_code(KC_LEFT_ALT);
             wait_ms(UNICODE_TYPE_DELAY);
-            tap_code(KC_KP_PLUS);
+            tap_code_delay(KC_KP_PLUS, UNICODE_TAP_DELAY);
             break;
         case UNICODE_MODE_WINCOMPOSE:
-            tap_code(UNICODE_KEY_WINC);
-            tap_code(KC_U);
+            tap_code_delay(UNICODE_KEY_WINC, UNICODE_TAP_DELAY);
+            tap_code_delay(KC_U, UNICODE_TAP_DELAY);
             break;
         case UNICODE_MODE_EMACS:
             // The usual way to type unicode in emacs is C-x-8 <RET> then the unicode number in hex
-            tap_code16(LCTL(KC_X));
-            tap_code16(KC_8);
-            tap_code16(KC_ENTER);
+            tap_code16_delay(LCTL(KC_X), UNICODE_TAP_DELAY);
+            tap_code16_delay(KC_8, UNICODE_TAP_DELAY);
+            tap_code16_delay(KC_ENTER, UNICODE_TAP_DELAY);
             break;
     }
 
@@ -253,22 +258,22 @@ __attribute__((weak)) void unicode_input_finish(void) {
             unregister_code(UNICODE_KEY_MAC);
             break;
         case UNICODE_MODE_LINUX:
-            tap_code(KC_SPACE);
+            tap_code_delay(KC_SPACE, UNICODE_TAP_DELAY);
             if (unicode_saved_led_state.caps_lock) {
-                tap_code(KC_CAPS_LOCK);
+                tap_code(KC_CAPS_LOCK); // Note: uses TAP_HOLD_CAPS_DELAY
             }
             break;
         case UNICODE_MODE_WINDOWS:
             unregister_code(KC_LEFT_ALT);
             if (!unicode_saved_led_state.num_lock) {
-                tap_code(KC_NUM_LOCK);
+                tap_code_delay(KC_NUM_LOCK, UNICODE_TAP_DELAY);
             }
             break;
         case UNICODE_MODE_WINCOMPOSE:
-            tap_code(KC_ENTER);
+            tap_code_delay(KC_ENTER, UNICODE_TAP_DELAY);
             break;
         case UNICODE_MODE_EMACS:
-            tap_code16(KC_ENTER);
+            tap_code16_delay(KC_ENTER, UNICODE_TAP_DELAY);
             break;
     }
 
@@ -281,22 +286,22 @@ __attribute__((weak)) void unicode_input_cancel(void) {
             unregister_code(UNICODE_KEY_MAC);
             break;
         case UNICODE_MODE_LINUX:
-            tap_code(KC_ESCAPE);
+            tap_code_delay(KC_ESCAPE, UNICODE_TAP_DELAY);
             if (unicode_saved_led_state.caps_lock) {
-                tap_code(KC_CAPS_LOCK);
+                tap_code(KC_CAPS_LOCK); // Note: uses TAP_HOLD_CAPS_DELAY
             }
             break;
         case UNICODE_MODE_WINCOMPOSE:
-            tap_code(KC_ESCAPE);
+            tap_code_delay(KC_ESCAPE, UNICODE_TAP_DELAY);
             break;
         case UNICODE_MODE_WINDOWS:
             unregister_code(KC_LEFT_ALT);
             if (!unicode_saved_led_state.num_lock) {
-                tap_code(KC_NUM_LOCK);
+                tap_code_delay(KC_NUM_LOCK, UNICODE_TAP_DELAY);
             }
             break;
         case UNICODE_MODE_EMACS:
-            tap_code16(LCTL(KC_G)); // C-g cancels
+            tap_code16_delay(LCTL(KC_G), UNICODE_TAP_DELAY); // C-g cancels
             break;
     }
 
@@ -310,10 +315,10 @@ static void send_nibble_wrapper(uint8_t digit) {
         uint8_t kc = digit < 10
                    ? KC_KP_1 + (10 + digit - 1) % 10
                    : KC_A + (digit - 10);
-        tap_code(kc);
+        tap_code_delay(kc, UNICODE_TAP_DELAY);
         return;
     }
-    send_nibble(digit);
+    send_nibble_with_delay(digit, UNICODE_TAP_DELAY);
 }
 
 // clang-format on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Adds a new `UNICODE_TAP_DELAY` define that allows configuring a different tap delay for Unicode.
It defaults to `TAP_CODE_DELAY`, which means the default behavior is unchanged.
Users may define it in their `config.h` to configure a different delay.

Note: I haven't updated the doc and tests yet, I'll do so if we agree on the solution.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Resolves #26304

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
