### PR TITLE
Fix `EECONFIG_MODULE_DATA_SIZE` for modules with zero provisioned eeconfig

### DIFF
--- a/lib/python/qmk/cli/generate/community_modules.py
+++ b/lib/python/qmk/cli/generate/community_modules.py
@@ -372,13 +372,16 @@ def generate_community_post_config_h(cli):
             lines.extend([
                 f'#ifndef EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE',
                 f'#    define EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE 0',
+                f'#    define EECONFIG_MODULE_{module_slug.upper()}_TOTAL_SIZE 0',
+                '#else',
+                f'#    define EECONFIG_MODULE_{module_slug.upper()}_TOTAL_SIZE ((EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE) + 4)',
                 '#endif',
                 f'#ifndef EECONFIG_MODULE_{module_slug.upper()}_DATA_VERSION',
                 f'#    define EECONFIG_MODULE_{module_slug.upper()}_DATA_VERSION (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE)',
                 '#endif',
                 '',
             ])
-        module_size = " + ".join([f'(4 + (EECONFIG_MODULE_{module_slug.upper()}_DATA_SIZE))' for module_slug in _module_slugs(modules)])
+        module_size = " + ".join([f'(EECONFIG_MODULE_{module_slug.upper()}_TOTAL_SIZE)' for module_slug in _module_slugs(modules)])
         lines.append(f'#define EECONFIG_MODULE_DATA_SIZE ({module_size})')
         lines.append('')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Currently the provisioned size of eeconfig for community modules is `(4 + data size)` regardless if the module uses eeconfig or not.

When enable/disable modules that do not use the eeprom/nvm, it will shift `EECONFIG_SIZE` by 4 bytes per module. For the dynamic keymap array (and everything after it), the net effect is it will shift the keymap array, leading to incorrect mapping of keycodes at runtime.

This PR fixes the accumulating of sizes so that the `+4` only happens when a module declares a `_DATA_SIZE > 0`.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
