### PR TITLE
Add digitizer absolute pointer mode

### DIFF
--- a/docs/features/digitizer.md
+++ b/docs/features/digitizer.md
@@ -2,7 +2,7 @@
 
 Digitizers allow the mouse cursor to be placed at absolute coordinates, unlike the [Pointing Device](pointing_device) feature which applies relative displacements.
 
-This feature implements a stylus device with a tip switch and barrel switch (generally equivalent to the primary and secondary mouse buttons respectively). Tip pressure is not currently implemented.
+By default, this feature implements a stylus device with a tip switch and barrel switch (generally equivalent to the primary and secondary mouse buttons respectively). Tip pressure is not currently implemented.
 
 ## Usage {#usage}
 
@@ -11,6 +11,16 @@ Add the following to your `rules.mk`:
 ```make
 DIGITIZER_ENABLE = yes
 ```
+
+## Absolute Pointer Mode {#absolute-pointer-mode}
+
+Some environments treat a stylus digitizer as a touch-like input and hide the on-screen cursor while it is in use -- KDE Plasma on Wayland is one example. If the cursor should remain visible, the digitizer can instead be presented to the host as a mouse with absolute coordinates, in the same style as the pointing devices exposed by virtual machine hypervisors. Add the following to your `config.h`:
+
+```c
+#define DIGITIZER_ABSOLUTE_POINTER
+```
+
+This changes only the HID report descriptor; the report layout and the API below are unchanged. In this mode the "in range" indicator is declared as padding and is ignored by the host, and the tip and barrel switches are reported as mouse buttons 1 and 2 respectively.
 
 ## Positioning {#positioning}
 
