### PR TITLE
[Keyboard] Add Anne Pro 2D C2D support

### DIFF
--- a/keyboards/annepro2/annepro2.c
+++ b/keyboards/annepro2/annepro2.c
@@ -18,33 +18,37 @@
 #include "annepro2.h"
 #include "annepro2_ble.h"
 #include "spi_master.h"
-#include "ap2_led.h"
-#include "protocol.h"
 
-#define RAM_MAGIC_LOCATION 0x20001ffc
+#ifdef ANNEPRO2_LED_MCU_ENABLE
+#    include "ap2_led.h"
+#    include "protocol.h"
+#endif
+
+#ifndef ANNEPRO2_IAP_MAGIC_LOCATION
+#    define ANNEPRO2_IAP_MAGIC_LOCATION 0x20001ffc
+#endif
+
 #define IAP_MAGIC_VALUE 0x0000fab2
 
+#ifdef ANNEPRO2_LED_MCU_ENABLE
 static const SerialConfig led_uart_init_config = {
     .speed = 115200,
 };
 
-#ifndef LED_UART_BAUD_RATE
-#    define LED_UART_BAUD_RATE 115200
-#endif  // LED_UART_BAUD_RATE
+#    ifndef LED_UART_BAUD_RATE
+#        define LED_UART_BAUD_RATE 115200
+#    endif  // LED_UART_BAUD_RATE
 
 static const SerialConfig led_uart_runtine_config = {
     .speed = LED_UART_BAUD_RATE,
 };
+#endif
 
-static const SerialConfig ble_uart_config = {
-    .speed = 115200,
-};
-
+#ifdef ANNEPRO2_LED_MCU_ENABLE
 static uint8_t led_mcu_wakeup[11] = {0x7b, 0x10, 0x43, 0x10, 0x03, 0x00, 0x00, 0x7d, 0x02, 0x01, 0x02};
+#endif
 
-ble_capslock_t ble_capslock = {._dummy = {0}, .caps_lock = false};
-
-#ifdef RGB_MATRIX_ENABLE
+#if defined(ANNEPRO2_LED_MCU_ENABLE) && defined(RGB_MATRIX_ENABLE)
 static uint8_t led_enabled = 1;
 #endif
 
@@ -54,11 +58,13 @@ void mcu_reset(void) {
 }
 
 void bootloader_jump(void) {
+#ifdef ANNEPRO2_LED_MCU_ENABLE
     // Send msg to shine to boot into IAP
     ap2_set_IAP();
 
     // wait for shine to boot into IAP
     wait_ms(15);
+#endif
 
     // Load ble into IAP
     annepro2_ble_bootload();
@@ -67,7 +73,7 @@ void bootloader_jump(void) {
     // Magic key to set keyboard to IAP
     // It’s from reversing original boot loader
     // If value is that it stays in boot loader aka IAP
-    *((uint32_t *)RAM_MAGIC_LOCATION) = IAP_MAGIC_VALUE;
+    *((uint32_t *)ANNEPRO2_IAP_MAGIC_LOCATION) = IAP_MAGIC_VALUE;
 
     // Load the main MCU into IAP
     __disable_irq();
@@ -75,6 +81,7 @@ void bootloader_jump(void) {
 }
 
 void keyboard_pre_init_kb(void) {
+#ifdef ANNEPRO2_LED_MCU_ENABLE
     // Start LED UART
     sdStart(&SD0, &led_uart_init_config);
     /* Let the LED chip settle a bit before switching the mode.
@@ -91,89 +98,49 @@ void keyboard_pre_init_kb(void) {
     while (!sdGetWouldBlock(&SD0)) sdGet(&SD0);
 
     sdStart(&SD0, &led_uart_runtine_config);
+#endif
     keyboard_pre_init_user();
 }
 
 void keyboard_post_init_kb(void) {
-    // Start BLE UART
-    sdStart(&SD1, &ble_uart_config);
-    annepro2_ble_startup();
+    annepro2_ble_init();
 
-    // Give the send uart thread some time to
-    // send out the queue before we read back
-    wait_ms(100);
-
-    // loop to clear out receive buffer from ble wakeup
-    while (!sdGetWouldBlock(&SD1)) sdGet(&SD1);
-
-    #ifdef RGB_MATRIX_ENABLE
+#if defined(ANNEPRO2_LED_MCU_ENABLE) && defined(RGB_MATRIX_ENABLE)
     ap2_led_set_manual_control(1);
     ap2_led_enable();
-    #endif
+#endif
 
     keyboard_post_init_user();
 }
 
 void matrix_scan_kb(void) {
-    // if there's stuff on the ble serial buffer
-    // read it into the capslock struct
-    while (!sdGetWouldBlock(&SD1)) {
-        sdReadTimeout(&SD1, (uint8_t *)&ble_capslock, sizeof(ble_capslock_t), 10);
-    }
+    annepro2_ble_task();
 
+#ifdef ANNEPRO2_LED_MCU_ENABLE
     /* While there's data from LED keyboard sent - read it. */
     while (!sdGetWouldBlock(&SD0)) {
         uint8_t byte = sdGet(&SD0);
         proto_consume(&proto, byte);
     }
-
+#endif
 
     matrix_scan_user();
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {
+#ifdef ANNEPRO2_LED_MCU_ENABLE
         if (ap2_led_status.matrix_enabled && ap2_led_status.is_reactive) {
             ap2_led_forward_keypress(record->event.key.row, record->event.key.col);
         }
+#endif
 
-        const ap2_led_t blue = {
-            .p.blue  = 0xff,
-            .p.red   = 0x00,
-            .p.green = 0x00,
-            .p.alpha = 0xff,
-        };
+        if (!annepro2_ble_process_record(keycode, record)) {
+            return false;
+        }
 
         switch (keycode) {
-            case KC_AP2_BT1:
-                annepro2_ble_broadcast(0);
-                /* FIXME: This hardcodes col/row position */
-                ap2_led_blink(record->event.key.row, record->event.key.col, blue, 8, 50);
-                return false;
-
-            case KC_AP2_BT2:
-                annepro2_ble_broadcast(1);
-                ap2_led_blink(record->event.key.row, record->event.key.col, blue, 8, 50);
-                return false;
-
-            case KC_AP2_BT3:
-                annepro2_ble_broadcast(2);
-                ap2_led_blink(record->event.key.row, record->event.key.col, blue, 8, 50);
-                return false;
-
-            case KC_AP2_BT4:
-                annepro2_ble_broadcast(3);
-                ap2_led_blink(record->event.key.row, record->event.key.col, blue, 8, 50);
-                return false;
-
-            case KC_AP2_USB:
-                annepro2_ble_disconnect();
-                return false;
-
-            case KC_AP2_BT_UNPAIR:
-                annepro2_ble_unpair();
-                return false;
-
+#ifdef ANNEPRO2_LED_MCU_ENABLE
             case KC_AP_LED_OFF:
                 ap2_led_disable();
                 break;
@@ -215,7 +182,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 ap2_led_next_animation_speed();
                 ap2_led_reset_foreground_color();
                 return false;
-            #ifdef RGB_MATRIX_ENABLE
+#    ifdef RGB_MATRIX_ENABLE
             case QK_RGB_MATRIX_TOGGLE:
                 if(rgb_matrix_is_enabled()) ap2_led_disable();
                 else ap2_led_enable();
@@ -282,11 +249,31 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                     }
                 }
                 return true;
-            #endif
+#    endif
 
             default:
                 break;
+#else
+            case KC_AP_LED_ON:
+            case KC_AP_LED_OFF:
+            case KC_AP_LED_TOG:
+            case KC_AP_LED_NEXT_PROFILE:
+            case KC_AP_LED_PREV_PROFILE:
+            case KC_AP_LED_NEXT_INTENSITY:
+            case KC_AP_LED_SPEED:
+            case KC_AP_RGB_VAI:
+            case KC_AP_RGB_VAD:
+            case KC_AP_RGB_TOG:
+            case KC_AP_RGB_MOD:
+                /* AP2D direct-drive RGB support is intentionally deferred. */
+                return false;
+
+            default:
+                break;
+#endif
         }
+    } else if (!annepro2_ble_process_record(keycode, record)) {
+        return false;
     }
     return process_record_user(keycode, record);
 }

--- a/keyboards/annepro2/annepro2.h
+++ b/keyboards/annepro2/annepro2.h
@@ -18,7 +18,9 @@
 #pragma once
 #include "quantum.h"
 #include <stdint.h>
