### PR TITLE
Implement UV installer path workaround for Msys

### DIFF
--- a/util/env-bootstrap.sh
+++ b/util/env-bootstrap.sh
@@ -440,6 +440,13 @@ __EOT__
     install_uv() {
         # Install `uv` (or update as necessary)
         download_url https://astral.sh/uv/install.sh - | TMPDIR="$(posix_ish_path "${TMPDIR:-}")" UV_INSTALL_DIR="$(windows_ish_path "${UV_INSTALL_DIR:-}")" sh
+
+        # Workaround for UV installer not pushing UV_TOOL_BIN_DIR into the env when used with their installer
+        if [ "$(uname -o 2>/dev/null || true)" = "Msys" ]; then
+            if [ "${UV_NO_MODIFY_PATH:-}" != "1" ]; then
+                echo -e "#!/bin/sh\n# Workaround for UV installer not pushing UV_TOOL_BIN_DIR into the env when used with their installer\nexport PATH=\"${UV_TOOL_BIN_DIR}:\$PATH\"" > /etc/profile.d/qmk-uv-env.sh
+            fi
+        fi
     }
 
     setup_paths() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Bootstrap script should generally give a working environment without any additional user actions. Right now on a manual install under msys (and not the customised qmk_distro_msys bundle), the installer picks a "safe" value for `UV_TOOL_BIN_DIR `. That value by default not on the PATH, which leads to `qmk` CLI not being accessible.

The workaround is gated by `UV_NO_MODIFY_PATH` so qmk_distro_msys which uses this, is not changed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #26434

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