@@ -29,7 +39,7 @@ digitizer_in_range_on();
 digitizer_set_position(0.5, 0.5);
 ```
 
-The "in range" indicator is required to be on for the change in coordinates to be taken. It can then be turned off again to signal the end of the digitizer interaction, but it is not strictly required.
+In the default stylus mode, the "in range" indicator is required to be on for the change in coordinates to be taken. It can then be turned off again to signal the end of the digitizer interaction, but it is not strictly required. In [Absolute Pointer Mode](#absolute-pointer-mode), the indicator is ignored by the host and the call can be omitted.
 
 You can also modify the digitizer state directly, if you need to change multiple fields in a single report:
 

--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -319,12 +319,54 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM DigitizerReport[] = {
 const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
 #        define SHARED_REPORT_STARTED
 #    endif
+#    ifdef DIGITIZER_ABSOLUTE_POINTER
+    // Absolute pointer variant; report layout is identical to the stylus variant below
+    HID_RI_USAGE_PAGE(8, 0x01),            // Generic Desktop
+    HID_RI_USAGE(8, 0x02),                 // Mouse
+    HID_RI_COLLECTION(8, 0x01),            // Application
+#        ifdef DIGITIZER_SHARED_EP
+        HID_RI_REPORT_ID(8, REPORT_ID_DIGITIZER),
+#        endif
+        HID_RI_USAGE(8, 0x01),             // Pointer
+        HID_RI_COLLECTION(8, 0x00),        // Physical
+            // Reset unit and physical range items inherited from preceding shared-EP reports
+            HID_RI_UNIT(8, 0x00),
+            HID_RI_UNIT_EXPONENT(8, 0x00),
+            HID_RI_PHYSICAL_MINIMUM(8, 0x00),
+            HID_RI_PHYSICAL_MAXIMUM(8, 0x00),
+            // In Range bit, unused in this mode (1 bit padding)
+            HID_RI_REPORT_COUNT(8, 0x01),
+            HID_RI_REPORT_SIZE(8, 0x01),
+            HID_RI_INPUT(8, HID_IOF_CONSTANT),
+            // Tip Switch & Barrel Switch as Buttons 1 & 2 (2 bits)
+            HID_RI_USAGE_PAGE(8, 0x09),    // Button
+            HID_RI_USAGE_MINIMUM(8, 0x01),
+            HID_RI_USAGE_MAXIMUM(8, 0x02),
+            HID_RI_LOGICAL_MINIMUM(8, 0x00),
+            HID_RI_LOGICAL_MAXIMUM(8, 0x01),
+            HID_RI_REPORT_COUNT(8, 0x02),
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+            // Padding (5 bits)
+            HID_RI_REPORT_COUNT(8, 0x05),
+            HID_RI_INPUT(8, HID_IOF_CONSTANT),
+
+            // X/Y Position (4 bytes)
+            HID_RI_USAGE_PAGE(8, 0x01),    // Generic Desktop
+            HID_RI_USAGE(8, 0x30),         // X
+            HID_RI_USAGE(8, 0x31),         // Y
+            HID_RI_LOGICAL_MAXIMUM(16, 0x7FFF),
+            HID_RI_REPORT_COUNT(8, 0x02),
+            HID_RI_REPORT_SIZE(8, 0x10),
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+        HID_RI_END_COLLECTION(0),
+    HID_RI_END_COLLECTION(0),
+#    else
     HID_RI_USAGE_PAGE(8, 0x0D),            // Digitizers
     HID_RI_USAGE(8, 0x01),                 // Digitizer
     HID_RI_COLLECTION(8, 0x01),            // Application
-#    ifdef DIGITIZER_SHARED_EP
+#        ifdef DIGITIZER_SHARED_EP
         HID_RI_REPORT_ID(8, REPORT_ID_DIGITIZER),
-#    endif
+#        endif
         HID_RI_USAGE(8, 0x20),             // Stylus
         HID_RI_COLLECTION(8, 0x00),        // Physical
             // In Range, Tip Switch & Barrel Switch (3 bits)
@@ -357,6 +399,7 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
         HID_RI_END_COLLECTION(0),
     HID_RI_END_COLLECTION(0),
+#    endif
 #    ifndef DIGITIZER_SHARED_EP
 };
 #    endif

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -706,6 +706,46 @@ const PROGMEM uchar shared_hid_report[] = {
 #endif
 
 #ifdef DIGITIZER_ENABLE
+#    ifdef DIGITIZER_ABSOLUTE_POINTER
+    // Digitizer report descriptor, absolute pointer variant (keep in sync with usb_descriptor.c)
+    0x05, 0x01,                // Usage Page (Generic Desktop)
+    0x09, 0x02,                // Usage (Mouse)
+    0xA1, 0x01,                // Collection (Application)
+    0x85, REPORT_ID_DIGITIZER, //   Report ID
+    0x09, 0x01,                //   Usage (Pointer)
+    0xA1, 0x00,                //   Collection (Physical)
+    // Reset unit and physical range items inherited from preceding reports
+    0x65, 0x00, //     Unit (None)
+    0x55, 0x00, //     Unit Exponent (0)
+    0x35, 0x00, //     Physical Minimum (0)
+    0x45, 0x00, //     Physical Maximum (0)
+    // In Range bit, unused in this mode (1 bit padding)
+    0x95, 0x01, //     Report Count (1)
+    0x75, 0x01, //     Report Size (1)
+    0x81, 0x03, //     Input (Constant)
+    // Tip Switch & Barrel Switch as Buttons 1 & 2 (2 bits)
+    0x05, 0x09, //     Usage Page (Button)
+    0x19, 0x01, //     Usage Minimum (1)
+    0x29, 0x02, //     Usage Maximum (2)
+    0x15, 0x00, //     Logical Minimum
+    0x25, 0x01, //     Logical Maximum
+    0x95, 0x02, //     Report Count (2)
+    0x81, 0x02, //     Input (Data, Variable, Absolute)
+    // Padding (5 bits)
+    0x95, 0x05, //     Report Count (5)
+    0x81, 0x03, //     Input (Constant)
+
+    // X/Y Position (4 bytes)
+    0x05, 0x01,       //     Usage Page (Generic Desktop)
+    0x09, 0x30,       //     Usage (X)
+    0x09, 0x31,       //     Usage (Y)
+    0x26, 0xFF, 0x7F, //     Logical Maximum (32767)
+    0x95, 0x02,       //     Report Count (2)
+    0x75, 0x10,       //     Report Size (16)
+    0x81, 0x02,       //     Input (Data, Variable, Absolute)
+    0xC0,             //   End Collection
+    0xC0,             // End Collection
+#    else
     // Digitizer report descriptor
     0x05, 0x0D,                // Usage Page (Digitizers)
     0x09, 0x01,                // Usage (Digitizer)
@@ -738,6 +778,7 @@ const PROGMEM uchar shared_hid_report[] = {
     0x81, 0x02,       //     Input (Data, Variable, Absolute)
     0xC0,             //   End Collection
     0xC0,             // End Collection
+#    endif
 #endif
 
 #ifdef PROGRAMMABLE_BUTTON_ENABLE


### PR DESCRIPTION
## Description

Some compositors (KDE Plasma on Wayland) treat stylus digitizers as touch and hide the cursor. DIGITIZER_ABSOLUTE_POINTER in config.h presents the digitizer as a mouse with absolute X/Y instead, same device class as VM pointing devices; the cursor then tracks the reported position and stays visible.

Wire format unchanged: in-range bit becomes constant padding, tip and barrel switches become buttons 1 and 2.

TL;DR: Required for my mousegrid module to stop hiding the damn mouse cursor on-screen.

## Types of Changes

- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