-#include "ap2_led.h"
+#ifdef ANNEPRO2_LED_MCU_ENABLE
+#    include "ap2_led.h"
+#endif
 
 typedef struct __attribute__((__packed__)) {
     uint8_t _dummy[10];

--- a/keyboards/annepro2/annepro2_ble.c
+++ b/keyboards/annepro2/annepro2_ble.c
@@ -15,6 +15,7 @@
 */
 
 #include "annepro2_ble.h"
+#include "ap2_led.h"
 #include "ch.h"
 #include "hal.h"
 #include "host.h"
@@ -32,6 +33,10 @@ static void ap2_ble_swtich_ble_driver(void);
 /* -------------------- Static Local Variables ------------------------------ */
 static host_driver_t ap2_ble_driver = {
     ap2_ble_leds, ap2_ble_keyboard, NULL, ap2_ble_mouse, ap2_ble_extra
+};
+
+static const SerialConfig ble_uart_config = {
+    .speed = 115200,
 };
 
 static uint8_t ble_mcu_wakeup[11] = {0x7b, 0x12, 0x53, 0x00, 0x03, 0x00, 0x01, 0x7d, 0x02, 0x01, 0x02};
@@ -59,11 +64,58 @@ static uint8_t ble_mcu_unpair[10] = {
 static uint8_t ble_mcu_bootload[11] = {0x7b, 0x10, 0x51, 0x10, 0x03, 0x00, 0x00, 0x7d, 0x02, 0x01, 0x01};
 
 static host_driver_t *last_host_driver = NULL;
+ble_capslock_t        ble_capslock     = {._dummy = {0}, .caps_lock = false};
 #ifdef NKRO_ENABLE
 static bool lastNkroStatus = false;
 #endif  // NKRO_ENABLE
 
 /* -------------------- Public Function Implementation ---------------------- */
+
+void annepro2_ble_init(void) {
+    sdStart(&SD1, &ble_uart_config);
+    annepro2_ble_startup();
+    wait_ms(100);
+    while (!sdGetWouldBlock(&SD1)) {
+        sdGet(&SD1);
+    }
+}
+
+void annepro2_ble_task(void) {
+    while (!sdGetWouldBlock(&SD1)) {
+        sdReadTimeout(&SD1, (uint8_t *)&ble_capslock, sizeof(ble_capslock_t), 10);
+    }
+}
+
+bool annepro2_ble_process_record(uint16_t keycode, keyrecord_t *record) {
+    if (!record->event.pressed) {
+        return true;
+    }
+
+    const ap2_led_t blue = {
+        .p.blue  = 0xff,
+        .p.red   = 0x00,
+        .p.green = 0x00,
+        .p.alpha = 0xff,
+    };
+
+    switch (keycode) {
+        case KC_AP2_BT1:
+        case KC_AP2_BT2:
+        case KC_AP2_BT3:
+        case KC_AP2_BT4:
+            annepro2_ble_broadcast(keycode - KC_AP2_BT1);
+            ap2_led_blink(record->event.key.row, record->event.key.col, blue, 8, 50);
+            return false;
+        case KC_AP2_USB:
+            annepro2_ble_disconnect();
+            return false;
+        case KC_AP2_BT_UNPAIR:
+            annepro2_ble_unpair();
+            return false;
+        default:
+            return true;
+    }
+}
 
 void annepro2_ble_bootload(void) { sdWrite(&SD1, ble_mcu_bootload, sizeof(ble_mcu_bootload)); }
 
@@ -94,6 +146,14 @@ void annepro2_ble_connect(uint8_t port) {
     ap2_ble_swtich_ble_driver();
 }
 
+void annepro2_ble_slot_press(uint8_t port) {
+    annepro2_ble_broadcast(port);
+}
+
+void annepro2_ble_slot_release(uint8_t port) {
+    (void)port;
+}
+
 void annepro2_ble_disconnect(void) {
     /* Skip if the driver is already enabled */
     if (host_get_driver() != &ap2_ble_driver) {
@@ -110,6 +170,10 @@ void annepro2_ble_disconnect(void) {
 void annepro2_ble_unpair(void) {
     // sdPut(&SD1, 0x0);
     sdWrite(&SD1, ble_mcu_unpair, sizeof(ble_mcu_unpair));
+}
+
+void annepro2_ble_rx_byte(uint8_t byte) {
+    (void)byte;
 }
 
 /* ------------------- Static Function Implementation ----------------------- */

--- a/keyboards/annepro2/annepro2_ble.h
+++ b/keyboards/annepro2/annepro2_ble.h
@@ -18,9 +18,31 @@
 
 #include "annepro2.h"
 
+typedef enum {
+    ANNEPRO2_BLE_STATUS_IDLE,
+    ANNEPRO2_BLE_STATUS_ADVERTISING,
+    ANNEPRO2_BLE_STATUS_CONNECTING,
+    ANNEPRO2_BLE_STATUS_CONNECTED,
+    ANNEPRO2_BLE_STATUS_FAILED,
+} annepro2_ble_status_t;
+
+void annepro2_ble_init(void);
+void annepro2_ble_task(void);
+bool annepro2_ble_process_record(uint16_t keycode, keyrecord_t *record);
 void annepro2_ble_bootload(void);
 void annepro2_ble_startup(void);
 void annepro2_ble_broadcast(uint8_t port);
 void annepro2_ble_connect(uint8_t port);
-void annepro2_ble_disconnect(void);
-void annepro2_ble_unpair(void);
+void                   annepro2_ble_slot_press(uint8_t port);
+void                   annepro2_ble_slot_release(uint8_t port);
+void                   annepro2_ble_disconnect(void);
+void                   annepro2_ble_unpair(void);
+
+/*
+ * Optional keymap hook for asynchronous BLE status indication.
+ * Slot is zero-based (0..3). The default implementation does nothing.
+ */
+void annepro2_ble_status_changed_user(annepro2_ble_status_t status, uint8_t slot);
+
+/* Feed bytes received from the BLE UART into the AnnePro2 frame parser. */
+void annepro2_ble_rx_byte(uint8_t byte);

--- a/keyboards/annepro2/annepro2_ble_213_slot.c
+++ b/keyboards/annepro2/annepro2_ble_213_slot.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 BHE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "annepro2_ble_213_slot.h"
+
+#include <string.h>
+
+/*
+ * AP2D KEY 3.08 queries and selects the BLE module's internal slot before
+ * issuing a pairing or connect command. This module is compiled only for the
+ * AP2D BLE 2.13 transport.
+ */
+static const uint8_t query_slot_frame[] = {
+    0x7b, 0x12, 0x53, 0x00, 0x02, 0x00, 0x00, 0x7d, 0xc0, 0x17,
+};
+
+static const uint8_t select_slot_frame[] = {
+    0x7b, 0x12, 0x53, 0x00, 0x03, 0x00, 0x00, 0x7d, 0x40, 0x17,
+};
+
+static const uint8_t prepare_slot_frame[] = {
+    0x7b, 0x10, 0x53, 0x00, 0x03, 0x00, 0x00, 0x7d, 0x02, 0x01,
+};
+
+static uint32_t elapsed(uint32_t now, uint32_t then) {
+    return now - then;
+}
+
+void ap2_ble_213_slot_reset(ap2_ble_213_slot_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    state->phase = AP2_BLE_213_SLOT_IDLE;
+}
+
+bool ap2_ble_213_slot_should_prepare(uint8_t command_retries) {
+    return command_retries == 0;
+}
+
+ap2_ble_213_slot_actions_t ap2_ble_213_slot_begin(ap2_ble_213_slot_state_t *state, uint8_t target_slot, uint16_t deferred_actions, uint32_t now) {
+    state->phase                   = AP2_BLE_213_SLOT_WAIT_QUERY;
+    state->target_slot             = target_slot > 3 ? 3 : target_slot;
+    state->query_response_received = false;
+    state->deferred_actions        = deferred_actions;
+    state->timer                   = now;
+    return AP2_BLE_213_SLOT_ACTION_QUERY;
+}
+
+void ap2_ble_213_slot_response(ap2_ble_213_slot_state_t *state, uint8_t current_slot) {
+    if (state->phase != AP2_BLE_213_SLOT_WAIT_QUERY || current_slot > 3) {
+        return;
+    }
+    state->current_slot            = current_slot;
+    state->query_response_received = true;
+}
+
+ap2_ble_213_slot_actions_t ap2_ble_213_slot_task(ap2_ble_213_slot_state_t *state, uint32_t now, uint16_t *deferred_actions) {
+    if (deferred_actions != NULL) {
+        *deferred_actions = 0;
+    }
+
+    switch (state->phase) {
+        case AP2_BLE_213_SLOT_WAIT_QUERY:
+            if (elapsed(now, state->timer) < ANNEPRO2_BLE_213_SLOT_QUERY_DELAY) {
+                return AP2_BLE_213_SLOT_ACTION_NONE;
+            }
+            if (state->query_response_received && state->current_slot == state->target_slot) {
+                if (deferred_actions != NULL) {
+                    *deferred_actions = state->deferred_actions;
+                }
+                state->phase            = AP2_BLE_213_SLOT_IDLE;
+                state->deferred_actions = 0;
+                return AP2_BLE_213_SLOT_ACTION_DISPATCH;
+            }
+            state->phase        = AP2_BLE_213_SLOT_WAIT_PREPARE_2;
+            state->current_slot = state->target_slot;
+            state->timer        = now;
+            return AP2_BLE_213_SLOT_ACTION_SELECT | AP2_BLE_213_SLOT_ACTION_PREPARE_1;
+
+        case AP2_BLE_213_SLOT_WAIT_PREPARE_2:
+            if (elapsed(now, state->timer) < ANNEPRO2_BLE_213_SLOT_PREPARE_DELAY) {
+                return AP2_BLE_213_SLOT_ACTION_NONE;
+            }
+            state->phase = AP2_BLE_213_SLOT_WAIT_COMMAND;
+            state->timer = now;
+            return AP2_BLE_213_SLOT_ACTION_PREPARE_2;
+
+        case AP2_BLE_213_SLOT_WAIT_COMMAND:
+            if (elapsed(now, state->timer) < ANNEPRO2_BLE_213_SLOT_PREPARE_DELAY) {
+                return AP2_BLE_213_SLOT_ACTION_NONE;
+            }
+            if (deferred_actions != NULL) {
+                *deferred_actions = state->deferred_actions;
+            }
+            state->phase            = AP2_BLE_213_SLOT_IDLE;
+            state->deferred_actions = 0;
+            return AP2_BLE_213_SLOT_ACTION_DISPATCH;
+
+        case AP2_BLE_213_SLOT_IDLE:
+            return AP2_BLE_213_SLOT_ACTION_NONE;
+    }
+
+    return AP2_BLE_213_SLOT_ACTION_NONE;
+}
+
+bool ap2_ble_213_slot_active(const ap2_ble_213_slot_state_t *state) {
+    return state->phase != AP2_BLE_213_SLOT_IDLE;
+}
+
+uint8_t ap2_ble_213_slot_encode_query(uint8_t out[AP2_BLE_213_SLOT_FRAME_MAX_SIZE]) {
+    memcpy(out, query_slot_frame, sizeof(query_slot_frame));
+    return sizeof(query_slot_frame);
+}
+
+uint8_t ap2_ble_213_slot_encode_select(uint8_t slot, uint8_t out[AP2_BLE_213_SLOT_FRAME_MAX_SIZE]) {
+    memcpy(out, select_slot_frame, sizeof(select_slot_frame));
+    out[sizeof(select_slot_frame)] = slot > 3 ? 3 : slot;
+    return sizeof(select_slot_frame) + 1;
+}
+
+uint8_t ap2_ble_213_slot_encode_prepare(uint8_t value, uint8_t out[AP2_BLE_213_SLOT_FRAME_MAX_SIZE]) {
+    memcpy(out, prepare_slot_frame, sizeof(prepare_slot_frame));
+    out[sizeof(prepare_slot_frame)] = value;
+    return sizeof(prepare_slot_frame) + 1;
+}
+
+bool ap2_ble_213_slot_decode_response(const uint8_t *frame, size_t size, uint8_t *slot) {
+    if (frame == NULL || slot == NULL || size != AP2_BLE_213_SLOT_FRAME_MAX_SIZE || frame[0] != 0x7b || frame[1] != 0x12 || frame[2] != 0x35 || frame[4] != 0x03 || frame[5] != 0x00 || frame[7] != 0x7d || frame[8] != 0xc0 || frame[9] != 0x17 || frame[10] > 3) {
+        return false;
+    }
+
+    *slot = frame[10];
+    return true;
+}

--- a/keyboards/annepro2/annepro2_ble_213_slot.h
+++ b/keyboards/annepro2/annepro2_ble_213_slot.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 BHE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef ANNEPRO2_BLE_213_SLOT_QUERY_DELAY
+#    define ANNEPRO2_BLE_213_SLOT_QUERY_DELAY 5
+#endif
+
+#ifndef ANNEPRO2_BLE_213_SLOT_PREPARE_DELAY
+#    define ANNEPRO2_BLE_213_SLOT_PREPARE_DELAY 20
+#endif
+
+#define AP2_BLE_213_SLOT_FRAME_MAX_SIZE 11
+
+typedef enum {
+    AP2_BLE_213_SLOT_IDLE,
+    AP2_BLE_213_SLOT_WAIT_QUERY,
+    AP2_BLE_213_SLOT_WAIT_PREPARE_2,
+    AP2_BLE_213_SLOT_WAIT_COMMAND,
+} ap2_ble_213_slot_phase_t;
+
+typedef enum {
+    AP2_BLE_213_SLOT_ACTION_NONE      = 0,
+    AP2_BLE_213_SLOT_ACTION_QUERY     = 1 << 0,
+    AP2_BLE_213_SLOT_ACTION_SELECT    = 1 << 1,
+    AP2_BLE_213_SLOT_ACTION_PREPARE_1 = 1 << 2,
+    AP2_BLE_213_SLOT_ACTION_PREPARE_2 = 1 << 3,
+    AP2_BLE_213_SLOT_ACTION_DISPATCH  = 1 << 4,
+} ap2_ble_213_slot_action_t;
+
+typedef uint8_t ap2_ble_213_slot_actions_t;
+
+typedef struct {
+    ap2_ble_213_slot_phase_t phase;
+    uint8_t                  target_slot;
+    uint8_t                  current_slot;
+    bool                     query_response_received;
+    uint16_t                 deferred_actions;
+    uint32_t                 timer;
+} ap2_ble_213_slot_state_t;
+
+void                       ap2_ble_213_slot_reset(ap2_ble_213_slot_state_t *state);
+bool                       ap2_ble_213_slot_should_prepare(uint8_t command_retries);
+ap2_ble_213_slot_actions_t ap2_ble_213_slot_begin(ap2_ble_213_slot_state_t *state, uint8_t target_slot, uint16_t deferred_actions, uint32_t now);
+void                       ap2_ble_213_slot_response(ap2_ble_213_slot_state_t *state, uint8_t current_slot);
+ap2_ble_213_slot_actions_t ap2_ble_213_slot_task(ap2_ble_213_slot_state_t *state, uint32_t now, uint16_t *deferred_actions);
+bool                       ap2_ble_213_slot_active(const ap2_ble_213_slot_state_t *state);
+uint8_t                    ap2_ble_213_slot_encode_query(uint8_t out[AP2_BLE_213_SLOT_FRAME_MAX_SIZE]);
+uint8_t                    ap2_ble_213_slot_encode_select(uint8_t slot, uint8_t out[AP2_BLE_213_SLOT_FRAME_MAX_SIZE]);
+uint8_t                    ap2_ble_213_slot_encode_prepare(uint8_t value, uint8_t out[AP2_BLE_213_SLOT_FRAME_MAX_SIZE]);
+bool                       ap2_ble_213_slot_decode_response(const uint8_t *frame, size_t size, uint8_t *slot);

--- a/keyboards/annepro2/annepro2_ble_parser.c
+++ b/keyboards/annepro2/annepro2_ble_parser.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 BHE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "annepro2_ble_parser.h"
+
+#include <string.h>
+
+static uint32_t elapsed(uint32_t now, uint32_t then) {
+    return now - then;
+}
+
+static void start_if_header(annepro2_ble_parser_t *parser, uint8_t byte, uint32_t now) {
+    if (byte == 0x7B) {
+        parser->frame[0]        = byte;
+        parser->size            = 1;
+        parser->last_byte_timer = now;
+    }
+}
+
+void annepro2_ble_parser_reset(annepro2_ble_parser_t *parser) {
+    memset(parser, 0, sizeof(*parser));
+}
+
+bool annepro2_ble_parser_expire(annepro2_ble_parser_t *parser, uint32_t now) {
+    if (parser->size == 0 || elapsed(now, parser->last_byte_timer) < ANNEPRO2_BLE_RX_TIMEOUT) {
+        return false;
+    }
+
+    parser->size          = 0;
+    parser->expected_size = 0;
+    return true;
+}
+
+annepro2_ble_parse_event_t annepro2_ble_parser_feed(annepro2_ble_parser_t *parser, uint8_t byte, uint32_t now, const uint8_t **frame, uint8_t *size) {
+    *frame = NULL;
+    *size  = 0;
+
+    const bool timed_out = annepro2_ble_parser_expire(parser, now);
+    if (parser->size == 0) {
+        start_if_header(parser, byte, now);
+        return timed_out ? ANNEPRO2_BLE_PARSE_TIMEOUT : ANNEPRO2_BLE_PARSE_NONE;
+    }
+
+    if (parser->size >= ANNEPRO2_BLE_RX_MAX_FRAME_SIZE) {
+        parser->size          = 0;
+        parser->expected_size = 0;
+        start_if_header(parser, byte, now);
+        return ANNEPRO2_BLE_PARSE_INVALID_LENGTH;
+    }
+
+    parser->frame[parser->size++] = byte;
+    parser->last_byte_timer       = now;
+
+    /*
+     * Liana encodes payload length in bytes 4..6. Supported BLE UART frames
+     * are small, so non-zero high bytes are corrupt rather than truncatable.
+     */
+    if (parser->size == 7) {
+        const uint8_t payload_size = parser->frame[4];
+        if (parser->frame[5] != 0 || parser->frame[6] != 0 || payload_size > ANNEPRO2_BLE_RX_MAX_PAYLOAD) {
+            parser->size          = 0;
+            parser->expected_size = 0;
+            start_if_header(parser, byte, now);
+            return ANNEPRO2_BLE_PARSE_INVALID_LENGTH;
+        }
+        parser->expected_size = ANNEPRO2_BLE_RX_HEADER_SIZE + payload_size;
+    }
+
+    if (parser->size == ANNEPRO2_BLE_RX_HEADER_SIZE && parser->frame[7] != 0x7D) {
+        parser->size          = 0;
+        parser->expected_size = 0;
+        start_if_header(parser, byte, now);
+        return ANNEPRO2_BLE_PARSE_INVALID_DELIMITER;
+    }
+
+    if (parser->expected_size != 0 && parser->size == parser->expected_size) {
+        *frame                = parser->frame;
+        *size                 = parser->size;
+        parser->size          = 0;
+        parser->expected_size = 0;
+        return ANNEPRO2_BLE_PARSE_FRAME;
+    }
+
+    return timed_out ? ANNEPRO2_BLE_PARSE_TIMEOUT : ANNEPRO2_BLE_PARSE_NONE;
+}

--- a/keyboards/annepro2/annepro2_ble_parser.h
+++ b/keyboards/annepro2/annepro2_ble_parser.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 BHE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define ANNEPRO2_BLE_RX_HEADER_SIZE 8
+#define ANNEPRO2_BLE_RX_MAX_PAYLOAD 32
+#define ANNEPRO2_BLE_RX_MAX_FRAME_SIZE (ANNEPRO2_BLE_RX_HEADER_SIZE + ANNEPRO2_BLE_RX_MAX_PAYLOAD)
+
+#ifndef ANNEPRO2_BLE_RX_TIMEOUT
+#    define ANNEPRO2_BLE_RX_TIMEOUT 20
+#endif
+
+typedef enum {
+    ANNEPRO2_BLE_PARSE_NONE,
+    ANNEPRO2_BLE_PARSE_FRAME,
+    ANNEPRO2_BLE_PARSE_TIMEOUT,
+    ANNEPRO2_BLE_PARSE_INVALID_LENGTH,
+    ANNEPRO2_BLE_PARSE_INVALID_DELIMITER,
+} annepro2_ble_parse_event_t;
+
+typedef struct {
+    uint8_t  frame[ANNEPRO2_BLE_RX_MAX_FRAME_SIZE];
+    uint8_t  size;
+    uint8_t  expected_size;
+    uint32_t last_byte_timer;
+} annepro2_ble_parser_t;
+
+void annepro2_ble_parser_reset(annepro2_ble_parser_t *parser);
+
+/*
+ * Feed one UART byte. A returned frame points into parser storage and remains
+ * valid until the next feed call.
+ */
+annepro2_ble_parse_event_t annepro2_ble_parser_feed(annepro2_ble_parser_t *parser, uint8_t byte, uint32_t now, const uint8_t **frame, uint8_t *size);
+
+/* Drop a stale partial frame when no new UART byte arrives. */
+bool annepro2_ble_parser_expire(annepro2_ble_parser_t *parser, uint32_t now);

--- a/keyboards/annepro2/annepro2_ble_profile.c
+++ b/keyboards/annepro2/annepro2_ble_profile.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 BHE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "annepro2_ble_profile.h"
+
+#include <string.h>
+
+#define AP2_BLE_EECONFIG_MAGIC 0xA2
+#define AP2_BLE_EECONFIG_VERSION 0x02
+#define AP2_BLE_EECONFIG_CHECK_XOR 0x5A
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_C18_205
+static bool annepro2_ble_consumer_205_bit(uint16_t usage, uint8_t *bit) {
+    switch (usage) {
+        case 0x00E2:
+            *bit = 0;
+            return true;
+        case 0x00E9:
+            *bit = 1;
+            return true;
+        case 0x00EA:
+            *bit = 2;
+            return true;
+        case 0x00CD:
+            *bit = 3;
+            return true;
+        case 0x00B5:
+            *bit = 4;
+            return true;
+        case 0x00B6:
+            *bit = 5;
+            return true;
+        case 0x006F:
+            *bit = 6;
+            return true;
+        case 0x0070:
+            *bit = 7;
+            return true;
+        default:
+            return false;
+    }
+}
+#endif
+
+bool annepro2_ble_encode_consumer(const uint16_t *usages, size_t usage_count, uint8_t out[ANNEPRO2_BLE_CONSUMER_REPORT_SIZE]) {
+    memset(out, 0, ANNEPRO2_BLE_CONSUMER_REPORT_SIZE);
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    if (usage_count > 4) {
+        return false;
+    }
+    for (size_t i = 0; i < usage_count; i++) {
+        out[i * 2]     = (uint8_t)usages[i];
+        out[i * 2 + 1] = (uint8_t)(usages[i] >> 8);
+    }
+    return true;
+#else
+    for (size_t i = 0; i < usage_count; i++) {
+        uint8_t bit;
+        if (usages[i] == 0) {
+            continue;
+        }
+        if (!annepro2_ble_consumer_205_bit(usages[i], &bit)) {
+            return false;
+        }
+        out[0] |= (uint8_t)(1U << bit);
+    }
+    return true;
+#endif
+}
+
+void annepro2_ble_encode_slot_state(bool broadcast, annepro2_ble_slot_state_t *state) {
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    state->command = broadcast ? 0x0B : 0x24;
+    state->action  = broadcast ? 1 : 2;
+#else
+    state->command = 0x0B;
+    state->action  = broadcast ? 1 : 0;
+#endif
+}
+
+bool annepro2_ble_decode_caps_lock(const uint8_t *frame, size_t size, bool *caps_lock) {
+    static const uint8_t prefix[] = {
+        0x7B, 0x12, 0x35, 0x00, 0x03, 0x00, 0x00, 0x7D, 0x20, 0x07,
+    };
+
+    if (frame == NULL || caps_lock == NULL || size != sizeof(prefix) + 1 || frame[sizeof(prefix)] > 1 || memcmp(frame, prefix, sizeof(prefix)) != 0) {
+        return false;
+    }
+
+    *caps_lock = frame[sizeof(prefix)] != 0;
+    return true;
+}
+
+bool annepro2_ble_encode_config(int8_t slot, uint32_t *config) {
+    if (config == NULL || slot < -1 || slot > 3) {
+        return false;
+    }
+
+    const uint8_t payload  = slot < 0 ? 0 : (uint8_t)slot + 1;
+    const uint8_t checksum = AP2_BLE_EECONFIG_MAGIC ^ AP2_BLE_EECONFIG_VERSION ^ payload ^ AP2_BLE_EECONFIG_CHECK_XOR;
+    *config                = ((uint32_t)AP2_BLE_EECONFIG_MAGIC << 24) | ((uint32_t)AP2_BLE_EECONFIG_VERSION << 16) | ((uint32_t)checksum << 8) | payload;
+    return true;
+}
+
+bool annepro2_ble_decode_config(uint32_t config, int8_t *slot) {
+    const uint8_t magic    = config >> 24;
+    const uint8_t version  = config >> 16;
+    const uint8_t checksum = config >> 8;
+    const uint8_t payload  = config;
+
+    if (slot == NULL || magic != AP2_BLE_EECONFIG_MAGIC || version != AP2_BLE_EECONFIG_VERSION || payload > 4 || checksum != (uint8_t)(magic ^ version ^ payload ^ AP2_BLE_EECONFIG_CHECK_XOR)) {
+        return false;
+    }
+
+    *slot = payload == 0 ? -1 : (int8_t)payload - 1;
+    return true;
+}

--- a/keyboards/annepro2/annepro2_ble_profile.h
+++ b/keyboards/annepro2/annepro2_ble_profile.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 BHE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define ANNEPRO2_BLE_PROFILE_C18_205 0
+#define ANNEPRO2_BLE_PROFILE_AP2D_213 1
+
+#ifndef ANNEPRO2_BLE_PROFILE
+#    define ANNEPRO2_BLE_PROFILE ANNEPRO2_BLE_PROFILE_C18_205
+#endif
+
+#if ANNEPRO2_BLE_PROFILE != ANNEPRO2_BLE_PROFILE_C18_205 && ANNEPRO2_BLE_PROFILE != ANNEPRO2_BLE_PROFILE_AP2D_213
+#    error "Unsupported Anne Pro 2 BLE profile"
+#endif
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+#    define ANNEPRO2_BLE_CONSUMER_REPORT_SIZE 8
+#else
+#    define ANNEPRO2_BLE_CONSUMER_REPORT_SIZE 4
+#endif
+
+typedef struct {
+    uint8_t command;
+    uint8_t action;
+} annepro2_ble_slot_state_t;
+
+bool annepro2_ble_encode_consumer(const uint16_t *usages, size_t usage_count, uint8_t out[ANNEPRO2_BLE_CONSUMER_REPORT_SIZE]);
+void annepro2_ble_encode_slot_state(bool broadcast, annepro2_ble_slot_state_t *state);
+bool annepro2_ble_decode_caps_lock(const uint8_t *frame, size_t size, bool *caps_lock);
+bool annepro2_ble_encode_config(int8_t slot, uint32_t *config);
+bool annepro2_ble_decode_config(uint32_t config, int8_t *slot);

--- a/keyboards/annepro2/annepro2_ble_state.c
+++ b/keyboards/annepro2/annepro2_ble_state.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "annepro2_ble_state.h"
+
+#include <string.h>
+
+static uint32_t elapsed(uint32_t now, uint32_t then) {
+    return now - then;
+}
+
+static uint8_t clamp_slot(uint8_t slot) {
+    return slot > 3 ? 3 : slot;
+}
+
+static void clear_transient_state(ap2_ble_state_t *state) {
+    state->command_retries            = 0;
+    state->handshake_recoveries       = 0;
+    state->handshake_timeout_enabled  = false;
+    state->command_slot_state_pending = false;
+    state->startup_slot               = -1;
+    state->held_slot                  = -1;
+    state->held_slot_broadcast        = false;
+    state->pending_slot               = -1;
+}
+
+static ap2_ble_actions_t start_broadcast(ap2_ble_state_t *state, uint8_t slot, int8_t slot_state, bool handshake_timeout, uint32_t now) {
+    state->state                      = AP2_BLE_STATE_WAIT_BROADCAST_ACK;
+    state->startup_slot               = -1;
+    state->selected_slot              = clamp_slot(slot);
+    state->command_slot_state_pending = slot_state >= 0;
+    state->command_slot_broadcast     = slot_state > 0;
+    state->handshake_timeout_enabled  = handshake_timeout;
+    state->command_retries            = 0;
+    state->command_timer              = now;
+
+    ap2_ble_actions_t actions = AP2_BLE_ACTION_ROUTE_USB | AP2_BLE_ACTION_SEND_BROADCAST;
+    if (state->command_slot_state_pending) {
+        state->command_slot_state_pending = false;
+        actions |= AP2_BLE_ACTION_SEND_SLOT_STATE;
+    }
+    return actions;
+}
+
+static ap2_ble_actions_t start_connect(ap2_ble_state_t *state, uint8_t slot, uint32_t now) {
+    state->state                      = AP2_BLE_STATE_WAIT_CONNECT_ACK;
+    state->startup_slot               = -1;
+    state->selected_slot              = clamp_slot(slot);
+    state->command_slot_state_pending = false;
+    state->command_slot_broadcast     = false;
+    state->handshake_timeout_enabled  = true;
+    state->command_retries            = 0;
+    state->command_timer              = now;
+    return AP2_BLE_ACTION_ROUTE_USB | AP2_BLE_ACTION_SEND_SLOT_STATE | AP2_BLE_ACTION_SEND_CONNECT;
+}
+
+static void queue_intent(ap2_ble_state_t *state, uint8_t slot, bool broadcast, uint32_t now) {
+    /*
+     * Stop retrying the old transaction immediately. The quiet window before
+     * dispatching the latest intent makes command-family ACKs from the old
+     * slot stale while the state is USB.
+     */
+    state->state                      = AP2_BLE_STATE_USB;
+    state->command_retries            = 0;
+    state->command_slot_state_pending = false;
+    state->handshake_timeout_enabled  = false;
+    state->pending_slot               = clamp_slot(slot);
+    state->pending_broadcast          = broadcast;
+    state->pending_timer              = now;
+}
+
+void ap2_ble_state_reset(ap2_ble_state_t *state) {
+    memset(state, 0, sizeof(*state));
+    state->state        = AP2_BLE_STATE_USB;
+    state->startup_slot = -1;
+    state->held_slot    = -1;
+    state->pending_slot = -1;
+}
+
+ap2_ble_actions_t ap2_ble_state_startup(ap2_ble_state_t *state, int8_t saved_slot, uint32_t now) {
+    ap2_ble_state_reset(state);
+    if (saved_slot >= 0 && saved_slot <= 3) {
+        state->startup_slot  = saved_slot;
+        state->selected_slot = (uint8_t)saved_slot;
+        state->startup_timer = now;
+        state->state         = AP2_BLE_STATE_STARTUP_PASSIVE;
+    }
+    return AP2_BLE_ACTION_SEND_WAKEUP;
+}
+
+ap2_ble_actions_t ap2_ble_state_connect(ap2_ble_state_t *state, uint8_t slot, uint32_t now) {
+    slot                = clamp_slot(slot);
+    state->startup_slot = -1;
+    if (state->state == AP2_BLE_STATE_STARTUP_PASSIVE) {
+        state->state = AP2_BLE_STATE_USB;
+    }
+    if (state->pending_slot >= 0) {
+        queue_intent(state, slot, false, now);
+        return AP2_BLE_ACTION_ROUTE_USB;
+    }
+    if (ap2_ble_state_operation_pending(state)) {
+        if (state->selected_slot == slot) {
+            state->pending_slot = -1;
+        } else {
+            queue_intent(state, slot, false, now);
+        }
+        return AP2_BLE_ACTION_ROUTE_USB;
+    }
+
+    state->pending_slot         = -1;
+    state->handshake_recoveries = 0;
+    return start_connect(state, slot, now);
+}
+
+ap2_ble_actions_t ap2_ble_state_broadcast(ap2_ble_state_t *state, uint8_t slot, uint32_t now) {
+    slot                = clamp_slot(slot);
+    state->startup_slot = -1;
+    if (state->state == AP2_BLE_STATE_STARTUP_PASSIVE) {
+        state->state = AP2_BLE_STATE_USB;
+    }
+    if (state->pending_slot >= 0) {
+        queue_intent(state, slot, true, now);
+        return AP2_BLE_ACTION_ROUTE_USB;
+    }
+    if (ap2_ble_state_operation_pending(state)) {
+        queue_intent(state, slot, true, now);
+        return AP2_BLE_ACTION_ROUTE_USB;
+    }
+
+    state->pending_slot         = -1;
+    state->handshake_recoveries = 0;
+    return start_broadcast(state, slot, 1, false, now);
+}
+
+ap2_ble_actions_t ap2_ble_state_slot_press(ap2_ble_state_t *state, uint8_t slot, uint32_t now) {
+    state->startup_slot = -1;
+    if (state->state == AP2_BLE_STATE_STARTUP_PASSIVE) {
+        state->state = AP2_BLE_STATE_USB;
+    }
+    state->held_slot           = (int8_t)clamp_slot(slot);
+    state->held_slot_broadcast = false;
+    state->slot_hold_timer     = now;
+    return AP2_BLE_ACTION_NONE;
+}
+
+ap2_ble_actions_t ap2_ble_state_slot_release(ap2_ble_state_t *state, uint8_t slot, uint32_t now) {
+    slot = clamp_slot(slot);
+    if (state->held_slot != (int8_t)slot) {
+        return AP2_BLE_ACTION_NONE;
+    }
+
+    state->held_slot = -1;
+    if (!state->held_slot_broadcast) {
+        state->held_slot_broadcast = false;
+        return ap2_ble_state_connect(state, slot, now);
+    }
+    state->held_slot_broadcast = false;
+    return AP2_BLE_ACTION_NONE;
+}
+
+ap2_ble_actions_t ap2_ble_state_task(ap2_ble_state_t *state, uint32_t now) {
+    ap2_ble_actions_t actions = AP2_BLE_ACTION_NONE;
+
+    if (state->held_slot >= 0 && !state->held_slot_broadcast && elapsed(now, state->slot_hold_timer) >= ANNEPRO2_BLE_SLOT_HOLD_TIME) {
+        state->held_slot_broadcast = true;
+        actions |= ap2_ble_state_broadcast(state, (uint8_t)state->held_slot, now);
+    }
+
+    if (state->startup_slot >= 0 && elapsed(now, state->startup_timer) >= ANNEPRO2_BLE_STARTUP_DELAY) {
+        const uint8_t slot = (uint8_t)state->startup_slot;
+        actions |= start_broadcast(state, slot, -1, true, now);
+    }
+
+    if (state->pending_slot >= 0 && elapsed(now, state->pending_timer) >= ANNEPRO2_BLE_SLOT_SWITCH_DELAY) {
+        const uint8_t slot                = (uint8_t)state->pending_slot;
+        const bool    broadcast           = state->pending_broadcast;
+        state->pending_slot               = -1;
+        state->command_slot_state_pending = false;
+        state->handshake_timeout_enabled  = false;
+        state->handshake_recoveries       = 0;
+        state->state                      = AP2_BLE_STATE_USB;
+        actions |= broadcast ? start_broadcast(state, slot, 1, false, now) : start_connect(state, slot, now);
+    }
+
+    if (state->state == AP2_BLE_STATE_WAIT_HANDSHAKE) {
+        if (!state->handshake_timeout_enabled || elapsed(now, state->handshake_timer) < ANNEPRO2_BLE_HANDSHAKE_TIMEOUT) {
+            return actions;
+        }
+
+        state->state                      = AP2_BLE_STATE_USB;
+        state->command_slot_state_pending = false;
+        state->handshake_timeout_enabled  = false;
+        actions |= AP2_BLE_ACTION_ROUTE_USB;
+        if (state->handshake_recoveries == 0) {
+            state->handshake_recoveries = 1;
+            state->startup_slot         = state->selected_slot;
+            state->startup_timer        = now;
+            actions |= AP2_BLE_ACTION_SEND_WAKEUP;
+        } else {
+            actions |= AP2_BLE_ACTION_NOTIFY_FAILURE;
+        }
+        return actions;
+    }
+
+    if (state->state != AP2_BLE_STATE_WAIT_BROADCAST_ACK && state->state != AP2_BLE_STATE_WAIT_CONNECT_ACK) {
+        return actions;
+    }
+    if (elapsed(now, state->command_timer) < ANNEPRO2_BLE_COMMAND_TIMEOUT) {
+        return actions;
+    }
+
+    if (state->command_retries >= ANNEPRO2_BLE_COMMAND_RETRIES) {
+        state->handshake_timer = now;
+        state->state           = AP2_BLE_STATE_WAIT_HANDSHAKE;
+        return actions;
+    }
+
+    state->command_retries++;
+    state->command_timer = now;
+    actions |= state->state == AP2_BLE_STATE_WAIT_BROADCAST_ACK ? AP2_BLE_ACTION_SEND_BROADCAST : AP2_BLE_ACTION_SEND_CONNECT;
+    return actions;
+}
+
+ap2_ble_actions_t ap2_ble_state_command_ack(ap2_ble_state_t *state, uint8_t command, uint32_t now) {
+    if ((command == 0x01 && state->state != AP2_BLE_STATE_WAIT_BROADCAST_ACK) || (command == 0x04 && state->state != AP2_BLE_STATE_WAIT_CONNECT_ACK)) {
+        return AP2_BLE_ACTION_NONE;
+    }
+    if (command != 0x01 && command != 0x04) {
+        return AP2_BLE_ACTION_NONE;
+    }
+    state->command_retries = 0;
+    state->handshake_timer = now;
+    state->state           = AP2_BLE_STATE_WAIT_HANDSHAKE;
+    return AP2_BLE_ACTION_NONE;
+}
+
+ap2_ble_actions_t ap2_ble_state_handshake(ap2_ble_state_t *state) {
+    if (!ap2_ble_state_route_requested(state)) {
+        return AP2_BLE_ACTION_NONE;
+    }
+
+    state->command_slot_state_pending = false;
+    state->startup_slot               = -1;
+    state->command_retries            = 0;
+    state->handshake_recoveries       = 0;
+    state->handshake_timeout_enabled  = false;
+    state->state                      = AP2_BLE_STATE_ACTIVE;
+    return AP2_BLE_ACTION_ROUTE_BLE | AP2_BLE_ACTION_SAVE_SLOT;
+}
+
+ap2_ble_actions_t ap2_ble_state_disconnect(ap2_ble_state_t *state) {
+    clear_transient_state(state);
+    state->state = AP2_BLE_STATE_USB;
+    return AP2_BLE_ACTION_ROUTE_USB | AP2_BLE_ACTION_CLEAR_SLOT;
+}
+
+ap2_ble_actions_t ap2_ble_state_unpair(ap2_ble_state_t *state) {
+    return AP2_BLE_ACTION_SEND_UNPAIR | ap2_ble_state_disconnect(state);
+}
+
+bool ap2_ble_state_route_requested(const ap2_ble_state_t *state) {
+    return state->state != AP2_BLE_STATE_USB;
+}
+
+bool ap2_ble_state_operation_pending(const ap2_ble_state_t *state) {
+    return state->state == AP2_BLE_STATE_WAIT_BROADCAST_ACK || state->state == AP2_BLE_STATE_WAIT_CONNECT_ACK || state->state == AP2_BLE_STATE_WAIT_HANDSHAKE;
+}

--- a/keyboards/annepro2/annepro2_ble_state.h
+++ b/keyboards/annepro2/annepro2_ble_state.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 QMK
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef ANNEPRO2_BLE_COMMAND_TIMEOUT
+#    define ANNEPRO2_BLE_COMMAND_TIMEOUT 500
+#endif
+
+#ifndef ANNEPRO2_BLE_COMMAND_RETRIES
+#    define ANNEPRO2_BLE_COMMAND_RETRIES 2
+#endif
+
+#ifndef ANNEPRO2_BLE_STARTUP_DELAY
+#    define ANNEPRO2_BLE_STARTUP_DELAY 500
+#endif
+
+#ifndef ANNEPRO2_BLE_SLOT_HOLD_TIME
+#    define ANNEPRO2_BLE_SLOT_HOLD_TIME 500
+#endif
+
+#ifndef ANNEPRO2_BLE_HANDSHAKE_TIMEOUT
+#    define ANNEPRO2_BLE_HANDSHAKE_TIMEOUT 10000
+#endif
+
+#ifndef ANNEPRO2_BLE_SLOT_SWITCH_DELAY
+#    define ANNEPRO2_BLE_SLOT_SWITCH_DELAY 1000
+#endif
+
+typedef enum {
+    AP2_BLE_STATE_USB,
+    AP2_BLE_STATE_WAIT_BROADCAST_ACK,
+    AP2_BLE_STATE_WAIT_CONNECT_ACK,
+    AP2_BLE_STATE_WAIT_HANDSHAKE,
+    AP2_BLE_STATE_ACTIVE,
+    AP2_BLE_STATE_STARTUP_PASSIVE,
+} ap2_ble_state_id_t;
+
+typedef enum {
+    AP2_BLE_ACTION_NONE            = 0,
+    AP2_BLE_ACTION_ROUTE_USB       = 1 << 0,
+    AP2_BLE_ACTION_ROUTE_BLE       = 1 << 1,
+    AP2_BLE_ACTION_SEND_WAKEUP     = 1 << 2,
+    AP2_BLE_ACTION_SEND_SLOT_STATE = 1 << 3,
+    AP2_BLE_ACTION_SEND_BROADCAST  = 1 << 4,
+    AP2_BLE_ACTION_SEND_CONNECT    = 1 << 5,
+    AP2_BLE_ACTION_SEND_UNPAIR     = 1 << 6,
+    AP2_BLE_ACTION_SAVE_SLOT       = 1 << 7,
+    AP2_BLE_ACTION_CLEAR_SLOT      = 1 << 8,
+    AP2_BLE_ACTION_NOTIFY_FAILURE  = 1 << 9,
+} ap2_ble_action_t;
+
+typedef uint16_t ap2_ble_actions_t;
+
+typedef struct {
+    ap2_ble_state_id_t state;
+    int8_t             startup_slot;
+    int8_t             held_slot;
+    int8_t             pending_slot;
+    uint8_t            selected_slot;
+    bool               held_slot_broadcast;
+    bool               pending_broadcast;
+    bool               command_slot_state_pending;
+    bool               command_slot_broadcast;
+    bool               handshake_timeout_enabled;
+    uint8_t            command_retries;
+    uint8_t            handshake_recoveries;
+    uint32_t           startup_timer;
+    uint32_t           slot_hold_timer;
+    uint32_t           handshake_timer;
+    uint32_t           command_timer;
+    uint32_t           pending_timer;
+} ap2_ble_state_t;
+
+void              ap2_ble_state_reset(ap2_ble_state_t *state);
+ap2_ble_actions_t ap2_ble_state_startup(ap2_ble_state_t *state, int8_t saved_slot, uint32_t now);
+ap2_ble_actions_t ap2_ble_state_connect(ap2_ble_state_t *state, uint8_t slot, uint32_t now);
+ap2_ble_actions_t ap2_ble_state_broadcast(ap2_ble_state_t *state, uint8_t slot, uint32_t now);
+ap2_ble_actions_t ap2_ble_state_slot_press(ap2_ble_state_t *state, uint8_t slot, uint32_t now);
+ap2_ble_actions_t ap2_ble_state_slot_release(ap2_ble_state_t *state, uint8_t slot, uint32_t now);
+ap2_ble_actions_t ap2_ble_state_task(ap2_ble_state_t *state, uint32_t now);
+ap2_ble_actions_t ap2_ble_state_command_ack(ap2_ble_state_t *state, uint8_t command, uint32_t now);
+ap2_ble_actions_t ap2_ble_state_handshake(ap2_ble_state_t *state);
+ap2_ble_actions_t ap2_ble_state_disconnect(ap2_ble_state_t *state);
+ap2_ble_actions_t ap2_ble_state_unpair(ap2_ble_state_t *state);
+
+bool ap2_ble_state_route_requested(const ap2_ble_state_t *state);
+bool ap2_ble_state_operation_pending(const ap2_ble_state_t *state);

--- a/keyboards/annepro2/annepro2_ble_transport.c
+++ b/keyboards/annepro2/annepro2_ble_transport.c
@@ -1,0 +1,600 @@
+/*
+    Copyright (C) 2020 Yaotian Feng, Codetector<codetector@codetector.cn>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/* Compile-time selected Anne Pro 2 C18/AP2D BLE transport. */
+#include "annepro2_ble.h"
+#include "annepro2_ble_213_slot.h"
+#include "annepro2_ble_parser.h"
+#include "annepro2_ble_profile.h"
+#include "annepro2_ble_state.h"
+#include "ch.h"
+#include "eeconfig.h"
+#include "hal.h"
+#include "host.h"
+#include "host_driver.h"
+#include "led.h"
+#include "print.h"
+#include "report.h"
+#include "timer.h"
+#ifdef ANNEPRO2_LED_MCU_ENABLE
+#    include "ap2_led.h"
+#endif
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+#    include "version.h"
+#endif
+
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+#    define AP2_BLE_LOG(fmt, ...) uprintf("AP2 BLE %08lX " fmt "\n", (unsigned long)timer_read32(), ##__VA_ARGS__)
+#    define AP2_BLE_BUILD_LOG_DELAY 2000
+#else
+#    define AP2_BLE_LOG(fmt, ...)
+#endif
+
+/* -------------------- Static Function Prototypes -------------------------- */
+static uint8_t ap2_ble_leds(void);
+static void    ap2_ble_mouse(report_mouse_t *report);
+static void    ap2_ble_extra(report_extra_t *report);
+static void    ap2_ble_keyboard(report_keyboard_t *report);
+
+static void   ap2_ble_switch_ble_driver(void);
+static void   ap2_ble_execute_actions(ap2_ble_actions_t actions);
+static void   ap2_ble_execute_actions_now(ap2_ble_actions_t actions);
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+static void   ap2_ble_execute_213_slot_actions(ap2_ble_213_slot_actions_t actions);
+#endif
+static void   ap2_ble_handle_rx_frame(const uint8_t *frame, uint8_t size);
+static void   ap2_ble_handle_command_ack(uint8_t command, uint8_t value);
+static void   ap2_ble_notify_status(annepro2_ble_status_t status);
+static void   ap2_ble_reset_rx_parser(void);
+static void   ap2_ble_send_broadcast(void);
+static void   ap2_ble_send_connect(void);
+static void   ap2_ble_send_slot_state(void);
+static int8_t ap2_ble_read_saved_slot(void);
+static void   ap2_ble_save_slot(int8_t slot);
+static void   ap2_ble_drain_rx(void);
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+static void ap2_ble_log_build(void);
+static void ap2_ble_log_rx_frame(const uint8_t *frame, uint8_t size);
+#endif
+
+/* -------------------- Static Local Variables ------------------------------ */
+static host_driver_t ap2_ble_driver = {ap2_ble_leds, ap2_ble_keyboard, NULL, ap2_ble_mouse, ap2_ble_extra};
+
+static const SerialConfig ble_uart_config = {
+    .speed = 115200,
+};
+
+static uint8_t ble_mcu_wakeup[11] = {0x7b, 0x12, 0x53, 0x00, 0x03, 0x00, 0x01, 0x7d, 0x02, 0x01, 0x02};
+
+static uint8_t ble_mcu_start_broadcast[10] = {
+    0x7b, 0x12, 0x53, 0x00, 0x03, 0x00, 0x00, 0x7d, 0x40, 0x01, // Broadcast ID[0-3]
+};
+
+static uint8_t ble_mcu_connect[10] = {
+    0x7b, 0x12, 0x53, 0x00, 0x03, 0x00, 0x00, 0x7d, 0x40, 0x04, // Connect ID [0-3]
+};
+
+static uint8_t ble_mcu_send_report[10] = {
+    0x7b, 0x12, 0x53, 0x00, 0x0A, 0x00, 0x00, 0x7d, 0x10, 0x04,
+};
+
+static uint8_t ble_mcu_send_consumer_report[10] = {
+    0x7b, 0x12, 0x53, 0x00, 0x06, 0x00, 0x00, 0x7d, 0x10, 0x08,
+};
+
+static uint8_t ble_mcu_unpair[10] = {
+    0x7b, 0x12, 0x53, 0x00, 0x02, 0x00, 0x00, 0x7d, 0x40, 0x05,
+};
+
+/* One-shot slot-key state sent before the official 0x40/0x01 or 0x04 command. */
+static uint8_t ble_mcu_slot_state[10] = {
+    0x7b, 0x12, 0x43, 0x00, 0x04, 0x00, 0x00, 0x7d, 0x20, 0x0b,
+};
+
+/* Reply sent by the official keyboard MCU after a BLE 0x20/0x0c request. */
+static uint8_t ble_mcu_hid_handshake_response[12] = {
+    0x7b, 0x12, 0x43, 0x00, 0x04, 0x00, 0x00, 0x7d, 0x20, 0x0c, 0x00, 0x00,
+};
+
+/* Reply emitted by the official keyboard MCU for an incoming 0x20/0x07. */
+static uint8_t ble_mcu_state_sync_response[10] = {
+    0x7b, 0x12, 0x43, 0x00, 0x03, 0x00, 0x00, 0x7d, 0x20, 0x07,
+};
+
+static uint8_t ble_mcu_bootload[11] = {0x7b, 0x10, 0x51, 0x10, 0x03, 0x00, 0x00, 0x7d, 0x02, 0x01, 0x01};
+
+static host_driver_t           *last_host_driver = NULL;
+ble_capslock_t                  ble_capslock = {._dummy = {0}, .caps_lock = false};
+static ap2_ble_state_t          ble_state;
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+static ap2_ble_213_slot_state_t ble_213_slot_state;
+#endif
+static annepro2_ble_parser_t    ble_rx_parser;
+static led_t                    ble_led_state;
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+static uint8_t  ble_debug_keyboard_reports;
+static bool     ble_debug_build_log_pending;
+static uint32_t ble_debug_build_log_timer;
+#endif
+#ifdef NKRO_ENABLE
+static bool lastNkroStatus = false;
+#endif // NKRO_ENABLE
+
+__attribute__((weak)) void annepro2_ble_status_changed_user(annepro2_ble_status_t status, uint8_t slot) {}
+
+static void ap2_ble_begin_route_request(void) {
+    /* Do not leave reports routed to an old BLE link while selecting a slot. */
+    ble_led_state.raw = 0;
+    if (host_get_driver() == &ap2_ble_driver) {
+        clear_keyboard();
+#ifdef NKRO_ENABLE
+        keymap_config.nkro = lastNkroStatus;
+#endif
+        host_set_driver(last_host_driver);
+        AP2_BLE_LOG("route pending");
+    }
+}
+
+/* -------------------- Public Function Implementation ---------------------- */
+
+void annepro2_ble_init(void) {
+    sdStart(&SD1, &ble_uart_config);
+    annepro2_ble_startup();
+    wait_ms(100);
+    ap2_ble_drain_rx();
+}
+
+bool annepro2_ble_process_record(uint16_t keycode, keyrecord_t *record) {
+    if (keycode >= KC_AP2_BT1 && keycode <= KC_AP2_BT4) {
+        const uint8_t slot = keycode - KC_AP2_BT1;
+        if (record->event.pressed) {
+            annepro2_ble_slot_press(slot);
+#ifdef ANNEPRO2_LED_MCU_ENABLE
+            const ap2_led_t blue = {
+                .p.blue  = 0xff,
+                .p.red   = 0x00,
+                .p.green = 0x00,
+                .p.alpha = 0xff,
+            };
+            ap2_led_blink(record->event.key.row, record->event.key.col, blue, 8, 50);
+#endif
+        } else {
+            annepro2_ble_slot_release(slot);
+        }
+        return false;
+    }
+
+    if (!record->event.pressed) {
+        return true;
+    }
+
+    switch (keycode) {
+        case KC_AP2_USB:
+            annepro2_ble_disconnect();
+            return false;
+        case KC_AP2_BT_UNPAIR:
+            annepro2_ble_unpair();
+            return false;
+        default:
+            return true;
+    }
+}
+
+void annepro2_ble_bootload(void) {
+    sdWrite(&SD1, ble_mcu_bootload, sizeof(ble_mcu_bootload));
+}
+
+void annepro2_ble_startup(void) {
+    const int8_t saved_slot = ap2_ble_read_saved_slot();
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    ap2_ble_213_slot_reset(&ble_213_slot_state);
+#endif
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+    ap2_ble_log_build();
+    ble_debug_build_log_pending = true;
+    ble_debug_build_log_timer   = timer_read32();
+#endif
+    AP2_BLE_LOG("wake %d", saved_slot);
+    ap2_ble_execute_actions(ap2_ble_state_startup(&ble_state, saved_slot, timer_read32()));
+}
+
+void annepro2_ble_broadcast(uint8_t port) {
+    AP2_BLE_LOG("broadcast request slot=%u", port > 3 ? 3 : port);
+    ap2_ble_execute_actions(ap2_ble_state_broadcast(&ble_state, port, timer_read32()));
+}
+
+void annepro2_ble_connect(uint8_t port) {
+    AP2_BLE_LOG("connect request slot=%u", port > 3 ? 3 : port);
+    ap2_ble_execute_actions(ap2_ble_state_connect(&ble_state, port, timer_read32()));
+}
+
+void annepro2_ble_slot_press(uint8_t port) {
+    /*
+     * Match the official keyboard MCU: a tap connects on key release, while a
+     * 500 ms hold starts pairing/advertising and does nothing on release.
+     */
+    AP2_BLE_LOG("slot %u press", port > 3 ? 3 : port);
+    ap2_ble_execute_actions(ap2_ble_state_slot_press(&ble_state, port, timer_read32()));
+}
+
+void annepro2_ble_slot_release(uint8_t port) {
+    AP2_BLE_LOG("slot %u release", port > 3 ? 3 : port);
+    ap2_ble_execute_actions(ap2_ble_state_slot_release(&ble_state, port, timer_read32()));
+}
+
+void annepro2_ble_disconnect(void) {
+    AP2_BLE_LOG("disconnect");
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    ap2_ble_213_slot_reset(&ble_213_slot_state);
+#endif
+    ap2_ble_execute_actions(ap2_ble_state_disconnect(&ble_state));
+    ap2_ble_notify_status(ANNEPRO2_BLE_STATUS_IDLE);
+    ap2_ble_reset_rx_parser();
+}
+
+void annepro2_ble_unpair(void) {
+    AP2_BLE_LOG("tx unpair");
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    ap2_ble_213_slot_reset(&ble_213_slot_state);
+#endif
+    ap2_ble_execute_actions(ap2_ble_state_unpair(&ble_state));
+    ap2_ble_notify_status(ANNEPRO2_BLE_STATUS_IDLE);
+    ap2_ble_reset_rx_parser();
+}
+
+void annepro2_ble_task(void) {
+    ap2_ble_drain_rx();
+    const uint32_t now = timer_read32();
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+    if (ble_debug_build_log_pending && timer_elapsed32(ble_debug_build_log_timer) >= AP2_BLE_BUILD_LOG_DELAY) {
+        ble_debug_build_log_pending = false;
+        ap2_ble_log_build();
+    }
+#endif
+    if (annepro2_ble_parser_expire(&ble_rx_parser, now)) {
+        AP2_BLE_LOG("rx partial timeout");
+    }
+    ap2_ble_execute_actions(ap2_ble_state_task(&ble_state, now));
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    uint16_t deferred_actions;
+    const ap2_ble_213_slot_actions_t slot_actions = ap2_ble_213_slot_task(&ble_213_slot_state, now, &deferred_actions);
+    ap2_ble_execute_213_slot_actions(slot_actions);
+    if (slot_actions & AP2_BLE_213_SLOT_ACTION_DISPATCH) {
+        ap2_ble_execute_actions_now((ap2_ble_actions_t)deferred_actions);
+    }
+#endif
+}
+
+void annepro2_ble_rx_byte(uint8_t byte) {
+    const uint8_t                   *frame;
+    uint8_t                          size;
+    const annepro2_ble_parse_event_t event = annepro2_ble_parser_feed(&ble_rx_parser, byte, timer_read32(), &frame, &size);
+
+    switch (event) {
+        case ANNEPRO2_BLE_PARSE_FRAME:
+            ap2_ble_handle_rx_frame(frame, size);
+            break;
+        case ANNEPRO2_BLE_PARSE_TIMEOUT:
+            AP2_BLE_LOG("rx partial timeout");
+            break;
+        case ANNEPRO2_BLE_PARSE_INVALID_LENGTH:
+            AP2_BLE_LOG("rx invalid length");
+            break;
+        case ANNEPRO2_BLE_PARSE_INVALID_DELIMITER:
+            AP2_BLE_LOG("rx invalid delimiter");
+            break;
+        case ANNEPRO2_BLE_PARSE_NONE:
+            break;
+    }
+}
+
+/* ------------------- Static Function Implementation ----------------------- */
+static void ap2_ble_execute_actions(ap2_ble_actions_t actions) {
+    const ap2_ble_actions_t command_actions = actions & (AP2_BLE_ACTION_SEND_BROADCAST | AP2_BLE_ACTION_SEND_CONNECT);
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    if (ap2_ble_213_slot_active(&ble_213_slot_state) && (actions & AP2_BLE_ACTION_ROUTE_USB) && command_actions == 0) {
+        AP2_BLE_LOG("cancel 213 slot prepare");
+        ap2_ble_213_slot_reset(&ble_213_slot_state);
+    }
+
+    if (command_actions != 0 && ap2_ble_213_slot_should_prepare(ble_state.command_retries)) {
+        const ap2_ble_actions_t deferred_actions = actions & (AP2_BLE_ACTION_SEND_SLOT_STATE | AP2_BLE_ACTION_SEND_BROADCAST | AP2_BLE_ACTION_SEND_CONNECT);
+        ap2_ble_execute_actions_now(actions & ~deferred_actions);
+        ap2_ble_execute_213_slot_actions(ap2_ble_213_slot_begin(&ble_213_slot_state, ble_state.selected_slot, deferred_actions, timer_read32()));
+        return;
+    }
+#else
+    (void)command_actions;
+#endif
+
+    ap2_ble_execute_actions_now(actions);
+}
+
+static void ap2_ble_execute_actions_now(ap2_ble_actions_t actions) {
+    if (actions != AP2_BLE_ACTION_NONE) {
+        AP2_BLE_LOG("actions=%03X state=%u slot=%u retries=%u", actions, (unsigned)ble_state.state, ble_state.selected_slot, ble_state.command_retries);
+    }
+
+    if (actions & AP2_BLE_ACTION_SEND_UNPAIR) {
+        sdWrite(&SD1, ble_mcu_unpair, sizeof(ble_mcu_unpair));
+    }
+    if (actions & AP2_BLE_ACTION_ROUTE_USB) {
+        ap2_ble_begin_route_request();
+    }
+    if (actions & AP2_BLE_ACTION_SEND_WAKEUP) {
+        sdWrite(&SD1, ble_mcu_wakeup, sizeof(ble_mcu_wakeup));
+    }
+    if (actions & AP2_BLE_ACTION_SEND_SLOT_STATE) {
+        ap2_ble_send_slot_state();
+    }
+    if (actions & AP2_BLE_ACTION_SEND_BROADCAST) {
+        if (ble_state.command_retries == 0) {
+            ap2_ble_notify_status(ble_state.command_slot_broadcast ? ANNEPRO2_BLE_STATUS_ADVERTISING : ANNEPRO2_BLE_STATUS_CONNECTING);
+        }
+        ap2_ble_send_broadcast();
+    }
+    if (actions & AP2_BLE_ACTION_SEND_CONNECT) {
+        if (ble_state.command_retries == 0) {
+            ap2_ble_notify_status(ANNEPRO2_BLE_STATUS_CONNECTING);
+        }
+        ap2_ble_send_connect();
+    }
+    if (actions & AP2_BLE_ACTION_CLEAR_SLOT) {
+        ap2_ble_save_slot(-1);
+    }
+    if (actions & AP2_BLE_ACTION_ROUTE_BLE) {
+        ap2_ble_switch_ble_driver();
+        ap2_ble_notify_status(ANNEPRO2_BLE_STATUS_CONNECTED);
+    }
+    if (actions & AP2_BLE_ACTION_SAVE_SLOT) {
+        ap2_ble_save_slot((int8_t)ble_state.selected_slot);
+    }
+    if (actions & AP2_BLE_ACTION_NOTIFY_FAILURE) {
+        ap2_ble_notify_status(ANNEPRO2_BLE_STATUS_FAILED);
+    }
+}
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+static void ap2_ble_execute_213_slot_actions(ap2_ble_213_slot_actions_t actions) {
+    uint8_t frame[AP2_BLE_213_SLOT_FRAME_MAX_SIZE];
+    uint8_t size;
+
+    if (actions & AP2_BLE_213_SLOT_ACTION_QUERY) {
+        AP2_BLE_LOG("tx 213 slot query target=%u", ble_213_slot_state.target_slot);
+        size = ap2_ble_213_slot_encode_query(frame);
+        sdWrite(&SD1, frame, size);
+    }
+    if (actions & AP2_BLE_213_SLOT_ACTION_SELECT) {
+        AP2_BLE_LOG("tx 213 slot select=%u", ble_213_slot_state.target_slot);
+        size = ap2_ble_213_slot_encode_select(ble_213_slot_state.target_slot, frame);
+        sdWrite(&SD1, frame, size);
+    }
+    if (actions & AP2_BLE_213_SLOT_ACTION_PREPARE_1) {
+        AP2_BLE_LOG("tx 213 slot prepare=1");
+        size = ap2_ble_213_slot_encode_prepare(1, frame);
+        sdWrite(&SD1, frame, size);
+    }
+    if (actions & AP2_BLE_213_SLOT_ACTION_PREPARE_2) {
+        AP2_BLE_LOG("tx 213 slot prepare=2");
+        size = ap2_ble_213_slot_encode_prepare(2, frame);
+        sdWrite(&SD1, frame, size);
+    }
+}
+#endif
+
+static void ap2_ble_send_broadcast(void) {
+    AP2_BLE_LOG("tx broadcast slot=%u attempt=%u", ble_state.selected_slot, ble_state.command_retries + 1);
+    sdWrite(&SD1, ble_mcu_start_broadcast, sizeof(ble_mcu_start_broadcast));
+    sdPut(&SD1, ble_state.selected_slot);
+}
+
+static void ap2_ble_send_connect(void) {
+    AP2_BLE_LOG("tx connect slot=%u attempt=%u", ble_state.selected_slot, ble_state.command_retries + 1);
+    sdWrite(&SD1, ble_mcu_connect, sizeof(ble_mcu_connect));
+    sdPut(&SD1, ble_state.selected_slot);
+}
+
+static void ap2_ble_send_slot_state(void) {
+    annepro2_ble_slot_state_t slot_state;
+    annepro2_ble_encode_slot_state(ble_state.command_slot_broadcast, &slot_state);
+
+    AP2_BLE_LOG("tx slot state command=%02X action=%u", slot_state.command, slot_state.action);
+    ble_mcu_slot_state[9] = slot_state.command;
+    sdWrite(&SD1, ble_mcu_slot_state, sizeof(ble_mcu_slot_state));
+    sdPut(&SD1, ble_state.selected_slot);
+    sdPut(&SD1, slot_state.action);
+}
+
+static void ap2_ble_handle_command_ack(uint8_t command, uint8_t value) {
+    const ap2_ble_state_id_t before = ble_state.state;
+    AP2_BLE_LOG("rx command ack=%02X value=%02X state=%u", command, value, (unsigned)before);
+    ap2_ble_execute_actions(ap2_ble_state_command_ack(&ble_state, command, timer_read32()));
+    if (before == ble_state.state) {
+        AP2_BLE_LOG("ignore stale command ack=%02X", command);
+    }
+}
+
+static void ap2_ble_notify_status(annepro2_ble_status_t status) {
+    AP2_BLE_LOG("status=%u slot=%u", (unsigned)status, ble_state.selected_slot);
+    annepro2_ble_status_changed_user(status, ble_state.selected_slot);
+}
+
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+static void ap2_ble_log_build(void) {
+#    if defined(QMK_USERSPACE_VERSION)
+    AP2_BLE_LOG("build qmk=%s userspace=%s", QMK_GIT_HASH, QMK_USERSPACE_VERSION);
+#    else
+    AP2_BLE_LOG("build qmk=%s", QMK_GIT_HASH);
+#    endif
+}
+#endif
+
+static void ap2_ble_switch_ble_driver(void) {
+    if (host_get_driver() == &ap2_ble_driver) {
+        return;
+    }
+    clear_keyboard();
+    last_host_driver = host_get_driver();
+#ifdef NKRO_ENABLE
+    lastNkroStatus = keymap_config.nkro;
+#endif
+    keymap_config.nkro = false;
+    host_set_driver(&ap2_ble_driver);
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+    ble_debug_keyboard_reports = 0;
+#endif
+    AP2_BLE_LOG("route ble");
+}
+
+static void ap2_ble_handle_rx_frame(const uint8_t *frame, uint8_t size) {
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+    ap2_ble_log_rx_frame(frame, size);
+#endif
+
+    if (size >= 11 && frame[1] == 0x12 && frame[2] == 0x35) {
+        AP2_BLE_LOG("rx decoded group=%02X command=%02X value=%02X state=%u", frame[8], frame[9], frame[10], (unsigned)ble_state.state);
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+        uint8_t current_slot;
+        if (ap2_ble_213_slot_decode_response(frame, size, &current_slot)) {
+            AP2_BLE_LOG("rx 213 current slot=%u", current_slot);
+            ap2_ble_213_slot_response(&ble_213_slot_state, current_slot);
+        }
+#endif
+
+        if (frame[4] == 0x03 && frame[5] == 0x00 && frame[8] == 0x40 && (frame[9] == 0x01 || frame[9] == 0x04)) {
+            ap2_ble_handle_command_ack(frame[9], frame[10]);
+        }
+
+        /*
+         * The official keyboard MCU preserves the value and reverses the
+         * routing field when replying to this state-sync request.
+         */
+        if (frame[4] == 0x03 && frame[5] == 0x00 && frame[8] == 0x20 && frame[9] == 0x07) {
+            bool caps_lock;
+            if (annepro2_ble_decode_caps_lock(frame, size, &caps_lock)) {
+                ble_capslock.caps_lock   = caps_lock;
+                ble_led_state.caps_lock = caps_lock;
+                AP2_BLE_LOG("rx caps lock=%u leds=%02X", caps_lock, ble_led_state.raw);
+            } else {
+                AP2_BLE_LOG("ignore invalid caps lock value=%02X", frame[10]);
+            }
+            AP2_BLE_LOG("tx state sync response value=%02X", frame[10]);
+            sdWrite(&SD1, ble_mcu_state_sync_response, sizeof(ble_mcu_state_sync_response));
+            sdPut(&SD1, frame[10]);
+        }
+
+        /*
+         * The official keyboard firmware answers an incoming 0x20/0x0c with
+         * a 0x20/0x0c response before continuing. Hardware traces show this
+         * handshake only after macOS has completed the BLE/HID setup.
+         * 0x40/0x01 and 0x40/0x04 are command acknowledgements and must not
+         * change QMK's host driver.
+         */
+        if (frame[4] == 0x03 && frame[5] == 0x00 && frame[8] == 0x20 && frame[9] == 0x0c) {
+            AP2_BLE_LOG("tx hid handshake response");
+            sdWrite(&SD1, ble_mcu_hid_handshake_response, sizeof(ble_mcu_hid_handshake_response));
+            const ap2_ble_actions_t actions = ap2_ble_state_handshake(&ble_state);
+            if (actions & AP2_BLE_ACTION_ROUTE_BLE) {
+                AP2_BLE_LOG("rx hid handshake ready");
+            }
+            ap2_ble_execute_actions(actions);
+        }
+    } else {
+        AP2_BLE_LOG("rx frame len=%u type=%02X/%02X", size, frame[1], frame[2]);
+    }
+}
+
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+static void ap2_ble_log_rx_frame(const uint8_t *frame, uint8_t size) {
+    uprintf("AP2 BLE %08lX rx%u", (unsigned long)timer_read32(), size);
+    for (uint8_t i = 0; i < size; i++) {
+        uprintf(" %02X", frame[i]);
+    }
+    uprintf("\n");
+}
+#endif
+
+static void ap2_ble_reset_rx_parser(void) {
+    annepro2_ble_parser_reset(&ble_rx_parser);
+}
+
+static void ap2_ble_drain_rx(void) {
+    while (!sdGetWouldBlock(&SD1)) {
+        annepro2_ble_rx_byte((uint8_t)sdGet(&SD1));
+    }
+}
+
+static int8_t ap2_ble_read_saved_slot(void) {
+    int8_t slot;
+    return annepro2_ble_decode_config(eeconfig_read_kb(), &slot) ? slot : -1;
+}
+
+static void ap2_ble_save_slot(int8_t slot) {
+    if (slot < -1 || slot > 3) {
+        return;
+    }
+
+    uint32_t config;
+    if (!annepro2_ble_encode_config(slot, &config)) {
+        return;
+    }
+    if (eeconfig_read_kb() != config) {
+        eeconfig_update_kb(config);
+    }
+}
+
+static uint8_t ap2_ble_leds(void) {
+    return ble_led_state.raw;
+}
+
+static void ap2_ble_mouse(report_mouse_t *report) {}
+
+static void ap2_ble_extra(report_extra_t *report) {
+    if (report->report_id == REPORT_ID_CONSUMER) {
+        const uint16_t usage       = report->usage;
+        const size_t   usage_count = usage == 0 ? 0 : 1;
+        uint8_t        payload[ANNEPRO2_BLE_CONSUMER_REPORT_SIZE];
+
+        if (!annepro2_ble_encode_consumer(&usage, usage_count, payload)) {
+            annepro2_ble_encode_consumer(&usage, 0, payload);
+        }
+
+        /* UART payload includes the 0x10/0x08 group and command bytes. */
+        ble_mcu_send_consumer_report[4] = sizeof(payload) + 2;
+        sdPut(&SD1, 0x0);
+        sdWrite(&SD1, ble_mcu_send_consumer_report, sizeof(ble_mcu_send_consumer_report));
+        sdWrite(&SD1, payload, sizeof(payload));
+        AP2_BLE_LOG("tx consumer usage=%04X bytes=%u", usage, (unsigned)sizeof(payload));
+    }
+}
+
+/*!
+ * @brief  Send keyboard HID report for Bluetooth driver
+ */
+static void ap2_ble_keyboard(report_keyboard_t *report) {
+    sdPut(&SD1, 0x0);
+    sdWrite(&SD1, ble_mcu_send_report, sizeof(ble_mcu_send_report));
+    sdWrite(&SD1, (uint8_t *)report, KEYBOARD_REPORT_SIZE);
+#if defined(CONSOLE_ENABLE) && defined(ANNEPRO2_BLE_DEBUG)
+    if (ble_debug_keyboard_reports < 3) {
+        ble_debug_keyboard_reports++;
+        AP2_BLE_LOG("tx keyboard report=%u", ble_debug_keyboard_reports);
+    }
+#endif
+}

--- a/keyboards/annepro2/boards/ANNEPRO2_C2D/board.c
+++ b/keyboards/annepro2/boards/ANNEPRO2_C2D/board.c
@@ -1,0 +1,92 @@
+/*
+    Copyright (C) 2020 Yaotian Feng, Codetector<codetector@codetector.cn>
+    Copyright (C) 2026 BHE
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "hal.h"
+
+#define PBIT(PORT, LINE) ((PAL_PORT(LINE) == PORT) ? (1 << PAL_PAD(LINE)) : 0)
+#define PAFIO_L(PORT, LINE, AF) (((PAL_PORT(LINE) == PORT) && (PAL_PAD(LINE) < 8)) ? (AF << (PAL_PAD(LINE) << 2)) : 0)
+#define PAFIO_H(PORT, LINE, AF) (((PAL_PORT(LINE) == PORT) && (PAL_PAD(LINE) >= 8)) ? (AF << ((PAL_PAD(LINE) - 8) << 2)) : 0)
+#define PAFIO(PORT, N, LINE, AF) ((N) ? PAFIO_H(PORT, LINE, AF) : PAFIO_L(PORT, LINE, AF))
+
+#define OUT_BITS(PORT) (PBIT(PORT, C3) | PBIT(PORT, C14) | PBIT(PORT, C15) | PBIT(PORT, C1) | PBIT(PORT, C2) | 0)
+
+#define IN_BITS(PORT) (PBIT(PORT, C4) | PBIT(PORT, C5) | PBIT(PORT, C8) | PBIT(PORT, C0) | PBIT(PORT, A10) | PBIT(PORT, B1) | PBIT(PORT, A8) | PBIT(PORT, C13) | PBIT(PORT, C12) | PBIT(PORT, A15) | PBIT(PORT, A14) | PBIT(PORT, A11) | PBIT(PORT, D1) | PBIT(PORT, D2) | 0)
+
+#define AF_BITS(PORT, N) (PAFIO(PORT, N, LINE_BT_UART_TX, AFIO_USART) | PAFIO(PORT, N, LINE_BT_UART_RX, AFIO_USART) | PAFIO(PORT, N, C3, AFIO_GPIO) | PAFIO(PORT, N, C14, AFIO_GPIO) | PAFIO(PORT, N, C15, AFIO_GPIO) | PAFIO(PORT, N, C1, AFIO_GPIO) | PAFIO(PORT, N, C2, AFIO_GPIO) | PAFIO(PORT, N, C4, AFIO_GPIO) | PAFIO(PORT, N, C5, AFIO_GPIO) | PAFIO(PORT, N, C8, AFIO_GPIO) | PAFIO(PORT, N, C0, AFIO_GPIO) | PAFIO(PORT, N, A10, AFIO_GPIO) | PAFIO(PORT, N, B1, AFIO_GPIO) | PAFIO(PORT, N, A8, AFIO_GPIO) | PAFIO(PORT, N, C13, AFIO_GPIO) | PAFIO(PORT, N, C12, AFIO_GPIO) | PAFIO(PORT, N, A15, AFIO_GPIO) | PAFIO(PORT, N, A14, AFIO_GPIO) | PAFIO(PORT, N, A11, AFIO_GPIO) | PAFIO(PORT, N, D1, AFIO_GPIO) | PAFIO(PORT, N, D2, AFIO_GPIO) | 0)
+
+const PALConfig pal_default_config = {
+    .setup[0] =
+        {
+            .DIR    = OUT_BITS(IOPORTA),
+            .INE    = IN_BITS(IOPORTA),
+            .PU     = IN_BITS(IOPORTA),
+            .PD     = 0x0000,
+            .OD     = 0x0000,
+            .DRV    = 0x0000,
+            .LOCK   = 0x0000,
+            .OUT    = 0x0000,
+            .CFG[0] = AF_BITS(IOPORTA, 0),
+            .CFG[1] = AF_BITS(IOPORTA, 1),
+        },
+    .setup[1] =
+        {
+            .DIR    = OUT_BITS(IOPORTB),
+            .INE    = IN_BITS(IOPORTB),
+            .PU     = IN_BITS(IOPORTB),
+            .PD     = 0x0000,
+            .OD     = 0x0000,
+            .DRV    = 0x0000,
+            .LOCK   = 0x0000,
+            .OUT    = 0x0000,
+            .CFG[0] = AF_BITS(IOPORTB, 0),
+            .CFG[1] = AF_BITS(IOPORTB, 1),
+        },
+    .setup[2] =
+        {
+            .DIR    = OUT_BITS(IOPORTC),
+            .INE    = IN_BITS(IOPORTC),
+            .PU     = IN_BITS(IOPORTC),
+            .PD     = 0x0000,
+            .OD     = 0x0000,
+            .DRV    = 0x0000,
+            .LOCK   = 0x0000,
+            .OUT    = 0x0000,
+            .CFG[0] = AF_BITS(IOPORTC, 0),
+            .CFG[1] = AF_BITS(IOPORTC, 1),
+        },
+    .setup[3] =
+        {
+            .DIR    = OUT_BITS(IOPORTD),
+            .INE    = IN_BITS(IOPORTD),
+            .PU     = IN_BITS(IOPORTD),
+            .PD     = 0x0000,
+            .OD     = 0x0000,
+            .DRV    = 0x0000,
+            .LOCK   = 0x0000,
+            .OUT    = 0x0000,
+            .CFG[0] = AF_BITS(IOPORTD, 0),
+            .CFG[1] = AF_BITS(IOPORTD, 1),
+        },
+    .ESSR[0] = 0x00000000,
+    .ESSR[1] = 0x00000000,
+};
+
+void __early_init(void) {
+    ht32_clock_init();
+}
+
+void boardInit(void) {}

--- a/keyboards/annepro2/boards/ANNEPRO2_C2D/board.h
+++ b/keyboards/annepro2/boards/ANNEPRO2_C2D/board.h
@@ -1,0 +1,34 @@
+/*
+    ChibiOS - Copyright (C) 2020 Codetector <codetector@codetector.cn>
+    Copyright (C) 2026 BHE
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#define BOARD_NAME "Anne Pro 2D C2D"
+
+#define HT32F52342
+
+#define FLASH_SIZE (0x20000 - 0x4000) // 128 KiB - 16 KiB bootloader
+
+#if !defined(_FROM_ASM_)
+#    ifdef __cplusplus
+extern "C" {
+#    endif
+void boardInit(void);
+#    ifdef __cplusplus
+}
+#    endif
+#endif

--- a/keyboards/annepro2/boards/ANNEPRO2_C2D/board.mk
+++ b/keyboards/annepro2/boards/ANNEPRO2_C2D/board.mk
@@ -1,0 +1,5 @@
+# List of all the board related files.
+BOARDSRC = $(BOARD_PATH)/boards/ANNEPRO2_C2D/board.c
+
+# Required include directories
+BOARDINC = $(BOARD_PATH)/boards/ANNEPRO2_C2D

--- a/keyboards/annepro2/c15/config.h
+++ b/keyboards/annepro2/c15/config.h
@@ -19,6 +19,8 @@
 
 #include "pin_defs.h"
 
+#define ANNEPRO2_LED_MCU_ENABLE
+
 #define LINE_UART_TX B0  // Master TX, LED RX
 #define LINE_UART_RX B1  // Master RX, LED TX
 

--- a/keyboards/annepro2/c15/keyboard.json
+++ b/keyboards/annepro2/c15/keyboard.json
@@ -7,5 +7,8 @@
     "matrix_pins": {
         "cols": ["C4", "C5", "B10", "B11", "C0", "A15", "A8", "A10", "A11", "A12", "A13", "A14", "B2", "B3"],
         "rows": ["C2", "C1", "B5", "B4", "C3"]
+    },
+    "features": {
+        "rgb_matrix": true
     }
 }

--- a/keyboards/annepro2/c18/config.h
+++ b/keyboards/annepro2/c18/config.h
@@ -19,6 +19,8 @@
 
 #include "pin_defs.h"
 
+#define ANNEPRO2_LED_MCU_ENABLE
+
 #define LINE_UART_TX B0
 #define LINE_UART_RX B1
 

--- a/keyboards/annepro2/c18/keyboard.json
+++ b/keyboards/annepro2/c18/keyboard.json
@@ -7,5 +7,8 @@
     "matrix_pins": {
         "cols": ["C4", "C5", "D0", "B15", "C11", "A15", "C12", "C13", "A8", "A10", "A11", "A14", "D2", "D3"],
         "rows": ["B5", "B4", "B3", "B2", "D1"]
+    },
+    "features": {
+        "rgb_matrix": true
     }
 }

--- a/keyboards/annepro2/c2d/config.h
+++ b/keyboards/annepro2/c2d/config.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 BHE
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include "pin_defs.h"
+
+#define LINE_BT_UART_TX A4 // Master TX, BLE RX
+#define LINE_BT_UART_RX A5 // Master RX, BLE TX
+
+/*
+ * AP2D KEY 3.08 writes 0x0000FAB2 to the final word of its 16 KiB RAM
+ * before resetting into IAP.
+ */
+#define ANNEPRO2_IAP_MAGIC_LOCATION 0x20003ffc
+
+/* AP2D always ships with the BLE 2.13 transport. */
+#define ANNEPRO2_BLE_PROFILE ANNEPRO2_BLE_PROFILE_AP2D_213
+
+#define PERMISSIVE_HOLD
+
+// External SPI flash configuration retained from the HT32F52352 platform.
+#define SPI_DRIVER SPID1
+#define SPI_SCK_PIN A0
+#define SPI_MOSI_PIN A1
+#define SPI_MISO_PIN A2
+
+#define EXTERNAL_FLASH_SPI_SLAVE_SELECT_PIN A3
+#define EXTERNAL_FLASH_SPI_CLOCK_DIVISOR 16
+#define EXTERNAL_FLASH_PAGE_SIZE 256
+#define EXTERNAL_FLASH_SECTOR_SIZE 4096
+#define EXTERNAL_FLASH_BLOCK_SIZE 4096
+#define EXTERNAL_FLASH_SIZE (256 * 1024)

--- a/keyboards/annepro2/c2d/keyboard.json
+++ b/keyboards/annepro2/c2d/keyboard.json
@@ -1,0 +1,11 @@
+{
+    "keyboard_name": "Anne Pro 2D C2D (QMK)",
+    "diode_direction": "COL2ROW",
+    "matrix_pins": {
+        "cols": ["C4", "C5", "C8", "C0", "A10", "B1", "A8", "C13", "C12", "A15", "A14", "A11", "D1", "D2"],
+        "rows": ["C3", "C14", "C15", "C1", "C2"]
+    },
+    "usb": {
+        "pid": "0x800A"
+    }
+}

--- a/keyboards/annepro2/c2d/rules.mk
+++ b/keyboards/annepro2/c2d/rules.mk
@@ -4,22 +4,19 @@ ARMV = 6
 USE_FPU = no
 MCU_FAMILY = HT32
 MCU_SERIES = HT32F523xx
-MCU_LDSCRIPT = HT32F52352_ANNEPRO2_C18
+MCU_LDSCRIPT = HT32F52352_ANNEPRO2_C2D
 MCU_STARTUP = ht32f523xx
 
-BOARD = ANNEPRO2_C18
+BOARD = ANNEPRO2_C2D
 
 # Bootloader selection
 BOOTLOADER = custom
 PROGRAM_CMD = annepro2_tools --boot $(BUILD_DIR)/$(TARGET).bin
 
-# Anne Pro 2
+# Anne Pro 2D: GPIO and BLE only. Direct-drive RGB is intentionally deferred.
 SRC = \
 	annepro2_ble_transport.c \
+	annepro2_ble_profile.c \
 	annepro2_ble_213_slot.c \
 	annepro2_ble_parser.c \
-	annepro2_ble_profile.c \
-	annepro2_ble_state.c \
-	ap2_led.c \
-	protocol.c \
-	rgb_driver.c \
+	annepro2_ble_state.c

--- a/keyboards/annepro2/info.json
+++ b/keyboards/annepro2/info.json
@@ -19,8 +19,7 @@
     "features": {
         "bootmagic": true,
         "mousekey": true,
-        "extrakey": true,
-        "rgb_matrix": true
+        "extrakey": true
     },
     "rgb_matrix": {
         "animations":{

--- a/keyboards/annepro2/ld/HT32F52352_ANNEPRO2_C2D.ld
+++ b/keyboards/annepro2/ld/HT32F52352_ANNEPRO2_C2D.ld
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2013-2016 Fabio UJonathan A. Kollaschtzig, http://fabioutzig.com
+ *           (c) 2020 Yaotian Feng (Codetector) <codetector@codetector.cn>
+ *           (c) 2025 Michał Kopeć <michal@nozomi.space>
+ *           (c) 2026 BHE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* HT32F52352 with the Anne Pro 2D 16 KiB bootloader region. */
+MEMORY {
+    flash0   : org = 0x00004000, len = 128k - 16k
+    flash1   : org = 0x00000000, len = 0
+    flash2   : org = 0x00000000, len = 0
+    flash3   : org = 0x00000000, len = 0
+    flash4   : org = 0x00000000, len = 0
+    flash5   : org = 0x00000000, len = 0
+    flash6   : org = 0x00000000, len = 0
+    flash7   : org = 0x00000000, len = 0
+    ram0     : org = 0x20000000, len = 16k
+    ram1     : org = 0x00000000, len = 0
+    ram2     : org = 0x00000000, len = 0
+    ram3     : org = 0x00000000, len = 0
+    ram4     : org = 0x00000000, len = 0
+    ram5     : org = 0x00000000, len = 0
+    ram6     : org = 0x00000000, len = 0
+    ram7     : org = 0x00000000, len = 0
+}
+
+REGION_ALIAS("VECTORS_FLASH", flash0);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash0);
+REGION_ALIAS("XTORS_FLASH", flash0);
+REGION_ALIAS("XTORS_FLASH_LMA", flash0);
+REGION_ALIAS("TEXT_FLASH", flash0);
+REGION_ALIAS("TEXT_FLASH_LMA", flash0);
+REGION_ALIAS("RODATA_FLASH", flash0);
+REGION_ALIAS("RODATA_FLASH_LMA", flash0);
+REGION_ALIAS("VARIOUS_FLASH", flash0);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash0);
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash0);
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", flash0);
+REGION_ALIAS("BSS_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram0);
+
+INCLUDE rules.ld

--- a/keyboards/annepro2/readme.md
+++ b/keyboards/annepro2/readme.md
@@ -1,10 +1,15 @@
-# Anne Pro 2 rev. C15 and C18 QMK firmware
+# Anne Pro 2 rev. C15, C18, and C2D QMK firmware
 
-An ANSI-layout 60% keyboard featuring Bluetooth support and per-key RGB lighting.
+An ANSI-layout 60% keyboard family featuring Bluetooth support.
 
 * Keyboard Maintainer: [bwisn](https://github.com/bwisn)
-* Hardware Supported: Anne Pro 2, [C15](c15/) and [C18](c18/) versions
+* Hardware Supported: Anne Pro 2 [C15](c15/) and [C18](c18/), and Anne Pro 2D [C2D](c2d/)
 * Hardware Availability: [annepro.net](https://www.annepro.net/), [Hexcore](https://www.hexcore.xyz/annepro2)
+
+C15 and C18 use a separate LED controller and retain the existing QMK RGB
+Matrix driver. C2D drives its RGB LEDs directly from the keyboard MCU; that
+driver is not implemented yet, so the C2D target currently provides matrix,
+USB, and BLE 2.13 support only.
 
 ## How to compile
 
@@ -15,6 +20,10 @@ After setting up your build environment, you can compile the Anne Pro 2 C18 defa
 If you want to compile the Anne Pro 2 C15 default keymap use:
 
     make annepro2/c15:default
+
+For the Anne Pro 2D C2D default keymap use:
+
+    make annepro2/c2d:default
 
 ## Installing
 

--- a/keyboards/annepro2/tests/ble_213_slot_test.c
+++ b/keyboards/annepro2/tests/ble_213_slot_test.c
@@ -1,0 +1,141 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "../annepro2_ble_213_slot.h"
+
+static bool has(ap2_ble_213_slot_actions_t actions, ap2_ble_213_slot_action_t action) {
+    return (actions & action) != 0;
+}
+
+static void test_first_command_only(void) {
+    assert(ap2_ble_213_slot_should_prepare(0));
+    assert(!ap2_ble_213_slot_should_prepare(1));
+}
+
+static void assert_bytes(const uint8_t *actual, const uint8_t *expected, uint8_t size) {
+    for (uint8_t i = 0; i < size; i++) {
+        assert(actual[i] == expected[i]);
+    }
+}
+
+static void test_ap2d_308_wire_frames(void) {
+    static const uint8_t expected_query[]   = {0x7b, 0x12, 0x53, 0x00, 0x02, 0x00, 0x00, 0x7d, 0xc0, 0x17};
+    static const uint8_t expected_select[]  = {0x7b, 0x12, 0x53, 0x00, 0x03, 0x00, 0x00, 0x7d, 0x40, 0x17, 0x02};
+    static const uint8_t expected_prepare[] = {0x7b, 0x10, 0x53, 0x00, 0x03, 0x00, 0x00, 0x7d, 0x02, 0x01, 0x01};
+    uint8_t              frame[AP2_BLE_213_SLOT_FRAME_MAX_SIZE];
+
+    uint8_t size = ap2_ble_213_slot_encode_query(frame);
+    assert(size == sizeof(expected_query));
+    assert_bytes(frame, expected_query, size);
+
+    size = ap2_ble_213_slot_encode_select(2, frame);
+    assert(size == sizeof(expected_select));
+    assert_bytes(frame, expected_select, size);
+
+    size = ap2_ble_213_slot_encode_prepare(1, frame);
+    assert(size == sizeof(expected_prepare));
+    assert_bytes(frame, expected_prepare, size);
+}
+
+static void test_current_slot_response(void) {
+    uint8_t frame[] = {0x7b, 0x12, 0x35, 0x00, 0x03, 0x00, 0x00, 0x7d, 0xc0, 0x17, 0x03};
+    uint8_t slot    = 0xff;
+
+    assert(ap2_ble_213_slot_decode_response(frame, sizeof(frame), &slot));
+    assert(slot == 3);
+
+    frame[10] = 4;
+    assert(!ap2_ble_213_slot_decode_response(frame, sizeof(frame), &slot));
+    frame[10] = 0;
+    frame[8]  = 0x40;
+    assert(!ap2_ble_213_slot_decode_response(frame, sizeof(frame), &slot));
+    assert(!ap2_ble_213_slot_decode_response(frame, sizeof(frame) - 1, &slot));
+    assert(!ap2_ble_213_slot_decode_response(NULL, sizeof(frame), &slot));
+    assert(!ap2_ble_213_slot_decode_response(frame, sizeof(frame), NULL));
+}
+
+static void test_same_slot_dispatches_after_query(void) {
+    ap2_ble_213_slot_state_t state;
+    uint16_t                 deferred = 0;
+    ap2_ble_213_slot_reset(&state);
+
+    assert(ap2_ble_213_slot_begin(&state, 2, 0x123, 100) == AP2_BLE_213_SLOT_ACTION_QUERY);
+    ap2_ble_213_slot_response(&state, 2);
+    assert(ap2_ble_213_slot_task(&state, 104, &deferred) == AP2_BLE_213_SLOT_ACTION_NONE);
+
+    const ap2_ble_213_slot_actions_t actions = ap2_ble_213_slot_task(&state, 105, &deferred);
+    assert(actions == AP2_BLE_213_SLOT_ACTION_DISPATCH);
+    assert(deferred == 0x123);
+    assert(!ap2_ble_213_slot_active(&state));
+}
+
+static void test_changed_slot_uses_full_prepare_sequence(void) {
+    ap2_ble_213_slot_state_t state;
+    uint16_t                 deferred = 0;
+    ap2_ble_213_slot_reset(&state);
+
+    assert(ap2_ble_213_slot_begin(&state, 3, 0x321, 1000) == AP2_BLE_213_SLOT_ACTION_QUERY);
+    ap2_ble_213_slot_response(&state, 0);
+
+    ap2_ble_213_slot_actions_t actions = ap2_ble_213_slot_task(&state, 1005, &deferred);
+    assert(has(actions, AP2_BLE_213_SLOT_ACTION_SELECT));
+    assert(has(actions, AP2_BLE_213_SLOT_ACTION_PREPARE_1));
+    assert(!has(actions, AP2_BLE_213_SLOT_ACTION_DISPATCH));
+    assert(deferred == 0);
+
+    assert(ap2_ble_213_slot_task(&state, 1024, &deferred) == AP2_BLE_213_SLOT_ACTION_NONE);
+    assert(ap2_ble_213_slot_task(&state, 1025, &deferred) == AP2_BLE_213_SLOT_ACTION_PREPARE_2);
+    assert(ap2_ble_213_slot_task(&state, 1044, &deferred) == AP2_BLE_213_SLOT_ACTION_NONE);
+
+    actions = ap2_ble_213_slot_task(&state, 1045, &deferred);
+    assert(actions == AP2_BLE_213_SLOT_ACTION_DISPATCH);
+    assert(deferred == 0x321);
+    assert(!ap2_ble_213_slot_active(&state));
+}
+
+static void test_missing_or_invalid_query_response_prepares_slot(void) {
+    ap2_ble_213_slot_state_t state;
+    uint16_t                 deferred;
+    ap2_ble_213_slot_reset(&state);
+
+    ap2_ble_213_slot_begin(&state, 1, 1, 10);
+    ap2_ble_213_slot_response(&state, 4);
+    const ap2_ble_213_slot_actions_t actions = ap2_ble_213_slot_task(&state, 15, &deferred);
+    assert(has(actions, AP2_BLE_213_SLOT_ACTION_SELECT));
+    assert(has(actions, AP2_BLE_213_SLOT_ACTION_PREPARE_1));
+}
+
+static void test_reset_cancels_deferred_command(void) {
+    ap2_ble_213_slot_state_t state;
+    uint16_t                 deferred = 0xffff;
+    ap2_ble_213_slot_reset(&state);
+    ap2_ble_213_slot_begin(&state, 1, 0x123, 10);
+    ap2_ble_213_slot_reset(&state);
+
+    assert(ap2_ble_213_slot_task(&state, 1000, &deferred) == AP2_BLE_213_SLOT_ACTION_NONE);
+    assert(deferred == 0);
+}
+
+static void test_timer_wraparound(void) {
+    ap2_ble_213_slot_state_t state;
+    uint16_t                 deferred;
+    ap2_ble_213_slot_reset(&state);
+    ap2_ble_213_slot_begin(&state, 0, 1, UINT32_MAX - 2);
+    ap2_ble_213_slot_response(&state, 0);
+
+    assert(ap2_ble_213_slot_task(&state, 1, &deferred) == AP2_BLE_213_SLOT_ACTION_NONE);
+    assert(ap2_ble_213_slot_task(&state, 2, &deferred) == AP2_BLE_213_SLOT_ACTION_DISPATCH);
+}
+
+int main(void) {
+    test_first_command_only();
+    test_ap2d_308_wire_frames();
+    test_current_slot_response();
+    test_same_slot_dispatches_after_query();
+    test_changed_slot_uses_full_prepare_sequence();
+    test_missing_or_invalid_query_response_prepares_slot();
+    test_reset_cancels_deferred_command();
+    test_timer_wraparound();
+    return 0;
+}

--- a/keyboards/annepro2/tests/ble_parser_test.c
+++ b/keyboards/annepro2/tests/ble_parser_test.c
@@ -1,0 +1,115 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "../annepro2_ble_parser.h"
+
+static const uint8_t connect_ack[] = {
+    0x7B, 0x12, 0x35, 0x00, 0x03, 0x00, 0x00, 0x7D, 0x40, 0x04, 0x00,
+};
+
+static annepro2_ble_parse_event_t feed_bytes(annepro2_ble_parser_t *parser, const uint8_t *bytes, size_t count, uint32_t start, const uint8_t **frame, uint8_t *size) {
+    annepro2_ble_parse_event_t event = ANNEPRO2_BLE_PARSE_NONE;
+    for (size_t i = 0; i < count; i++) {
+        event = annepro2_ble_parser_feed(parser, bytes[i], start + (uint32_t)i, frame, size);
+    }
+    return event;
+}
+
+static void test_valid_frame_and_noise(void) {
+    annepro2_ble_parser_t parser;
+    const uint8_t        *frame;
+    uint8_t               size;
+
+    annepro2_ble_parser_reset(&parser);
+    assert(annepro2_ble_parser_feed(&parser, 0x00, 0, &frame, &size) == ANNEPRO2_BLE_PARSE_NONE);
+    assert(feed_bytes(&parser, connect_ack, sizeof(connect_ack), 1, &frame, &size) == ANNEPRO2_BLE_PARSE_FRAME);
+    assert(size == sizeof(connect_ack));
+    assert(memcmp(frame, connect_ack, size) == 0);
+    assert(parser.size == 0);
+}
+
+static void test_payload_may_contain_header_byte(void) {
+    const uint8_t source[] = {
+        0x7B, 0x12, 0x35, 0x00, 0x03, 0x00, 0x00, 0x7D, 0x20, 0x07, 0x7B,
+    };
+    annepro2_ble_parser_t parser;
+    const uint8_t        *frame;
+    uint8_t               size;
+
+    annepro2_ble_parser_reset(&parser);
+    assert(feed_bytes(&parser, source, sizeof(source), 0, &frame, &size) == ANNEPRO2_BLE_PARSE_FRAME);
+    assert(size == sizeof(source));
+    assert(memcmp(frame, source, size) == 0);
+}
+
+static void test_timeout_and_resynchronization(void) {
+    annepro2_ble_parser_t parser;
+    const uint8_t        *frame;
+    uint8_t               size;
+
+    annepro2_ble_parser_reset(&parser);
+    assert(feed_bytes(&parser, connect_ack, 4, 100, &frame, &size) == ANNEPRO2_BLE_PARSE_NONE);
+    assert(annepro2_ble_parser_feed(&parser, 0x7B, 123, &frame, &size) == ANNEPRO2_BLE_PARSE_TIMEOUT);
+    assert(parser.size == 1);
+    assert(feed_bytes(&parser, connect_ack + 1, sizeof(connect_ack) - 1, 124, &frame, &size) == ANNEPRO2_BLE_PARSE_FRAME);
+    assert(memcmp(frame, connect_ack, size) == 0);
+
+    annepro2_ble_parser_reset(&parser);
+    assert(feed_bytes(&parser, connect_ack, 4, UINT32_MAX - 5, &frame, &size) == ANNEPRO2_BLE_PARSE_NONE);
+    assert(!annepro2_ble_parser_expire(&parser, 10));
+    assert(annepro2_ble_parser_expire(&parser, 18));
+}
+
+static void test_invalid_lengths(void) {
+    uint8_t               invalid[sizeof(connect_ack)];
+    annepro2_ble_parser_t parser;
+    const uint8_t        *frame;
+    uint8_t               size;
+
+    memcpy(invalid, connect_ack, sizeof(invalid));
+    invalid[4] = ANNEPRO2_BLE_RX_MAX_PAYLOAD + 1;
+    annepro2_ble_parser_reset(&parser);
+    assert(feed_bytes(&parser, invalid, 7, 0, &frame, &size) == ANNEPRO2_BLE_PARSE_INVALID_LENGTH);
+    assert(parser.size == 0);
+
+    memcpy(invalid, connect_ack, sizeof(invalid));
+    invalid[5] = 1;
+    annepro2_ble_parser_reset(&parser);
+    assert(feed_bytes(&parser, invalid, 7, 0, &frame, &size) == ANNEPRO2_BLE_PARSE_INVALID_LENGTH);
+    assert(parser.size == 0);
+
+    memcpy(invalid, connect_ack, sizeof(invalid));
+    invalid[6] = 1;
+    annepro2_ble_parser_reset(&parser);
+    assert(feed_bytes(&parser, invalid, 7, 0, &frame, &size) == ANNEPRO2_BLE_PARSE_INVALID_LENGTH);
+    assert(parser.size == 0);
+}
+
+static void test_invalid_delimiter_and_zero_payload(void) {
+    uint8_t               invalid[sizeof(connect_ack)];
+    const uint8_t         empty[] = {0x7B, 0x12, 0x35, 0x00, 0x00, 0x00, 0x00, 0x7D};
+    annepro2_ble_parser_t parser;
+    const uint8_t        *frame;
+    uint8_t               size;
+
+    memcpy(invalid, connect_ack, sizeof(invalid));
+    invalid[7] = 0;
+    annepro2_ble_parser_reset(&parser);
+    assert(feed_bytes(&parser, invalid, 8, 0, &frame, &size) == ANNEPRO2_BLE_PARSE_INVALID_DELIMITER);
+    assert(parser.size == 0);
+
+    assert(feed_bytes(&parser, empty, sizeof(empty), 20, &frame, &size) == ANNEPRO2_BLE_PARSE_FRAME);
+    assert(size == sizeof(empty));
+    assert(memcmp(frame, empty, size) == 0);
+}
+
+int main(void) {
+    test_valid_frame_and_noise();
+    test_payload_may_contain_header_byte();
+    test_timeout_and_resynchronization();
+    test_invalid_lengths();
+    test_invalid_delimiter_and_zero_payload();
+    return 0;
+}

--- a/keyboards/annepro2/tests/ble_profile_test.c
+++ b/keyboards/annepro2/tests/ble_profile_test.c
@@ -1,0 +1,128 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "../annepro2_ble_profile.h"
+
+static void test_empty_consumer_report(void) {
+    uint8_t report[ANNEPRO2_BLE_CONSUMER_REPORT_SIZE];
+
+    assert(annepro2_ble_encode_consumer(NULL, 0, report));
+    for (size_t i = 0; i < sizeof(report); i++) {
+        assert(report[i] == 0);
+    }
+}
+
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+static void test_consumer_report(void) {
+    const uint16_t usages[]   = {0x0001, 0x0183, 0x1234, 0xFFFF};
+    const uint8_t  expected[] = {0x01, 0x00, 0x83, 0x01, 0x34, 0x12, 0xFF, 0xFF};
+    uint8_t        report[ANNEPRO2_BLE_CONSUMER_REPORT_SIZE];
+
+    assert(sizeof(report) == 8);
+    assert(annepro2_ble_encode_consumer(usages, 4, report));
+    for (size_t i = 0; i < sizeof(report); i++) {
+        assert(report[i] == expected[i]);
+    }
+    assert(!annepro2_ble_encode_consumer(usages, 5, report));
+}
+#else
+static void test_consumer_report(void) {
+    static const uint16_t usages[] = {
+        0x00E2, // Mute
+        0x00E9, // Volume up
+        0x00EA, // Volume down
+        0x00CD, // Play/pause
+        0x00B5, // Next track
+        0x00B6, // Previous track
+        0x006F, // Brightness up
+        0x0070, // Brightness down
+    };
+    uint8_t report[ANNEPRO2_BLE_CONSUMER_REPORT_SIZE];
+
+    assert(sizeof(report) == 4);
+    for (uint8_t bit = 0; bit < 8; bit++) {
+        assert(annepro2_ble_encode_consumer(&usages[bit], 1, report));
+        assert(report[0] == (uint8_t)(1U << bit));
+        assert(report[1] == 0 && report[2] == 0 && report[3] == 0);
+    }
+    assert(annepro2_ble_encode_consumer(usages, 8, report));
+    assert(report[0] == 0xFF);
+
+    const uint16_t unsupported = 0x0183;
+    assert(!annepro2_ble_encode_consumer(&unsupported, 1, report));
+}
+#endif
+
+static void test_slot_state(void) {
+    annepro2_ble_slot_state_t state;
+
+    annepro2_ble_encode_slot_state(true, &state);
+    assert(state.command == 0x0B);
+    assert(state.action == 1);
+
+    annepro2_ble_encode_slot_state(false, &state);
+#if ANNEPRO2_BLE_PROFILE == ANNEPRO2_BLE_PROFILE_AP2D_213
+    assert(state.command == 0x24);
+    assert(state.action == 2);
+#else
+    assert(state.command == 0x0B);
+    assert(state.action == 0);
+#endif
+}
+
+static void test_caps_lock(void) {
+    uint8_t frame[] = {
+        0x7B, 0x12, 0x35, 0x00, 0x03, 0x00, 0x00, 0x7D, 0x20, 0x07, 0x00,
+    };
+    bool caps_lock = true;
+
+    assert(annepro2_ble_decode_caps_lock(frame, sizeof(frame), &caps_lock));
+    assert(!caps_lock);
+
+    frame[10] = 1;
+    assert(annepro2_ble_decode_caps_lock(frame, sizeof(frame), &caps_lock));
+    assert(caps_lock);
+
+    frame[10] = 2;
+    assert(!annepro2_ble_decode_caps_lock(frame, sizeof(frame), &caps_lock));
+    frame[10] = 0;
+
+    frame[9] = 0x0C;
+    assert(!annepro2_ble_decode_caps_lock(frame, sizeof(frame), &caps_lock));
+    frame[9] = 0x07;
+
+    assert(!annepro2_ble_decode_caps_lock(frame, sizeof(frame) - 1, &caps_lock));
+    assert(!annepro2_ble_decode_caps_lock(NULL, sizeof(frame), &caps_lock));
+    assert(!annepro2_ble_decode_caps_lock(frame, sizeof(frame), NULL));
+}
+
+static void test_slot_config_has_no_runtime_profile(void) {
+    for (int8_t expected = -1; expected <= 3; expected++) {
+        uint32_t config;
+        int8_t   slot;
+
+        assert(annepro2_ble_encode_config(expected, &config));
+        assert(annepro2_ble_decode_config(config, &slot));
+        assert(slot == expected);
+        assert(!annepro2_ble_decode_config(config ^ 0x00000100, &slot));
+        assert(!annepro2_ble_decode_config(config ^ 0x01000000, &slot));
+    }
+
+    uint32_t config;
+    int8_t   slot;
+    assert(!annepro2_ble_encode_config(-2, &config));
+    assert(!annepro2_ble_encode_config(4, &config));
+    assert(!annepro2_ble_encode_config(0, NULL));
+    assert(!annepro2_ble_decode_config(0, &slot));
+    assert(!annepro2_ble_decode_config(0, NULL));
+}
+
+int main(void) {
+    test_empty_consumer_report();
+    test_consumer_report();
+    test_slot_state();
+    test_caps_lock();
+    test_slot_config_has_no_runtime_profile();
+    return 0;
+}

--- a/keyboards/annepro2/tests/ble_state_test.c
+++ b/keyboards/annepro2/tests/ble_state_test.c
@@ -1,0 +1,246 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "../annepro2_ble_state.h"
+
+static bool has(ap2_ble_actions_t actions, ap2_ble_action_t action) {
+    return (actions & action) != 0;
+}
+
+static void test_startup_restore(void) {
+    ap2_ble_state_t state;
+
+    ap2_ble_actions_t actions = ap2_ble_state_startup(&state, 1, 100);
+    assert(actions == AP2_BLE_ACTION_SEND_WAKEUP);
+    assert(state.state == AP2_BLE_STATE_STARTUP_PASSIVE);
+    assert(state.selected_slot == 1);
+
+    actions = ap2_ble_state_task(&state, 599);
+    assert(actions == AP2_BLE_ACTION_NONE);
+    actions = ap2_ble_state_task(&state, 600);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_SEND_BROADCAST));
+    assert(!has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+    assert(state.state == AP2_BLE_STATE_WAIT_BROADCAST_ACK);
+
+    actions = ap2_ble_state_startup(&state, 2, 1000);
+    assert(actions == AP2_BLE_ACTION_SEND_WAKEUP);
+    actions = ap2_ble_state_handshake(&state);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_BLE));
+    assert(has(actions, AP2_BLE_ACTION_SAVE_SLOT));
+    assert(state.state == AP2_BLE_STATE_ACTIVE);
+    assert(state.selected_slot == 2);
+
+    actions = ap2_ble_state_startup(&state, -1, 2000);
+    assert(actions == AP2_BLE_ACTION_SEND_WAKEUP);
+    assert(state.state == AP2_BLE_STATE_USB);
+    assert(ap2_ble_state_task(&state, 3000) == AP2_BLE_ACTION_NONE);
+}
+
+static void test_tap_and_hold(void) {
+    ap2_ble_state_t state;
+    ap2_ble_state_reset(&state);
+
+    assert(ap2_ble_state_slot_press(&state, 0, 10) == AP2_BLE_ACTION_NONE);
+    ap2_ble_actions_t actions = ap2_ble_state_slot_release(&state, 0, 100);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+    assert(has(actions, AP2_BLE_ACTION_SEND_CONNECT));
+    assert(state.state == AP2_BLE_STATE_WAIT_CONNECT_ACK);
+    assert(state.selected_slot == 0);
+    assert(!state.command_slot_broadcast);
+
+    ap2_ble_state_reset(&state);
+    assert(ap2_ble_state_slot_press(&state, 3, 1000) == AP2_BLE_ACTION_NONE);
+    assert(ap2_ble_state_task(&state, 1499) == AP2_BLE_ACTION_NONE);
+    actions = ap2_ble_state_task(&state, 1500);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+    assert(has(actions, AP2_BLE_ACTION_SEND_BROADCAST));
+    assert(state.command_slot_broadcast);
+    assert(ap2_ble_state_slot_release(&state, 3, 1501) == AP2_BLE_ACTION_NONE);
+}
+
+static void test_all_four_slots_connect_and_pair(void) {
+    for (uint8_t slot = 0; slot < 4; slot++) {
+        ap2_ble_state_t state;
+        ap2_ble_state_reset(&state);
+
+        ap2_ble_actions_t actions = ap2_ble_state_connect(&state, slot, 100);
+        assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+        assert(has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+        assert(has(actions, AP2_BLE_ACTION_SEND_CONNECT));
+        assert(state.selected_slot == slot);
+        assert(state.state == AP2_BLE_STATE_WAIT_CONNECT_ACK);
+
+        assert(ap2_ble_state_command_ack(&state, 0x04, 200) == AP2_BLE_ACTION_NONE);
+        assert(state.state == AP2_BLE_STATE_WAIT_HANDSHAKE);
+        actions = ap2_ble_state_handshake(&state);
+        assert(has(actions, AP2_BLE_ACTION_ROUTE_BLE));
+        assert(has(actions, AP2_BLE_ACTION_SAVE_SLOT));
+        assert(state.state == AP2_BLE_STATE_ACTIVE);
+        assert(state.selected_slot == slot);
+
+        actions = ap2_ble_state_disconnect(&state);
+        assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+        assert(has(actions, AP2_BLE_ACTION_CLEAR_SLOT));
+
+        actions = ap2_ble_state_broadcast(&state, slot, 300);
+        assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+        assert(has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+        assert(has(actions, AP2_BLE_ACTION_SEND_BROADCAST));
+        assert(state.selected_slot == slot);
+        assert(state.state == AP2_BLE_STATE_WAIT_BROADCAST_ACK);
+
+        assert(ap2_ble_state_command_ack(&state, 0x01, 400) == AP2_BLE_ACTION_NONE);
+        assert(state.state == AP2_BLE_STATE_WAIT_HANDSHAKE);
+        actions = ap2_ble_state_handshake(&state);
+        assert(has(actions, AP2_BLE_ACTION_ROUTE_BLE));
+        assert(has(actions, AP2_BLE_ACTION_SAVE_SLOT));
+        assert(state.state == AP2_BLE_STATE_ACTIVE);
+        assert(state.selected_slot == slot);
+    }
+}
+
+static void test_command_retry_and_handshake(void) {
+    ap2_ble_state_t state;
+    ap2_ble_state_reset(&state);
+
+    ap2_ble_actions_t actions = ap2_ble_state_connect(&state, 1, 0);
+    assert(has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+    assert(has(actions, AP2_BLE_ACTION_SEND_CONNECT));
+
+    actions = ap2_ble_state_task(&state, ANNEPRO2_BLE_COMMAND_TIMEOUT);
+    assert(actions == AP2_BLE_ACTION_SEND_CONNECT);
+    assert(!has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+    assert(state.command_retries == 1);
+
+    actions = ap2_ble_state_task(&state, ANNEPRO2_BLE_COMMAND_TIMEOUT * 2);
+    assert(actions == AP2_BLE_ACTION_SEND_CONNECT);
+    assert(state.command_retries == 2);
+
+    actions = ap2_ble_state_task(&state, ANNEPRO2_BLE_COMMAND_TIMEOUT * 3);
+    assert(actions == AP2_BLE_ACTION_NONE);
+    assert(state.state == AP2_BLE_STATE_WAIT_HANDSHAKE);
+
+    actions = ap2_ble_state_command_ack(&state, 0x04, 1600);
+    assert(actions == AP2_BLE_ACTION_NONE);
+    assert(state.state == AP2_BLE_STATE_WAIT_HANDSHAKE);
+
+    actions = ap2_ble_state_handshake(&state);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_BLE));
+    assert(has(actions, AP2_BLE_ACTION_SAVE_SLOT));
+    assert(state.state == AP2_BLE_STATE_ACTIVE);
+}
+
+static void test_ack_is_not_connection(void) {
+    ap2_ble_state_t state;
+    ap2_ble_state_reset(&state);
+    ap2_ble_state_connect(&state, 1, 0);
+
+    assert(ap2_ble_state_command_ack(&state, 0x01, 10) == AP2_BLE_ACTION_NONE);
+    assert(state.state == AP2_BLE_STATE_WAIT_CONNECT_ACK);
+
+    assert(ap2_ble_state_command_ack(&state, 0x04, 20) == AP2_BLE_ACTION_NONE);
+    assert(state.state == AP2_BLE_STATE_WAIT_HANDSHAKE);
+    assert(!has(ap2_ble_state_command_ack(&state, 0x04, 30), AP2_BLE_ACTION_ROUTE_BLE));
+    assert(state.state == AP2_BLE_STATE_WAIT_HANDSHAKE);
+}
+
+static void test_latest_slot_intent_wins(void) {
+    ap2_ble_state_t state;
+    ap2_ble_state_reset(&state);
+    ap2_ble_state_connect(&state, 1, 0);
+
+    assert(ap2_ble_state_connect(&state, 2, 100) == AP2_BLE_ACTION_ROUTE_USB);
+    assert(state.pending_slot == 2);
+    assert(ap2_ble_state_connect(&state, 0, 200) == AP2_BLE_ACTION_ROUTE_USB);
+    assert(state.pending_slot == 0);
+    assert(ap2_ble_state_task(&state, 1199) == AP2_BLE_ACTION_NONE);
+
+    ap2_ble_actions_t actions = ap2_ble_state_task(&state, 1200);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+    assert(has(actions, AP2_BLE_ACTION_SEND_CONNECT));
+    assert(state.selected_slot == 0);
+    assert(state.pending_slot == -1);
+    assert(state.state == AP2_BLE_STATE_WAIT_CONNECT_ACK);
+
+    /* An ACK for a different command family cannot advance the new request. */
+    assert(ap2_ble_state_command_ack(&state, 0x01, 1201) == AP2_BLE_ACTION_NONE);
+    assert(state.state == AP2_BLE_STATE_WAIT_CONNECT_ACK);
+}
+
+static void test_handshake_timeout_recovery_is_bounded(void) {
+    ap2_ble_state_t state;
+    ap2_ble_state_reset(&state);
+    ap2_ble_state_connect(&state, 3, 0);
+    ap2_ble_state_command_ack(&state, 0x04, 10);
+
+    ap2_ble_actions_t actions = ap2_ble_state_task(&state, 10 + ANNEPRO2_BLE_HANDSHAKE_TIMEOUT);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_SEND_WAKEUP));
+    assert(state.state == AP2_BLE_STATE_USB);
+    assert(state.startup_slot == 3);
+    assert(state.handshake_recoveries == 1);
+
+    actions = ap2_ble_state_task(&state, 10 + ANNEPRO2_BLE_HANDSHAKE_TIMEOUT + ANNEPRO2_BLE_STARTUP_DELAY);
+    assert(has(actions, AP2_BLE_ACTION_SEND_BROADCAST));
+    assert(!has(actions, AP2_BLE_ACTION_SEND_SLOT_STATE));
+    assert(state.state == AP2_BLE_STATE_WAIT_BROADCAST_ACK);
+
+    ap2_ble_state_command_ack(&state, 0x01, 11000);
+    actions = ap2_ble_state_task(&state, 11000 + ANNEPRO2_BLE_HANDSHAKE_TIMEOUT);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_NOTIFY_FAILURE));
+    assert(!has(actions, AP2_BLE_ACTION_SEND_WAKEUP));
+    assert(state.state == AP2_BLE_STATE_USB);
+    assert(state.startup_slot == -1);
+    assert(state.handshake_recoveries == 1);
+}
+
+static void test_disconnect_and_unpair_clear_transient_state(void) {
+    ap2_ble_state_t state;
+    ap2_ble_state_reset(&state);
+    ap2_ble_state_slot_press(&state, 2, 0);
+    ap2_ble_state_connect(&state, 1, 1);
+    ap2_ble_state_connect(&state, 3, 2);
+
+    ap2_ble_actions_t actions = ap2_ble_state_disconnect(&state);
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_CLEAR_SLOT));
+    assert(state.state == AP2_BLE_STATE_USB);
+    assert(state.held_slot == -1);
+    assert(state.pending_slot == -1);
+    assert(state.startup_slot == -1);
+    assert(!state.handshake_timeout_enabled);
+
+    ap2_ble_state_connect(&state, 0, 100);
+    actions = ap2_ble_state_unpair(&state);
+    assert(has(actions, AP2_BLE_ACTION_SEND_UNPAIR));
+    assert(has(actions, AP2_BLE_ACTION_ROUTE_USB));
+    assert(has(actions, AP2_BLE_ACTION_CLEAR_SLOT));
+    assert(state.state == AP2_BLE_STATE_USB);
+}
+
+static void test_timer_wraparound(void) {
+    ap2_ble_state_t state;
+    ap2_ble_state_reset(&state);
+    ap2_ble_state_connect(&state, 0, UINT32_MAX - 100);
+    assert(ap2_ble_state_task(&state, 398) == AP2_BLE_ACTION_NONE);
+    assert(ap2_ble_state_task(&state, 399) == AP2_BLE_ACTION_SEND_CONNECT);
+}
+
+int main(void) {
+    test_startup_restore();
+    test_tap_and_hold();
+    test_all_four_slots_connect_and_pair();
+    test_command_retry_and_handshake();
+    test_ack_is_not_connection();
+    test_latest_slot_intent_wins();
+    test_handshake_timeout_recovery_is_bounded();
+    test_disconnect_and_unpair_clear_transient_state();
+    test_timer_wraparound();
+    return 0;
+}


