### PR TITLE
Add STM32_USB_USE_OTG2 to USB_ENDPOINTS_ARE_REORDERABLE

### DIFF
--- a/tmk_core/protocol/usb_descriptor.h
+++ b/tmk_core/protocol/usb_descriptor.h
@@ -47,7 +47,7 @@
 
 #ifdef PROTOCOL_CHIBIOS
 #    include <hal.h>
-#    if STM32_USB_USE_OTG1 == TRUE
+#    if STM32_USB_USE_OTG1 == TRUE || STM32_USB_USE_OTG2 == TRUE
 #        define USB_ENDPOINTS_ARE_REORDERABLE
 #    endif
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* from discord discussion [here](https://discord.com/channels/440868230475677696/888113551334580324/1525322371462860834)

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
