### PR TITLE
Fix JSON keymap formatter

### DIFF
--- a/lib/python/qmk/cli/format/json.py
+++ b/lib/python/qmk/cli/format/json.py
@@ -2,6 +2,7 @@
 
 Spits out a JSON file formatted with one of QMK's formatters.
 """
+
 import json
 
 from jsonschema import ValidationError
@@ -9,13 +10,12 @@ from milc import cli
 
 from qmk.info import info_json
 from qmk.json_schema import json_load, validate
-from qmk.json_encoders import InfoJSONEncoder, KeymapJSONEncoder, UserspaceJSONEncoder, CommunityModuleJSONEncoder
+from qmk.json_encoders import InfoJSONEncoder, KeymapJSONEncoder, UserspaceJSONEncoder, CommunityModuleJSONEncoder, JSON_NEWLINE
 from qmk.path import normpath
 
 
 def _detect_json_format(file, json_data):
-    """Detect the format of a json file.
-    """
+    """Detect the format of a json file."""
     json_encoder = None
     try:
         validate(json_data, 'qmk.user_repo.v1_1')
@@ -50,8 +50,7 @@ def _detect_json_format(file, json_data):
 
 
 def _get_json_encoder(file, json_data):
-    """Get the json encoder for a file.
-    """
+    """Get the json encoder for a file."""
     json_encoder = None
     if cli.args.format == 'auto':
         json_encoder = _detect_json_format(file, json_data)
@@ -75,8 +74,7 @@ def _get_json_encoder(file, json_data):
 @cli.argument('-p', '--print', action='store_true', arg_only=True, help='If set, will print the formatted json to stdout ')
 @cli.subcommand('Generate an info.json file for a keyboard.', hidden=False if cli.config.user.developer else True)
 def format_json(cli):
-    """Format a json file.
-    """
+    """Format a json file."""
     json_data = json_load(cli.args.json_file)
 
     json_encoder = _get_json_encoder(cli.args.json_file, json_data)
@@ -94,13 +92,12 @@ def format_json(cli):
         if layout in info_data.get('layouts'):
             for layer_num, layer in enumerate(json_data['layers']):
                 current_layer = []
-                last_row = 0
+                last_col = 0
 
                 for keymap_key, info_key in zip(layer, info_data['layouts'][layout]['layout']):
-                    if last_row != info_key['y']:
-                        current_layer.append('JSON_NEWLINE')
-                        last_row = info_key['y']
-
+                    if info_key['x'] < last_col:
+                        current_layer.append(JSON_NEWLINE)
+                    last_col = info_key['x']
                     current_layer.append(keymap_key)
 
                 json_data['layers'][layer_num] = current_layer

--- a/lib/python/qmk/json_encoders.py
+++ b/lib/python/qmk/json_encoders.py
@@ -1,15 +1,17 @@
-"""Class that pretty-prints QMK info.json files.
-"""
+"""Class that pretty-prints QMK info.json files."""
+
 import json
 from decimal import Decimal
+
+JSON_NEWLINE = "__JSON_NEWLINE__"
 
 _sentinel = object()
 newline = '\n'
 
 
 class QMKJSONEncoder(json.JSONEncoder):
-    """Base class for all QMK JSON encoders.
-    """
+    """Base class for all QMK JSON encoders."""
+
     container_types = (list, tuple, dict)
     indentation_char = " "
 
@@ -21,16 +23,14 @@ class QMKJSONEncoder(json.JSONEncoder):
             self.indent = 4
 
     def encode_decimal(self, obj):
-        """Encode a decimal object.
-        """
+        """Encode a decimal object."""
         if obj == int(obj):  # I can't believe Decimal objects don't have .is_integer()
             return int(obj)
 
         return float(obj)
 
     def encode_dict(self, obj, path):
-        """Encode a dict-like object.
-        """
+        """Encode a dict-like object."""
         if obj:
             self.indentation_level += 1
 
@@ -43,14 +43,13 @@ class QMKJSONEncoder(json.JSONEncoder):
         else:
             return "{}"
 
-    def encode_dict_single_line(self, obj, path):
-        """Encode a dict-like object onto a single line.
-        """
-        return "{" + ", ".join(f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in sorted(obj.items(), key=self.sort_layout)) + "}"
+    def encode_dict_single_line(self, obj, path, sort_keys=True):
+        """Encode a dict-like object onto a single line."""
+        items = sorted(obj.items(), key=self.sort_layout) if sort_keys else obj.items()
+        return "{" + ", ".join(f"{json.dumps(key)}: {self.encode(value, path + [key])}" for key, value in items) + "}"
 
     def encode_list(self, obj, path):
-        """Encode a list-like object.
-        """
+        """Encode a list-like object."""
         if self.primitives_only(obj):
             return "[" + ", ".join(self.encode(value, path + [index]) for index, value in enumerate(obj)) + "]"
 
@@ -68,8 +67,7 @@ class QMKJSONEncoder(json.JSONEncoder):
             return "[\n" + ",\n".join(output) + "\n" + self.indent_str + "]"
 
     def encode(self, obj, path=_sentinel):
-        """Encode JSON objects for QMK.
-        """
+        """Encode JSON objects for QMK."""
         if path is _sentinel:
             path = []
 
@@ -86,8 +84,7 @@ class QMKJSONEncoder(json.JSONEncoder):
             return super().encode(obj)
 
     def primitives_only(self, obj):
-        """Returns true if the object doesn't have any container type objects (list, tuple, dict).
-        """
+        """Returns true if the object doesn't have any container type objects (list, tuple, dict)."""
         if isinstance(obj, dict):
             obj = obj.values()
 
