### PR TITLE
Add positron/osupad keyboard

### DIFF
--- a/keyboards/positron/osupad/keyboard.json
+++ b/keyboards/positron/osupad/keyboard.json
@@ -1,0 +1,54 @@
+{
+  "manufacturer": "Positron Electronic",
+  "keyboard_name": "OSUpad",
+  "maintainer": "juarendra",
+  "url": "https://www.tokopedia.com/positronelectronic/osupad-macropad-mini-for-playing-osu-with-3-mechanical-switch-3-tactile-switch-and-underglow-1731022532695066320",
+  "development_board": "bluepill",
+  "matrix_pins": {
+    "direct": [
+      ["B0", "A7", "A6"],
+      ["B12", "B13", "B14"]
+    ]
+  },
+  "usb": {
+    "device_version": "1.0.0",
+    "pid": "0x7050",
+    "vid": "0x1209"
+  },
+  "features": {
+    "bootmagic": true,
+    "extrakey": true,
+    "mousekey": true,
+    "nkro": true,
+    "rgblight": true
+  },
+  "rgblight": {
+    "led_count": 8,
+    "animations": {
+      "alternating": true,
+      "breathing": true,
+      "christmas": true,
+      "knight": true,
+      "rainbow_mood": true,
+      "rainbow_swirl": true,
+      "rgb_test": true,
+      "snake": true,
+      "static_gradient": true
+    }
+  },
+  "ws2812": {
+    "pin": "A5"
+  },
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {"matrix": [0, 0], "x": 0, "y": 0},
+        {"matrix": [0, 1], "x": 1, "y": 0},
+        {"matrix": [0, 2], "x": 2, "y": 0},
+        {"matrix": [1, 0], "x": 0, "y": 1},
+        {"matrix": [1, 1], "x": 1, "y": 1},
+        {"matrix": [1, 2], "x": 2, "y": 1}
+      ]
+    }
+  }
+}

--- a/keyboards/positron/osupad/keymaps/default/keymap.c
+++ b/keyboards/positron/osupad/keymaps/default/keymap.c
@@ -1,0 +1,11 @@
+// Copyright 2024-2026 Juarendra Ramadhani (@juarendra)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(
+        KC_A, KC_B, KC_C,
+        KC_E, KC_F, KC_G
+    ),
+};

--- a/keyboards/positron/osupad/readme.md
+++ b/keyboards/positron/osupad/readme.md
@@ -1,0 +1,21 @@
+# Positron OSUpad
+
+A 2x3 hotswap mechanical macropad with RGB lighting, designed for rhythm gamers.
+
+- Keyboard Maintainer: [Juarendra Ramadhani](https://github.com/juarendra)
+- Hardware Supported: Positron OSUpad (STM32F103)
+- Hardware Availability: [Positron Electronic](https://www.tokopedia.com/positronelectronic)
+
+Make example for this keyboard (after setting up your build environment):
+
+    make positron/osupad:default
+
+Flashing example for this keyboard:
+
+    make positron/osupad:default:flash
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader using Bootmagic reset: hold the top-left key while plugging in the keyboard.


### PR DESCRIPTION
## Description

Adds the Positron Electronic OSUpad, an open-source 2x3 hotswap mechanical macropad with eight WS2812 RGB LEDs for rhythm games.

- MCU: STM32F103 using the Bluepill development board definition
- Matrix: 2x3 direct pins
- RGB: 8 WS2812 LEDs
- USB VID/PID: `0x1209` / `0x7050`, requested at pid.codes (https://github.com/pidcodes/pidcodes.github.com/pull/1258)
- Hardware/source: https://github.com/juarendra/12pad-QMK-VIA
- Keymap: `default`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

