### PR TITLE
Resolve recursive keyboard aliases when locating userspace keymaps

### DIFF
--- a/lib/python/qmk/keyboard.py
+++ b/lib/python/qmk/keyboard.py
@@ -140,15 +140,21 @@ def keyboard_aliases(keyboard):
 
     Includes the keyboard itself.
     """
-    aliases = json_load(Path('data/mappings/keyboard_aliases.hjson'))
+    aliases = keyboard_alias_definitions()
 
-    if keyboard in aliases:
-        keyboard = aliases[keyboard].get('target', keyboard)
+    def _resolve_recursive_aliases(kb):
+        ret = set()
+        for found in filter(lambda k: aliases[k].get('target', '') == kb, aliases.keys()):
+            ret.update(_resolve_recursive_aliases(found))
+            ret.add(found)
+        return ret
 
-    keyboards = set(filter(lambda k: aliases[k].get('target', '') == keyboard, aliases.keys()))
+    keyboard = keyboard_folder(keyboard)
+
+    keyboards = _resolve_recursive_aliases(keyboard)
     keyboards.add(keyboard)
-    keyboards = list(sorted(keyboards))
-    return keyboards
+
+    return list(sorted(keyboards))
 
 
 def keyboard_folder_or_all(keyboard):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Locating userspace keymap currently fails when a keyboard alias chain is recursive, eg `kyria` -> `splitkb/kyria` -> `splitkb/kyria/rev3`. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