@@ -99,11 +96,9 @@ class QMKJSONEncoder(json.JSONEncoder):
 
 
 class InfoJSONEncoder(QMKJSONEncoder):
-    """Custom encoder to make info.json's a little nicer to work with.
-    """
+    """Custom encoder to make info.json's a little nicer to work with."""
     def sort_layout(self, item):
-        """Sorts the hashes in a nice way.
-        """
+        """Sorts the hashes in a nice way."""
         key = item[0]
 
         if key == 'label':
@@ -130,8 +125,7 @@ class InfoJSONEncoder(QMKJSONEncoder):
         return key
 
     def sort_dict(self, item):
-        """Forces layout to the back of the sort order.
-        """
+        """Forces layout to the back of the sort order."""
         key = item[0]
 
         if self.indentation_level == 1:
@@ -160,45 +154,74 @@ class InfoJSONEncoder(QMKJSONEncoder):
 
 
 class KeymapJSONEncoder(QMKJSONEncoder):
-    """Custom encoder to make keymap.json's a little nicer to work with.
-    """
+    """Custom encoder to make keymap.json's a little nicer to work with."""
+    def encode_layout(self, obj, path):
+        """Encode a layout object."""
+        if JSON_NEWLINE not in obj:
+            return "[" + ", ".join(self.encode(value, path + [index]) for index, value in enumerate(obj)) + "]"
+
+        self.indentation_level += 1
+
+        # We want to align the keycodes roughly in line with layout, however this breaks down if a keycode is longer than 7 characters (9 when quoted).
+        # When a keycode is longer than 7 characters, we stop padding for the rest of the line.
+        can_pad = True
+
+        output = []
+        for index, value in enumerate(obj):
+            if value == JSON_NEWLINE:
+                val = "\n" + self.indent_str
+                can_pad = True
+            elif index == len(obj) - 1:
+                val = self.encode(value, path + [index])
+            else:
+                if len(value) > 9:
+                    can_pad = False
+                val = self.encode(value, path + [index]) + ","
+                val = val.ljust(11) if can_pad else f"{val} "
+            output.append(val)
+
+        output.insert(0, self.indent_str)
+
+        self.indentation_level -= 1
+
+        return "[\n" + "".join(output) + "\n" + self.indent_str + "]"
+
+    def encode_macro(self, obj, path):
+        """Encode a macro object."""
+        self.indentation_level += 1
+
+        output = []
+        for index, value in enumerate(obj):
+            if isinstance(value, dict):
+                output.append(f"{self.indent_str}{self.encode_dict_single_line(value, path + [index], sort_keys=False)}")
+            else:
+                output.append(f"{self.indent_str}{self.encode(value, path + [index])}")
+
+        self.indentation_level -= 1
+
+        return "[\n" + ",\n".join(output) + "\n" + self.indent_str + "]"
+
     def encode_list(self, obj, path):
-        """Encode a list-like object.
-        """
-        if self.indentation_level == 2:
-            indent_level = self.indentation_level + 1
-            # We have a list of keycodes
-            layer = [[]]
-
-            for key in obj:
-                if key == 'JSON_NEWLINE':
-                    layer.append([])
-                else:
-                    if isinstance(key, dict):
-                        # We have a macro
-
-                        # TODO: Add proper support for nicely formatting keymap.json macros
-                        layer[-1].append(f'{self.encode(key)}')
-                    else:
-                        layer[-1].append(f'"{key}"')
-
-            layer = [f"{self.indent_str * indent_level}{', '.join(row)}" for row in layer]
-
-            return f"{self.indent_str}[\n{newline.join(layer)}\n{self.indent_str * self.indentation_level}]"
-
-        elif self.primitives_only(obj):
-            return "[" + ", ".join(self.encode(element) for element in obj) + "]"
+        """Encode a list-like object."""
+        if self.primitives_only(obj):
+            return "[" + ", ".join(self.encode(value, path + [index]) for index, value in enumerate(obj)) + "]"
 
         else:
             self.indentation_level += 1
