### PR TITLE
Skip network-backed mounts when enumerating UF2 drives

### DIFF
--- a/util/uf2conv.py
+++ b/util/uf2conv.py
@@ -207,8 +207,41 @@ def convert_from_hex_to_uf2(buf):
 def to_str(b):
     return b.decode("utf-8")
 
+
+def _slow_mount_points():
+    """Return mount points backed by network filesystems.
+    """
+    slow_types = {"autofs", "nfs", "nfs4", "cifs", "smbfs", "sshfs"}
+    slow_prefixes = ("fuse.",)
+    slow = set()
+    try:
+        with open("/proc/self/mountinfo") as f:
+            for line in f:
+                parts = line.split()
+                if "-" not in parts:
+                    continue
+                dash = parts.index("-")
+                if len(parts) <= dash + 1:
+                    continue
+                fs_type = parts[dash + 1].lower()
+                if fs_type in slow_types or fs_type.startswith(slow_prefixes):
+                    slow.add(os.path.normpath(parts[4].replace("\\040", " ")))
+    except OSError:
+        pass
+    return slow
+
+
+def _is_slow_mount(path, slow_mounts):
+    """Check whether path is on or under a slow mount point.
+    """
+    path = os.path.normpath(path)
+    return any(path == slow or path.startswith(slow + os.sep) for slow in slow_mounts)
+
+
 def get_drives():
     drives = []
+    # Skip network-backed mounts to avoid hangs when enumerating drives.
+    slow_mounts = _slow_mount_points() if sys.platform == "linux" else set()
     if sys.platform == "win32":
         r = subprocess.check_output([
             "powershell",
@@ -227,10 +260,14 @@ def get_drives():
                 searchpaths += ["/run/media/" + os.environ["SUDO_USER"]]
 
         for rootpath in searchpaths:
-            if os.path.isdir(rootpath):
-                for d in os.listdir(rootpath):
-                    if os.path.isdir(os.path.join(rootpath, d)):
-                        drives.append(os.path.join(rootpath, d))
+            if _is_slow_mount(rootpath, slow_mounts):
+                continue
+            try:
+                for entry in os.scandir(rootpath):
+                    if entry.is_dir() and not _is_slow_mount(entry.path, slow_mounts):
+                        drives.append(entry.path)
+            except OSError:
+                continue
 
 
     def has_info(d):


### PR DESCRIPTION
## Description

When searching /media, /mnt, and similar paths for UF2-capable drives, os.listdir and os.path.isdir can hang indefinitely on network-backed filesystems (NFS, CIFS, SSHFS, autofs, network FUSE). Parse /proc/self/mountinfo to identify these mount points and skip them during enumeration. Local FUSE filesystems (exFAT, NTFS) are excluded from the skip list since they are not slow.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation


## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes. 
> `util/uf2conv.py` is outside the test suite (`lib/python/qmk/tests/`); no existing test infrastructure for `util/` scripts.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).