### PR TITLE
Update magic_force/mf17 to WS2812 PWM driver

### DIFF
--- a/keyboards/magic_force/mf17/config.h
+++ b/keyboards/magic_force/mf17/config.h
@@ -1,0 +1,9 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#define WS2812_PWM_DRIVER PWMD15
+#define WS2812_PWM_CHANNEL 1
+#define WS2812_PWM_PAL_MODE 0
+#define WS2812_PWM_DMA_STREAM STM32_DMA1_STREAM5
+#define WS2812_PWM_DMA_CHANNEL 5

--- a/keyboards/magic_force/mf17/halconf.h
+++ b/keyboards/magic_force/mf17/halconf.h
@@ -1,0 +1,7 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#define HAL_USE_PWM TRUE
+
+#include_next <halconf.h>

--- a/keyboards/magic_force/mf17/keyboard.json
+++ b/keyboards/magic_force/mf17/keyboard.json
@@ -28,6 +28,7 @@
         "rgb_matrix": true
     },
     "ws2812": {
+        "driver": "pwm",
         "pin": "A2"
     },
     "rgb_matrix": {
@@ -78,23 +79,23 @@
         },
         "driver": "ws2812",
         "layout": [
-            {"flags": 1, "matrix": [4,  1], "x": 37,  "y": 64},
-            {"flags": 1, "matrix": [4,  2], "x": 150, "y": 64},
-            {"flags": 1, "matrix": [4,  3], "x": 224, "y": 56},
-            {"flags": 1, "matrix": [3,  0], "x": 0,   "y": 48},
-            {"flags": 1, "matrix": [3,  1], "x": 75,  "y": 48},
-            {"flags": 1, "matrix": [3,  2], "x": 150, "y": 48},
-            {"flags": 1, "matrix": [2, 0], "x": 0,   "y": 32},
-            {"flags": 1, "matrix": [2,  1], "x": 75,  "y": 32},
-            {"flags": 1, "matrix": [2,  2], "x": 150, "y": 32},
-            {"flags": 1, "matrix": [2,  3], "x": 224, "y": 24},
-            {"flags": 1, "matrix": [1, 0], "x": 0,   "y": 16},
-            {"flags": 1, "matrix": [1, 1], "x": 75,  "y": 16},
-            {"flags": 1, "matrix": [1, 2], "x": 150, "y": 16},
-            {"flags": 1, "matrix": [0, 0], "x": 0,   "y": 0},
-            {"flags": 1, "matrix": [0, 1], "x": 75,  "y": 0},
-            {"flags": 1, "matrix": [0, 2], "x": 150, "y": 0},
-            {"flags": 1, "matrix": [0, 3], "x": 224, "y": 0}
+            {"flags": 4, "matrix": [4,  1], "x": 37,  "y": 64},
+            {"flags": 4, "matrix": [4,  2], "x": 150, "y": 64},
+            {"flags": 4, "matrix": [4,  3], "x": 224, "y": 56},
+            {"flags": 4, "matrix": [3,  0], "x": 0,   "y": 48},
+            {"flags": 4, "matrix": [3,  1], "x": 75,  "y": 48},
+            {"flags": 4, "matrix": [3,  2], "x": 150, "y": 48},
+            {"flags": 4, "matrix": [2, 0], "x": 0,   "y": 32},
+            {"flags": 4, "matrix": [2,  1], "x": 75,  "y": 32},
+            {"flags": 4, "matrix": [2,  2], "x": 150, "y": 32},
+            {"flags": 4, "matrix": [2,  3], "x": 224, "y": 24},
+            {"flags": 4, "matrix": [1, 0], "x": 0,   "y": 16},
+            {"flags": 4, "matrix": [1, 1], "x": 75,  "y": 16},
+            {"flags": 4, "matrix": [1, 2], "x": 150, "y": 16},
+            {"flags": 4, "matrix": [0, 0], "x": 0,   "y": 0},
+            {"flags": 4, "matrix": [0, 1], "x": 75,  "y": 0},
+            {"flags": 4, "matrix": [0, 2], "x": 150, "y": 0},
+            {"flags": 4, "matrix": [0, 3], "x": 224, "y": 0}
         ],
         "max_brightness": 180,
         "sleep": true

--- a/keyboards/magic_force/mf17/keymaps/default/keymap.c
+++ b/keyboards/magic_force/mf17/keymaps/default/keymap.c
@@ -1,32 +1,20 @@
-/*
-Copyright 2012,2013 gezhaoyou <gezhaoyou@126.com>
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright 2012,2013 gezhaoyou <gezhaoyou@126.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
 #include QMK_KEYBOARD_H
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = LAYOUT_numpad_5x4(
-        KC_NUM_LOCK,            KC_PSLS,    KC_PAST,        LT(1, KC_PMNS),
-        KC_P7,                  KC_P8,      KC_P9,
-        KC_P4,                  KC_P5,      KC_P6,          KC_PPLS,
-        KC_P1,                  KC_P2,      KC_P3,
-                                KC_P0,      KC_PDOT,        KC_PENT),
-   [1] = LAYOUT_numpad_5x4(
-        KC_TRNS,                KC_CALCULATOR,          KC_BSPC,    KC_TRNS,
-        RM_NEXT,                RM_VALU,                RM_HUEU,
-        RM_SPDD,                RM_TOGG,                RM_SPDU,    QK_BOOTLOADER,
-        RM_PREV,                RM_VALD,                RM_HUED,
-                                KC_TRNS,                KC_TRNS,    QK_CLEAR_EEPROM),
+    [0] = LAYOUT_numpad_5x4(
+        KC_NUM,  KC_PSLS, KC_PAST, LT(1, KC_PMNS),
+        KC_P7,   KC_P8,   KC_P9,
+        KC_P4,   KC_P5,   KC_P6,   KC_PPLS,
+        KC_P1,   KC_P2,   KC_P3,
+        KC_P0,   KC_PDOT,          KC_PENT
+    ),
+    [1] = LAYOUT_numpad_5x4(
+        _______, KC_CALC, KC_BSPC, _______,
+        RM_NEXT, RM_VALU, RM_HUEU,
+        RM_SPDD, RM_TOGG, RM_SPDU, QK_BOOT,
+        RM_PREV, RM_VALD, RM_HUED,
+        _______, _______,          EE_CLR
+    ),
 };

--- a/keyboards/magic_force/mf17/mcuconf.h
+++ b/keyboards/magic_force/mf17/mcuconf.h
@@ -1,0 +1,10 @@
+// Copyright 2026 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include_next <mcuconf.h>
+
+#undef STM32_PWM_USE_TIM15
+#define STM32_PWM_USE_TIM15 TRUE
+
+#define STM32_TIM15_SUPPRESS_ISR

--- a/keyboards/magic_force/mf17/readme.md
+++ b/keyboards/magic_force/mf17/readme.md
@@ -4,6 +4,7 @@ A customizable 17  keyboard, support both HOTSWAP and SOLDER.
 
 * Keyboard Maintainer: [gezhaoyou](https://github.com/gezhaoyou)
 * Hardware Supported: [gezhaoyou](https://github.com/gezhaoyou)
+
 Make example for this keyboard (after setting up your build environment):
 
     make magic_force/mf17:default


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Fixes RGB only white on later GCC versions.

Reported, and tested on Discord.

Updated a few nits while touching the keyboard files:
* Formatted keymap
* Corrected RGB matrix flags
* Fixed readme list rendering

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* <https://discord.com/channels/440868230475677696/1532813120421236947/1532813120421236947>

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
