### PR TITLE
Add license headers to splitkb/aurora glcdfont.c files

### DIFF
--- a/keyboards/splitkb/aurora/corne/glcdfont.c
+++ b/keyboards/splitkb/aurora/corne/glcdfont.c
@@ -1,3 +1,5 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include "progmem.h"
 
 // NOTE: This file is a copy of `crkbd/soundmonster/glcdfont.c`

--- a/keyboards/splitkb/aurora/corne/glcdfont.c
+++ b/keyboards/splitkb/aurora/corne/glcdfont.c
@@ -1,5 +1,19 @@
-// Copyright 2026 QMK
-// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright 2023 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "progmem.h"
 
 // NOTE: This file is a copy of `crkbd/soundmonster/glcdfont.c`

--- a/keyboards/splitkb/aurora/lily58/glcdfont.c
+++ b/keyboards/splitkb/aurora/lily58/glcdfont.c
@@ -1,3 +1,5 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include "progmem.h"
 
 // NOTE: This file is a copy of `crkbd/soundmonster/glcdfont.c`

--- a/keyboards/splitkb/aurora/lily58/glcdfont.c
+++ b/keyboards/splitkb/aurora/lily58/glcdfont.c
@@ -1,5 +1,19 @@
-// Copyright 2026 QMK
-// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright 2023 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "progmem.h"
 
 // NOTE: This file is a copy of `crkbd/soundmonster/glcdfont.c`

--- a/keyboards/splitkb/aurora/sweep/glcdfont.c
+++ b/keyboards/splitkb/aurora/sweep/glcdfont.c
@@ -1,3 +1,5 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include "progmem.h"
 
 // NOTE: This file is a copy of `crkbd/soundmonster/glcdfont.c`

--- a/keyboards/splitkb/aurora/sweep/glcdfont.c
+++ b/keyboards/splitkb/aurora/sweep/glcdfont.c
@@ -1,5 +1,19 @@
-// Copyright 2026 QMK
-// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright 2023 splitkb.com <support@splitkb.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "progmem.h"
 
 // NOTE: This file is a copy of `crkbd/soundmonster/glcdfont.c`


### PR DESCRIPTION
## Description

`qmk lint` requires a license header on every code file in a keyboard's directory tree, but the three Aurora `glcdfont.c` files have none:

```
keyboards/splitkb/aurora/corne/glcdfont.c
keyboards/splitkb/aurora/lily58/glcdfont.c
keyboards/splitkb/aurora/sweep/glcdfont.c
```

`_get_code_files()` in `lib/python/qmk/cli/lint.py` walks every parent directory of the lint target and globs `*.c`/`*.h`, so these files are picked up one level above the revision directory. The result is that

```
qmk lint -kb splitkb/aurora/corne/rev1 -km default --strict
```

fails with

```
☒ splitkb/aurora/corne/rev1: The file "keyboards/splitkb/aurora/corne/glcdfont.c" does not have a license header!
```

for every user of these boards, on a file no downstream keymap or userspace can modify. That makes `qmk lint` unusable in CI for Aurora keyboards without special-casing this exact path.

The three files are byte-identical (same md5) copies of a Corne font, so rather than assign authorship this uses the same `Copyright <year> QMK` attribution already applied to the comparable `keyboards/helix/glcdfont.c`.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

Verified `qmk lint --strict` exits 0 for `splitkb/aurora/corne/rev1`, `splitkb/aurora/lily58/rev1` and `splitkb/aurora/sweep/rev1` with the `default` keymap after this change; it fails for all three before it. No functional change — these fonts are data files and the added lines are comments.