-            output = [self.indent_str + self.encode(element) for element in obj]
+
+            if path[-1] == 'layers':
+                output = [self.indent_str + self.encode_layout(value, path + [index]) for index, value in enumerate(obj)]
+            elif path[-1] == 'macros':
+                output = [self.indent_str + self.encode_macro(value, path + [index]) for index, value in enumerate(obj)]
+            else:
+                output = [self.indent_str + self.encode(value, path + [index]) for index, value in enumerate(obj)]
+
             self.indentation_level -= 1
 
             return "[\n" + ",\n".join(output) + "\n" + self.indent_str + "]"
 
     def sort_dict(self, item):
-        """Sorts the hashes in a nice way.
-        """
+        """Sorts the hashes in a nice way."""
         key = item[0]
 
         if self.indentation_level == 1:
@@ -224,11 +247,9 @@ class KeymapJSONEncoder(QMKJSONEncoder):
 
 
 class UserspaceJSONEncoder(QMKJSONEncoder):
-    """Custom encoder to make userspace qmk.json's a little nicer to work with.
-    """
+    """Custom encoder to make userspace qmk.json's a little nicer to work with."""
     def sort_dict(self, item):
-        """Sorts the hashes in a nice way.
-        """
+        """Sorts the hashes in a nice way."""
         key = item[0]
 
         if self.indentation_level == 1:
@@ -242,11 +263,9 @@ class UserspaceJSONEncoder(QMKJSONEncoder):
 
 
 class CommunityModuleJSONEncoder(QMKJSONEncoder):
-    """Custom encoder to make qmk_module.json's a little nicer to work with.
-    """
+    """Custom encoder to make qmk_module.json's a little nicer to work with."""
     def sort_dict(self, item):
-        """Sorts the hashes in a nice way.
-        """
+        """Sorts the hashes in a nice way."""
         key = item[0]
 
         if self.indentation_level == 1:

--- a/lib/python/qmk/tests/test_cli_commands.py
+++ b/lib/python/qmk/tests/test_cli_commands.py
@@ -330,7 +330,7 @@ def test_format_json_keyboard():
 def test_format_json_keymap():
     result = check_subcommand('format-json', '--format', 'keymap', 'lib/python/qmk/tests/minimal_keymap.json')
     check_returncode(result)
-    assert result.stdout == '{\n    "version": 1,\n    "keyboard": "handwired/pytest/basic",\n    "keymap": "test",\n    "layout": "LAYOUT_ortho_1x1",\n    "layers": [\n                [\n                        "KC_A"\n                ]\n    ]\n}\n'
+    assert result.stdout == '{\n    "version": 1,\n    "keyboard": "handwired/pytest/basic",\n    "keymap": "test",\n    "layout": "LAYOUT_ortho_1x1",\n    "layers": [\n        ["KC_A"]\n    ]\n}\n'
 
 
 def test_format_json_keyboard_auto():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the formatter will spit out keymaps that do not contain commas after keycodes, and inconsistent indentation.

```
qmk format-json -f keymap keyboards/splitkb/halcyon/ferris/keymaps/default/keymap.json | tail
                        "KC_TRNS"
                        "RALT_T(KC_COMM)"
                        "RCTL_T(KC_DOT)"
                        "QK_BOOT"
                        "KC_TRNS"
                        "KC_TAB", "KC_NO"
                        "KC_TRNS"
                ]
    ]
}
```

While not perfect in all cases, this should generally improve the overall situation.

```
qmk format-json -f keymap keyboards/splitkb/halcyon/ferris/keymaps/default/keymap.json | tail
            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
        ],
        [
            "KC_TRNS", "KC_TRNS", "KC_COLN", "KC_ESC",  "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_DEL",  
            "KC_TRNS", "KC_PERC", "KC_SLSH", "KC_ENT",  "KC_TRNS", "DF(1)",   "KC_LGUI", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
            "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_EXLM", "KC_TRNS", "DF(0)",   "KC_TRNS", "RALT_T(KC_COMM)", "RCTL_T(KC_DOT)", "QK_BOOT", 
            "KC_TRNS", "KC_TAB",  "KC_NO",   "KC_TRNS"
        ]
    ]
}
```
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