### PR DESCRIPTION
## Description

Adds QMK support for the Anne Pro 2D C2D revision:

- adds the HT32F52352 C2D board, linker, matrix GPIO, UART, SPI flash, and IAP configuration
- implements the AP2D BLE 2.13 UART protocol, bounded RX parser, connection state machine, slot selection, HID handshake, Caps Lock sync, and consumer reports
- moves BLE initialization, UART processing, and BLE key handling out of `annepro2.c` into dedicated BLE transport files
- makes the C18 BLE 2.05/2.13 compatibility choice compile-time only; C2D always selects AP2D BLE 2.13
- keeps C15/C18 external-controller RGB support unchanged

C2D direct-drive RGB is intentionally not included in this PR and will be handled separately.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

None.

## Validation

- `qmk compile -kb annepro2/c18 -km default -j20`
- C18 BLE 2.13 compile-time compatibility build
- `qmk compile -kb annepro2/c15 -km default -j20`
- `qmk compile -kb annepro2/c2d -km default -j20`
- host tests for both compile-time BLE report formats, BLE state transitions, AP2D slot protocol, and bounded UART parsing
- `git diff --check`

All builds and host-side tests pass. I do not currently have C2D hardware, so USB, matrix, BLE radio behavior, and IAP behavior have not been validated on a physical device.

`qmk lint -kb annepro2/c2d` still reports the existing Anne Pro 2 missing-license headers and legacy hyphenated keymap names; this PR does not modify those inherited files.

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the PR Checklist document and made the appropriate changes
- [x] My change requires a documentation update
- [x] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [x] I have added tests to cover my changes
- [x] I have tested the changes and verified that they work as well as I can manage