### PR TITLE
feat(keycodes): add KC_GLOBE for Apple Globe/FN key

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.2_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.2_basic.hjson
@@ -15,6 +15,14 @@
             "aliases": [
                 "KC_LPAD"
             ]
+        },
+        "0x00C3": {
+            "group": "media",
+            "key": "KC_GLOBE",
+            "label": "Apple Globe/FN Key",
+            "aliases": [
+                "KC_GLOB"
+            ]
         }
     }
 }

--- a/quantum/keycodes.h
+++ b/quantum/keycodes.h
@@ -295,6 +295,7 @@ enum qk_keycode_defines {
     KC_ASSISTANT = 0x00C0,
     KC_MISSION_CONTROL = 0x00C1,
     KC_LAUNCHPAD = 0x00C2,
+    KC_GLOBE = 0x00C3,
     QK_MOUSE_CURSOR_UP = 0x00CD,
     QK_MOUSE_CURSOR_DOWN = 0x00CE,
     QK_MOUSE_CURSOR_LEFT = 0x00CF,
@@ -955,6 +956,7 @@ enum qk_keycode_defines {
     KC_ASST    = KC_ASSISTANT,
     KC_MCTL    = KC_MISSION_CONTROL,
     KC_LPAD    = KC_LAUNCHPAD,
+    KC_GLOB    = KC_GLOBE,
     MS_UP      = QK_MOUSE_CURSOR_UP,
     MS_DOWN    = QK_MOUSE_CURSOR_DOWN,
     MS_LEFT    = QK_MOUSE_CURSOR_LEFT,
@@ -1505,7 +1507,7 @@ enum qk_keycode_defines {
 #define IS_INTERNAL_KEYCODE(code) ((code) >= KC_NO && (code) <= KC_TRANSPARENT)
 #define IS_BASIC_KEYCODE(code) ((code) >= KC_A && (code) <= KC_EXSEL)
 #define IS_SYSTEM_KEYCODE(code) ((code) >= KC_SYSTEM_POWER && (code) <= KC_SYSTEM_WAKE)
-#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_LAUNCHPAD)
+#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_GLOBE)
 #define IS_MOUSE_KEYCODE(code) ((code) >= QK_MOUSE_CURSOR_UP && (code) <= QK_MOUSE_ACCELERATION_2)
 #define IS_MODIFIER_KEYCODE(code) ((code) >= KC_LEFT_CTRL && (code) <= KC_RIGHT_GUI)
 #define IS_SWAP_HANDS_KEYCODE(code) ((code) >= QK_SWAP_HANDS_TOGGLE && (code) <= QK_SWAP_HANDS_ONE_SHOT)
@@ -1531,7 +1533,7 @@ enum qk_keycode_defines {
 #define INTERNAL_KEYCODE_RANGE              KC_NO ... KC_TRANSPARENT
 #define BASIC_KEYCODE_RANGE                 KC_A ... KC_EXSEL
 #define SYSTEM_KEYCODE_RANGE                KC_SYSTEM_POWER ... KC_SYSTEM_WAKE
-#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_LAUNCHPAD
+#define CONSUMER_KEYCODE_RANGE              KC_AUDIO_MUTE ... KC_GLOBE
 #define MOUSE_KEYCODE_RANGE                 QK_MOUSE_CURSOR_UP ... QK_MOUSE_ACCELERATION_2
 #define MODIFIER_KEYCODE_RANGE              KC_LEFT_CTRL ... KC_RIGHT_GUI
 #define SWAP_HANDS_KEYCODE_RANGE            QK_SWAP_HANDS_TOGGLE ... QK_SWAP_HANDS_ONE_SHOT

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -335,6 +335,8 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
             return AC_DESKTOP_SHOW_ALL_WINDOWS;
         case KC_LAUNCHPAD:
             return AC_SOFT_KEY_LEFT;
+        case KC_GLOBE:
+            return AC_NEXT_KEYBOARD_LAYOUT_SELECT;
         default:
             return 0;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Adds `KC_GLOBE` (0x00C3) keycode for the Apple Globe/FN key, mapping to HID Consumer usage `AC_NEXT_KEYBOARD_LAYOUT_SELECT` (0x29D), per Apple's Accessory Design Guidelines (Table 14-3). Requires EXTRAKEY_ENABLE.

Changes:
- `data/constants/keycodes/keycodes_0.0.2_basic.hjson`: add `0x00C3` entry for `KC_GLOBE` (alias `KC_GLOB`), in the fragment alongside adjacent Apple keys `0x00C1`/`0x00C2`
- `quantum/keycodes.h`: add enum entry `KC_GLOBE = 0x00C3`, alias `KC_GLOB`, extend `IS_CONSUMER_KEYCODE` and `CONSUMER_KEYCODE_RANGE` upper bound to `KC_GLOBE`
- `tmk_core/protocol/report.h`: add `case KC_GLOBE` returning `AC_NEXT_KEYBOARD_LAYOUT_SELECT` in `KEYCODE2CONSUMER`

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).