### PR TITLE
Fix UnicodeDecodeError in `git_check_deviation`

### DIFF
--- a/lib/python/qmk/git.py
+++ b/lib/python/qmk/git.py
@@ -134,7 +134,8 @@ def git_check_deviation(active_branch):
     """Return True if branch has custom commits
     """
     cli.run(['git', 'fetch', 'upstream', active_branch])
-    deviations = cli.run(['git', '--no-pager', 'log', f'upstream/{active_branch}...{active_branch}'])
+    # As we only care about exit code, decode to bytes to avoid UnicodeDecodeError
+    deviations = cli.run(['git', '--no-pager', 'log', f'upstream/{active_branch}...{active_branch}'], text=False)
     return bool(deviations.returncode)
 
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
`qmk doctor` under msys UCRT64 is currently throwing:
```
Ψ Repo version: 0.33.8
⚠ Git has unstashed/uncommitted changes.
Exception in thread Thread-27 (_readerthread):
Traceback (most recent call last):
  File "C:\Users\zvecr\AppData\Roaming\uv\python\cpython-3.14.1-windows-x86_64-none\Lib\threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "C:\Users\zvecr\AppData\Roaming\uv\python\cpython-3.14.1-windows-x86_64-none\Lib\threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\zvecr\AppData\Roaming\uv\python\cpython-3.14.1-windows-x86_64-none\Lib\subprocess.py", line 1613, in _readerthread
    buffer.append(fh.read())
                  ~~~~~~~^^
  File "C:\Users\zvecr\AppData\Roaming\uv\python\cpython-3.14.1-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 18511: character maps to <undefined>
Ψ - Latest develop: 2026-07-08 01:41:47 +0100 (12139903ce) -- Require `--keyboard` for some CLI subcommands (#26308)
```

As we only care about exit code, decode git log output to bytes to prevent Unicode errors.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
