### PR TITLE
docs: fix dead links in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,11 +19,10 @@ Please keep these things in mind:
 * Everyone involved with QMK is donating their time and energy. We don't get paid to work on or answer questions about QMK.
 * Try to ask your question so it's as easy to answer as possible. If you're not sure how to do that these are some good guides:
   * https://opensource.com/life/16/10/how-ask-technical-questions
-  * http://www.catb.org/esr/faqs/smart-questions.html
 
 # Project Overview
 
-QMK is largely written in C, with specific features and parts written in C++. It targets embedded processors found in keyboards, particularly AVR ([LUFA](https://www.fourwalledcubicle.com/LUFA.php)) and ARM ([ChibiOS](https://www.chibios.org)). If you are already well versed in Arduino programming you'll find a lot of the concepts and limitations familiar. Prior experience with Arduino is not required to successfully contribute to QMK.
+QMK is largely written in C, with specific features and parts written in C++. It targets embedded processors found in keyboards, particularly AVR ([LUFA](https://github.com/abcminiuser/lufa)) and ARM ([ChibiOS](https://www.chibios.org)). If you are already well versed in Arduino programming you'll find a lot of the concepts and limitations familiar. Prior experience with Arduino is not required to successfully contribute to QMK.
 
 <!-- FIXME: We should include a list of resources for learning C here. -->
 


### PR DESCRIPTION
## Description

Replace inaccessible external links in the contributing documentation.

### Changes

* Replace the dead LUFA website link with the official LUFA GitHub repository.
* Remove the inaccessible "How To Ask Questions The Smart Way" (`catb.org`) link.
* Update the wording from "these are some good guides" to "this is a good guide".

## Types of Changes

* [ ] Core
* [ ] Bugfix
* [ ] New feature
* [ ] Enhancement/optimization
* [ ] Keyboard (addition or update)
* [ ] Keymap/layout (addition or update)
* [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes #26368

## Checklist

* [ ] My code follows the code style of this project: **C**, **Python**
* [x] I have read the **PR Checklist** document and have made the appropriate changes.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
